### PR TITLE
Fix flaky delta type-swap E2E with deterministic repro

### DIFF
--- a/tests/e2e/tests/import-34-delta-type-swap-cache-invalidation.test.js
+++ b/tests/e2e/tests/import-34-delta-type-swap-cache-invalidation.test.js
@@ -1,0 +1,150 @@
+/**
+ * Test 34: Delta type swaps across requests (single-process API server)
+ *
+ * Reproduces stale path-type behavior across sequential requests by using a
+ * single-process PHP built-in server. Verifies both transitions:
+ * - symlink -> file
+ * - symlink -> directory (with nested file)
+ */
+import { describe, it, beforeAll, afterAll } from 'vitest';
+import assert from 'node:assert/strict';
+import { existsSync, lstatSync, readFileSync } from 'node:fs';
+import { execSync, spawn } from 'node:child_process';
+import { join } from 'node:path';
+import { setTimeout as sleep } from 'node:timers/promises';
+import {
+    runImporter, createTempDir, cleanupTempDir,
+    getSiteSecret, getSiteDir,
+} from '../lib/test-helpers.js';
+import { ensureSite } from '../lib/site-setup.js';
+
+describe('Import: Delta type swaps cache invalidation', () => {
+    const site = 'file-changes';
+    const port = 8112;
+    const scenarioName = 'delta-cache-type-swaps';
+    const remoteRoot = join(getSiteDir(site), 'test-data', scenarioName);
+
+    let apiServer = null;
+
+    const sh = (v) => JSON.stringify(v);
+    const sudoRun = (script) => {
+        const oneLine = script
+            .split('\n')
+            .map((line) => line.trim())
+            .filter(Boolean)
+            .join('; ');
+        execSync(`sudo bash -lc ${JSON.stringify(`set -euo pipefail; ${oneLine}`)}`);
+    };
+
+    async function startApiServer() {
+        const docRoot = join(getSiteDir(site), 'wp-content', 'plugins', 'site-export');
+        apiServer = spawn('php', ['-S', `127.0.0.1:${port}`, '-t', docRoot], {
+            stdio: 'ignore',
+        });
+
+        const deadline = Date.now() + 15000;
+        while (Date.now() < deadline) {
+            if (apiServer.exitCode !== null) {
+                throw new Error(`Built-in API server exited early with code ${apiServer.exitCode}`);
+            }
+            try {
+                const res = await fetch(`http://127.0.0.1:${port}/api.php`, { method: 'GET' });
+                if (res.status >= 200) {
+                    return;
+                }
+            } catch (_) {
+                // retry
+            }
+            await sleep(100);
+        }
+
+        throw new Error(`Timed out waiting for API server on port ${port}`);
+    }
+
+    function stopApiServer() {
+        if (apiServer && apiServer.exitCode === null) {
+            apiServer.kill('SIGTERM');
+        }
+    }
+
+    function importUrl() {
+        return `http://127.0.0.1:${port}/api.php?directory=${getSiteDir(site)}`;
+    }
+
+    function setupInitialRemoteLayout() {
+        sudoRun(`
+rm -rf ${sh(remoteRoot)}
+mkdir -p ${sh(join(remoteRoot, 'targets', 'start-dir'))}
+${`printf %b ${sh('start-dir-file\\n')} > ${sh(join(remoteRoot, 'targets', 'start-dir', 'a.txt'))}`}
+${`printf %b ${sh('start-file\\n')} > ${sh(join(remoteRoot, 'targets', 'start-file.txt'))}`}
+ln -s ${sh('targets/start-dir')} ${sh(join(remoteRoot, 'symlink-to-dir-to-file'))}
+ln -s ${sh('targets/start-file.txt')} ${sh(join(remoteRoot, 'symlink-to-file-to-dir'))}
+chown -R nginx:nginx ${sh(remoteRoot)}
+`);
+    }
+
+    function applyDeltaRemoteChanges() {
+        sudoRun(`
+rm -f ${sh(join(remoteRoot, 'symlink-to-dir-to-file'))}
+${`printf %b ${sh('became-file\\n')} > ${sh(join(remoteRoot, 'symlink-to-dir-to-file'))}`}
+
+rm -f ${sh(join(remoteRoot, 'symlink-to-file-to-dir'))}
+mkdir -p ${sh(join(remoteRoot, 'symlink-to-file-to-dir', 'x', 'y', 'z'))}
+${`printf %b ${sh('became-directory\\n')} > ${sh(join(remoteRoot, 'symlink-to-file-to-dir', 'x', 'y', 'z', 'value.txt'))}`}
+
+chown -R nginx:nginx ${sh(remoteRoot)}
+`);
+    }
+
+    function runScenarioOnce(tempPrefix) {
+        const tempDir = createTempDir(tempPrefix);
+        setupInitialRemoteLayout();
+
+        const initial = runImporter(importUrl(), tempDir, 'files-sync', {
+            secret: getSiteSecret(site),
+        });
+        assert.equal(initial.exitCode, 0, `Expected exit 0\nstderr: ${initial.stderr}\nstdout: ${initial.stdout}`);
+
+        applyDeltaRemoteChanges();
+        const delta = runImporter(importUrl(), tempDir, 'files-sync', {
+            secret: getSiteSecret(site),
+        });
+        assert.equal(delta.exitCode, 0, `Expected exit 0\nstderr: ${delta.stderr}\nstdout: ${delta.stdout}`);
+
+        return tempDir;
+    }
+
+    beforeAll(async () => {
+        await ensureSite(site);
+        await startApiServer();
+    });
+
+    afterAll(() => {
+        stopApiServer();
+        execSync(`sudo rm -rf ${sh(remoteRoot)} 2>/dev/null || true`);
+    });
+
+    it('delta keeps symlink->file transition', () => {
+        const tempDir = runScenarioOnce('e2e-delta-cache-type-swaps-file');
+        try {
+            const root = join(tempDir, 'filesystem-root', remoteRoot);
+            const symlinkToDirToFile = join(root, 'symlink-to-dir-to-file');
+            assert.ok(lstatSync(symlinkToDirToFile).isFile(), 'Expected symlink-to-dir-to-file to become a regular file');
+            assert.equal(readFileSync(symlinkToDirToFile, 'utf-8'), 'became-file\n');
+        } finally {
+            cleanupTempDir(tempDir);
+        }
+    });
+
+    it('delta keeps symlink->directory transition with nested data', () => {
+        const tempDir = runScenarioOnce('e2e-delta-cache-type-swaps-dir');
+        try {
+            const root = join(tempDir, 'filesystem-root', remoteRoot);
+            const nestedFile = join(root, 'symlink-to-file-to-dir', 'x', 'y', 'z', 'value.txt');
+            assert.ok(existsSync(nestedFile), `Expected nested file at ${nestedFile}`);
+            assert.equal(readFileSync(nestedFile, 'utf-8'), 'became-directory\n');
+        } finally {
+            cleanupTempDir(tempDir);
+        }
+    });
+});

