### PR TITLE
Encode state paths and harden delta type-swap sync

### DIFF
--- a/importer/import.php
+++ b/importer/import.php
@@ -766,6 +766,13 @@ class ImportClient
 {
 
     private const SAVE_STATE_EVERY_N_CHUNKS = 50;
+    private const STATE_PATH_ENCODING_PREFIX = "base64:";
+    private const STATE_PATH_FIELDS = [
+        ["diff", "local_after"],
+        ["fetch", "batch_file"],
+        ["current_file"],
+        ["db_index", "file"],
+    ];
 
     /** @var string Export server URL. */
     private $remote_url;
@@ -3396,20 +3403,52 @@ class ImportClient
             return;
         }
 
-        if (is_dir($local_path) && !is_link($local_path)) {
-            if (true !== @rmdir($local_path)) {
-                $this->audit_log("Failed to delete directory: {$path}", true);
-            } else {
-                $this->audit_log("Deleted directory: {$path}", false);
-            }
+        if ($this->remove_local_path_without_following_symlinks($local_path)) {
+            $this->audit_log("Deleted: {$path}", false);
             return;
         }
 
-        if (true !== @unlink($local_path)) {
-            $this->audit_log("Failed to delete: {$path}", true);
-        } else {
-            $this->audit_log("Deleted: {$path}", false);
+        $this->audit_log("Failed to delete: {$path}", true);
+    }
+
+    /**
+     * Remove a local path recursively without traversing symlink targets.
+     *
+     * Symlinks are always unlinked as links. Directories are traversed
+     * depth-first.
+     */
+    private function remove_local_path_without_following_symlinks(
+        string $local_path
+    ): bool {
+        if (!file_exists($local_path) && !is_link($local_path)) {
+            return true;
         }
+
+        if (is_link($local_path) || is_file($local_path)) {
+            return true === @unlink($local_path);
+        }
+
+        if (is_dir($local_path)) {
+            $entries = @scandir($local_path);
+            if ($entries === false) {
+                return false;
+            }
+            foreach ($entries as $entry) {
+                if ($entry === "." || $entry === "..") {
+                    continue;
+                }
+                if (
+                    !$this->remove_local_path_without_following_symlinks(
+                        $local_path . "/" . $entry
+                    )
+                ) {
+                    return false;
+                }
+            }
+            return true === @rmdir($local_path);
+        }
+
+        return true === @unlink($local_path);
     }
 
     /**
@@ -4241,6 +4280,21 @@ class ImportClient
 
         // Open file on first chunk
         if ($is_first) {
+            if (
+                (file_exists($local_path) || is_link($local_path)) &&
+                (!is_file($local_path) || is_link($local_path))
+            ) {
+                if (
+                    !$this->remove_local_path_without_following_symlinks(
+                        $local_path
+                    )
+                ) {
+                    throw new RuntimeException(
+                        "Failed to replace path with file: {$path}",
+                    );
+                }
+            }
+
             // Check if file exists locally
             $exists_locally = file_exists($local_path);
             $local_size = $exists_locally ? filesize($local_path) : 0;
@@ -4406,7 +4460,7 @@ class ImportClient
             }
         }
 
-        if (is_dir($dir)) {
+        if (is_dir($dir) && !is_link($dir)) {
             return;
         }
 
@@ -4492,6 +4546,18 @@ class ImportClient
         }
 
         $local_path = $this->remote_path_to_local_path_within_import_root($path);
+        if (
+            (file_exists($local_path) || is_link($local_path)) &&
+            (!is_dir($local_path) || is_link($local_path))
+        ) {
+            if (
+                !$this->remove_local_path_without_following_symlinks($local_path)
+            ) {
+                throw new RuntimeException(
+                    "Failed to replace path with directory: {$path}",
+                );
+            }
+        }
 
         // Create directory, removing any files that block the path
         $this->ensure_directory_path($local_path);
@@ -4558,7 +4624,21 @@ class ImportClient
 
         // Remove existing file/symlink if present
         if (file_exists($local_path) || is_link($local_path)) {
-            unlink($local_path);
+            if (
+                !$this->remove_local_path_without_following_symlinks($local_path)
+            ) {
+                $this->audit_log(
+                    "Failed to remove existing path for symlink: {$local_path}",
+                    true,
+                );
+                $this->output_progress([
+                    "type" => "symlink_error",
+                    "path" => $path,
+                    "target" => $target,
+                    "error" => "Failed to replace existing path",
+                ]);
+                return;
+            }
         }
 
         // Create parent directory
@@ -5600,6 +5680,110 @@ class ImportClient
     }
 
     /**
+     * Encode state path fields as base64 to make JSON persistence byte-safe.
+     */
+    private function encode_state_paths(array $state): array
+    {
+        foreach (self::STATE_PATH_FIELDS as $field_keys) {
+            $state = $this->transform_state_path_field(
+                $state,
+                $field_keys,
+                function ($value) {
+                    return $this->encode_state_path_value($value);
+                },
+            );
+        }
+        return $state;
+    }
+
+    /**
+     * Decode base64-encoded path fields in state after loading.
+     *
+     * Supports legacy plain-string fields for backward compatibility.
+     */
+    private function decode_state_paths(array $state): array
+    {
+        foreach (self::STATE_PATH_FIELDS as $field_keys) {
+            $state = $this->transform_state_path_field(
+                $state,
+                $field_keys,
+                function ($value) {
+                    return $this->decode_state_path_value($value);
+                },
+            );
+        }
+        return $state;
+    }
+
+    /**
+     * Apply a transform to a top-level or two-level state field.
+     *
+     * @param array<int, string> $field_keys
+     */
+    private function transform_state_path_field(
+        array $state,
+        array $field_keys,
+        callable $transform
+    ): array {
+        if (count($field_keys) === 1) {
+            $key = $field_keys[0];
+            if (array_key_exists($key, $state)) {
+                $state[$key] = $transform($state[$key]);
+            }
+            return $state;
+        }
+
+        $outer = $field_keys[0];
+        $inner = $field_keys[1];
+        if (
+            !array_key_exists($outer, $state) ||
+            !is_array($state[$outer]) ||
+            !array_key_exists($inner, $state[$outer])
+        ) {
+            return $state;
+        }
+
+        $state[$outer][$inner] = $transform($state[$outer][$inner]);
+        return $state;
+    }
+
+    /**
+     * @param mixed $value
+     * @return mixed
+     */
+    private function encode_state_path_value($value)
+    {
+        if (!is_string($value) || $value === "") {
+            return $value;
+        }
+        return self::STATE_PATH_ENCODING_PREFIX . base64_encode($value);
+    }
+
+    /**
+     * @param mixed $value
+     * @return mixed
+     */
+    private function decode_state_path_value($value)
+    {
+        if (!is_string($value) || $value === "") {
+            return $value;
+        }
+        if (!str_starts_with($value, self::STATE_PATH_ENCODING_PREFIX)) {
+            return $value;
+        }
+        $encoded = substr($value, strlen(self::STATE_PATH_ENCODING_PREFIX));
+        $decoded = base64_decode($encoded, true);
+        if ($decoded === false) {
+            $this->audit_log(
+                "Warning: invalid base64-encoded state path; resetting field",
+                true,
+            );
+            return null;
+        }
+        return $decoded;
+    }
+
+    /**
      * Load import state from disk.
      */
     private function load_state(): array
@@ -5624,7 +5808,8 @@ class ImportClient
             return $this->default_state();
         }
 
