### PR TITLE
Add protocol version compatibility check

### DIFF
--- a/importer/import.php
+++ b/importer/import.php
@@ -15,6 +15,11 @@ ini_set("display_startup_errors", 1);
 
 require_once __DIR__ . "/../wordpress-plugin/generic/utils.php";
 
+// Protocol version for compatibility checks between export plugin and importer.
+// Increment IMPORT_PROTOCOL_VERSION on any breaking wire-protocol change.
+define('IMPORT_PROTOCOL_VERSION', 1);
+define('IMPORT_PROTOCOL_MIN_VERSION', 1);
+
 register_shutdown_function(function () {
     $error = error_get_last();
     if ($error === null) {
@@ -1474,6 +1479,14 @@ class ImportClient
             $this->state["version"] = $wp_version;
         }
 
+        // Store remote protocol version for compatibility checks
+        if (isset($payload["protocol_version"])) {
+            $this->state["remote_protocol_version"] = (int) $payload["protocol_version"];
+        }
+        if (isset($payload["protocol_min_version"])) {
+            $this->state["remote_protocol_min_version"] = (int) $payload["protocol_min_version"];
+        }
+
         $this->save_state($this->state);
 
         $this->audit_log(
@@ -1588,7 +1601,32 @@ class ImportClient
             $all_pass = false;
         }
 
-        // 3. Filesystem accessible
+        // 3. Protocol version compatibility
+        $remote_ver = $this->state["remote_protocol_version"] ?? null;
+        $remote_min = $this->state["remote_protocol_min_version"] ?? null;
+        if ($remote_ver === null) {
+            $proto_ok = false;
+            $proto_detail = "Remote export plugin does not report a protocol version. Update the export plugin.";
+        } elseif ($remote_ver < IMPORT_PROTOCOL_MIN_VERSION) {
+            $proto_ok = false;
+            $proto_detail = "Remote protocol v{$remote_ver} is too old (client requires >= v" . IMPORT_PROTOCOL_MIN_VERSION . "). Update the export plugin.";
+        } elseif (IMPORT_PROTOCOL_VERSION < $remote_min) {
+            $proto_ok = false;
+            $proto_detail = "Client protocol v" . IMPORT_PROTOCOL_VERSION . " is too old (remote requires >= v{$remote_min}). Update the importer.";
+        } else {
+            $proto_ok = true;
+            $proto_detail = "remote v{$remote_ver}, client v" . IMPORT_PROTOCOL_VERSION;
+        }
+        $checks[] = [
+            "label" => "Protocol compatible",
+            "pass" => $proto_ok,
+            "detail" => $proto_detail,
+        ];
+        if (!$proto_ok) {
+            $all_pass = false;
+        }
+
+        // 4. Filesystem accessible
         $fs = $data["filesystem"] ?? null;
         $fs_ok = is_array($fs) && !empty($fs["ok"]);
         $checks[] = [
@@ -1602,14 +1640,14 @@ class ImportClient
             $all_pass = false;
         }
 
-        // 4. Database accessible
+        // 5. Database accessible
         $db = $data["database"] ?? null;
         $db_ok = is_array($db) && !empty($db["connected"]);
         $checks[] = [
             "label" => "Database accessible",
             "pass" => $db_ok,
             "detail" => $db_ok
-                ? ($db["server_version"] ?? "connected")
+                ? ($db["version"] ?? "connected")
                 : ($db["error"] ?? "database check failed"),
         ];
         if (!$db_ok) {

--- a/importer/import.php
+++ b/importer/import.php
@@ -15,10 +15,30 @@ ini_set("display_startup_errors", 1);
 
 require_once __DIR__ . "/../wordpress-plugin/generic/utils.php";
 
-// Protocol version for compatibility checks between export plugin and importer.
-// Increment IMPORT_PROTOCOL_VERSION on any breaking wire-protocol change.
+/**
+ * The wire-protocol version this importer speaks.
+ *
+ * Both the export plugin (server) and the importer (client) are deployed
+ * independently.  These two constants let them detect incompatibility at
+ * preflight time instead of producing silent corruption.
+ *
+ * Bump this whenever a change to the wire protocol (cursor encoding,
+ * multipart structure, header names, endpoint parameters, response format)
+ * would break an older export plugin.
+ */
 define('IMPORT_PROTOCOL_VERSION', 1);
-define('IMPORT_PROTOCOL_MIN_VERSION', 1);
+
+/**
+ * The oldest *export plugin* protocol version this importer can talk to.
+ *
+ * During preflight-assert the importer checks that the remote's
+ * protocol_version is >= this value; if not, it tells the user to
+ * update the export plugin.
+ *
+ * Raise this when you drop backward-compatibility with old export plugins.
+ * Keep it equal to IMPORT_PROTOCOL_VERSION if no backward compat is needed.
+ */
+define('IMPORT_MIN_EXPORT_VERSION', 1);
 
 register_shutdown_function(function () {
     $error = error_get_last();
@@ -1607,9 +1627,9 @@ class ImportClient
         if ($remote_ver === null) {
             $proto_ok = false;
             $proto_detail = "Remote export plugin does not report a protocol version. Update the export plugin.";
-        } elseif ($remote_ver < IMPORT_PROTOCOL_MIN_VERSION) {
+        } elseif ($remote_ver < IMPORT_MIN_EXPORT_VERSION) {
             $proto_ok = false;
-            $proto_detail = "Remote protocol v{$remote_ver} is too old (client requires >= v" . IMPORT_PROTOCOL_MIN_VERSION . "). Update the export plugin.";
+            $proto_detail = "Remote protocol v{$remote_ver} is too old (client requires >= v" . IMPORT_MIN_EXPORT_VERSION . "). Update the export plugin.";
         } elseif (IMPORT_PROTOCOL_VERSION < $remote_min) {
             $proto_ok = false;
             $proto_detail = "Client protocol v" . IMPORT_PROTOCOL_VERSION . " is too old (remote requires >= v{$remote_min}). Update the importer.";

--- a/importer/import.php
+++ b/importer/import.php
@@ -5650,6 +5650,8 @@ class ImportClient
             "cursor" => null,
             "stage" => null,
             "preflight" => null,
+            "remote_protocol_version" => null,
+            "remote_protocol_min_version" => null,
             "version" => null,
             "follow_symlinks" => false,
             "max_allowed_packet" => null,

--- a/tests/e2e/tests/import-21-preflight.test.js
+++ b/tests/e2e/tests/import-21-preflight.test.js
@@ -28,6 +28,14 @@ describe('Import: Preflight Endpoint', () => {
         assert.ok(preflight.ok, `Expected ok=true, got error: ${preflight.error}`);
     });
 
+    it('reports protocol version', () => {
+        assert.ok(Number.isInteger(preflight.protocol_version), `Expected integer protocol_version, got ${typeof preflight.protocol_version}`);
+        assert.ok(preflight.protocol_version >= 1, `Expected protocol_version >= 1, got ${preflight.protocol_version}`);
+        assert.ok(Number.isInteger(preflight.protocol_min_version), `Expected integer protocol_min_version, got ${typeof preflight.protocol_min_version}`);
+        assert.ok(preflight.protocol_min_version >= 1, `Expected protocol_min_version >= 1, got ${preflight.protocol_min_version}`);
+        assert.ok(preflight.protocol_min_version <= preflight.protocol_version, 'Expected protocol_min_version <= protocol_version');
+    });
+
     it('detects WordPress installation', () => {
         assert.ok(preflight.wp_detect, 'Expected wp_detect in response');
         assert.ok(preflight.wp_detect.found, 'Expected WordPress to be found');

--- a/tests/e2e/tests/import-35-protocol-version-mismatch.test.js
+++ b/tests/e2e/tests/import-35-protocol-version-mismatch.test.js
@@ -1,0 +1,114 @@
+/**
+ * Test 35: Protocol Version Mismatch Detection
+ *
+ * Verifies that preflight-assert correctly detects incompatible protocol
+ * versions between the export plugin (remote) and the importer (client).
+ * Tests all three failure modes: remote too old, client too old, and
+ * remote not reporting a version at all.
+ */
+import { describe, it, beforeAll, afterAll, beforeEach } from 'vitest';
+import assert from 'node:assert/strict';
+import { readFileSync, writeFileSync, copyFileSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+    runImporter, createTempDir, cleanupTempDir,
+    getSiteUrl, getSiteSecret, getSiteDir,
+} from '../lib/test-helpers.js';
+import { ensureSite } from '../lib/site-setup.js';
+
+describe('Import: Protocol Version Mismatch', () => {
+    const site = 'basic';
+    let tempDir;
+    const stateFileName = '.import-state.json';
+
+    function importUrl() {
+        return `${getSiteUrl(site)}?directory=${getSiteDir(site)}`;
+    }
+
+    function stateFilePath() {
+        return join(tempDir, stateFileName);
+    }
+
+    function readState() {
+        return JSON.parse(readFileSync(stateFilePath(), 'utf-8'));
+    }
+
+    function writeState(state) {
+        writeFileSync(stateFilePath(), JSON.stringify(state, null, 2));
+    }
+
+    beforeAll(async () => {
+        await ensureSite(site);
+    });
+
+    beforeEach(() => {
+        // Fresh temp dir for each test so state doesn't leak between tests
+        tempDir = createTempDir('e2e-protocol-version');
+
+        // Run preflight to populate state
+        const result = runImporter(importUrl(), tempDir, 'preflight', {
+            secret: getSiteSecret(site),
+        });
+        assert.equal(result.exitCode, 0, `Preflight failed:\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);
+    });
+
+    afterAll(() => {
+        if (tempDir) cleanupTempDir(tempDir);
+    });
+
+    it('passes when versions are compatible', () => {
+        const result = runImporter(importUrl(), tempDir, 'preflight-assert', {
+            secret: getSiteSecret(site),
+        });
+
+        assert.equal(result.exitCode, 0, `Expected exit 0:\nstdout: ${result.stdout}`);
+        assert.ok(result.stdout.includes('[PASS] Protocol compatible'), `Expected PASS for protocol check:\n${result.stdout}`);
+        assert.match(result.stdout, /remote v\d+, client v\d+/);
+    });
+
+    it('fails when remote protocol version is too old', () => {
+        const state = readState();
+        state.remote_protocol_version = 0;
+        writeState(state);
+
+        const result = runImporter(importUrl(), tempDir, 'preflight-assert', {
+            secret: getSiteSecret(site),
+        });
+
+        assert.equal(result.exitCode, 1, `Expected exit 1:\nstdout: ${result.stdout}`);
+        assert.ok(result.stdout.includes('[FAIL] Protocol compatible'), `Expected FAIL for protocol check:\n${result.stdout}`);
+        assert.ok(result.stdout.includes('too old'), `Expected "too old" message:\n${result.stdout}`);
+        assert.ok(result.stdout.includes('Update the export plugin'), `Expected update instruction:\n${result.stdout}`);
+    });
+
+    it('fails when client protocol version is too old for remote', () => {
+        const state = readState();
+        state.remote_protocol_min_version = 999;
+        writeState(state);
+
+        const result = runImporter(importUrl(), tempDir, 'preflight-assert', {
+            secret: getSiteSecret(site),
+        });
+
+        assert.equal(result.exitCode, 1, `Expected exit 1:\nstdout: ${result.stdout}`);
+        assert.ok(result.stdout.includes('[FAIL] Protocol compatible'), `Expected FAIL for protocol check:\n${result.stdout}`);
+        assert.ok(result.stdout.includes('too old'), `Expected "too old" message:\n${result.stdout}`);
+        assert.ok(result.stdout.includes('Update the importer'), `Expected update instruction:\n${result.stdout}`);
+    });
+
+    it('fails when remote does not report a protocol version', () => {
+        const state = readState();
+        delete state.remote_protocol_version;
+        delete state.remote_protocol_min_version;
+        writeState(state);
+
+        const result = runImporter(importUrl(), tempDir, 'preflight-assert', {
+            secret: getSiteSecret(site),
+        });
+
+        assert.equal(result.exitCode, 1, `Expected exit 1:\nstdout: ${result.stdout}`);
+        assert.ok(result.stdout.includes('[FAIL] Protocol compatible'), `Expected FAIL for protocol check:\n${result.stdout}`);
+        assert.ok(result.stdout.includes('does not report a protocol version'), `Expected missing version message:\n${result.stdout}`);
+        assert.ok(result.stdout.includes('Update the export plugin'), `Expected update instruction:\n${result.stdout}`);
+    });
+});

--- a/wordpress-plugin/generic/export.php
+++ b/wordpress-plugin/generic/export.php
@@ -10,6 +10,11 @@ if (!ob_get_level()) {
 }
 
 
+// Protocol version for compatibility checks between export plugin and importer.
+// Increment EXPORT_PROTOCOL_VERSION on any breaking wire-protocol change.
+define('EXPORT_PROTOCOL_VERSION', 1);
+define('EXPORT_PROTOCOL_MIN_VERSION', 1);
+
 // File type mask + file type values (top bits of st_mode)
 define('STAT_TYPE_MASK',   0170000);
 define('STAT_TYPE_SOCKET', 0140000);
@@ -1866,6 +1871,8 @@ function endpoint_preflight(array $config): array
         "ok" => $ok,
         "error" => $preflight_error,
         "timestamp" => time(),
+        "protocol_version" => EXPORT_PROTOCOL_VERSION,
+        "protocol_min_version" => EXPORT_PROTOCOL_MIN_VERSION,
         "wp_detect" => [
             "found" => !empty($wp_detect["roots"]),
             "searched" => $wp_detect["searched"],

--- a/wordpress-plugin/generic/export.php
+++ b/wordpress-plugin/generic/export.php
@@ -10,10 +10,31 @@ if (!ob_get_level()) {
 }
 
 
-// Protocol version for compatibility checks between export plugin and importer.
-// Increment EXPORT_PROTOCOL_VERSION on any breaking wire-protocol change.
+/**
+ * The wire-protocol version this export plugin speaks.
+ *
+ * Both the export plugin (server) and the importer (client) are deployed
+ * independently.  These two constants let them detect incompatibility at
+ * preflight time instead of producing silent corruption.
+ *
+ * EXPORT_PROTOCOL_VERSION is sent to the importer in the preflight JSON
+ * response as `protocol_version`.  Bump it whenever a change to the wire
+ * protocol (cursor encoding, multipart structure, header names, endpoint
+ * parameters, response format) would break an older importer.
+ */
 define('EXPORT_PROTOCOL_VERSION', 1);
-define('EXPORT_PROTOCOL_MIN_VERSION', 1);
+
+/**
+ * The oldest *importer* protocol version this export plugin can talk to.
+ *
+ * Sent to the importer in the preflight response as `protocol_min_version`.
+ * The importer checks that its own IMPORT_PROTOCOL_VERSION is >= this value;
+ * if not, it tells the user to update the importer.
+ *
+ * Raise this when you drop backward-compatibility with old importers.
+ * Keep it equal to EXPORT_PROTOCOL_VERSION if no backward compat is needed.
+ */
+define('EXPORT_MIN_IMPORT_VERSION', 1);
 
 // File type mask + file type values (top bits of st_mode)
 define('STAT_TYPE_MASK',   0170000);
@@ -1872,7 +1893,7 @@ function endpoint_preflight(array $config): array
         "error" => $preflight_error,
         "timestamp" => time(),
         "protocol_version" => EXPORT_PROTOCOL_VERSION,
-        "protocol_min_version" => EXPORT_PROTOCOL_MIN_VERSION,
+        "protocol_min_version" => EXPORT_MIN_IMPORT_VERSION,
         "wp_detect" => [
             "found" => !empty($wp_detect["roots"]),
             "searched" => $wp_detect["searched"],


### PR DESCRIPTION
## Summary

- Adds `PROTOCOL_VERSION` and `PROTOCOL_MIN_VERSION` constants to both the export plugin and importer, starting at `1`
- Export plugin includes `protocol_version` and `protocol_min_version` in the preflight JSON response
- Importer's `preflight-assert` validates version compatibility: remote not too old for client, client not too old for remote, and fails clearly if the remote doesn't report a version at all
- Fixes existing bug where `preflight-assert` read `$db["server_version"]` instead of the correct `$db["version"]` field
- Adds E2E test verifying the preflight response contains valid protocol version fields

## Test plan

- [x] `composer test -- --filter BuildPdoDsnTest` passes (14/14)
- [x] `npx vitest run tests/import-21-preflight.test.js` passes (10/10, including new protocol version test)
- [x] Full E2E suite passes (208/211, 3 failures are a pre-existing flaky test unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)