### PR TITLE
Refactor import/export for reusable helpers and lower complexity

### DIFF
--- a/importer/import.php
+++ b/importer/import.php
@@ -36,6 +36,84 @@ register_shutdown_function(function () {
     fwrite(STDERR, $json . "\n");
 });
 
+/**
+ * Atomically write a file via temp file + rename.
+ *
+ * @param string $target_path Final destination path.
+ * @param string $contents    File contents to write.
+ * @param string $context     Human-readable context for error messages.
+ * @param bool   $throw_on_error Whether to throw or return false on failure.
+ */
+function atomic_write_file(
+    string $target_path,
+    string $contents,
+    string $context = "file",
+    bool $throw_on_error = true
+): bool {
+    $tmp_path = $target_path . ".tmp";
+    $bytes = file_put_contents($tmp_path, $contents);
+    if ($bytes === false) {
+        if ($throw_on_error) {
+            throw new RuntimeException("Failed to write {$context}: {$tmp_path} (disk full?)");
+        }
+        return false;
+    }
+    if (!rename($tmp_path, $target_path)) {
+        @unlink($tmp_path);
+        if ($throw_on_error) {
+            throw new RuntimeException("Failed to rename {$context}: {$tmp_path} -> {$target_path}");
+        }
+        return false;
+    }
+    return true;
+}
+
+/**
+ * Check whether a PHP function is available and not disabled.
+ */
+function is_runtime_function_available(string $name): bool
+{
+    if (!function_exists($name)) {
+        return false;
+    }
+    $disabled = ini_get("disable_functions");
+    if ($disabled === false || trim($disabled) === "") {
+        return true;
+    }
+    $list = array_map("trim", explode(",", $disabled));
+    return !in_array($name, $list, true);
+}
+
+/**
+ * Parse one JSON index line into a normalized entry.
+ */
+function parse_index_entry_line(string $line): ?array
+{
+    $line = trim($line);
+    if ($line === "") {
+        return null;
+    }
+    $data = json_decode($line, true);
+    if (!is_array($data)) {
+        throw new RuntimeException("Invalid index line format");
+    }
+    $path_encoded = $data["path"] ?? "";
+    if (!is_string($path_encoded) || $path_encoded === "") {
+        throw new RuntimeException("Invalid index path");
+    }
+    $path = base64_decode($path_encoded, true);
+    if ($path === "" || $path === false) {
+        throw new RuntimeException("Invalid index path (base64 decode failed)");
+    }
+    assert_valid_path($path, "index path");
+    return [
+        "path" => $path,
+        "ctime" => (int) ($data["ctime"] ?? 0),
+        "size" => (int) ($data["size"] ?? 0),
+        "type" => (string) ($data["type"] ?? "file"),
+    ];
+}
+
 
 /**
  * Streaming multipart parser.
@@ -3075,7 +3153,7 @@ class ImportClient
             }
 
             $remote_offset = ftell($remote_handle);
-            $remote = $this->parse_index_line($line);
+            $remote = parse_index_entry_line($line);
             if (!$remote) {
                 continue;
             }
@@ -3446,36 +3524,6 @@ class ImportClient
     }
 
     /**
-     * Parse one JSON index line into an array.
-     */
-    private function parse_index_line(string $line): ?array
-    {
-        $line = trim($line);
-        if ($line === "") {
-            return null;
-        }
-        $data = json_decode($line, true);
-        if (!is_array($data)) {
-            throw new RuntimeException("Invalid index line format");
-        }
-        $path_encoded = $data["path"] ?? "";
-        if (!is_string($path_encoded) || $path_encoded === "") {
-            throw new RuntimeException("Invalid index path");
-        }
-        $path = base64_decode($path_encoded, true);
-        if ($path === "" || $path === false) {
-            throw new RuntimeException("Invalid index path (base64 decode failed)");
-        }
-        assert_valid_path($path, "index path");
-        return [
-            "path" => $path,
-            "ctime" => (int) ($data["ctime"] ?? 0),
-            "size" => (int) ($data["size"] ?? 0),
-            "type" => (string) ($data["type"] ?? "file"),
-        ];
-    }
-
-    /**
      * Start collecting index updates into a temp file for streaming merge.
      */
     private function begin_index_updates(): void
