### PR TITLE
Parse DB_HOST for non-standard port and socket formats

### DIFF
--- a/tests/BuildPdoDsnTest.php
+++ b/tests/BuildPdoDsnTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../wordpress-plugin/generic/utils.php';
+
+use PHPUnit\Framework\TestCase;
+
+class BuildPdoDsnTest extends TestCase
+{
+    public function testPlainHostname(): void
+    {
+        $dsn = build_pdo_dsn('localhost', 'wp_db');
+        $this->assertSame('mysql:host=localhost;dbname=wp_db;charset=utf8mb4', $dsn);
+    }
+
+    public function testHostnameWithPort(): void
+    {
+        $dsn = build_pdo_dsn('db.host.com:3307', 'wp_db');
+        $this->assertSame('mysql:host=db.host.com;port=3307;dbname=wp_db;charset=utf8mb4', $dsn);
+    }
+
+    public function testHostnameWithSocket(): void
+    {
+        $dsn = build_pdo_dsn('localhost:/var/run/mysqld/mysqld.sock', 'wp_db');
+        $this->assertSame('mysql:unix_socket=/var/run/mysqld/mysqld.sock;dbname=wp_db;charset=utf8mb4', $dsn);
+    }
+
+    public function testBareSocketPath(): void
+    {
+        $dsn = build_pdo_dsn('/var/run/mysqld/mysqld.sock', 'wp_db');
+        $this->assertSame('mysql:unix_socket=/var/run/mysqld/mysqld.sock;dbname=wp_db;charset=utf8mb4', $dsn);
+    }
+
+    public function testIpAddressWithPort(): void
+    {
+        $dsn = build_pdo_dsn('127.0.0.1:3306', 'mydb');
+        $this->assertSame('mysql:host=127.0.0.1;port=3306;dbname=mydb;charset=utf8mb4', $dsn);
+    }
+
+    public function testIpAddressOnly(): void
+    {
+        $dsn = build_pdo_dsn('127.0.0.1', 'mydb');
+        $this->assertSame('mysql:host=127.0.0.1;dbname=mydb;charset=utf8mb4', $dsn);
+    }
+}

