### PR TITLE
Encode preflight path fields in state with simple logic

### DIFF
--- a/importer/import.php
+++ b/importer/import.php
@@ -767,12 +767,6 @@ class ImportClient
 
     private const SAVE_STATE_EVERY_N_CHUNKS = 50;
     private const STATE_PATH_ENCODING_PREFIX = "base64:";
-    private const STATE_PATH_FIELDS = [
-        ["diff", "local_after"],
-        ["fetch", "batch_file"],
-        ["current_file"],
-        ["db_index", "file"],
-    ];
 
     /** @var string Export server URL. */
     private $remote_url;
@@ -5700,15 +5694,30 @@ class ImportClient
      */
     private function encode_state_paths(array $state): array
     {
-        foreach (self::STATE_PATH_FIELDS as $field_keys) {
-            $state = $this->transform_state_path_field(
-                $state,
-                $field_keys,
-                function ($value) {
-                    return $this->encode_state_path_value($value);
-                },
+        $state["diff"]["local_after"] = $this->encode_state_path_value(
+            $state["diff"]["local_after"] ?? null,
+        );
+        $state["fetch"]["batch_file"] = $this->encode_state_path_value(
+            $state["fetch"]["batch_file"] ?? null,
+        );
+        $state["current_file"] = $this->encode_state_path_value(
+            $state["current_file"] ?? null,
+        );
+        $state["db_index"]["file"] = $this->encode_state_path_value(
+            $state["db_index"]["file"] ?? null,
+        );
+
+        if (
+            isset($state["preflight"]) &&
+            is_array($state["preflight"]) &&
+            isset($state["preflight"]["data"]) &&
+            is_array($state["preflight"]["data"])
+        ) {
+            $state["preflight"]["data"] = $this->encode_preflight_data_paths(
+                $state["preflight"]["data"],
             );
         }
+
         return $state;
     }
 
@@ -5719,48 +5728,163 @@ class ImportClient
      */
     private function decode_state_paths(array $state): array
     {
-        foreach (self::STATE_PATH_FIELDS as $field_keys) {
-            $state = $this->transform_state_path_field(
-                $state,
-                $field_keys,
-                function ($value) {
-                    return $this->decode_state_path_value($value);
-                },
+        $state["diff"]["local_after"] = $this->decode_state_path_value(
+            $state["diff"]["local_after"] ?? null,
+        );
+        $state["fetch"]["batch_file"] = $this->decode_state_path_value(
+            $state["fetch"]["batch_file"] ?? null,
+        );
+        $state["current_file"] = $this->decode_state_path_value(
+            $state["current_file"] ?? null,
+        );
+        $state["db_index"]["file"] = $this->decode_state_path_value(
+            $state["db_index"]["file"] ?? null,
+        );
+
+        if (
+            isset($state["preflight"]) &&
+            is_array($state["preflight"]) &&
+            isset($state["preflight"]["data"]) &&
+            is_array($state["preflight"]["data"])
+        ) {
+            $state["preflight"]["data"] = $this->decode_preflight_data_paths(
+                $state["preflight"]["data"],
             );
         }
+
         return $state;
     }
 
     /**
-     * Apply a transform to a top-level or two-level state field.
-     *
-     * @param array<int, string> $field_keys
+     * Encode preflight path fields.
      */
-    private function transform_state_path_field(
-        array $state,
-        array $field_keys,
-        callable $transform
-    ): array {
-        if (count($field_keys) === 1) {
-            $key = $field_keys[0];
-            if (array_key_exists($key, $state)) {
-                $state[$key] = $transform($state[$key]);
+    private function encode_preflight_data_paths(array $data): array
+    {
+        if (isset($data["wp_detect"]["searched"]) && is_array($data["wp_detect"]["searched"])) {
+            foreach ($data["wp_detect"]["searched"] as $idx => $path) {
+                $data["wp_detect"]["searched"][$idx] = $this->encode_state_path_value($path);
             }
-            return $state;
         }
 
-        $outer = $field_keys[0];
-        $inner = $field_keys[1];
-        if (
-            !array_key_exists($outer, $state) ||
-            !is_array($state[$outer]) ||
-            !array_key_exists($inner, $state[$outer])
-        ) {
-            return $state;
+        if (isset($data["wp_detect"]["roots"]) && is_array($data["wp_detect"]["roots"])) {
+            foreach ($data["wp_detect"]["roots"] as $idx => $root) {
+                if (!is_array($root)) {
+                    continue;
+                }
+                foreach (["path", "wp_load_path", "wp_config_path"] as $key) {
+                    if (array_key_exists($key, $root)) {
+                        $data["wp_detect"]["roots"][$idx][$key] = $this->encode_state_path_value($root[$key]);
+                    }
+                }
+            }
         }
 
-        $state[$outer][$inner] = $transform($state[$outer][$inner]);
-        return $state;
+        if (isset($data["runtime"]) && is_array($data["runtime"])) {
+            foreach (["php_ini", "temp_dir", "document_root", "script_filename", "cwd"] as $key) {
+                if (array_key_exists($key, $data["runtime"])) {
+                    $data["runtime"][$key] = $this->encode_state_path_value($data["runtime"][$key]);
+                }
+            }
+        }
+
+        if (isset($data["filesystem"]["directories"]) && is_array($data["filesystem"]["directories"])) {
+            foreach ($data["filesystem"]["directories"] as $idx => $dir_entry) {
+                if (!is_array($dir_entry) || !array_key_exists("path", $dir_entry)) {
+                    continue;
+                }
+                $data["filesystem"]["directories"][$idx]["path"] = $this->encode_state_path_value($dir_entry["path"]);
+            }
+        }
+
+        if (isset($data["htaccess"]["files"]) && is_array($data["htaccess"]["files"])) {
+            foreach ($data["htaccess"]["files"] as $idx => $file_entry) {
+                if (!is_array($file_entry) || !array_key_exists("path", $file_entry)) {
+                    continue;
+                }
+                $data["htaccess"]["files"][$idx]["path"] = $this->encode_state_path_value($file_entry["path"]);
+            }
+        }
+
+        if (isset($data["wp_content"]["roots"]) && is_array($data["wp_content"]["roots"])) {
+            foreach ($data["wp_content"]["roots"] as $idx => $root_entry) {
+                if (!is_array($root_entry)) {
+                    continue;
+                }
+                foreach (["root", "content_dir"] as $key) {
+                    if (array_key_exists($key, $root_entry)) {
+                        $data["wp_content"]["roots"][$idx][$key] = $this->encode_state_path_value($root_entry[$key]);
+                    }
+                }
+            }
+        }
+
+        return $data;
+    }
+
+    /**
+     * Decode preflight path fields.
+     */
+    private function decode_preflight_data_paths(array $data): array
+    {
+        if (isset($data["wp_detect"]["searched"]) && is_array($data["wp_detect"]["searched"])) {
+            foreach ($data["wp_detect"]["searched"] as $idx => $path) {
+                $data["wp_detect"]["searched"][$idx] = $this->decode_state_path_value($path);
+            }
+        }
+
+        if (isset($data["wp_detect"]["roots"]) && is_array($data["wp_detect"]["roots"])) {
+            foreach ($data["wp_detect"]["roots"] as $idx => $root) {
+                if (!is_array($root)) {
+                    continue;
+                }
+                foreach (["path", "wp_load_path", "wp_config_path"] as $key) {
+                    if (array_key_exists($key, $root)) {
+                        $data["wp_detect"]["roots"][$idx][$key] = $this->decode_state_path_value($root[$key]);
+                    }
+                }
+            }
+        }
+
+        if (isset($data["runtime"]) && is_array($data["runtime"])) {
+            foreach (["php_ini", "temp_dir", "document_root", "script_filename", "cwd"] as $key) {
+                if (array_key_exists($key, $data["runtime"])) {
+                    $data["runtime"][$key] = $this->decode_state_path_value($data["runtime"][$key]);
+                }
+            }
+        }
+
+        if (isset($data["filesystem"]["directories"]) && is_array($data["filesystem"]["directories"])) {
+            foreach ($data["filesystem"]["directories"] as $idx => $dir_entry) {
+                if (!is_array($dir_entry) || !array_key_exists("path", $dir_entry)) {
+                    continue;
+                }
+                $data["filesystem"]["directories"][$idx]["path"] = $this->decode_state_path_value($dir_entry["path"]);
+            }
+        }
+
+        if (isset($data["htaccess"]["files"]) && is_array($data["htaccess"]["files"])) {
+            foreach ($data["htaccess"]["files"] as $idx => $file_entry) {
+                if (!is_array($file_entry) || !array_key_exists("path", $file_entry)) {
+                    continue;
+                }
+                $data["htaccess"]["files"][$idx]["path"] = $this->decode_state_path_value($file_entry["path"]);
+            }
+        }
+
+        if (isset($data["wp_content"]["roots"]) && is_array($data["wp_content"]["roots"])) {
+            foreach ($data["wp_content"]["roots"] as $idx => $root_entry) {
+                if (!is_array($root_entry)) {
+                    continue;
+                }
+                foreach (["root", "content_dir"] as $key) {
+                    if (array_key_exists($key, $root_entry)) {
+                        $data["wp_content"]["roots"][$idx][$key] = $this->decode_state_path_value($root_entry[$key]);
+                    }
+                }
+            }
+        }
+
+        return $data;
     }
 
     /**

--- a/tests/e2e/tests/import-33-preflight-state-path-encoding.test.js
+++ b/tests/e2e/tests/import-33-preflight-state-path-encoding.test.js
@@ -1,0 +1,113 @@
+/**
+ * Test 33: Preflight state path encoding
+ *
+ * Verifies that path-like fields inside preflight state are persisted as
+ * base64 strings and decoded correctly on subsequent loads.
+ */
+import { describe, it, beforeAll, afterAll } from 'vitest';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+    runImporter, createTempDir, cleanupTempDir,
+    getSiteUrl, getSiteSecret, getSiteDir,
+} from '../lib/test-helpers.js';
+import { ensureSite } from '../lib/site-setup.js';
+
+describe('Import: Preflight state path encoding', () => {
+    const site = 'basic';
+    let tempDir;
+
+    function importUrlWithDirectory() {
+        return `${getSiteUrl(site)}?directory=${getSiteDir(site)}`;
+    }
+
+    function assertEncoded(value, label) {
+        assert.equal(typeof value, 'string', `Expected ${label} to be a string`);
+        assert.ok(value.startsWith('base64:'), `Expected ${label} to be base64-encoded, got: ${value}`);
+    }
+
+    beforeAll(async () => {
+        await ensureSite(site);
+        tempDir = createTempDir('e2e-preflight-path-encoding');
+
+        const result = runImporter(importUrlWithDirectory(), tempDir, 'preflight', {
+            secret: getSiteSecret(site),
+        });
+        assert.equal(result.exitCode, 0, `Expected exit 0\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);
+    });
+
+    afterAll(() => {
+        cleanupTempDir(tempDir);
+    });
+
+    it('stores requested preflight path fields as base64 in state file', () => {
+        const state = JSON.parse(readFileSync(join(tempDir, '.import-state.json'), 'utf-8'));
+        const data = state.preflight?.data;
+        assert.ok(data, 'Expected preflight.data in state');
+
+        const searched = data.wp_detect?.searched || [];
+        assert.ok(Array.isArray(searched) && searched.length > 0, 'Expected wp_detect.searched entries');
+        for (const [idx, path] of searched.entries()) {
+            assertEncoded(path, `wp_detect.searched[${idx}]`);
+        }
+
+        const roots = data.wp_detect?.roots || [];
+        assert.ok(Array.isArray(roots) && roots.length > 0, 'Expected wp_detect.roots entries');
+        for (const [idx, root] of roots.entries()) {
+            if (typeof root.path === 'string') {
+                assertEncoded(root.path, `wp_detect.roots[${idx}].path`);
+            }
+            if (typeof root.wp_load_path === 'string') {
+                assertEncoded(root.wp_load_path, `wp_detect.roots[${idx}].wp_load_path`);
+            }
+            if (typeof root.wp_config_path === 'string') {
+                assertEncoded(root.wp_config_path, `wp_detect.roots[${idx}].wp_config_path`);
+            }
+        }
+
+        const runtime = data.runtime || {};
+        for (const key of ['php_ini', 'temp_dir', 'document_root', 'script_filename', 'cwd']) {
+            if (typeof runtime[key] === 'string') {
+                assertEncoded(runtime[key], `runtime.${key}`);
+            }
+        }
+
+        const directories = data.filesystem?.directories || [];
+        assert.ok(Array.isArray(directories) && directories.length > 0, 'Expected filesystem.directories entries');
+        for (const [idx, dir] of directories.entries()) {
+            if (typeof dir.path === 'string') {
+                assertEncoded(dir.path, `filesystem.directories[${idx}].path`);
+            }
+        }
+
+        const htaccessFiles = data.htaccess?.files || [];
+        if (Array.isArray(htaccessFiles)) {
+            for (const [idx, file] of htaccessFiles.entries()) {
+                if (typeof file.path === 'string') {
+                    assertEncoded(file.path, `htaccess.files[${idx}].path`);
+                }
+            }
+        }
+
+        const contentRoots = data.wp_content?.roots || [];
+        if (Array.isArray(contentRoots)) {
+            for (const [idx, root] of contentRoots.entries()) {
+                if (typeof root.root === 'string') {
+                    assertEncoded(root.root, `wp_content.roots[${idx}].root`);
+                }
+                if (typeof root.content_dir === 'string') {
+                    assertEncoded(root.content_dir, `wp_content.roots[${idx}].content_dir`);
+                }
+            }
+        }
+    });
+
+    it('decodes encoded preflight roots when loading state', () => {
+        const result = runImporter(getSiteUrl(site), tempDir, 'files-index', {
+            secret: getSiteSecret(site),
+            skipPreflight: true,
+        });
+        assert.equal(result.exitCode, 0, `Expected exit 0\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);
+    });
+});


### PR DESCRIPTION
  Encodes additional path fields in `.import-state.json` as base64:... and decodes them on load, including preflight path data.

  This now covers:

  - existing sync state paths: diff.local_after, fetch.batch_file, current_file, db_index.file
  - preflight paths:
      - preflight.data.wp_detect.searched[]
      - preflight.data.wp_detect.roots[].path
      - preflight.data.wp_detect.roots[].wp_load_path
      - preflight.data.wp_detect.roots[].wp_config_path
      - preflight.data.runtime.php_ini
      - preflight.data.runtime.temp_dir
      - preflight.data.runtime.document_root
      - preflight.data.runtime.script_filename
      - preflight.data.runtime.cwd
      - preflight.data.filesystem.directories[].path
      - preflight.data.htaccess.files[].path
      - preflight.data.wp_content.roots[].root
      - preflight.data.wp_content.roots[].content_dir

  ## Rationale

  Preflight and state data can contain filesystem paths that should not be persisted as raw JSON strings when bytes may be arbitrary.
  Encoding these values at rest keeps state serialization safe and consistent, while decode-on-load preserves current runtime behavior.

  ## Implementation

  Reworked state path handling in importer/import.php to be explicit and simple:

  - Removed the generic callback + field-matrix transformer.
  - Kept direct encode/decode assignments for core sync fields.
  - Added two straightforward helpers:
      - encode_preflight_data_paths(array $data): array
      - decode_preflight_data_paths(array $data): array
  - Hooked these into save_state() and load_state() via encode_state_paths() / decode_state_paths().
  - Preserved backward compatibility: non-encoded legacy values still load correctly.

  ## Testing instructions

```
  cd tests/e2e
  npx vitest run tests/import-33-preflight-state-path-encoding.test.js
  npx vitest run tests/import-32-delta-deletions-and-type-swaps.test.js
  npx vitest run tests/import-25-state-corruption.test.js
```

  import-33 is new and verifies both:

  1. preflight path fields are stored as base64:... in state, and
  2. those values are decoded correctly on subsequent load (by running files-index from saved preflight state).