@@ -3738,7 +3786,7 @@ class ImportClient
             return null;
         }
         while (($line = fgets($handle)) !== false) {
-            $parsed = $this->parse_index_line($line);
+            $parsed = parse_index_entry_line($line);
             if ($parsed !== null) {
                 return $parsed;
             }
@@ -4825,23 +4873,6 @@ class ImportClient
     }
 
     /**
-     * Check if a function is available (not disabled).
-     */
-    private function function_available(string $name): bool
-    {
-        if (!function_exists($name)) {
-            return false;
-        }
-        $disabled = ini_get("disable_functions");
-        if ($disabled === false || trim($disabled) === "") {
-            return true;
-        }
-        $list = array_map("trim", explode(",", $disabled));
-        return !in_array($name, $list, true);
-    }
-
-
-    /**
      * Fast-path index sort via shell exec.
      *
      * Prepends a hex-encoded sort key to each line, shells out to `sort(1)`,
@@ -4854,7 +4885,7 @@ class ImportClient
      */
     private function try_exec_sort(string $path, string $tmp): bool
     {
-        if (!$this->function_available("exec")) {
+        if (!is_runtime_function_available("exec")) {
             return false;
         }
 
@@ -4877,7 +4908,7 @@ class ImportClient
             if ($line === "") {
                 continue;
             }
-            $entry = $this->parse_index_line($line);
+            $entry = parse_index_entry_line($line);
             if ($entry === null) {
                 continue;
             }
@@ -5005,7 +5036,7 @@ class ImportClient
         }
         $entries = [];
         foreach ($raw_lines as $line) {
-            $entry = $this->parse_index_line($line);
+            $entry = parse_index_entry_line($line);
             if ($entry === null) {
                 continue;
             }
@@ -5969,19 +6000,11 @@ class ImportClient
         $state = $this->normalize_state($state);
         $state = $this->encode_state_paths($state);
 
-        // Write to temp file first, then atomic rename
         $json = json_encode($state, JSON_PRETTY_PRINT);
         if ($json === false) {
             throw new RuntimeException("Failed to encode state: " . json_last_error_msg());
         }
-        $tmp_file = $this->state_file . '.tmp';
-        $bytes = file_put_contents($tmp_file, $json);
-        if ($bytes === false) {
-            throw new RuntimeException("Failed to write state file: $tmp_file (disk full?)");
-        }
-        if (!rename($tmp_file, $this->state_file)) {
-            throw new RuntimeException("Failed to rename state file: $tmp_file -> {$this->state_file}");
-        }
+        atomic_write_file($this->state_file, $json, "state file");
 
         $indexed = $this->index_count();
         $files_imported = $this->files_imported; // Completed in this run
@@ -6034,10 +6057,7 @@ class ImportClient
         if ($json === false) {
             return; // Best-effort — don't crash the import over a status file
         }
-        $tmp = $this->status_file . ".tmp";
-        if (file_put_contents($tmp, $json) !== false) {
-            rename($tmp, $this->status_file);
-        }
+        atomic_write_file($this->status_file, $json, "status file", false);
     }
 
     /**

--- a/wordpress-plugin/generic/export.php
+++ b/wordpress-plugin/generic/export.php
@@ -193,6 +193,78 @@ function resolve_db_credentials(): array
 require_once __DIR__ . "/utils.php";
 
 /**
+ * Build multipart part headers (without body/trailing CRLF).
+ */
+function build_multipart_chunk_preamble(
+    string $boundary,
+    string $content_type,
+    int $content_length,
+    string $chunk_type,
+    array $headers = []
+): string {
+    $chunk =
+        "--{$boundary}\r\n" .
+        "Content-Type: {$content_type}\r\n" .
+        "Content-Length: {$content_length}\r\n" .
+        "X-Chunk-Type: {$chunk_type}\r\n";
+    foreach ($headers as $name => $value) {
+        if ($value === null) {
+            continue;
+        }
+        $chunk .= $name . ": " . (string) $value . "\r\n";
+    }
+    return $chunk . "\r\n";
+}
+
+/**
+ * Build a full multipart part (headers + body + trailing CRLF).
+ */
+function build_multipart_chunk(
+    string $boundary,
+    string $content_type,
+    string $chunk_type,
+    string $body = "",
+    array $headers = []
+): string {
+    return
+        build_multipart_chunk_preamble(
+            $boundary,
+            $content_type,
+            strlen($body),
+            $chunk_type,
+            $headers,
+        ) .
+        $body .
+        "\r\n";
+}
+
+/**
+ * Write a complete multipart part and optionally sync.
+ */
+function write_multipart_chunk(
+    $gz,
+    string $boundary,
+    string $content_type,
+    string $chunk_type,
+    string $body = "",
+    array $headers = [],
+    bool $sync = true
+): void {
+    $gz->write(
+        build_multipart_chunk(
+            $boundary,
+            $content_type,
+            $chunk_type,
+            $body,
+            $headers,
+        ),
+    );
+    if ($sync) {
+        $gz->sync();
+    }
+}
+
+/**
  * Emits an error chunk into a gzip multipart stream.
  */
 function emit_error_chunk($gz, string $boundary, string $message): void
@@ -205,13 +277,12 @@ function emit_error_chunk($gz, string $boundary, string $message): void
     if ($json === false) {
         $json = '{"error_type":"php_error","path":"","message":"Error (json_encode failed)"}';
     }
-    $chunk =
-        "--{$boundary}\r\n" .
-        "Content-Type: application/json\r\n" .
-        "Content-Length: " . strlen($json) . "\r\n" .
-        "X-Chunk-Type: error\r\n" .
-        "\r\n" .
-        $json . "\r\n";
+    $chunk = build_multipart_chunk(
+        $boundary,
+        "application/json",
+        "error",
+        $json,
+    );
     try {
         $gz->write($chunk);
         $gz->sync();
@@ -774,17 +845,16 @@ function endpoint_sql_chunk(
             }
 
             $cursor = $reader->get_reentrancy_cursor();
-            $gz->write(
-                "--{$boundary}\r\n" .
-                "Content-Type: application/sql\r\n" .
-                "Content-Length: " . strlen($sql) . "\r\n" .
-                "X-Chunk-Type: sql\r\n" .
-                "X-Cursor: " . base64_encode($cursor) . "\r\n" .
-                "\r\n",
+            write_multipart_chunk(
+                $gz,
+                $boundary,
+                "application/sql",
+                "sql",
+                $sql,
+                [
+                    "X-Cursor" => base64_encode($cursor),
+                ],
             );
-            $gz->write($sql);
-            $gz->write("\r\n");
-            $gz->sync();
 
             $batches_processed++;
 
@@ -808,21 +878,23 @@ function endpoint_sql_chunk(
     }
 
     try {
-        $gz->write(
-            "--{$boundary}\r\n" .
-            "Content-Type: application/octet-stream\r\n" .
-            "Content-Length: 0\r\n" .
-            "X-Chunk-Type: completion\r\n" .
-            "X-Status: {$status}\r\n" .
-            "X-Batches-Processed: {$batches_processed}\r\n" .
-            "X-SQL-Bytes: {$sql_bytes_processed}\r\n" .
-            "X-Memory-Used: " . memory_get_peak_usage(true) . "\r\n" .
-            "X-Memory-Limit: " . $max_memory . "\r\n" .
-            "X-Time-Elapsed: " . (microtime(true) - $script_start) . "\r\n" .
-            "\r\n" .
-            "\r\n" .
-            "--{$boundary}--\r\n",
+        write_multipart_chunk(
+            $gz,
+            $boundary,
+            "application/octet-stream",
+            "completion",
+            "",
+            [
+                "X-Status" => $status,
+                "X-Batches-Processed" => $batches_processed,
+                "X-SQL-Bytes" => $sql_bytes_processed,
+                "X-Memory-Used" => memory_get_peak_usage(true),
+                "X-Memory-Limit" => $max_memory,
+                "X-Time-Elapsed" => microtime(true) - $script_start,
+            ],
+            false,
         );
+        $gz->write("--{$boundary}--\r\n");
         $gz->finish();
     } catch (\Throwable $e) {
         error_log("Export: failed to write completion chunk: " . $e->getMessage());
@@ -950,17 +1022,17 @@ function endpoint_db_index(
                 "last_table" => $last_table,
             ]);
 
-            $gz->write(
-                "--{$boundary}\r\n" .
-                "Content-Type: application/json\r\n" .
-                "Content-Length: " . strlen($payload) . "\r\n" .
-                "X-Chunk-Type: table_stats\r\n" .
-                "X-Tables: " . count($tables) . "\r\n" .
-                "X-Cursor: " . base64_encode($cursor_json) . "\r\n" .
-                "\r\n" .
-                $payload . "\r\n",
+            write_multipart_chunk(
+                $gz,
+                $boundary,
+                "application/json",
+                "table_stats",
+                $payload,
+                [
+                    "X-Tables" => count($tables),
+                    "X-Cursor" => base64_encode($cursor_json),
+                ],
             );
-            $gz->sync();
 
             if (count($rows) < $tables_per_batch) {
                 $status = "complete";
@@ -973,21 +1045,23 @@ function endpoint_db_index(
     }
 
     try {
-        $gz->write(
-            "--{$boundary}\r\n" .
-            "Content-Type: application/octet-stream\r\n" .
-            "Content-Length: 0\r\n" .
-            "X-Chunk-Type: completion\r\n" .
-            "X-Status: " . ($aborted ? "partial" : $status) . "\r\n" .
-            "X-Tables-Processed: {$tables_processed}\r\n" .
-            "X-Rows-Estimated: {$rows_estimated}\r\n" .
-            "X-Memory-Used: " . memory_get_peak_usage(true) . "\r\n" .
-            "X-Memory-Limit: " . $max_memory . "\r\n" .
-            "X-Time-Elapsed: " . (microtime(true) - $script_start) . "\r\n" .
-            "\r\n" .
-            "\r\n" .
-            "--{$boundary}--\r\n",
+        write_multipart_chunk(
+            $gz,
+            $boundary,
+            "application/octet-stream",
+            "completion",
+            "",
+            [
+                "X-Status" => $aborted ? "partial" : $status,
+                "X-Tables-Processed" => $tables_processed,
+                "X-Rows-Estimated" => $rows_estimated,
+                "X-Memory-Used" => memory_get_peak_usage(true),
+                "X-Memory-Limit" => $max_memory,
+                "X-Time-Elapsed" => microtime(true) - $script_start,
+            ],
+            false,
         );
+        $gz->write("--{$boundary}--\r\n");
         $gz->finish();
     } catch (\Throwable $e) {
         error_log("Export: failed to write completion chunk: " . $e->getMessage());
@@ -1970,16 +2044,16 @@ function stream_file_producer(
         $initial_progress_json = json_encode_or_throw($initial_progress);
         $initial_cursor = $producer->get_reentrancy_cursor();
         $last_cursor = $initial_cursor;
-        $gz->write(
-            "--{$boundary}\r\n" .
-            "Content-Type: application/json\r\n" .
-            "Content-Length: " . strlen($initial_progress_json) . "\r\n" .
-            "X-Chunk-Type: progress\r\n" .
-            "X-Cursor: " . base64_encode($initial_cursor) . "\r\n" .
-            "\r\n" .
-            $initial_progress_json . "\r\n",
+        write_multipart_chunk(
+            $gz,
+            $boundary,
+            "application/json",
+            "progress",
+            $initial_progress_json,
+            [
+                "X-Cursor" => base64_encode($initial_cursor),
+            ],
         );
-        $gz->sync();
         while (true) {
             if (
                 !should_continue(
@@ -2007,16 +2081,16 @@ function stream_file_producer(
                 ];
                 $metadata_json = json_encode_or_throw($metadata);
 
-                $gz->write(
-                    "--{$boundary}\r\n" .
-                    "Content-Type: application/json\r\n" .
-                    "Content-Length: " . strlen($metadata_json) . "\r\n" .
-                    "X-Chunk-Type: metadata\r\n" .
-                    "X-Filesystem-Root: " . base64_encode($filesystem_root ?? "") . "\r\n" .
-                    "\r\n" .
-                    $metadata_json . "\r\n",
+                write_multipart_chunk(
+                    $gz,
+                    $boundary,
+                    "application/json",
+                    "metadata",
+                    $metadata_json,
+                    [
+                        "X-Filesystem-Root" => base64_encode($filesystem_root ?? ""),
+                    ],
                 );
-                $gz->sync();
 
                 $metadata_sent = true;
             }
@@ -2028,16 +2102,16 @@ function stream_file_producer(
                     $cursor = $producer->get_reentrancy_cursor();
                     $last_cursor = $cursor;
 
-                    $gz->write(
-                        "--{$boundary}\r\n" .
-                        "Content-Type: application/json\r\n" .
-                        "Content-Length: " . strlen($progress_json) . "\r\n" .
-                        "X-Chunk-Type: progress\r\n" .
-                        "X-Cursor: " . base64_encode($cursor) . "\r\n" .
-                        "\r\n" .
-                        $progress_json . "\r\n",
+                    write_multipart_chunk(
+                        $gz,
+                        $boundary,
+                        "application/json",
+                        "progress",
+                        $progress_json,
+                        [
+                            "X-Cursor" => base64_encode($cursor),
+                        ],
                     );
-                    $gz->sync();
 
                     $last_progress_output = $now;
                 }
@@ -2050,55 +2124,61 @@ function stream_file_producer(
             $last_cursor = $cursor;
 
             if ($chunk_type === "directory") {
-                $part =
-                    "--{$boundary}\r\n" .
-                    "Content-Type: application/octet-stream\r\n" .
-                    "Content-Length: 0\r\n" .
-                    "X-Chunk-Type: directory\r\n" .
-                    "X-Cursor: " . base64_encode($cursor) . "\r\n" .
-                    "X-Directory-Path: " . base64_encode($chunk["path"]) . "\r\n";
+                $headers = [
+                    "X-Cursor" => base64_encode($cursor),
+                    "X-Directory-Path" => base64_encode($chunk["path"]),
+                ];
                 if (isset($chunk["ctime"])) {
-                    $part .= "X-Directory-Ctime: " . $chunk["ctime"] . "\r\n";
+                    $headers["X-Directory-Ctime"] = $chunk["ctime"];
                 }
-                $gz->write($part . "\r\n\r\n");
-                $gz->sync();
+                write_multipart_chunk(
+                    $gz,
+                    $boundary,
+                    "application/octet-stream",
+                    "directory",
+                    "",
+                    $headers,
+                );
             } elseif ($chunk_type === "symlink") {
-                $gz->write(
-                    "--{$boundary}\r\n" .
-                    "Content-Type: application/octet-stream\r\n" .
-                    "Content-Length: 0\r\n" .
-                    "X-Chunk-Type: symlink\r\n" .
-                    "X-Cursor: " . base64_encode($cursor) . "\r\n" .
-                    "X-Symlink-Path: " . base64_encode($chunk["path"]) . "\r\n" .
-                    "X-Symlink-Target: " . base64_encode($chunk["target"]) . "\r\n" .
-                    "X-Symlink-Ctime: " . $chunk["ctime"] . "\r\n" .
-                    "\r\n\r\n",
+                write_multipart_chunk(
+                    $gz,
+                    $boundary,
+                    "application/octet-stream",
+                    "symlink",
+                    "",
+                    [
+                        "X-Cursor" => base64_encode($cursor),
+                        "X-Symlink-Path" => base64_encode($chunk["path"]),
+                        "X-Symlink-Target" => base64_encode($chunk["target"]),
+                        "X-Symlink-Ctime" => $chunk["ctime"],
+                    ],
                 );
-                $gz->sync();
             } elseif ($chunk_type === "index") {
-                $gz->write(
-                    "--{$boundary}\r\n" .
-                    "Content-Type: application/octet-stream\r\n" .
-                    "Content-Length: 0\r\n" .
-                    "X-Chunk-Type: index\r\n" .
-                    "X-Cursor: " . base64_encode($cursor) . "\r\n" .
-                    "X-Index-Path: " . base64_encode($chunk["path"]) . "\r\n" .
-                    "X-File-Ctime: " . $chunk["ctime"] . "\r\n" .
-                    "X-File-Size: " . $chunk["size"] . "\r\n" .
-                    "\r\n\r\n",
+                write_multipart_chunk(
+                    $gz,
+                    $boundary,
+                    "application/octet-stream",
+                    "index",
+                    "",
+                    [
+                        "X-Cursor" => base64_encode($cursor),
+                        "X-Index-Path" => base64_encode($chunk["path"]),
+                        "X-File-Ctime" => $chunk["ctime"],
+                        "X-File-Size" => $chunk["size"],
+                    ],
                 );
-                $gz->sync();
             } elseif ($chunk_type === "missing") {
-                $gz->write(
-                    "--{$boundary}\r\n" .
-                    "Content-Type: application/octet-stream\r\n" .
-                    "Content-Length: 0\r\n" .
-                    "X-Chunk-Type: missing\r\n" .
-                    "X-Cursor: " . base64_encode($cursor) . "\r\n" .
-                    "X-File-Path: " . base64_encode($chunk["path"]) . "\r\n" .
-                    "\r\n\r\n",
+                write_multipart_chunk(
+                    $gz,
+                    $boundary,
+                    "application/octet-stream",
+                    "missing",
+                    "",
+                    [
+                        "X-Cursor" => base64_encode($cursor),
+                        "X-File-Path" => base64_encode($chunk["path"]),
+                    ],
                 );
-                $gz->sync();
             } elseif ($chunk_type === "error") {
                 $payload = [
                     "error_type" => $chunk["error_type"] ?? "unknown",
@@ -2112,16 +2192,16 @@ function stream_file_producer(
                     $payload["actual_ctime"] = $chunk["actual_ctime"];
                 }
                 $json = json_encode_or_throw($payload);
-                $gz->write(
-                    "--{$boundary}\r\n" .
-                    "Content-Type: application/json\r\n" .
-                    "Content-Length: " . strlen($json) . "\r\n" .
-                    "X-Chunk-Type: error\r\n" .
-                    "X-Cursor: " . base64_encode($cursor) . "\r\n" .
-                    "\r\n" .
-                    $json . "\r\n",
+                write_multipart_chunk(
+                    $gz,
+                    $boundary,
+                    "application/json",
+                    "error",
+                    $json,
+                    [
+                        "X-Cursor" => base64_encode($cursor),
+                    ],
                 );
-                $gz->sync();
             } else {
                 // E2E test hook: before file chunk is emitted
                 if (getenv('SITE_EXPORT_TEST_MODE')) {
@@ -2139,29 +2219,34 @@ function stream_file_producer(
 
                 $data = $chunk["data"];
 
-                $headers =
-                    "--{$boundary}\r\n" .
-                    "Content-Type: application/octet-stream\r\n" .
-                    "Content-Length: " . strlen($data) . "\r\n" .
-                    "X-Chunk-Type: file\r\n" .
-                    "X-Cursor: " . base64_encode($cursor) . "\r\n" .
-                    "X-File-Path: " . base64_encode($chunk["path"]) . "\r\n" .
-                    "X-File-Size: " . $chunk["size"] . "\r\n" .
-                    "X-File-Ctime: " . $chunk["ctime"] . "\r\n" .
-                    "X-Chunk-Offset: " . $chunk["offset"] . "\r\n" .
-                    "X-Chunk-Size: " . strlen($data) . "\r\n" .
-                    "X-First-Chunk: " . ($chunk["is_first_chunk"] ? "1" : "0") . "\r\n" .
-                    "X-Last-Chunk: " . ($chunk["is_last_chunk"] ? "1" : "0") . "\r\n";
+                $headers = [
+                    "X-Cursor" => base64_encode($cursor),
+                    "X-File-Path" => base64_encode($chunk["path"]),
+                    "X-File-Size" => $chunk["size"],
+                    "X-File-Ctime" => $chunk["ctime"],
+                    "X-Chunk-Offset" => $chunk["offset"],
+                    "X-Chunk-Size" => strlen($data),
+                    "X-First-Chunk" => $chunk["is_first_chunk"] ? "1" : "0",
+                    "X-Last-Chunk" => $chunk["is_last_chunk"] ? "1" : "0",
+                ];
                 if (!empty($chunk["file_changed"])) {
-                    $headers .= "X-File-Changed: 1\r\n";
+                    $headers["X-File-Changed"] = 1;
                     if ($chunk["change_ctime"] !== null) {
-                        $headers .= "X-File-Change-Ctime: " . $chunk["change_ctime"] . "\r\n";
+                        $headers["X-File-Change-Ctime"] = $chunk["change_ctime"];
                     }
                     if ($chunk["change_size"] !== null) {
-                        $headers .= "X-File-Change-Size: " . $chunk["change_size"] . "\r\n";
+                        $headers["X-File-Change-Size"] = $chunk["change_size"];
                     }
                 }
-                $gz->write($headers . "\r\n");
+                $gz->write(
+                    build_multipart_chunk_preamble(
+                        $boundary,
+                        "application/octet-stream",
+                        strlen($data),
+                        "file",
+                        $headers,
+                    ),
+                );
                 $gz->write($data);
                 $gz->write("\r\n");
                 $gz->sync();
@@ -2185,16 +2270,16 @@ function stream_file_producer(
         //        previous content-length value if possible.
         if ($abort_payload !== null) {
             $json = json_encode_or_throw($abort_payload);
-            $gz->write(
-                "--{$boundary}\r\n" .
-                "Content-Type: application/json\r\n" .
-                "Content-Length: " . strlen($json) . "\r\n" .
-                "X-Chunk-Type: error\r\n" .
-                "X-Cursor: " . base64_encode($last_cursor) . "\r\n" .
-                "\r\n" .
-                $json . "\r\n",
+            write_multipart_chunk(
+                $gz,
+                $boundary,
+                "application/json",
+                "error",
+                $json,
+                [
+                    "X-Cursor" => base64_encode($last_cursor),
+                ],
             );
-            $gz->sync();
         }
 
         $progress = $producer->get_progress();
@@ -2212,22 +2297,24 @@ function stream_file_producer(
                 "chunks={$chunks_processed}, files={$files_completed}, bytes={$bytes_processed}",
         );
 
-        $gz->write(
-            "--{$boundary}\r\n" .
-            "Content-Type: application/octet-stream\r\n" .
-            "Content-Length: 0\r\n" .
-            "X-Chunk-Type: completion\r\n" .
-            "X-Status: {$status}\r\n" .
-            "X-Chunks-Processed: {$chunks_processed}\r\n" .
-            "X-Files-Completed: {$files_completed}\r\n" .
-            "X-Bytes-Processed: {$bytes_processed}\r\n" .
-            "X-Memory-Used: " . memory_get_peak_usage(true) . "\r\n" .
-            "X-Memory-Limit: " . $max_memory . "\r\n" .
-            "X-Time-Elapsed: " . (microtime(true) - $script_start) . "\r\n" .
-            "\r\n" .
-            "\r\n" .
-            "--{$boundary}--\r\n",
+        write_multipart_chunk(
+            $gz,
+            $boundary,
+            "application/octet-stream",
+            "completion",
+            "",
+            [
+                "X-Status" => $status,
+                "X-Chunks-Processed" => $chunks_processed,
+                "X-Files-Completed" => $files_completed,
+                "X-Bytes-Processed" => $bytes_processed,
+                "X-Memory-Used" => memory_get_peak_usage(true),
+                "X-Memory-Limit" => $max_memory,
+                "X-Time-Elapsed" => microtime(true) - $script_start,
+            ],
+            false,
         );
+        $gz->write("--{$boundary}--\r\n");
         $gz->finish();
     } catch (\Throwable $e) {
         error_log("Export: failed to write completion chunk: " . $e->getMessage());
@@ -2576,17 +2663,17 @@ function endpoint_file_index(
         ];
         $metadata_json = json_encode_or_throw($metadata);
 
-        $gz->write(
-            "--{$boundary}\r\n" .
-            "Content-Type: application/json\r\n" .
-            "Content-Length: " . strlen($metadata_json) . "\r\n" .
-            "X-Chunk-Type: metadata\r\n" .
-            "X-Filesystem-Root: " . base64_encode($filesystem_root ?? "") . "\r\n" .
-            "X-Index-Dir: " . base64_encode($list_dir_real ?? "") . "\r\n" .
-            "\r\n" .
-            $metadata_json . "\r\n",
+        write_multipart_chunk(
+            $gz,
+            $boundary,
+            "application/json",
+            "metadata",
+            $metadata_json,
+            [
+                "X-Filesystem-Root" => base64_encode($filesystem_root ?? ""),
+                "X-Index-Dir" => base64_encode($list_dir_real ?? ""),
+            ],
         );
-        $gz->sync();
         $stop = false;
         while (!$stop) {
             if (empty($stack)) {
@@ -2614,16 +2701,16 @@ function endpoint_file_index(
                     JSON_UNESCAPED_SLASHES,
                 );
                 $cursor_b64 = base64_encode($cursor_json);
-                $gz->write(
-                    "--{$boundary}\r\n" .
-                    "Content-Type: application/json\r\n" .
-                    "Content-Length: " . strlen($json) . "\r\n" .
-                    "X-Chunk-Type: error\r\n" .
-                    "X-Cursor: " . $cursor_b64 . "\r\n" .
-                    "\r\n" .
-                    $json . "\r\n",
+                write_multipart_chunk(
+                    $gz,
+                    $boundary,
+                    "application/json",
+                    "error",
+                    $json,
+                    [
+                        "X-Cursor" => $cursor_b64,
+                    ],
                 );
-                $gz->sync();
                 $abort_payload = null;
                 continue;
             }
@@ -2653,16 +2740,16 @@ function endpoint_file_index(
                     JSON_UNESCAPED_SLASHES,
                 );
                 $cursor_b64 = base64_encode($cursor_json);
-                $gz->write(
-                    "--{$boundary}\r\n" .
-                    "Content-Type: application/json\r\n" .
-                    "Content-Length: " . strlen($json) . "\r\n" .
-                    "X-Chunk-Type: error\r\n" .
-                    "X-Cursor: " . $cursor_b64 . "\r\n" .
-                    "\r\n" .
-                    $json . "\r\n",
+                write_multipart_chunk(
+                    $gz,
+                    $boundary,
+                    "application/json",
+                    "error",
+                    $json,
+                    [
+                        "X-Cursor" => $cursor_b64,
+                    ],
                 );
-                $gz->sync();
                 $abort_payload = null;
                 continue;
             }
@@ -2688,16 +2775,16 @@ function endpoint_file_index(
                     JSON_UNESCAPED_SLASHES,
                 );
                 $cursor_b64 = base64_encode($cursor_json);
-                $gz->write(
-                    "--{$boundary}\r\n" .
-                    "Content-Type: application/json\r\n" .
-                    "Content-Length: " . strlen($json) . "\r\n" .
-                    "X-Chunk-Type: error\r\n" .
-                    "X-Cursor: " . $cursor_b64 . "\r\n" .
-                    "\r\n" .
-                    $json . "\r\n",
+                write_multipart_chunk(
+                    $gz,
+                    $boundary,
+                    "application/json",
+                    "error",
+                    $json,
+                    [
+                        "X-Cursor" => $cursor_b64,
+                    ],
                 );
-                $gz->sync();
                 $abort_payload = null;
                 array_pop($stack);
                 continue;
@@ -2844,13 +2931,16 @@ function endpoint_file_index(
                     );
 
                     $gz->write(
-                        "--{$boundary}\r\n" .
-                        "Content-Type: application/json\r\n" .
-                        "Content-Length: " . strlen($json) . "\r\n" .
-                        "X-Chunk-Type: index_batch\r\n" .
-                        "X-Cursor: " . $cursor_b64 . "\r\n" .
-                        "X-Batch-Size: " . count($batch_items) . "\r\n" .
-                        "\r\n",
+                        build_multipart_chunk_preamble(
+                            $boundary,
+                            "application/json",
+                            strlen($json),
+                            "index_batch",
+                            [
+                                "X-Cursor" => $cursor_b64,
+                                "X-Batch-Size" => count($batch_items),
+                            ],
+                        ),
                     );
                     $gz->write($json);
                     $gz->write("\r\n");
@@ -2921,13 +3011,16 @@ function endpoint_file_index(
         );
 
         $gz->write(
-            "--{$boundary}\r\n" .
-            "Content-Type: application/json\r\n" .
-            "Content-Length: " . strlen($json) . "\r\n" .
-            "X-Chunk-Type: index_batch\r\n" .
-            "X-Cursor: " . $cursor_b64 . "\r\n" .
-            "X-Batch-Size: " . count($batch_items) . "\r\n" .
-            "\r\n",
+            build_multipart_chunk_preamble(
+                $boundary,
+                "application/json",
+                strlen($json),
+                "index_batch",
+                [
+                    "X-Cursor" => $cursor_b64,
+                    "X-Batch-Size" => count($batch_items),
+                ],
+            ),
         );
         $gz->write($json);
         $gz->write("\r\n");
@@ -2945,16 +3038,16 @@ function endpoint_file_index(
                 JSON_UNESCAPED_SLASHES,
             );
             $cursor_b64 = base64_encode($cursor_json);
-            $gz->write(
-                "--{$boundary}\r\n" .
-                "Content-Type: application/json\r\n" .
-                "Content-Length: " . strlen($json) . "\r\n" .
-                "X-Chunk-Type: error\r\n" .
-                "X-Cursor: " . $cursor_b64 . "\r\n" .
-                "\r\n" .
-                $json . "\r\n",
+            write_multipart_chunk(
+                $gz,
+                $boundary,
+                "application/json",
+                "error",
+                $json,
+                [
+                    "X-Cursor" => $cursor_b64,
+                ],
             );
-            $gz->sync();
             $status = "partial";
         }
 
@@ -2964,23 +3057,25 @@ function endpoint_file_index(
         );
         $cursor_b64 = base64_encode($cursor_json);
 
-        $gz->write(
-            "--{$boundary}\r\n" .
-            "Content-Type: application/octet-stream\r\n" .
-            "Content-Length: 0\r\n" .
-            "X-Chunk-Type: completion\r\n" .
-            "X-Status: " . ($aborted ? "partial" : $status) . "\r\n" .
-            "X-Cursor: " . $cursor_b64 . "\r\n" .
-            "X-Index-Dir: " . base64_encode($list_dir_real) . "\r\n" .
-            "X-Batches-Emitted: {$batches_emitted}\r\n" .
-            "X-Total-Entries: {$total_entries}\r\n" .
-            "X-Memory-Used: " . memory_get_peak_usage(true) . "\r\n" .
-            "X-Memory-Limit: " . $max_memory . "\r\n" .
-            "X-Time-Elapsed: " . (microtime(true) - $script_start) . "\r\n" .
-            "\r\n" .
-            "\r\n" .
-            "--{$boundary}--\r\n",
+        write_multipart_chunk(
+            $gz,
+            $boundary,
+            "application/octet-stream",
+            "completion",
+            "",
+            [
+                "X-Status" => $aborted ? "partial" : $status,
+                "X-Cursor" => $cursor_b64,
+                "X-Index-Dir" => base64_encode($list_dir_real),
+                "X-Batches-Emitted" => $batches_emitted,
+                "X-Total-Entries" => $total_entries,
+                "X-Memory-Used" => memory_get_peak_usage(true),
+                "X-Memory-Limit" => $max_memory,
+                "X-Time-Elapsed" => microtime(true) - $script_start,
+            ],
+            false,
         );
+        $gz->write("--{$boundary}--\r\n");
         $gz->finish();
     } catch (\Throwable $e) {
         error_log("Export: failed to write completion chunk: " . $e->getMessage());


### PR DESCRIPTION
## Summary
- add reusable multipart chunk helpers in `wordpress-plugin/generic/export.php`
- replace repeated manual multipart string assembly in SQL, DB index, file producer, and file index streaming paths
- add shared atomic write helper in `importer/import.php` and reuse it for state/status writes
- move pure utility logic out of `ImportClient` methods into reusable functions (`parse_index_entry_line`, `is_runtime_function_available`)

## Behavior
- keeps existing import/export logic and wire protocol intact
- focuses on reducing duplication and simplifying expression of existing flow

## Validation
- `php -l importer/import.php`
- `php -l wordpress-plugin/generic/export.php`