--- a/tests/BuildPdoDsnTest.php
+++ b/tests/BuildPdoDsnTest.php
@@ -8,6 +8,20 @@ use PHPUnit\Framework\TestCase;
 
 class BuildPdoDsnTest extends TestCase
 {
+    private string $tmpSocket;
+
+    protected function setUp(): void
+    {
+        $this->tmpSocket = tempnam(sys_get_temp_dir(), 'sock_');
+    }
+
+    protected function tearDown(): void
+    {
+        if (file_exists($this->tmpSocket)) {
+            unlink($this->tmpSocket);
+        }
+    }
+
     public function testPlainHostname(): void
     {
         $dsn = build_pdo_dsn('localhost', 'wp_db');
@@ -22,14 +36,26 @@ class BuildPdoDsnTest extends TestCase
 
     public function testHostnameWithSocket(): void
     {
-        $dsn = build_pdo_dsn('localhost:/var/run/mysqld/mysqld.sock', 'wp_db');
-        $this->assertSame('mysql:unix_socket=/var/run/mysqld/mysqld.sock;dbname=wp_db;charset=utf8mb4', $dsn);
+        $dsn = build_pdo_dsn("localhost:{$this->tmpSocket}", 'wp_db');
+        $this->assertSame("mysql:unix_socket={$this->tmpSocket};dbname=wp_db;charset=utf8mb4", $dsn);
+    }
+
+    public function testHostnameWithNonexistentSocketTreatedAsPort(): void
+    {
+        $dsn = build_pdo_dsn('localhost:/no/such/file.sock', 'wp_db');
+        $this->assertSame('mysql:host=localhost;port=/no/such/file.sock;dbname=wp_db;charset=utf8mb4', $dsn);
     }
 
     public function testBareSocketPath(): void
     {
-        $dsn = build_pdo_dsn('/var/run/mysqld/mysqld.sock', 'wp_db');
-        $this->assertSame('mysql:unix_socket=/var/run/mysqld/mysqld.sock;dbname=wp_db;charset=utf8mb4', $dsn);
+        $dsn = build_pdo_dsn($this->tmpSocket, 'wp_db');
+        $this->assertSame("mysql:unix_socket={$this->tmpSocket};dbname=wp_db;charset=utf8mb4", $dsn);
+    }
+
+    public function testBareNonexistentPathTreatedAsHost(): void
+    {
+        $dsn = build_pdo_dsn('/no/such/mysql.sock', 'wp_db');
+        $this->assertSame('mysql:host=/no/such/mysql.sock;dbname=wp_db;charset=utf8mb4', $dsn);
     }
 
     public function testIpAddressWithPort(): void
@@ -64,8 +90,14 @@ class BuildPdoDsnTest extends TestCase
 
     public function testBracketedIpv6WithSocket(): void
     {
-        $dsn = build_pdo_dsn('[::1]:/var/run/mysqld/mysqld.sock', 'wp_db');
-        $this->assertSame('mysql:unix_socket=/var/run/mysqld/mysqld.sock;dbname=wp_db;charset=utf8mb4', $dsn);
+        $dsn = build_pdo_dsn("[::1]:{$this->tmpSocket}", 'wp_db');
+        $this->assertSame("mysql:unix_socket={$this->tmpSocket};dbname=wp_db;charset=utf8mb4", $dsn);
+    }
+
+    public function testBracketedIpv6WithNonexistentSocketTreatedAsPort(): void
+    {
+        $dsn = build_pdo_dsn('[::1]:/no/such/file.sock', 'wp_db');
+        $this->assertSame('mysql:host=::1;port=/no/such/file.sock;dbname=wp_db;charset=utf8mb4', $dsn);
     }
 
     public function testFullIpv6Address(): void

--- a/tests/BuildPdoDsnTest.php
+++ b/tests/BuildPdoDsnTest.php
@@ -43,4 +43,34 @@ class BuildPdoDsnTest extends TestCase
         $dsn = build_pdo_dsn('127.0.0.1', 'mydb');
         $this->assertSame('mysql:host=127.0.0.1;dbname=mydb;charset=utf8mb4', $dsn);
     }
+
+    public function testBareIpv6(): void
+    {
+        $dsn = build_pdo_dsn('::1', 'wp_db');
+        $this->assertSame('mysql:host=::1;dbname=wp_db;charset=utf8mb4', $dsn);
+    }
+
+    public function testBracketedIpv6(): void
+    {
+        $dsn = build_pdo_dsn('[::1]', 'wp_db');
+        $this->assertSame('mysql:host=::1;dbname=wp_db;charset=utf8mb4', $dsn);
+    }
+
+    public function testBracketedIpv6WithPort(): void
+    {
+        $dsn = build_pdo_dsn('[::1]:3306', 'wp_db');
+        $this->assertSame('mysql:host=::1;port=3306;dbname=wp_db;charset=utf8mb4', $dsn);
+    }
+
+    public function testBracketedIpv6WithSocket(): void
+    {
+        $dsn = build_pdo_dsn('[::1]:/var/run/mysqld/mysqld.sock', 'wp_db');
+        $this->assertSame('mysql:unix_socket=/var/run/mysqld/mysqld.sock;dbname=wp_db;charset=utf8mb4', $dsn);
+    }
+
+    public function testFullIpv6Address(): void
+    {
+        $dsn = build_pdo_dsn('2001:db8::1', 'wp_db');
+        $this->assertSame('mysql:host=2001:db8::1;dbname=wp_db;charset=utf8mb4', $dsn);
+    }
 }

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -16,6 +16,9 @@
         <testsuite name="Import Tests">
             <directory>Import</directory>
         </testsuite>
+        <testsuite name="Export Utility Tests">
+            <file>BuildPdoDsnTest.php</file>
+        </testsuite>
     </testsuites>
     <php>
         <env name="DB_HOST" value="127.0.0.1"/>

