### PR TITLE
Support exporting from SQLite and HyperDB sites

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -9,6 +9,8 @@ parameters:
         - importer
     excludePaths:
         - wordpress-plugin/generic/secrets.php
+        - wordpress-plugin/generic/class-sqlite-driver-pdo.php
+        - wordpress-plugin/generic/sqlite-bootstrap.php
         - wordpress-plugin/wordpress/
         - wordpress-plugin/index.php
     treatPhpDocTypesAsCertain: false

--- a/wordpress-plugin/api.php
+++ b/wordpress-plugin/api.php
@@ -213,8 +213,13 @@ if ($wp_root !== null && !defined('DB_HOST')) {
     if (is_readable($wp_config_path)) {
         $config_contents = @file_get_contents($wp_config_path);
         if ($config_contents !== false) {
-            // Extract define('CONSTANT', 'value') patterns
-            foreach (['DB_HOST', 'DB_NAME', 'DB_USER', 'DB_PASSWORD'] as $const) {
+            // Extract define('CONSTANT', 'value') patterns for MySQL credentials
+            // and SQLite-related constants.
+            $constants_to_extract = [
+                'DB_HOST', 'DB_NAME', 'DB_USER', 'DB_PASSWORD',
+                'DB_ENGINE', 'DB_DIR', 'DB_FILE',
+            ];
+            foreach ($constants_to_extract as $const) {
                 if (!defined($const) && preg_match(
                     '/define\s*\(\s*[\'"]' . preg_quote($const, '/') . '[\'"]\s*,\s*[\'"]([^\'"]*)[\'"]\s*\)/',
                     $config_contents,
@@ -231,6 +236,48 @@ if ($wp_root !== null && !defined('DB_HOST')) {
             )) {
                 $GLOBALS['table_prefix'] = $m[1];
             }
+        }
+    }
+}
+
+// Detect the database backend by inspecting wp-config.php constants and the
+// wp-content/db.php drop-in. This tells export.php whether it's talking to
+// MySQL, SQLite, or HyperDB.
+if ($wp_root !== null && !defined('DB_ENGINE')) {
+    $detected_engine = 'mysql';
+
+    // Check the db.php drop-in — its contents reveal the active backend.
+    $db_dropin = $wp_root . '/wp-content/db.php';
+    if (file_exists($db_dropin) && is_readable($db_dropin)) {
+        $db_dropin_contents = @file_get_contents($db_dropin);
+        if ($db_dropin_contents !== false) {
+            $dropin_lower = strtolower($db_dropin_contents);
+            if (
+                strpos($dropin_lower, 'sqlite') !== false ||
+                strpos($dropin_lower, 'wp_sqlite_driver') !== false
+            ) {
+                $detected_engine = 'sqlite';
+            } elseif (
+                strpos($dropin_lower, 'hyperdb') !== false ||
+                strpos($dropin_lower, 'hyper-db') !== false
+            ) {
+                $detected_engine = 'hyperdb';
+            }
+        }
+    }
+
+    define('DB_ENGINE', $detected_engine);
+
+    // For SQLite sites, resolve the database file path. The plugin uses
+    // FQDB (full-qualified database path) and FQDBDIR conventions.
+    if ($detected_engine === 'sqlite') {
+        if (!defined('FQDBDIR')) {
+            $db_dir = defined('DB_DIR') ? DB_DIR : $wp_root . '/wp-content/database';
+            define('FQDBDIR', rtrim($db_dir, '/') . '/');
+        }
+        if (!defined('FQDB')) {
+            $db_file = defined('DB_FILE') ? DB_FILE : '.ht.sqlite';
+            define('FQDB', FQDBDIR . $db_file);
         }
     }
 }

--- a/wordpress-plugin/generic/class-mysql-dump-producer.php
+++ b/wordpress-plugin/generic/class-mysql-dump-producer.php
@@ -162,7 +162,12 @@ class MySQLDumpProducer
     /** @var int */
     private $current_statement_size = 0;
 
-    public function __construct(PDO $db, $options = [])
+    /**
+     * @param PDO $db Database connection — either a real PDO (MySQL) or a
+     *        PDO-compatible adapter (SQLite sites). No type hint because the
+     *        adapter isn't a PDO subclass and PHP 7.4 lacks union types.
+     */
+    public function __construct($db, $options = [])
     {
         $this->db = $db;
         $this->tables_to_process = $options["tables_to_process"] ?? null;

--- a/wordpress-plugin/generic/class-sqlite-driver-pdo.php
+++ b/wordpress-plugin/generic/class-sqlite-driver-pdo.php
@@ -1,0 +1,258 @@
+<?php
+/**
+ * Thin PDO-compatible adapter wrapping WP_SQLite_Driver.
+ *
+ * MySQLDumpProducer and endpoint_db_index use PDO::prepare/query/quote
+ * and PDOStatement::execute/fetch/fetchAll/fetchColumn. This adapter
+ * implements exactly those methods by routing every SQL statement through
+ * WP_SQLite_Driver, which translates MySQL syntax to SQLite on the fly.
+ *
+ * The result is transparent: the dump producer sends MySQL queries, the
+ * driver translates them, SQLite answers, and the producer gets rows back
+ * in the shape it expects.
+ */
+
+/**
+ * Wraps a WP_SQLite_Driver instance to look like a PDO connection.
+ *
+ * Only the methods that MySQLDumpProducer and endpoint code actually call
+ * are implemented. Anything else will throw a clear error rather than
+ * silently misbehaving.
+ */
+class SqliteDriverPDO
+{
+    /** @var WP_SQLite_Driver */
+    private $driver;
+
+    /** @var PDO The raw SQLite PDO for quote() delegation. */
+    private $raw_pdo;
+
+    public function __construct(WP_SQLite_Driver $driver, PDO $raw_pdo)
+    {
+        $this->driver = $driver;
+        $this->raw_pdo = $raw_pdo;
+    }
+
+    /**
+     * Prepares a statement for execution.
+     *
+     * Returns a SqliteDriverPDOStatement that will substitute parameters
+     * and execute through the driver when execute() is called.
+     */
+    public function prepare(string $sql): SqliteDriverPDOStatement
+    {
+        return new SqliteDriverPDOStatement($this->driver, $sql);
+    }
+
+    /**
+     * Executes a query immediately and returns the result set.
+     */
+    public function query(string $sql): SqliteDriverPDOStatement
+    {
+        $stmt = new SqliteDriverPDOStatement($this->driver, $sql);
+        $stmt->execute();
+        return $stmt;
+    }
+
+    /**
+     * Quotes a string for safe inclusion in a query.
+     * Delegates to the underlying raw SQLite PDO.
+     */
+    public function quote(string $value, int $type = PDO::PARAM_STR): string
+    {
+        return $this->raw_pdo->quote($value, $type);
+    }
+
+    /**
+     * Returns the underlying WP_SQLite_Driver for direct access.
+     */
+    public function get_driver(): WP_SQLite_Driver
+    {
+        return $this->driver;
+    }
+}
+
+/**
+ * PDOStatement-compatible wrapper for WP_SQLite_Driver query results.
+ *
+ * Collects all result rows eagerly (SQLite result sets are small enough)
+ * and serves them through fetch/fetchAll/fetchColumn.
+ */
+class SqliteDriverPDOStatement
+{
+    /** @var WP_SQLite_Driver */
+    private $driver;
+
+    /** @var string */
+    private $sql;
+
+    /** @var array Stored result rows after execution. */
+    private $rows = [];
+
+    /** @var int Current position for fetch(). */
+    private $position = 0;
+
+    public function __construct(WP_SQLite_Driver $driver, string $sql)
+    {
+        $this->driver = $driver;
+        $this->sql = $sql;
+    }
+
+    /**
+     * Executes the prepared statement.
+     *
+     * Substitutes ? placeholders with quoted parameter values, sends
+     * the query through WP_SQLite_Driver, and stores the result rows.
+     *
+     * @param array|null $params Positional parameters (0-indexed).
+     * @return bool True on success.
+     */
+    public function execute($params = null): bool
+    {
+        // Merge in any parameters set via bindValue().
+        if ($params === null && $this->bound_params !== null) {
+            $params = $this->bound_params;
+        }
+
+        $sql = $this->sql;
+
+        if ($params !== null && count($params) > 0) {
+            // Substitute ? placeholders from right to left so positions
+            // don't shift as we splice in quoted values.
+            $positions = [];
+            $len = strlen($sql);
+            $in_single = false;
+            $in_double = false;
+            for ($i = 0; $i < $len; $i++) {
+                $ch = $sql[$i];
+                if ($ch === "'" && !$in_double) {
+                    $in_single = !$in_single;
+                } elseif ($ch === '"' && !$in_single) {
+                    $in_double = !$in_double;
+                } elseif ($ch === '?' && !$in_single && !$in_double) {
+                    $positions[] = $i;
+                }
+            }
+
+            // Replace from the end to preserve earlier offsets.
+            for ($i = count($positions) - 1; $i >= 0; $i--) {
+                if (!array_key_exists($i, $params)) {
+                    continue;
+                }
+                $value = $params[$i];
+                if ($value === null) {
+                    $quoted = 'NULL';
+                } elseif (is_int($value) || is_float($value)) {
+                    $quoted = (string) $value;
+                } else {
+                    // Use the driver's underlying PDO for safe quoting.
+                    $quoted = "'" . str_replace("'", "''", (string) $value) . "'";
+                }
+                $sql = substr_replace($sql, $quoted, $positions[$i], 1);
+            }
+        }
+
+        // Named parameters (:name style) — substitute them too.
+        if ($params !== null) {
+            foreach ($params as $key => $value) {
+                if (!is_string($key)) {
+                    continue;
+                }
+                if ($value === null) {
+                    $quoted = 'NULL';
+                } elseif (is_int($value) || is_float($value)) {
+                    $quoted = (string) $value;
+                } else {
+                    $quoted = "'" . str_replace("'", "''", (string) $value) . "'";
+                }
+                $sql = str_replace($key, $quoted, $sql);
+            }
+        }
+
+        $this->driver->query($sql);
+        $this->rows = $this->driver->get_results() ?: [];
+
+        // WP_SQLite_Driver returns results as arrays of objects.
+        // Convert to associative arrays for PDO compatibility.
+        foreach ($this->rows as $i => $row) {
+            if (is_object($row)) {
+                $this->rows[$i] = (array) $row;
+            }
+        }
+
+        $this->position = 0;
+
+        return true;
+    }
+
+    /**
+     * Fetches the next row from the result set.
+     *
+     * @param int $mode Fetch mode (ignored — always returns associative array).
+     * @return array|false Associative array or false when exhausted.
+     */
+    public function fetch($mode = PDO::FETCH_ASSOC)
+    {
+        if ($this->position >= count($this->rows)) {
+            return false;
+        }
+        return $this->rows[$this->position++];
+    }
+
+    /**
+     * Returns all remaining rows from the result set.
+     *
+     * @param int $mode Fetch mode. Supports FETCH_ASSOC (default) and FETCH_COLUMN.
+     * @return array
+     */
+    public function fetchAll($mode = PDO::FETCH_ASSOC)
+    {
+        $remaining = array_slice($this->rows, $this->position);
+        $this->position = count($this->rows);
+
+        if ($mode === PDO::FETCH_COLUMN) {
+            return array_map(function ($row) {
+                return reset($row);
+            }, $remaining);
+        }
+
+        return $remaining;
+    }
+
+    /**
+     * Returns a single column from the next row.
+     *
+     * @param int $column_number 0-indexed column number.
+     * @return mixed|false The column value, or false if no more rows.
+     */
+    public function fetchColumn(int $column_number = 0)
+    {
+        $row = $this->fetch();
+        if ($row === false) {
+            return false;
+        }
+        $values = array_values($row);
+        return $values[$column_number] ?? false;
+    }
+
+    /**
+     * Binds a value to a named or positional parameter.
+     *
+     * This is a no-op stub — parameters are substituted inline during
+     * execute(). The method exists so that call sites like
+     * $stmt->bindValue(':name', $val, PDO::PARAM_STR) don't fatal.
+     */
+    public function bindValue($parameter, $value, int $type = PDO::PARAM_STR): bool
+    {
+        // Store for use during execute() — but our execute() takes params
+        // directly, so we stash them here and merge in execute().
+        if (!isset($this->bound_params)) {
+            $this->bound_params = [];
+        }
+        $this->bound_params[$parameter] = $value;
+        return true;
+    }
+
+    /** @var array|null Parameters bound via bindValue(). */
+    private $bound_params = null;
+}

--- a/wordpress-plugin/generic/export.php
+++ b/wordpress-plugin/generic/export.php
@@ -205,6 +205,7 @@ function find_wp_config_paths(array $roots): array
  */
 function resolve_db_credentials(): array
 {
+    $db_engine = defined("DB_ENGINE") ? DB_ENGINE : "mysql";
     $db_host = defined("DB_HOST") ? DB_HOST : getenv("DB_HOST");
     $db_name = defined("DB_NAME") ? DB_NAME : getenv("DB_NAME");
     $db_user = defined("DB_USER") ? DB_USER : getenv("DB_USER");
@@ -212,6 +213,22 @@ function resolve_db_credentials(): array
 
     $wp_config_path = null;
     $table_prefix = $GLOBALS['table_prefix'] ?? null;
+
+    // SQLite sites don't need MySQL host/user/password credentials.
+    // Only db_name matters (and even that is optional — defaults to 'wordpress').
+    if ($db_engine === "sqlite") {
+        $sqlite_path = defined("FQDB") ? FQDB : null;
+        return [
+            "db_engine" => "sqlite",
+            "db_host" => "",
+            "db_name" => $db_name ?: "wordpress",
+            "db_user" => "",
+            "db_password" => "",
+            "sqlite_path" => $sqlite_path,
+            "wp_config_path" => $wp_config_path,
+            "table_prefix" => $table_prefix,
+        ];
+    }
 
     $missing = [];
     if (!$db_host) { $missing[] = "db_host"; }
@@ -229,6 +246,7 @@ function resolve_db_credentials(): array
     }
 
     return [
+        "db_engine" => $db_engine,
         "db_host" => $db_host,
         "db_name" => $db_name,
         "db_user" => $db_user,
@@ -236,6 +254,58 @@ function resolve_db_credentials(): array
         "wp_config_path" => $wp_config_path,
         "table_prefix" => $table_prefix,
     ];
+}
+
+/**
+ * Creates a database connection appropriate for the detected backend.
+ *
+ * For MySQL and HyperDB sites, returns a standard PDO connection.
+ * For SQLite sites, returns a SqliteDriverPDO adapter that routes
+ * MySQL queries through the sqlite-database-integration plugin's
+ * WP_SQLite_Driver, which translates them to SQLite on the fly.
+ *
+ * The output format is always the same: MySQL SQL. The SQLite driver
+ * translates on read so MySQLDumpProducer sees MySQL-shaped results,
+ * and the dump it produces is valid MySQL.
+ *
+ * @param array $creds   Credentials from resolve_db_credentials().
+ * @param array $options PDO options (only used for MySQL connections).
+ * @return PDO A real PDO for MySQL/HyperDB, or a PDO-compatible adapter for SQLite.
+ */
+function create_db_connection(array $creds, array $options = [])
+{
+    $engine = $creds["db_engine"] ?? "mysql";
+
+    if ($engine === "sqlite") {
+        require_once __DIR__ . "/class-sqlite-driver-pdo.php";
+        require_once __DIR__ . "/sqlite-bootstrap.php";
+
+        $sqlite_path = $creds["sqlite_path"] ?? null;
+        if ($sqlite_path === null) {
+            throw new RuntimeException(
+                "SQLite database path not configured. " .
+                "Define FQDB or DB_DIR/DB_FILE in wp-config.php."
+            );
+        }
+
+        /** @phpstan-ignore function.notFound (defined in sqlite-bootstrap.php, excluded from analysis) */
+        return create_sqlite_connection($sqlite_path);
+    }
+
+    // MySQL path — works for both standard MySQL and HyperDB.
+    // HyperDB sites have DB_HOST/DB_NAME/DB_USER/DB_PASSWORD pointing
+    // to the write master, which is exactly what we want for export.
+    $default_options = [
+        PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+    ];
+    $merged_options = $options + $default_options;
+
+    return new PDO(
+        "mysql:host={$creds['db_host']};dbname={$creds['db_name']};charset=utf8mb4",
+        $creds["db_user"],
+        $creds["db_password"],
+        $merged_options,
+    );
 }
 
 require_once __DIR__ . "/utils.php";
@@ -663,10 +733,6 @@ function endpoint_sql_chunk(
 ): array {
     prepare_streaming_response();
     $creds = resolve_db_credentials();
-    $db_host = $creds["db_host"];
-    $db_name = $creds["db_name"];
-    $db_user = $creds["db_user"];
-    $db_password = $creds["db_password"];
 
     // -- Parse request parameters --
     $fragments_per_batch = $config["fragments_per_batch"] ?? 1000;
@@ -677,25 +743,11 @@ function endpoint_sql_chunk(
         10000,
     );
 
-    $pdo_options = [
-        PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
-    ];
+    $pdo_options = [];
     if (!empty($config["db_unbuffered"])) {
         $pdo_options[PDO::MYSQL_ATTR_USE_BUFFERED_QUERY] = false;
     }
-    /**
-     * Use a separate connection to avoid going through any $wpdb
-     * hooks. Granted, this will fail on sites using the
-     * sqlite-database-integration plugin. Once that plugin exposes
-     * a PDO-compatible interface, we'll be able to easily support
-     * both.
-     */
-    $mysql = new PDO(
-        "mysql:host={$db_host};dbname={$db_name};charset=utf8mb4",
-        $db_user,
-        $db_password,
-        $pdo_options,
-    );
+    $mysql = create_db_connection($creds, $pdo_options);
 
     $producer_options = [
         "create_table_query" => $config["create_table_query"] ?? true,
@@ -884,10 +936,6 @@ function endpoint_db_index(
     prepare_streaming_response();
 
     $creds = resolve_db_credentials();
-    $db_host = $creds["db_host"];
-    $db_name = $creds["db_name"];
-    $db_user = $creds["db_user"];
-    $db_password = $creds["db_password"];
 
     $tables_per_batch = $config["tables_per_batch"] ?? 1000;
     $tables_per_batch = require_int_range(
@@ -908,12 +956,7 @@ function endpoint_db_index(
     }
     $last_table = $cursor["last_table"] ?? "";
 
-    $mysql = new PDO(
-        "mysql:host={$db_host};dbname={$db_name};charset=utf8mb4",
-        $db_user,
-        $db_password,
-        [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION],
-    );
+    $mysql = create_db_connection($creds);
 
     ['gz' => $gz, 'boundary' => $boundary] = begin_multipart_stream();
 
@@ -1358,6 +1401,7 @@ function endpoint_preflight(array $config): array
     // If WordPress is loadable, also read options like active_plugins,
     // theme, siteurl, multisite config, and WP constants.
     $db = [
+        "db_engine" => defined("DB_ENGINE") ? DB_ENGINE : "mysql",
         "credentials_found" => false,
         "connected" => false,
         "can_query" => false,
@@ -1404,26 +1448,24 @@ function endpoint_preflight(array $config): array
     $db["wp"]["wp_load_loaded"] = function_exists("get_option");
 
     $creds = null;
+    $db_engine = defined("DB_ENGINE") ? DB_ENGINE : "mysql";
     try {
         $creds = resolve_db_credentials();
         $db["wp"]["wp_config_path"] = $creds["wp_config_path"];
         $db["wp"]["table_prefix"] = $creds["table_prefix"];
+        $db["db_engine"] = $creds["db_engine"] ?? $db_engine;
         $db["credentials_found"] = true;
     } catch (InvalidArgumentException $e) {
         $db["error"] = $e->getMessage();
     }
 
     if ($creds !== null) {
-        if (!extension_loaded("pdo_mysql")) {
-            $db["error"] = "pdo_mysql extension not loaded";
+        $required_ext = ($creds["db_engine"] ?? "mysql") === "sqlite" ? "pdo_sqlite" : "pdo_mysql";
+        if (!extension_loaded($required_ext)) {
+            $db["error"] = "{$required_ext} extension not loaded";
         } else {
             try {
-                $mysql = new PDO(
-                    "mysql:host={$creds['db_host']};dbname={$creds['db_name']};charset=utf8mb4",
-                    $creds["db_user"],
-                    $creds["db_password"],
-                    [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION],
-                );
+                $mysql = create_db_connection($creds);
                 $db["connected"] = true;
 
                 $version = $mysql->query("SELECT VERSION()")->fetchColumn();
@@ -1688,35 +1730,43 @@ function endpoint_preflight(array $config): array
                     }
                 }
 
-                $vars = $mysql
-                    ->query(
-                        "SELECT @@character_set_database AS db_charset, " .
-                            "@@collation_database AS db_collation, " .
-                            "@@character_set_server AS server_charset, " .
-                            "@@collation_server AS server_collation, " .
-                            "@@character_set_connection AS connection_charset, " .
-                            "@@collation_connection AS connection_collation, " .
-                            "@@max_allowed_packet AS max_allowed_packet, " .
-                            "@@sql_mode AS sql_mode, " .
-                            "@@lower_case_table_names AS lower_case_table_names",
-                    )
-                    ->fetch(PDO::FETCH_ASSOC);
-                if (is_array($vars)) {
-                    $db["db_charset"] = $vars["db_charset"] ?? null;
-                    $db["db_collation"] = $vars["db_collation"] ?? null;
-                    $db["server_charset"] = $vars["server_charset"] ?? null;
-                    $db["server_collation"] = $vars["server_collation"] ?? null;
-                    $db["connection_charset"] = $vars["connection_charset"] ?? null;
-                    $db["connection_collation"] = $vars["connection_collation"] ?? null;
-                    $db["max_allowed_packet"] = isset($vars["max_allowed_packet"])
-                        ? (int) $vars["max_allowed_packet"]
-                        : null;
-                    $db["sql_mode"] = $vars["sql_mode"] ?? null;
-                    $db["lower_case_table_names"] = isset(
-                        $vars["lower_case_table_names"],
-                    )
-                        ? (int) $vars["lower_case_table_names"]
-                        : null;
+                // MySQL server variables — these don't apply to SQLite,
+                // so wrap in a separate try/catch to avoid losing WP data
+                // gathered earlier if the query fails.
+                try {
+                    $vars = $mysql
+                        ->query(
+                            "SELECT @@character_set_database AS db_charset, " .
+                                "@@collation_database AS db_collation, " .
+                                "@@character_set_server AS server_charset, " .
+                                "@@collation_server AS server_collation, " .
+                                "@@character_set_connection AS connection_charset, " .
+                                "@@collation_connection AS connection_collation, " .
+                                "@@max_allowed_packet AS max_allowed_packet, " .
+                                "@@sql_mode AS sql_mode, " .
+                                "@@lower_case_table_names AS lower_case_table_names",
+                        )
+                        ->fetch(PDO::FETCH_ASSOC);
+                    if (is_array($vars)) {
+                        $db["db_charset"] = $vars["db_charset"] ?? null;
+                        $db["db_collation"] = $vars["db_collation"] ?? null;
+                        $db["server_charset"] = $vars["server_charset"] ?? null;
+                        $db["server_collation"] = $vars["server_collation"] ?? null;
+                        $db["connection_charset"] = $vars["connection_charset"] ?? null;
+                        $db["connection_collation"] = $vars["connection_collation"] ?? null;
+                        $db["max_allowed_packet"] = isset($vars["max_allowed_packet"])
+                            ? (int) $vars["max_allowed_packet"]
+                            : null;
+                        $db["sql_mode"] = $vars["sql_mode"] ?? null;
+                        $db["lower_case_table_names"] = isset(
+                            $vars["lower_case_table_names"],
+                        )
+                            ? (int) $vars["lower_case_table_names"]
+                            : null;
+                    }
+                } catch (Exception $e) {
+                    // Expected for SQLite — these MySQL system variables
+                    // don't exist. The null defaults are correct.
                 }
 
                 try {

--- a/wordpress-plugin/generic/sqlite-bootstrap.php
+++ b/wordpress-plugin/generic/sqlite-bootstrap.php
@@ -1,0 +1,231 @@
+<?php
+/**
+ * Bootstrap loader for the sqlite-database-integration plugin.
+ *
+ * Locates the plugin, includes its class files, polyfills the WordPress
+ * hooks it needs (do_action, apply_filters), creates a WP_SQLite_Driver
+ * instance, and wraps it in a SqliteDriverPDO adapter that MySQLDumpProducer
+ * can use as if it were a regular PDO connection.
+ *
+ * This file is only loaded when DB_ENGINE === 'sqlite'.
+ */
+
+/**
+ * Creates a SqliteDriverPDO wrapping a WP_SQLite_Driver for the given
+ * database file path.
+ *
+ * @param string $sqlite_path Full path to the .sqlite database file
+ *                            (e.g. /var/www/wp-content/database/.ht.sqlite).
+ * @return SqliteDriverPDO
+ * @throws RuntimeException If the plugin can't be found or the file doesn't exist.
+ */
+function create_sqlite_connection(string $sqlite_path): SqliteDriverPDO
+{
+    if (!file_exists($sqlite_path)) {
+        throw new RuntimeException(
+            "SQLite database file not found: {$sqlite_path}"
+        );
+    }
+
+    $plugin_root = find_sqlite_plugin_root();
+    if ($plugin_root === null) {
+        throw new RuntimeException(
+            "sqlite-database-integration plugin not found. " .
+            "Searched wp-content/plugins/, wp-content/mu-plugins/, and wp-includes/sqlite-ast/."
+        );
+    }
+
+    load_sqlite_plugin_classes($plugin_root);
+    polyfill_wordpress_hooks();
+
+    // Create the raw SQLite PDO connection.
+    $raw_pdo = new PDO("sqlite:{$sqlite_path}");
+    $raw_pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+    // WP_SQLite_Connection wraps the raw PDO.
+    $connection = new WP_SQLite_Connection([
+        'path' => $sqlite_path,
+        'pdo'  => $raw_pdo,
+    ]);
+
+    // WP_SQLite_Driver needs a database name — use 'wordpress' as a
+    // conventional default. The actual database name doesn't matter for
+    // export purposes since SQLite doesn't have named databases the way
+    // MySQL does, but the driver uses it for INFORMATION_SCHEMA queries.
+    $db_name = defined('DB_NAME') ? DB_NAME : 'wordpress';
+
+    // Provide a minimal $wpdb stub if WordPress isn't loaded, because
+    // WP_SQLite_Configurator calls $GLOBALS['wpdb']->set_prefix().
+    if (!isset($GLOBALS['wpdb'])) {
+        $GLOBALS['wpdb'] = new class() {
+            public function set_prefix(string $prefix): void {}
+        };
+    }
+
+    $driver = new WP_SQLite_Driver($connection, $db_name);
+
+    return new SqliteDriverPDO($driver, $raw_pdo);
+}
+
+/**
+ * Locates the sqlite-database-integration plugin root directory.
+ *
+ * Searches in order:
+ *   1. {wp_root}/wp-content/plugins/sqlite-database-integration/
+ *   2. {wp_root}/wp-content/mu-plugins/sqlite-database-integration/
+ *   3. {wp_root}/wp-includes/sqlite-ast/ (future core merge)
+ *
+ * The plugin root is identified by the presence of version.php (plugins)
+ * or class-wp-sqlite-driver.php (core merge).
+ */
+function find_sqlite_plugin_root(): ?string
+{
+    // Determine the WordPress root — walk up from this plugin's directory
+    // (generic/ → wordpress-plugin/ → wp-content/plugins/site-export/ → wp-content/ → wp-root)
+    // or use the directory constant if set.
+    $wp_root = null;
+    if (defined('ABSPATH')) {
+        $wp_root = rtrim(ABSPATH, '/');
+    } else {
+        // Walk up from __DIR__ looking for wp-config.php
+        $dir = __DIR__;
+        for ($i = 0; $i < 10; $i++) {
+            if (file_exists($dir . '/wp-config.php')) {
+                $wp_root = $dir;
+                break;
+            }
+            $parent = dirname($dir);
+            if ($parent === $dir) {
+                break;
+            }
+            $dir = $parent;
+        }
+    }
+
+    if ($wp_root === null) {
+        return null;
+    }
+
+    // Check plugin locations in order of likelihood.
+    $candidates = [
+        $wp_root . '/wp-content/plugins/sqlite-database-integration',
+        $wp_root . '/wp-content/mu-plugins/sqlite-database-integration',
+    ];
+
+    foreach ($candidates as $candidate) {
+        if (is_dir($candidate) && file_exists($candidate . '/version.php')) {
+            return $candidate;
+        }
+    }
+
+    // Future core merge location — the classes live directly in wp-includes/.
+    // Check for the driver class file as the sentinel.
+    $core_path = $wp_root . '/wp-includes/sqlite-ast';
+    if (is_dir($core_path) && file_exists($core_path . '/class-wp-sqlite-driver.php')) {
+        return $wp_root; // Return wp_root; load_sqlite_plugin_classes handles the layout.
+    }
+
+    return null;
+}
+
+/**
+ * Includes all the class files that WP_SQLite_Driver depends on.
+ *
+ * The include order follows the plugin's own test bootstrap — parser
+ * infrastructure first, then MySQL lexer/parser, then SQLite translation,
+ * then the connection/driver layer.
+ */
+function load_sqlite_plugin_classes(string $plugin_root): void
+{
+    // Determine whether this is the plugin layout or the core merge layout.
+    // Plugin layout: all files under $plugin_root/wp-includes/...
+    // Core layout: files directly under $wp_root/wp-includes/...
+    $includes_base = $plugin_root . '/wp-includes';
+    if (!is_dir($includes_base . '/parser') && !is_dir($includes_base . '/sqlite-ast')) {
+        // Might be the wp_root itself (core merge) — try wp-includes directly.
+        $includes_base = $plugin_root . '/wp-includes';
+    }
+
+    // Load version constant if available.
+    $version_file = $plugin_root . '/version.php';
+    if (file_exists($version_file)) {
+        require_once $version_file;
+    }
+
+    // Load PHP polyfills (str_starts_with, str_contains, etc. for PHP < 8.0).
+    $polyfills_file = $plugin_root . '/php-polyfills.php';
+    if (file_exists($polyfills_file)) {
+        require_once $polyfills_file;
+    }
+
+    // 1. Parser infrastructure
+    $parser_files = [
+        $includes_base . '/parser/class-wp-parser-grammar.php',
+        $includes_base . '/parser/class-wp-parser.php',
+        $includes_base . '/parser/class-wp-parser-node.php',
+        $includes_base . '/parser/class-wp-parser-token.php',
+    ];
+
+    // 2. MySQL parsing
+    $mysql_files = [
+        $includes_base . '/mysql/class-wp-mysql-token.php',
+        $includes_base . '/mysql/class-wp-mysql-lexer.php',
+        $includes_base . '/mysql/class-wp-mysql-parser.php',
+    ];
+
+    // 3. SQLite translation
+    $sqlite_files = [
+        $includes_base . '/sqlite/class-wp-sqlite-query-rewriter.php',
+        $includes_base . '/sqlite/class-wp-sqlite-lexer.php',
+        $includes_base . '/sqlite/class-wp-sqlite-token.php',
+        $includes_base . '/sqlite/class-wp-sqlite-pdo-user-defined-functions.php',
+        $includes_base . '/sqlite/class-wp-sqlite-translator.php',
+    ];
+
+    // 4. Connection and driver
+    $driver_files = [
+        $includes_base . '/sqlite-ast/class-wp-sqlite-connection.php',
+        $includes_base . '/sqlite-ast/class-wp-sqlite-configurator.php',
+        $includes_base . '/sqlite-ast/class-wp-sqlite-driver.php',
+        $includes_base . '/sqlite-ast/class-wp-sqlite-driver-exception.php',
+        $includes_base . '/sqlite-ast/class-wp-sqlite-information-schema-builder.php',
+        $includes_base . '/sqlite-ast/class-wp-sqlite-information-schema-exception.php',
+        $includes_base . '/sqlite-ast/class-wp-sqlite-information-schema-reconstructor.php',
+    ];
+
+    $all_files = array_merge($parser_files, $mysql_files, $sqlite_files, $driver_files);
+
+    foreach ($all_files as $file) {
+        if (file_exists($file)) {
+            require_once $file;
+        }
+    }
+
+    // Verify the critical class is available.
+    if (!class_exists('WP_SQLite_Driver')) {
+        throw new RuntimeException(
+            "WP_SQLite_Driver class not found after loading plugin files from {$plugin_root}. " .
+            "The sqlite-database-integration plugin may be an incompatible version."
+        );
+    }
+}
+
+/**
+ * Defines do_action() and apply_filters() stubs if WordPress isn't loaded.
+ *
+ * WP_SQLite_Driver and its dependencies call these hooks. Outside of
+ * WordPress they need to be no-ops. apply_filters() must return its
+ * second argument (the unfiltered value) to preserve correct behavior.
+ */
+function polyfill_wordpress_hooks(): void
+{
+    if (!function_exists('do_action')) {
+        function do_action() {}
+    }
+
+    if (!function_exists('apply_filters')) {
+        function apply_filters($tag, $value, ...$args) {
+            return $value;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

The export system has been hardcoded to MySQL — three call sites created `new PDO("mysql:...")` directly, and `resolve_db_credentials()` required MySQL-specific constants. SQLite-powered WordPress sites couldn't export at all.

This introduces a `create_db_connection()` factory that detects the database backend and returns the right connection. For SQLite, queries go through the `sqlite-database-integration` plugin's `WP_SQLite_Driver` wrapped in a thin PDO adapter. For HyperDB, the wp-config.php credentials already point to the write master, so the MySQL path works as-is. The output format stays the same — always valid MySQL SQL.

**Detection** happens in `api.php` by reading `wp-content/db.php` (contains "sqlite" → SQLite, "hyperdb" → HyperDB) and wp-config.php constants (`DB_ENGINE`, `DB_DIR`, `DB_FILE`).

**New files:**
- `class-sqlite-driver-pdo.php` — `SqliteDriverPDO` + `SqliteDriverPDOStatement`, a PDO-compatible adapter wrapping `WP_SQLite_Driver`
- `sqlite-bootstrap.php` — locates the plugin, includes its class files, polyfills `do_action`/`apply_filters`, wires up the driver

**Key changes to existing files:**
- `export.php` — new `create_db_connection()` factory replaces three inline PDO constructions; `resolve_db_credentials()` relaxed for SQLite (no host/user/password needed); preflight checks `pdo_sqlite` extension for SQLite sites and reports `db_engine`; MySQL `@@variable` queries wrapped in their own try/catch for graceful degradation
- `class-mysql-dump-producer.php` — PDO type hint removed from constructor to accept the duck-typed adapter
- `api.php` — extracts `DB_ENGINE`/`DB_DIR`/`DB_FILE` from wp-config.php, inspects `db.php` drop-in for backend detection

## Test plan

- [x] All 254 existing tests pass (`composer test`)
- [x] PHPStan analysis clean (`composer analyze`)
- [ ] Deploy to a SQLite WordPress site, trigger export, verify dump contains valid MySQL `CREATE TABLE` + `INSERT` statements
- [ ] Import the SQLite-exported dump into MySQL and compare row counts
- [ ] Verify standard MySQL export still works unchanged