-        return $this->normalize_state($state);
+        $state = $this->normalize_state($state);
+        return $this->decode_state_paths($state);
     }
 
     /**
@@ -5642,6 +5827,7 @@ class ImportClient
             ];
         }
         $state = $this->normalize_state($state);
+        $state = $this->encode_state_paths($state);
 
         // Write to temp file first, then atomic rename
         $json = json_encode($state, JSON_PRETTY_PRINT);

--- a/tests/e2e/tests/import-32-delta-deletions-and-type-swaps.test.js
+++ b/tests/e2e/tests/import-32-delta-deletions-and-type-swaps.test.js
@@ -1,0 +1,242 @@
+/**
+ * Test 32: Delta sync deletions + type swaps (file/dir/symlink)
+ *
+ * Covers:
+ * - Deleting file, deep directory tree, symlink to file, symlink to directory
+ * - Replacing paths across types: file<->dir<->symlink
+ * - Ensuring local directory deletion does not follow symlink targets
+ * - State path persistence uses base64-encoded values
+ */
+import { describe, it, beforeAll, afterAll } from 'vitest';
+import assert from 'node:assert/strict';
+import { existsSync, lstatSync, readlinkSync, readFileSync } from 'node:fs';
+import { execSync } from 'node:child_process';
+import { join } from 'node:path';
+import {
+    runImporter, createTempDir, cleanupTempDir,
+    getSiteUrl, getSiteSecret, getSiteDir,
+} from '../lib/test-helpers.js';
+import { ensureSite } from '../lib/site-setup.js';
+
+describe('Import: Delta deletions and type swaps', () => {
+    const site = 'file-changes';
+    const scenarioName = 'delta-rigorous';
+    const preserveName = 'delta-rigorous-preserve';
+    const remoteScenarioRoot = join(getSiteDir(site), 'test-data', scenarioName);
+    const remotePreserveRoot = join(getSiteDir(site), 'test-data', preserveName);
+
+    let tempDir;
+
+    const sh = (v) => JSON.stringify(v);
+    const sudoRun = (script) => {
+        const oneLine = script
+            .split('\n')
+            .map((line) => line.trim())
+            .filter(Boolean)
+            .join('; ');
+        execSync(`sudo bash -lc ${JSON.stringify(`set -euo pipefail; ${oneLine}`)}`);
+    };
+
+    const writeText = (path, content) => `printf %b ${sh(content)} > ${sh(path)}`;
+
+    function importUrl() {
+        return `${getSiteUrl(site)}?directory=${getSiteDir(site)}`;
+    }
+
+    function localScenarioRoot() {
+        return join(tempDir, 'filesystem-root', getSiteDir(site), 'test-data', scenarioName);
+    }
+
+    function localPreserveFile() {
+        return join(tempDir, 'filesystem-root', getSiteDir(site), 'test-data', preserveName, 'keep.txt');
+    }
+
+    function lstatIfExists(path) {
+        try {
+            return lstatSync(path);
+        } catch (e) {
+            if (e && e.code === 'ENOENT') return null;
+            throw e;
+        }
+    }
+
+    function setupInitialRemoteLayout() {
+        sudoRun(`
+rm -rf ${sh(remoteScenarioRoot)} ${sh(remotePreserveRoot)}
+mkdir -p ${sh(remoteScenarioRoot)} ${sh(remotePreserveRoot)}
+
+mkdir -p ${sh(join(remoteScenarioRoot, 'targets', 'delete-dir'))}
+mkdir -p ${sh(join(remoteScenarioRoot, 'targets', 'start-dir', 'deep'))}
+mkdir -p ${sh(join(remoteScenarioRoot, 'targets', 'new-link-dir', 'nested'))}
+mkdir -p ${sh(join(remoteScenarioRoot, 'dir-delete', 'level1', 'level2', 'level3'))}
+mkdir -p ${sh(join(remoteScenarioRoot, 'dir-to-file', 'n1', 'n2'))}
+mkdir -p ${sh(join(remoteScenarioRoot, 'dir-to-symlink', 'deep'))}
+mkdir -p ${sh(join(remoteScenarioRoot, 'delete-dir-with-symlink', 'sub'))}
+
+${writeText(join(remoteScenarioRoot, 'file-delete.txt'), 'delete-me\n')}
+${writeText(join(remoteScenarioRoot, 'file-to-dir'), 'initial-file-to-dir\n')}
+${writeText(join(remoteScenarioRoot, 'file-to-symlink'), 'initial-file-to-symlink\n')}
+${writeText(join(remoteScenarioRoot, 'targets', 'delete-file.txt'), 'delete-file-target\n')}
+${writeText(join(remoteScenarioRoot, 'targets', 'delete-dir', 'inside.txt'), 'delete-dir-target\n')}
+${writeText(join(remoteScenarioRoot, 'targets', 'start-dir', 'deep', 'start.txt'), 'start-dir\n')}
+${writeText(join(remoteScenarioRoot, 'targets', 'start-file.txt'), 'start-file\n')}
+${writeText(join(remoteScenarioRoot, 'targets', 'new-link-file.txt'), 'new-link-file\n')}
+${writeText(join(remoteScenarioRoot, 'targets', 'new-link-dir', 'nested', 'linked.txt'), 'linked-dir-content\n')}
+${writeText(join(remoteScenarioRoot, 'dir-delete', 'level1', 'level2', 'level3', 'deep.txt'), 'deep-delete\n')}
+${writeText(join(remoteScenarioRoot, 'dir-delete', 'level1', 'level2', 'sibling.txt'), 'deep-delete-sibling\n')}
+${writeText(join(remoteScenarioRoot, 'dir-to-file', 'n1', 'n2', 'original.txt'), 'dir-to-file-initial\n')}
+${writeText(join(remoteScenarioRoot, 'dir-to-symlink', 'deep', 'original.txt'), 'dir-to-symlink-initial\n')}
+${writeText(join(remoteScenarioRoot, 'delete-dir-with-symlink', 'sub', 'nested.txt'), 'remove-dir-with-link\n')}
+${writeText(join(remotePreserveRoot, 'keep.txt'), 'must-survive-local-delete\n')}
+
+ln -s ${sh('targets/delete-file.txt')} ${sh(join(remoteScenarioRoot, 'symlink-delete-file'))}
+ln -s ${sh('targets/delete-dir')} ${sh(join(remoteScenarioRoot, 'symlink-delete-dir'))}
+ln -s ${sh('targets/start-dir')} ${sh(join(remoteScenarioRoot, 'symlink-to-dir-to-file'))}
+ln -s ${sh('targets/start-file.txt')} ${sh(join(remoteScenarioRoot, 'symlink-to-file-to-dir'))}
+ln -s ${sh('../' + preserveName)} ${sh(join(remoteScenarioRoot, 'delete-dir-with-symlink', 'escape-link'))}
+
+chown -R nginx:nginx ${sh(remoteScenarioRoot)} ${sh(remotePreserveRoot)}
+`);
+    }
+
+    function applyDeltaRemoteChanges() {
+        sudoRun(`
+rm -f ${sh(join(remoteScenarioRoot, 'file-delete.txt'))}
+rm -rf ${sh(join(remoteScenarioRoot, 'dir-delete'))}
+rm -f ${sh(join(remoteScenarioRoot, 'symlink-delete-file'))}
+rm -f ${sh(join(remoteScenarioRoot, 'symlink-delete-dir'))}
+rm -rf ${sh(join(remoteScenarioRoot, 'delete-dir-with-symlink'))}
+
+rm -f ${sh(join(remoteScenarioRoot, 'file-to-dir'))}
+mkdir -p ${sh(join(remoteScenarioRoot, 'file-to-dir', 'nested', 'deeper'))}
+${writeText(join(remoteScenarioRoot, 'file-to-dir', 'nested', 'deeper', 'value.txt'), 'file-became-dir\n')}
+
+rm -f ${sh(join(remoteScenarioRoot, 'file-to-symlink'))}
+ln -s ${sh('targets/new-link-file.txt')} ${sh(join(remoteScenarioRoot, 'file-to-symlink'))}
+
+rm -rf ${sh(join(remoteScenarioRoot, 'dir-to-file'))}
+${writeText(join(remoteScenarioRoot, 'dir-to-file'), 'dir-became-file\n')}
+
+rm -rf ${sh(join(remoteScenarioRoot, 'dir-to-symlink'))}
+ln -s ${sh('targets/new-link-dir')} ${sh(join(remoteScenarioRoot, 'dir-to-symlink'))}
+
+rm -f ${sh(join(remoteScenarioRoot, 'symlink-to-dir-to-file'))}
+${writeText(join(remoteScenarioRoot, 'symlink-to-dir-to-file'), 'symlink-dir-became-file\n')}
+
+rm -f ${sh(join(remoteScenarioRoot, 'symlink-to-file-to-dir'))}
+mkdir -p ${sh(join(remoteScenarioRoot, 'symlink-to-file-to-dir', 'x', 'y', 'z'))}
+${writeText(join(remoteScenarioRoot, 'symlink-to-file-to-dir', 'x', 'y', 'z', 'value.txt'), 'symlink-file-became-dir\n')}
+
+chown -R nginx:nginx ${sh(remoteScenarioRoot)} ${sh(remotePreserveRoot)}
+`);
+    }
+
+    beforeAll(async () => {
+        await ensureSite(site);
+        tempDir = createTempDir('e2e-delta-rigorous');
+        setupInitialRemoteLayout();
+    });
+
+    afterAll(() => {
+        cleanupTempDir(tempDir);
+        execSync(`sudo rm -rf ${sh(remoteScenarioRoot)} ${sh(remotePreserveRoot)} 2>/dev/null || true`);
+    });
+
+    it('initial files-sync completes', () => {
+        const result = runImporter(importUrl(), tempDir, 'files-sync', {
+            secret: getSiteSecret(site),
+        });
+        assert.equal(result.exitCode, 0, `Expected exit 0\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);
+    });
+
+    it('delta sync applies deletions and type swaps', () => {
+        applyDeltaRemoteChanges();
+
+        const result = runImporter(importUrl(), tempDir, 'files-sync', {
+            secret: getSiteSecret(site),
+        });
+        assert.equal(result.exitCode, 0, `Expected exit 0\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);
+    });
+
+    it('deleted file, deep directory tree, and symlinks are removed locally', () => {
+        const base = localScenarioRoot();
+
+        assert.equal(existsSync(join(base, 'file-delete.txt')), false, 'Expected deleted file to be removed');
+        assert.equal(existsSync(join(base, 'dir-delete')), false, 'Expected deleted deep directory tree to be removed');
+        assert.equal(lstatIfExists(join(base, 'symlink-delete-file')), null, 'Expected deleted file symlink to be removed');
+        assert.equal(lstatIfExists(join(base, 'symlink-delete-dir')), null, 'Expected deleted directory symlink to be removed');
+        assert.equal(existsSync(join(base, 'delete-dir-with-symlink')), false, 'Expected deleted directory with symlink to be removed');
+    });
+
+    it('directory deletion does not follow symlinks outside the deleted directory', () => {
+        const preserveFile = localPreserveFile();
+        assert.equal(existsSync(preserveFile), true, `Expected preserve file to remain: ${preserveFile}`);
+        assert.equal(readFileSync(preserveFile, 'utf-8'), 'must-survive-local-delete\n');
+    });
+
+    it('type swaps file<->dir<->symlink are applied with correct final types', () => {
+        const base = localScenarioRoot();
+
+        const fileToDir = join(base, 'file-to-dir');
+        assert.ok(lstatSync(fileToDir).isDirectory(), 'Expected file-to-dir to be a directory');
+        assert.equal(
+            readFileSync(join(fileToDir, 'nested', 'deeper', 'value.txt'), 'utf-8'),
+            'file-became-dir\n',
+        );
+
+        const fileToSymlink = join(base, 'file-to-symlink');
+        assert.ok(lstatSync(fileToSymlink).isSymbolicLink(), 'Expected file-to-symlink to be a symlink');
+        assert.equal(readlinkSync(fileToSymlink), 'targets/new-link-file.txt');
+
+        const dirToFile = join(base, 'dir-to-file');
+        assert.ok(lstatSync(dirToFile).isFile(), 'Expected dir-to-file to be a regular file');
+        assert.equal(readFileSync(dirToFile, 'utf-8'), 'dir-became-file\n');
+
+        const dirToSymlink = join(base, 'dir-to-symlink');
+        assert.ok(lstatSync(dirToSymlink).isSymbolicLink(), 'Expected dir-to-symlink to be a symlink');
+        assert.equal(readlinkSync(dirToSymlink), 'targets/new-link-dir');
+        assert.equal(
+            readFileSync(join(dirToSymlink, 'nested', 'linked.txt'), 'utf-8'),
+            'linked-dir-content\n',
+        );
+
+        const symlinkDirToFile = join(base, 'symlink-to-dir-to-file');
+        assert.ok(lstatSync(symlinkDirToFile).isFile(), 'Expected symlink-to-dir-to-file to be a regular file');
+        assert.equal(readFileSync(symlinkDirToFile, 'utf-8'), 'symlink-dir-became-file\n');
+
+        const symlinkFileToDir = join(base, 'symlink-to-file-to-dir');
+        assert.ok(lstatSync(symlinkFileToDir).isDirectory(), 'Expected symlink-to-file-to-dir to be a directory');
+        assert.equal(
+            readFileSync(join(symlinkFileToDir, 'x', 'y', 'z', 'value.txt'), 'utf-8'),
+            'symlink-file-became-dir\n',
+        );
+    });
+
+    it('state stores path fields in base64 form', () => {
+        const statePath = join(tempDir, '.import-state.json');
+        const state = JSON.parse(readFileSync(statePath, 'utf-8'));
+
+        assert.equal(typeof state.diff.local_after, 'string', 'Expected diff.local_after to be persisted');
+        assert.ok(
+            state.diff.local_after.startsWith('base64:'),
+            `Expected base64-encoded diff.local_after, got: ${state.diff.local_after}`,
+        );
+
+        if (typeof state.fetch.batch_file === 'string') {
+            assert.ok(state.fetch.batch_file.startsWith('base64:'), 'Expected fetch.batch_file to use base64');
+        }
+        if (typeof state.current_file === 'string') {
+            assert.ok(state.current_file.startsWith('base64:'), 'Expected current_file to use base64');
+        }
+        if (state.db_index && typeof state.db_index.file === 'string') {
+            assert.ok(state.db_index.file.startsWith('base64:'), 'Expected db_index.file to use base64');
+        }
+    });
+
+    it('subsequent files-sync still works with encoded state paths', () => {
+        const result = runImporter(importUrl(), tempDir, 'files-sync', {
+            secret: getSiteSecret(site),
+        });
+        assert.equal(result.exitCode, 0, `Expected exit 0\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);
+    });
+});


### PR DESCRIPTION
## Description

  - Persists path-like fields in .import-state.json as base64 (base64:...) instead of raw strings.
  - Hardens delta sync so path type changes are handled safely and correctly (file ↔ dir ↔ symlink).
  - Makes local deletion recursive without following symlink targets.
  - Adds a new E2E suite covering deep nested deletions and type swaps, including a containment/symlink-safety assertion.

  ## Rationale

  Some state paths can contain arbitrary bytes, which are unsafe to store as raw JSON strings.

  Also, delta sync had fragile behavior when a remote path changed type (for example dir -> file) or when deleting directories containing symlinks. We need deterministic replacement behavior while preserving
  the security boundary: operations must stay within filesystem-root and never delete via symlink traversal.

  ## Implementation

  - In importer/import.php:
      - Added state-path encode/decode flow:
          - Encoded on save_state()
          - Decoded on load_state()
          - Backward-compatible with legacy plain-string state
      - Encoded fields:
          - diff.local_after
          - fetch.batch_file
          - current_file
          - db_index.file
      - Added remove_local_path_without_following_symlinks() and used it for:
          - delta deletions
          - replacing conflicting local paths before writing files/directories/symlinks
      - Tightened directory creation check to avoid treating symlinked dirs as normal dirs (is_dir(...) && !is_link(...)).
  - Added tests/e2e/tests/import-32-delta-deletions-and-type-swaps.test.js:
      - Verifies deletions of:
          - regular file
          - deeply nested directory tree
          - symlink to file
          - symlink to directory
      - Verifies type swaps:
          - file -> dir, file -> symlink
          - dir -> file, dir -> symlink
          - symlink -> file, symlink -> dir
      - Verifies deleting a local directory does not follow a symlink pointing outside that directory.
      - Verifies persisted state paths are stored with base64: prefix and still support subsequent sync runs.

  ## Testing instructions

```
  cd tests/e2e
  npx vitest run tests/import-32-delta-deletions-and-type-swaps.test.js
  npx vitest run tests/import-22-delta-with-deletions.test.js tests/import-31-follow-symlinks.test.js tests/import-25-state-corruption.test.js
  npx vitest run tests/import-02-sql-sync.test.js tests/import-09-resume-sql.test.js tests/import-10-resume-files.test.js
```

  All commands above pass on this branch.