--- a/wordpress-plugin/generic/export.php
+++ b/wordpress-plugin/generic/export.php
@@ -691,7 +691,7 @@ function endpoint_sql_chunk(
      * both.
      */
     $mysql = new PDO(
-        "mysql:host={$db_host};dbname={$db_name};charset=utf8mb4",
+        build_pdo_dsn($db_host, $db_name),
         $db_user,
         $db_password,
         $pdo_options,
@@ -909,7 +909,7 @@ function endpoint_db_index(
     $last_table = $cursor["last_table"] ?? "";
 
     $mysql = new PDO(
-        "mysql:host={$db_host};dbname={$db_name};charset=utf8mb4",
+        build_pdo_dsn($db_host, $db_name),
         $db_user,
         $db_password,
         [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION],
@@ -1419,7 +1419,7 @@ function endpoint_preflight(array $config): array
         } else {
             try {
                 $mysql = new PDO(
-                    "mysql:host={$creds['db_host']};dbname={$creds['db_name']};charset=utf8mb4",
+                    build_pdo_dsn($creds['db_host'], $creds['db_name']),
                     $creds["db_user"],
                     $creds["db_password"],
                     [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION],

--- a/wordpress-plugin/generic/utils.php
+++ b/wordpress-plugin/generic/utils.php
@@ -10,6 +10,62 @@ if (!function_exists('str_starts_with')) {
     }
 }
 
+// Polyfill for PHP 7.4 which lacks str_contains().
+if (!function_exists('str_contains')) {
+    function str_contains(string $haystack, string $needle): bool {
+        return $needle === '' || strpos($haystack, $needle) !== false;
+    }
+}
+
+/**
+ * Builds a PDO DSN string from a WordPress DB_HOST value.
+ *
+ * WordPress's DB_HOST supports several non-standard formats that shared
+ * hosts commonly use:
+ *   - "localhost"             → standard hostname
+ *   - "db.host.com:3307"     → hostname with port
+ *   - "localhost:/path/sock"  → hostname with Unix socket
+ *   - "/path/to/mysql.sock"  → bare Unix socket path
+ *
+ * PDO needs these broken out into separate DSN parameters (host, port,
+ * unix_socket), so we parse the value the same way WordPress core does.
+ *
+ * @param string $db_host  Raw DB_HOST value.
+ * @param string $db_name  Database name.
+ * @return string PDO DSN string.
+ */
+function build_pdo_dsn(string $db_host, string $db_name): string
+{
+    $socket = '';
+    $host   = $db_host;
+    $port   = '';
+
+    if (str_starts_with($db_host, '/')) {
+        // Bare socket path: "/var/run/mysqld/mysqld.sock"
+        $socket = $db_host;
+        $host   = '';
+    } elseif (str_contains($db_host, ':')) {
+        // "host:port" or "host:/path/to/socket"
+        [$host, $after_colon] = explode(':', $db_host, 2);
+        if (str_starts_with($after_colon, '/')) {
+            $socket = $after_colon;
+        } else {
+            $port = $after_colon;
+        }
+    }
+
+    if ($socket !== '') {
+        return "mysql:unix_socket={$socket};dbname={$db_name};charset=utf8mb4";
+    }
+
+    $dsn = "mysql:host={$host}";
+    if ($port !== '') {
+        $dsn .= ";port={$port}";
+    }
+    $dsn .= ";dbname={$db_name};charset=utf8mb4";
+    return $dsn;
+}
+
 /**
  * Parse a human-readable size string (e.g. "16M", "1G", "512K") into bytes.
  * Accepts plain integers as well.

--- a/wordpress-plugin/generic/utils.php
+++ b/wordpress-plugin/generic/utils.php
@@ -22,10 +22,14 @@ if (!function_exists('str_contains')) {
  *
  * WordPress's DB_HOST supports several non-standard formats that shared
  * hosts commonly use:
- *   - "localhost"             → standard hostname
- *   - "db.host.com:3307"     → hostname with port
- *   - "localhost:/path/sock"  → hostname with Unix socket
- *   - "/path/to/mysql.sock"  → bare Unix socket path
+ *   - "localhost"              → standard hostname
+ *   - "db.host.com:3307"      → hostname with port
+ *   - "localhost:/path/sock"   → hostname with Unix socket
+ *   - "/path/to/mysql.sock"   → bare Unix socket path
+ *   - "::1"                   → IPv6 address
+ *   - "[::1]"                 → bracketed IPv6
+ *   - "[::1]:3306"            → bracketed IPv6 with port
+ *   - "[::1]:/path/to/socket" → bracketed IPv6 with Unix socket
  *
  * PDO needs these broken out into separate DSN parameters (host, port,
  * unix_socket), so we parse the value the same way WordPress core does.
@@ -44,15 +48,32 @@ function build_pdo_dsn(string $db_host, string $db_name): string
         // Bare socket path: "/var/run/mysqld/mysqld.sock"
         $socket = $db_host;
         $host   = '';
-    } elseif (str_contains($db_host, ':')) {
-        // "host:port" or "host:/path/to/socket"
-        [$host, $after_colon] = explode(':', $db_host, 2);
-        if (str_starts_with($after_colon, '/')) {
-            $socket = $after_colon;
-        } else {
-            $port = $after_colon;
+    } elseif (str_starts_with($db_host, '[')) {
+        // Bracketed IPv6: "[::1]", "[::1]:3306", "[::1]:/path/to/socket"
+        $bracket_end = strpos($db_host, ']');
+        if ($bracket_end !== false) {
+            $host = substr($db_host, 1, $bracket_end - 1);
+            $after = substr($db_host, $bracket_end + 1);
+            if (str_starts_with($after, ':/')) {
+                $socket = substr($after, 1);
+            } elseif (str_starts_with($after, ':')) {
+                $port = substr($after, 1);
+            }
         }
+    } elseif (($socket_pos = strpos($db_host, ':/')) !== false) {
+        // "host:/path/to/socket" — check before general colon split
+        // to avoid misinterpreting IPv6 addresses as host:port
+        $host   = substr($db_host, 0, $socket_pos);
+        $socket = substr($db_host, $socket_pos + 1);
+    } elseif (
+        str_contains($db_host, ':') &&
+        substr_count($db_host, ':') === 1
+    ) {
+        // Exactly one colon: "host:port" — not IPv6
+        [$host, $port] = explode(':', $db_host, 2);
     }
+    // Otherwise (multiple colons, no socket marker): bare IPv6 like "::1"
+    // — $host stays as the full value.
 
     if ($socket !== '') {
         return "mysql:unix_socket={$socket};dbname={$db_name};charset=utf8mb4";

--- a/wordpress-plugin/generic/utils.php
+++ b/wordpress-plugin/generic/utils.php
@@ -44,7 +44,7 @@ function build_pdo_dsn(string $db_host, string $db_name): string
     $host   = $db_host;
     $port   = '';
 
-    if (str_starts_with($db_host, '/')) {
+    if (str_starts_with($db_host, '/') && file_exists($db_host)) {
         // Bare socket path: "/var/run/mysqld/mysqld.sock"
         $socket = $db_host;
         $host   = '';
@@ -55,16 +55,23 @@ function build_pdo_dsn(string $db_host, string $db_name): string
         // Bracketed IPv6: "[::1]", "[::1]:3306", "[::1]:/path/to/socket"
         $host = substr($db_host, 1, $bracket_end - 1);
         $after = substr($db_host, $bracket_end + 1);
-        if (str_starts_with($after, ':/')) {
-            $socket = substr($after, 1);
+        $candidate_socket = str_starts_with($after, ':/') ? substr($after, 1) : '';
+        if ($candidate_socket !== '' && file_exists($candidate_socket)) {
+            $socket = $candidate_socket;
         } elseif (str_starts_with($after, ':')) {
             $port = substr($after, 1);
         }
     } elseif (($socket_pos = strpos($db_host, ':/')) !== false) {
         // "host:/path/to/socket" — check before general colon split
         // to avoid misinterpreting IPv6 addresses as host:port
-        $host   = substr($db_host, 0, $socket_pos);
-        $socket = substr($db_host, $socket_pos + 1);
+        $candidate_socket = substr($db_host, $socket_pos + 1);
+        if (file_exists($candidate_socket)) {
+            $host   = substr($db_host, 0, $socket_pos);
+            $socket = $candidate_socket;
+        } elseif (substr_count($db_host, ':') === 1) {
+            // Single colon but not a socket — treat as host:port
+            [$host, $port] = explode(':', $db_host, 2);
+        }
     } elseif (
         str_contains($db_host, ':') &&
         substr_count($db_host, ':') === 1

--- a/wordpress-plugin/generic/utils.php
+++ b/wordpress-plugin/generic/utils.php
@@ -48,17 +48,17 @@ function build_pdo_dsn(string $db_host, string $db_name): string
         // Bare socket path: "/var/run/mysqld/mysqld.sock"
         $socket = $db_host;
         $host   = '';
-    } elseif (str_starts_with($db_host, '[')) {
+    } elseif (
+        str_starts_with($db_host, '[') &&
+        ($bracket_end = strpos($db_host, ']')) !== false
+    ) {
         // Bracketed IPv6: "[::1]", "[::1]:3306", "[::1]:/path/to/socket"
-        $bracket_end = strpos($db_host, ']');
-        if ($bracket_end !== false) {
-            $host = substr($db_host, 1, $bracket_end - 1);
-            $after = substr($db_host, $bracket_end + 1);
-            if (str_starts_with($after, ':/')) {
-                $socket = substr($after, 1);
-            } elseif (str_starts_with($after, ':')) {
-                $port = substr($after, 1);
-            }
+        $host = substr($db_host, 1, $bracket_end - 1);
+        $after = substr($db_host, $bracket_end + 1);
+        if (str_starts_with($after, ':/')) {
+            $socket = substr($after, 1);
+        } elseif (str_starts_with($after, ':')) {
+            $port = substr($after, 1);
         }
     } elseif (($socket_pos = strpos($db_host, ':/')) !== false) {
         // "host:/path/to/socket" — check before general colon split


### PR DESCRIPTION
## Summary
- Adds `build_pdo_dsn()` to parse WordPress's `DB_HOST` into a proper PDO DSN
- Handles `host:port`, `host:/path/to/socket`, and bare socket paths (`/var/run/mysqld/mysqld.sock`)
- Replaces all 3 raw DSN interpolations in `export.php` with the new function
- Adds `str_contains` polyfill for PHP 7.4

Previously, the raw `DB_HOST` value was interpolated directly into `mysql:host={$db_host}`, which fails on any host using a non-standard port or Unix socket (WP Engine, Flywheel, Pressable, and many managed WordPress hosts).

## Test plan
- [x] 6 new unit tests covering plain hostname, host:port, host:/path/socket, bare socket, IP:port, IP-only
- [ ] Verify existing PHPUnit tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)