--- a/wordpress-plugin/generic/class-file-tree-producer.php
+++ b/wordpress-plugin/generic/class-file-tree-producer.php
@@ -137,6 +137,7 @@ class FileTreeProducer
 
         if ($path !== null && $byte_offset > 0) {
             // Resuming mid-file.
+            clearstatcache(true, $path);
             $size = @filesize($path);
             if ($size === false) {
                 // File disappeared; treat as completed.
@@ -348,12 +349,14 @@ class FileTreeProducer
             return null;
         }
 
+        clearstatcache(true, $path);
         if ($path[0] === "/" && (file_exists($path) || is_link($path))) {
             return $path;
         }
 
         foreach ($this->directories as $dir) {
             $candidate = $dir . "/" . ltrim($path, "/");
+            clearstatcache(true, $candidate);
             if (file_exists($candidate) || is_link($candidate)) {
                 return $candidate;
             }
@@ -373,6 +376,24 @@ class FileTreeProducer
     private function stream_file_chunk(array $file): void
     {
         if ($this->streaming_file_handle === null) {
+            clearstatcache(true, $file["path"]);
+            $pre_stat = @lstat($file["path"]);
+            if ($pre_stat === false || (($pre_stat["mode"] & 0170000) !== 0100000)) {
+                $this->streaming_file_handle = null;
+                $this->current_file_meta = null;
+                $this->current_chunk = [
+                    "type" => "error",
+                    "error_type" => $pre_stat === false ? "file_missing" : "file_changed",
+                    "path" => $file["path"],
+                    "message" => $pre_stat === false
+                        ? "File disappeared before read"
+                        : "Path is no longer a regular file",
+                ];
+                $this->last_emitted_path = $file["path"];
+                $this->last_emitted_ctime = $file["ctime"];
+                return;
+            }
+
             $this->streaming_file_handle = @fopen($file["path"], "r");
             if (!$this->streaming_file_handle) {
                 $this->streaming_file_handle = null;
@@ -603,6 +624,7 @@ class FileTreeProducer
      */
     private function lstat_path(string $path): ?array
     {
+        clearstatcache(true, $path);
         $stat = @lstat($path);
         if ($stat === false) {
             return null;

--- a/wordpress-plugin/generic/export.php
+++ b/wordpress-plugin/generic/export.php
@@ -2407,6 +2407,11 @@ function endpoint_file_index(
     int $max_memory,
     float $memory_threshold
 ): array {
+    // This endpoint may run repeatedly in the same PHP process (e.g. PHP built-in
+    // server, long-lived workers). Clear stale stat/realpath cache from previous
+    // requests so path type transitions (symlink/file/dir) are seen correctly.
+    clearstatcache(true);
+
     $directories = resolve_directories($config);
     $batch_size = $config["batch_size"] ?? 5000;
     $batch_size = require_int_range(
@@ -2471,6 +2476,7 @@ function endpoint_file_index(
             throw new InvalidArgumentException("list_dir is required for file_index");
         }
 
+        clearstatcache(true, $list_dir);
         $list_dir_real = realpath($list_dir);
         if ($list_dir_real === false || !is_dir($list_dir_real)) {
             throw new InvalidArgumentException(
@@ -2593,6 +2599,7 @@ function endpoint_file_index(
             $current_dir = $frame["dir"];
             $current_after = $frame["after"] ?? null;
 
+            clearstatcache(true, $current_dir);
             $current_real = realpath($current_dir);
             if ($current_real === false || !is_dir($current_real)) {
                 $abort_payload = [
@@ -2667,6 +2674,7 @@ function endpoint_file_index(
             // This keeps root dirs and symlink-followed dirs consistent.
             $stack[$frame_index]["dir"] = $current_real;
             $current_dir = $current_real;
+            clearstatcache(true, $current_real);
             $entries = @scandir($current_real, SCANDIR_SORT_ASCENDING);
             if ($entries === false) {
                 $abort_payload = [
@@ -2725,6 +2733,7 @@ function endpoint_file_index(
 
                 $stack[$frame_index]["after"] = $entry;
                 $path = $current_dir . "/" . $entry;
+                clearstatcache(true, $path);
                 $stat = @lstat($path);
                 if ($stat === false) {
                     if (
@@ -2759,6 +2768,7 @@ function endpoint_file_index(
                     // uses targets to discover additional directories to index,
                     // so file symlink targets are not useful.
                     // @TODO: Understand this thoroughly.
+                    clearstatcache(true, $path);
                     $resolved_target = @realpath($path);
                     if (
                         $resolved_target !== false &&
@@ -2997,6 +3007,10 @@ function endpoint_file_fetch(
     int $max_memory,
     float $memory_threshold
 ): array {
+    // Same rationale as endpoint_file_index(): avoid stale path metadata across
+    // requests in long-lived PHP processes.
+    clearstatcache(true);
+
     $directories = resolve_directories($config);
 
     $list_path = $config["file_list_path"] ?? null;


### PR DESCRIPTION
## What it does

- Adds a deterministic E2E reproducer for the intermittent `import-32` delta type-swap failures.
- Fixes stale filesystem metadata handling in exporter file index/fetch paths.
- Prevents stale path type (`symlink`/`file`/`dir`) from leaking across requests in long-lived PHP processes.

## Rationale

CI was intermittently failing when paths changed type between sync runs:
- `symlink -> file`
- `symlink -> directory` (with nested file)

The failure was caused by stale PHP stat/realpath metadata being reused across requests, which made the exporter treat updated paths as old types.

## Implementation

- Added `tests/e2e/tests/import-34-delta-type-swap-cache-invalidation.test.js`:
  - Runs against a single-process PHP built-in server (deterministic).
  - Verifies both transitions independently:
    - `symlink-to-dir-to-file` becomes a regular file
    - `symlink-to-file-to-dir/x/y/z/value.txt` exists after delta

- Updated `wordpress-plugin/generic/export.php`:
  - `clearstatcache(true)` at start of `endpoint_file_index` and `endpoint_file_fetch`
  - targeted cache clears before `realpath`, `scandir`, `lstat`, and symlink target `realpath` during traversal

- Updated `wordpress-plugin/generic/class-file-tree-producer.php`:
  - cache clears in path resolution and `lstat_path`
  - cache clear before resume `filesize`
  - pre-open `lstat` type check to avoid reading a directory as a file

## Testing instructions

```bash
cd tests/e2e
npx vitest run tests/import-34-delta-type-swap-cache-invalidation.test.js
npx vitest run tests/import-32-delta-deletions-and-type-swaps.test.js
npx vitest run tests/import-21-preflight.test.js tests/import-25-state-corruption.test.js
```

I also repeated `import-34` in a 5x loop to confirm stability.
