### PR TITLE
Split <local-path> into --state-dir and --docroot

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,7 +94,7 @@ Override with environment variables if needed.
 
 ### Symlink Security
 
-Symlinks ARE automatically recreated during import. This is safe because all paths are relative to the import directory's `filesystem-root/`, preventing directory traversal outside it. Errors are logged to the audit log.
+Symlinks ARE automatically recreated during import. This is safe because all paths are relative to the `--docroot` directory, preventing directory traversal outside it. Errors are logged to the audit log.
 
 ### SQL Dump Batching
 
@@ -165,12 +165,14 @@ Always consult these when working on the respective components.
 
 ### Progress Computation
 
-Progress is computed client-side by reading state files:
+Progress is computed client-side by reading state files (all in `--state-dir`):
 - `.import-state.json`: Current command, status, cursor, stage
 - `.import-index.jsonl`: Local file index (line count = files indexed)
 - `.import-remote-index.jsonl`: Remote file index (for delta comparison)
 - `.import-download-list.jsonl`: Files pending download
-- `filesystem-root/`: Actual downloaded files (recursive size/count)
 - `db.sql`: SQL dump file size
+
+And from `--docroot`:
+- Actual downloaded files (recursive size/count)
 
 This keeps the protocol minimal while enabling rich progress visualization.

--- a/README.md
+++ b/README.md
@@ -48,16 +48,17 @@ All commands below use the same base invocation. We'll use `$URL` and `$DIR` as 
 
 ```bash
 URL="https://example.com/?site-export-api"
-DIR="./local-directory-where-all-the-files-will-be-created"
+STATE_DIR="./local-directory-where-the-migration-state-will-be-tracked"
+DOCROOT="./local-directory-where-the-remote-site-files-will-be-recreated"
 SECRET="your-shared-secret"
 ```
 
 #### Step 1 — Preflight.
 
-First, wel'l makes sure the server is reachable and the environment is in a good shape:
+First, we'll make sure the server is reachable and the environment is in a good shape:
 
 ```bash
-php importer/import.php preflight "$URL" --state-dir="$DIR" --docroot="$DIR/docroot" --secret="$SECRET"
+php importer/import.php preflight "$URL" --state-dir="$STATE_DIR" --docroot="$DOCROOT" --secret="$SECRET"
 ```
 
 The preflight contacts the export server and collects environment details: PHP/MySQL versions, memory limits, filesystem access, database connectivity, WordPress version, plugins, themes, and directory layout. The result is stored in `.import-state.json` under the `preflight` key.
@@ -68,7 +69,7 @@ To run very basic diagnostics that confirms the remote server replied and it has
 sound-looking filesystem and a database connection, run:
 
 ```bash
-php importer/import.php preflight-assert "$URL" --state-dir="$DIR" --docroot="$DIR/docroot" --secret="$SECRET"
+php importer/import.php preflight-assert "$URL" --state-dir="$STATE_DIR" --docroot="$DOCROOT" --secret="$SECRET"
 ```
 
 For hosting platform-specific checks, such as database version compatibility or
@@ -81,7 +82,7 @@ This first builds a full index of the remote directory tree, then streams every 
 It can be interrupted and resumed at any time — just re-run the same command:
 
 ```bash
-php importer/import.php files-sync "$URL" --state-dir="$DIR" --docroot="$DIR/docroot" --secret="$SECRET"
+php importer/import.php files-sync "$URL" --state-dir="$STATE_DIR" --docroot="$DOCROOT" --secret="$SECRET"
 ```
 
 The command returns one of three exit codes:
@@ -97,7 +98,7 @@ Which is to say, you'll need to wrap it in a loop that runs until failure or ful
 This streams a SQL dump into `db.sql`:
 
 ```bash
-php importer/import.php db-sync "$URL" --state-dir="$DIR" --docroot="$DIR/docroot" --secret="$SECRET"
+php importer/import.php db-sync "$URL" --state-dir="$STATE_DIR" --docroot="$DOCROOT" --secret="$SECRET"
 ```
 
 The command returns one of three exit codes:
@@ -114,7 +115,7 @@ First, we must abort the previous files-sync. Otherwise, it would just
 tell us it's completed and refuse to proceed:
 
 ```bash
-php importer/import.php files-sync "$URL" --state-dir="$DIR" --docroot="$DIR/docroot" --secret="$SECRET" --abort
+php importer/import.php files-sync "$URL" --state-dir="$STATE_DIR" --docroot="$DOCROOT" --secret="$SECRET" --abort
 ```
 
 From here, we can run the `files-sync` command again. It will index
@@ -122,7 +123,7 @@ the remote filesystem once again, compute which files have changed
 since the initial sync, and apply that delta in the local directory:
 
 ```bash
-php importer/import.php files-sync "$URL" --state-dir="$DIR" --docroot="$DIR/docroot" --secret="$SECRET"
+php importer/import.php files-sync "$URL" --state-dir="$STATE_DIR" --docroot="$DOCROOT" --secret="$SECRET"
 ```
 
 The command returns one of three exit codes:

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ SECRET="your-shared-secret"
 First, wel'l makes sure the server is reachable and the environment is in a good shape:
 
 ```bash
-php importer/import.php preflight "$URL" "$DIR" --secret="$SECRET"
+php importer/import.php preflight "$URL" --state-dir="$DIR" --docroot="$DIR/docroot" --secret="$SECRET"
 ```
 
 The preflight contacts the export server and collects environment details: PHP/MySQL versions, memory limits, filesystem access, database connectivity, WordPress version, plugins, themes, and directory layout. The result is stored in `.import-state.json` under the `preflight` key.
@@ -68,7 +68,7 @@ To run very basic diagnostics that confirms the remote server replied and it has
 sound-looking filesystem and a database connection, run:
 
 ```bash
-php importer/import.php preflight-assert "$URL" "$DIR" --secret="$SECRET"
+php importer/import.php preflight-assert "$URL" --state-dir="$DIR" --docroot="$DIR/docroot" --secret="$SECRET"
 ```
 
 For hosting platform-specific checks, such as database version compatibility or
@@ -81,7 +81,7 @@ This first builds a full index of the remote directory tree, then streams every 
 It can be interrupted and resumed at any time — just re-run the same command:
 
 ```bash
-php importer/import.php files-sync "$URL" "$DIR" --secret="$SECRET"
+php importer/import.php files-sync "$URL" --state-dir="$DIR" --docroot="$DIR/docroot" --secret="$SECRET"
 ```
 
 The command returns one of three exit codes:
@@ -97,7 +97,7 @@ Which is to say, you'll need to wrap it in a loop that runs until failure or ful
 This streams a SQL dump into `db.sql`:
 
 ```bash
-php importer/import.php db-sync "$URL" "$DIR" --secret="$SECRET"
+php importer/import.php db-sync "$URL" --state-dir="$DIR" --docroot="$DIR/docroot" --secret="$SECRET"
 ```
 
 The command returns one of three exit codes:
@@ -114,7 +114,7 @@ First, we must abort the previous files-sync. Otherwise, it would just
 tell us it's completed and refuse to proceed:
 
 ```bash
-php importer/import.php files-sync "$URL" "$DIR" --secret="$SECRET --abort"
+php importer/import.php files-sync "$URL" --state-dir="$DIR" --docroot="$DIR/docroot" --secret="$SECRET" --abort
 ```
 
 From here, we can run the `files-sync` command again. It will index
@@ -122,7 +122,7 @@ the remote filesystem once again, compute which files have changed
 since the initial sync, and apply that delta in the local directory:
 
 ```bash
-php importer/import.php files-sync "$URL" "$DIR" --secret="$SECRET"
+php importer/import.php files-sync "$URL" --state-dir="$DIR" --docroot="$DIR/docroot" --secret="$SECRET"
 ```
 
 The command returns one of three exit codes:
@@ -133,8 +133,8 @@ The command returns one of three exit codes:
 
 #### Shoehorning the site onto your platform
 
-You've got a copy of the remote files in `$DIR/filesystem-root/` and
-the database in `$DIR/db.sql`. From here, you need to figure out how
+You've got a copy of the remote files in the `--docroot` directory and
+the database in `--state-dir/db.sql`. From here, you need to figure out how
 to run that on your platform.
 
 The `db.sql` file will contain the relevant `DELETE TABLE IF EXISTS`
@@ -241,7 +241,7 @@ If the JSON is invalid on load, the importer renames it to
 
   // Crash recovery: if the importer dies mid-write, these let it
   // truncate the partially-written file back to its last good state.
-  "current_file": "filesystem-root/wp-content/uploads/photo.jpg",
+  "current_file": "wp-content/uploads/photo.jpg",
   "current_file_bytes": 1048576,  // expected size after last complete write
   "sql_bytes": 524288,            // expected db.sql size
 
@@ -300,7 +300,7 @@ This is useful for debugging but noisy for production use.
 The importer client (`import.php`) accepts the following commands:
 
 ```
-php importer/import.php <command> <URL> <local-path> [options]
+php importer/import.php <command> <URL> --state-dir=DIR --docroot=DIR [options]
 ```
 
 * `preflight` — Runs the preflight check and prints the full result as JSON. Exits with code 0 if OK, code 1 if not.
@@ -417,7 +417,7 @@ the **migration target** chooses how to handle it. A few choices are:
 
 Symlinks are automatically recreated during import. The importer receives symlink chunks from the
 export stream and calls `symlink()` to recreate them locally. This is safe because all paths are
-constrained to the import directory's `filesystem-root/`.
+constrained to the `--docroot` directory.
 
 Some symlinks may point to places on the remote filesystem that are
 outside of the requested directory root. When that happens, they're
@@ -425,7 +425,7 @@ not recreated unless you use the `--follow-symlinks` option.
 
 With the `--follow-symlinks`, the importer will create local
 symlinks even if they point ourside of the directory root. They're
-still constrained within the confines of the `filesystem-root/`
+still constrained within the confines of the `--docroot`
 
 ## Database synchronization
 

--- a/importer/import.php
+++ b/importer/import.php
@@ -796,8 +796,11 @@ class ImportClient
     /** @var string Export server URL. */
     private $remote_url;
 
-    /** @var string Local directory for all import artifacts (state files, filesystem-root/, db.sql, etc.). */
-    private $local_path;
+    /** @var string Directory for import state files (.import-state.json, db.sql, etc.). */
+    private $state_dir;
+
+    /** @var string Directory where downloaded site files are written (no filesystem-root/ wrapper). */
+    private $docroot;
 
     /** @var string Path to .import-state.json — persists command, cursor, stage across invocations. */
     private $state_file;
@@ -926,21 +929,22 @@ class ImportClient
      */
     public $exit_code = 0;
 
-    public function __construct(string $remote_url, string $local_path)
+    public function __construct(string $remote_url, string $state_dir, string $docroot)
     {
         $this->remote_url = rtrim($remote_url, "?&");
-        $this->local_path = rtrim($local_path, "/");
-        $this->state_file = $this->local_path . "/.import-state.json";
-        $this->index_file = $this->local_path . "/.import-index.jsonl";
+        $this->state_dir = rtrim($state_dir, "/");
+        $this->docroot = rtrim($docroot, "/");
+        $this->state_file = $this->state_dir . "/.import-state.json";
+        $this->index_file = $this->state_dir . "/.import-index.jsonl";
         $this->index_updates_file =
-            $this->local_path . "/.import-index-updates.jsonl";
+            $this->state_dir . "/.import-index-updates.jsonl";
         $this->remote_index_file =
-            $this->local_path . "/.import-remote-index.jsonl";
+            $this->state_dir . "/.import-remote-index.jsonl";
         $this->download_list_file =
-            $this->local_path . "/.import-download-list.jsonl";
-        $this->audit_log = $this->local_path . "/.import-audit.log";
-        $this->volatile_files_file = $this->local_path . "/.import-volatile-files.json";
-        $this->status_file = $this->local_path . "/.import-status.json";
+            $this->state_dir . "/.import-download-list.jsonl";
+        $this->audit_log = $this->state_dir . "/.import-audit.log";
+        $this->volatile_files_file = $this->state_dir . "/.import-volatile-files.json";
+        $this->status_file = $this->state_dir . "/.import-status.json";
 
         // Detect TTY for progress display
         $this->is_tty = function_exists("posix_isatty") && posix_isatty(STDOUT);
@@ -956,14 +960,14 @@ class ImportClient
         }
 
         // Create directories
-        if (!is_dir($this->local_path)) {
-            if (!mkdir($this->local_path, 0755, true)) {
-                throw new RuntimeException("Failed to create directory: {$this->local_path}");
+        if (!is_dir($this->state_dir)) {
+            if (!mkdir($this->state_dir, 0755, true)) {
+                throw new RuntimeException("Failed to create directory: {$this->state_dir}");
             }
         }
-        if (!is_dir($this->local_path . "/filesystem-root")) {
-            if (!mkdir($this->local_path . "/filesystem-root", 0755, true)) {
-                throw new RuntimeException("Failed to create directory: {$this->local_path}/filesystem-root");
+        if (!is_dir($this->docroot)) {
+            if (!mkdir($this->docroot, 0755, true)) {
+                throw new RuntimeException("Failed to create directory: {$this->docroot}");
             }
         }
     }
@@ -1407,14 +1411,14 @@ class ImportClient
                 $this->reset_state();
                 $this->save_state($this->state);
 
-                $sql_file = $this->local_path . "/db.sql";
+                $sql_file = $this->state_dir . "/db.sql";
                 if (file_exists($sql_file)) {
                     unlink($sql_file);
                     $this->audit_log(
                         "FILE DELETE | {$sql_file} | abort db-sync",
                     );
                 }
-                $tables_file = $this->local_path . "/db-tables.jsonl";
+                $tables_file = $this->state_dir . "/db-tables.jsonl";
                 if (file_exists($tables_file)) {
                     unlink($tables_file);
                     $this->audit_log(
@@ -1431,7 +1435,7 @@ class ImportClient
                 $this->reset_state();
                 $this->save_state($this->state);
 
-                $tables_file = $this->local_path . "/db-tables.jsonl";
+                $tables_file = $this->state_dir . "/db-tables.jsonl";
                 if (file_exists($tables_file)) {
                     unlink($tables_file);
                     $this->audit_log(
@@ -1847,9 +1851,8 @@ class ImportClient
             return;
         }
 
-        $filesystem_root = $this->local_path . "/filesystem-root";
         $is_empty =
-            !is_dir($filesystem_root) || count(scandir($filesystem_root)) <= 2; // only . and ..
+            !is_dir($this->docroot) || count(scandir($this->docroot)) <= 2; // only . and ..
 
         // Resuming an in-progress sync
         if ($has_progress) {
@@ -2389,8 +2392,8 @@ class ImportClient
      *
      * Since the server indexes everything under realpath()-resolved paths,
      * the files are already downloaded to the target location (e.g.
-     * filesystem-root/wordpress/...).  We just need to create the symlink
-     * (e.g. filesystem-root/srv/wordpress -> /wordpress) so the directory
+     * docroot/wordpress/...).  We just need to create the symlink
+     * (e.g. docroot/srv/wordpress -> /wordpress) so the directory
      * layout matches the server.
      */
     private function recreate_intermediate_symlinks(): void
@@ -2534,7 +2537,7 @@ class ImportClient
     private function run_db_sync(): void
     {
         $state_command = $this->state["command"] ?? null;
-        $sql_file = $this->local_path . "/db.sql";
+        $sql_file = $this->state_dir . "/db.sql";
 
         $has_progress =
             $state_command === "db-sync" &&
@@ -2644,7 +2647,7 @@ class ImportClient
     private function run_db_index(): void
     {
         $state_command = $this->state["command"] ?? null;
-        $tables_file = $this->local_path . "/db-tables.jsonl";
+        $tables_file = $this->state_dir . "/db-tables.jsonl";
 
         $has_cursor =
             $state_command === "db-index" &&
@@ -3455,7 +3458,7 @@ class ImportClient
     }
 
     /**
-     * Delete a local file path safely under filesystem-root.
+     * Delete a local file path safely under the docroot.
      */
     private function delete_local_file_path(string $path): void
     {
@@ -3909,7 +3912,7 @@ class ImportClient
     {
         $cursor = $this->state["cursor"] ?? null;
         $complete = false;
-        $sql_file = $this->local_path . "/db.sql";
+        $sql_file = $this->state_dir . "/db.sql";
 
         // Crash recovery: if SQL file is larger than expected, truncate it.
         // This happens if we crashed after writing but before saving the new cursor.
@@ -4078,7 +4081,7 @@ class ImportClient
     {
         $cursor = $this->state["cursor"] ?? null;
         $complete = false;
-        $tables_file = $this->local_path . "/db-tables.jsonl";
+        $tables_file = $this->state_dir . "/db-tables.jsonl";
 
         $stats = $this->state["db_index"] ?? [];
         $tables_written = (int) ($stats["tables"] ?? 0);
@@ -4269,23 +4272,22 @@ class ImportClient
     }
 
     /**
-     * Return canonical filesystem-root path, creating it if it doesn't exist.
+     * Return canonical docroot path, creating it if it doesn't exist.
      */
     private function get_filesystem_root_path(): string
     {
-        $filesystem_root_base = $this->local_path . "/filesystem-root";
-        if (!is_dir($filesystem_root_base)) {
-            if (!mkdir($filesystem_root_base, 0755, true) && !is_dir($filesystem_root_base)) {
+        if (!is_dir($this->docroot)) {
+            if (!mkdir($this->docroot, 0755, true) && !is_dir($this->docroot)) {
                 throw new RuntimeException(
-                    "Failed to create filesystem-root directory: {$filesystem_root_base}",
+                    "Failed to create docroot directory: {$this->docroot}",
                 );
             }
         }
 
-        $real = realpath($filesystem_root_base);
+        $real = realpath($this->docroot);
         if ($real === false) {
             throw new RuntimeException(
-                "Failed to resolve filesystem-root path: {$filesystem_root_base}",
+                "Failed to resolve docroot path: {$this->docroot}",
             );
         }
 
@@ -4294,12 +4296,12 @@ class ImportClient
 
 
     /**
-     * Resolve a remote absolute path into a local path under filesystem-root.
+     * Resolve a remote absolute path into a local path under the docroot.
      *
      * Maps a remote absolute path (e.g. "/wp-content/uploads/photo.jpg") to a
-     * local path under the import directory's filesystem-root/. Performs symlink
-     * traversal security checks to prevent directory traversal attacks that could
-     * write files outside the import root.
+     * local path under the import docroot. Performs symlink traversal security
+     * checks to prevent directory traversal attacks that could write files
+     * outside the import root.
      */
     private function remote_path_to_local_path_within_import_root(
         string $path
@@ -4507,7 +4509,7 @@ class ImportClient
      */
     private function ensure_directory_path(string $dir): void
     {
-        // Security: Ensure path is under filesystem-root
+        // Security: Ensure path is under the docroot
         $real_filesystem_root = $this->get_filesystem_root_path();
 
         // Resolve the target path (or what it would be)
@@ -4527,7 +4529,7 @@ class ImportClient
                 !path_is_within_root($real_check, $real_filesystem_root)
             ) {
                 throw new RuntimeException(
-                    "Security: Refusing to create directory outside filesystem-root: {$dir}",
+                    "Security: Refusing to create directory outside docroot: {$dir}",
                 );
             }
         }
@@ -4541,7 +4543,7 @@ class ImportClient
             !str_starts_with($dir, $real_filesystem_root . "/")
         ) {
             throw new RuntimeException(
-                "Security: Refusing to create directory outside filesystem-root: {$dir}",
+                "Security: Refusing to create directory outside docroot: {$dir}",
             );
         }
 
@@ -4599,7 +4601,7 @@ class ImportClient
             $resolved = realpath($current);
             if ($resolved === false || !path_is_within_root($resolved, $real_filesystem_root)) {
                 throw new RuntimeException(
-                    "Security: Refusing to create directory outside filesystem-root: {$current}",
+                    "Security: Refusing to create directory outside docroot: {$current}",
                 );
             }
         }
@@ -4812,7 +4814,7 @@ class ImportClient
             true,
         );
         if ($path !== "" && $is_file_error) {
-            $local_path = $this->local_path . "/filesystem-root" . $path;
+            $local_path = $this->docroot . $path;
             if ($context->file_handle && $context->file_path === $local_path) {
                 fclose($context->file_handle);
                 $context->file_handle = null;
@@ -6293,7 +6295,7 @@ if (
         "files-sync" => [
             "short" => "Sync files (auto-detects initial vs delta)",
             "detail" =>
-                "Streams files from the remote server into <local-path>/filesystem-root/.\n" .
+                "Streams files from the remote server into the --docroot directory.\n" .
                 "Auto-detects whether to run an initial or delta sync based on state:\n" .
                 "\n" .
                 "  - No prior sync: downloads the full directory tree (initial)\n" .
@@ -6307,7 +6309,7 @@ if (
                 "  --verbose, -v      Show detailed request/response logs\n" .
                 "\n" .
                 "Output files:\n" .
-                "  filesystem-root/              Downloaded files\n" .
+                "  (docroot)/                    Downloaded files\n" .
                 "  .import-index.jsonl           Local file index\n" .
                 "  .import-remote-index.jsonl    Remote index snapshot\n" .
                 "  .import-download-list.jsonl   Files pending download\n" .
@@ -6328,7 +6330,7 @@ if (
         "db-sync" => [
             "short" => "Download the database as a SQL dump",
             "detail" =>
-                "Streams the full database dump into <local-path>/db.sql.\n" .
+                "Streams the full database dump into --state-dir/db.sql.\n" .
                 "Automatically resumes from the last cursor if interrupted.\n" .
                 "\n" .
                 "Options:\n" .
@@ -6344,7 +6346,7 @@ if (
             "short" => "Index database tables and their statistics",
             "detail" =>
                 "Streams table metadata (name, estimated rows, data size) into\n" .
-                "<local-path>/db-tables.jsonl. Useful for planning and diagnostics.\n" .
+                "--state-dir/db-tables.jsonl. Useful for planning and diagnostics.\n" .
                 "\n" .
                 "Options:\n" .
                 "  --abort        Clear state and output, then exit\n" .
@@ -6387,7 +6389,7 @@ if (
 
     // Show main help when invoked with no arguments or just --help
     if ($argc < 2 || (isset($argv[1]) && in_array($argv[1], ["--help", "-h", "help"]))) {
-        echo "Usage: php import.php <command> <remote-url> <local-path> [options]\n";
+        echo "Usage: php import.php <command> <remote-url> --state-dir=DIR --docroot=DIR [options]\n";
         echo "\n";
         echo "Commands:\n";
         $max_len = max(array_map('strlen', array_keys($command_help)));
@@ -6396,6 +6398,10 @@ if (
         }
         echo "\n";
         echo "Run 'php import.php <command> --help' for command-specific help.\n";
+        echo "\n";
+        echo "Required options:\n";
+        echo "  --state-dir=DIR      Directory for import state files and SQL dumps\n";
+        echo "  --docroot=DIR        Directory where downloaded site files are written\n";
         echo "\n";
         echo "Global options:\n";
         echo "  --secret=TOKEN       HMAC shared secret for export API authentication\n";
@@ -6411,7 +6417,7 @@ if (
         echo "  2  Partial progress — run the same command again to continue\n";
         echo "  1  Error\n";
         echo "\n";
-        echo "State is stored in <local-path>/.import-state.json. Interrupted\n";
+        echo "State is stored in --state-dir/.import-state.json. Interrupted\n";
         echo "commands automatically resume. Use --abort to abort the current\n";
         echo "sync and exit — downloaded files are preserved.\n";
         exit(1);
@@ -6422,7 +6428,7 @@ if (
     // Per-command --help (can be requested before providing url/path)
     if (in_array("--help", array_slice($argv, 2)) || in_array("-h", array_slice($argv, 2))) {
         if (isset($command_help[$command])) {
-            echo "Usage: php import.php {$command} <remote-url> <local-path> [options]\n";
+            echo "Usage: php import.php {$command} <remote-url> --state-dir=DIR --docroot=DIR [options]\n";
             echo "\n";
             echo $command_help[$command]["detail"] . "\n";
         } else {
@@ -6432,21 +6438,16 @@ if (
     }
 
     $remote_url = $argv[2] ?? null;
-    $local_path = $argv[3] ?? null;
 
     if (!$remote_url) {
         fwrite(STDERR, "Error: <remote-url> is required\n");
-        fwrite(STDERR, "Usage: php import.php {$command} <remote-url> <local-path> [options]\n");
+        fwrite(STDERR, "Usage: php import.php {$command} <remote-url> --state-dir=DIR --docroot=DIR [options]\n");
         exit(1);
     }
 
-    if (!$local_path) {
-        fwrite(STDERR, "Error: <local-path> is required\n");
-        fwrite(STDERR, "Usage: php import.php {$command} <remote-url> <local-path> [options]\n");
-        exit(1);
-    }
-
-    // Parse options
+    // Parse options (--state-dir and --docroot are required named options)
+    $state_dir = null;
+    $docroot = null;
     $options = [
         "command" => $command,
         "abort" => false,
@@ -6455,8 +6456,12 @@ if (
         "tuning_config" => [],
     ];
 
-    for ($i = 4; $i < $argc; $i++) {
-        if (strpos($argv[$i], "--secret=") === 0) {
+    for ($i = 3; $i < $argc; $i++) {
+        if (strpos($argv[$i], "--state-dir=") === 0) {
+            $state_dir = substr($argv[$i], strlen("--state-dir="));
+        } elseif (strpos($argv[$i], "--docroot=") === 0) {
+            $docroot = substr($argv[$i], strlen("--docroot="));
+        } elseif (strpos($argv[$i], "--secret=") === 0) {
             $options["secret"] = substr($argv[$i], strlen("--secret="));
         } elseif ($argv[$i] === "--abort") {
             $options["abort"] = true;
@@ -6641,8 +6646,20 @@ if (
         }
     }
 
+    if (!$state_dir) {
+        fwrite(STDERR, "Error: --state-dir=DIR is required\n");
+        fwrite(STDERR, "Usage: php import.php {$command} <remote-url> --state-dir=DIR --docroot=DIR [options]\n");
+        exit(1);
+    }
+
+    if (!$docroot) {
+        fwrite(STDERR, "Error: --docroot=DIR is required\n");
+        fwrite(STDERR, "Usage: php import.php {$command} <remote-url> --state-dir=DIR --docroot=DIR [options]\n");
+        exit(1);
+    }
+
     try {
-        $client = new ImportClient($remote_url, $local_path);
+        $client = new ImportClient($remote_url, $state_dir, $docroot);
         $client->run($options);
         exit($client->exit_code);
     } catch (\Throwable $e) {

--- a/preview.js
+++ b/preview.js
@@ -9,7 +9,7 @@
  * thinks it's on its original domain.
  *
  * Usage:
- *   node preview.js <export-dir> [--url=<original-url>] [--port=<port>]
+ *   node preview.js --state-dir=DIR --docroot=DIR [--url=<original-url>] [--port=<port>]
  *
  * Environment variables (all optional):
  *   DB_HOST          MySQL host          (default: 127.0.0.1)
@@ -27,26 +27,30 @@ import http from 'node:http';
 // ── CLI args ────────────────────────────────────────────────────────
 
 const args = process.argv.slice(2);
-let exportDir = null;
+let stateDir = null;
+let docroot = null;
 let urlOverride = null;
 let port = null;
 
 for (const arg of args) {
-	if (arg.startsWith('--url=')) {
+	if (arg.startsWith('--state-dir=')) {
+		stateDir = arg.slice('--state-dir='.length);
+	} else if (arg.startsWith('--docroot=')) {
+		docroot = arg.slice('--docroot='.length);
+	} else if (arg.startsWith('--url=')) {
 		urlOverride = arg.slice('--url='.length);
 	} else if (arg.startsWith('--port=')) {
 		port = arg.slice('--port='.length);
-	} else if (!arg.startsWith('--')) {
-		exportDir = arg;
 	}
 }
 
-if (!exportDir) {
-	console.error('Usage: node preview.js <export-dir> [--url=<original-url>] [--port=<port>]');
+if (!stateDir || !docroot) {
+	console.error('Usage: node preview.js --state-dir=DIR --docroot=DIR [--url=<original-url>] [--port=<port>]');
 	process.exit(1);
 }
 
-exportDir = path.resolve(exportDir);
+stateDir = path.resolve(stateDir);
+docroot = path.resolve(docroot);
 
 const DB_HOST = process.env.DB_HOST || '127.0.0.1';
 const DB_USER = process.env.DB_USER || 'root';
@@ -106,9 +110,8 @@ function findDir(root, name, maxDepth = 6) {
 
 // ── Layout detection ────────────────────────────────────────────────
 
-const fsRoot = path.join(exportDir, 'filesystem-root');
-if (!fs.existsSync(fsRoot)) {
-	console.error(`Error: filesystem-root not found in ${exportDir}`);
+if (!fs.existsSync(docroot)) {
+	console.error(`Error: docroot not found: ${docroot}`);
 	process.exit(1);
 }
 
@@ -116,8 +119,8 @@ if (!fs.existsSync(fsRoot)) {
 // (__wp__ contains core, wp-config.php lives in the parent htdocs dir).
 // Check for standard layout first — a standard WP install might contain
 // a stray __wp__ directory inside a plugin or cache.
-const wpConfigFile = findFile(fsRoot, 'wp-config.php');
-const wpCoreDir = findDir(fsRoot, '__wp__');
+const wpConfigFile = findFile(docroot, 'wp-config.php');
+const wpCoreDir = findDir(docroot, '__wp__');
 const isWpcom = !!wpCoreDir && (!wpConfigFile || path.dirname(wpConfigFile) === path.dirname(wpCoreDir));
 
 let wpRoot;     // standard: dir containing wp-config.php; wpcom: __wp__ dir
@@ -137,21 +140,21 @@ if (isWpcom) {
 	console.log('Detected standard WordPress layout');
 	console.log(`  root: ${wpRoot}`);
 } else {
-	console.error(`Error: Could not detect WordPress layout under ${fsRoot}`);
+	console.error(`Error: Could not detect WordPress layout under ${docroot}`);
 	console.error('  No wp-config.php or __wp__ directory found.');
 	process.exit(1);
 }
 
 // ── 1. Create database ─────────────────────────────────────────────
 
-const dirBasename = path.basename(exportDir);
+const dirBasename = path.basename(stateDir);
 const dbName = `import_${dirBasename}`;
 console.log(`\nCreating database ${dbName}...`);
 mysqlExec(`DROP DATABASE IF EXISTS \`${dbName}\`; CREATE DATABASE \`${dbName}\`;`);
 
 // ── 2. Import SQL ───────────────────────────────────────────────────
 
-const sqlFile = path.join(exportDir, 'db.sql');
+const sqlFile = path.join(stateDir, 'db.sql');
 if (!fs.existsSync(sqlFile)) {
 	console.error(`Error: ${sqlFile} not found.`);
 	process.exit(1);

--- a/tests/Import/ImportSymlinkTest.php
+++ b/tests/Import/ImportSymlinkTest.php
@@ -18,7 +18,7 @@ class ImportSymlinkTest extends TestCase
         parent::setUp();
         $this->tempDir = sys_get_temp_dir() . '/import-symlink-test-' . uniqid();
         mkdir($this->tempDir, 0755, true);
-        mkdir($this->tempDir . '/filesystem-root', 0755, true);
+        mkdir($this->tempDir . '/docroot', 0755, true);
     }
 
     protected function tearDown(): void
@@ -56,7 +56,7 @@ class ImportSymlinkTest extends TestCase
 
     public function testSymlinkIsCreated()
     {
-        $client = new \ImportClient('http://fake.url', $this->tempDir);
+        $client = new \ImportClient('http://fake.url', $this->tempDir, $this->tempDir . '/docroot');
 
         $reflection = new \ReflectionClass($client);
         $method = $reflection->getMethod('handle_symlink_chunk');
@@ -71,7 +71,7 @@ class ImportSymlinkTest extends TestCase
 
         $method->invoke($client, $chunk);
 
-        $symlinkPath = $this->tempDir . '/filesystem-root/test/link';
+        $symlinkPath = $this->tempDir . '/docroot/test/link';
         $this->assertTrue(is_link($symlinkPath), 'Symlink should be created');
         $this->assertEquals('target', readlink($symlinkPath), 'Symlink target should match');
     }
@@ -79,11 +79,11 @@ class ImportSymlinkTest extends TestCase
     /**
      * A relative symlink that escapes the filesystem root should be rejected.
      * Path /a/link with target ../../../escape resolves to
-     * filesystem-root/a/../../escape = filesystem-root/../escape — outside root.
+     * docroot/a/../../escape = docroot/../escape — outside root.
      */
     public function testRelativeSymlinkEscapingRootRejected()
     {
-        $client = new \ImportClient('http://fake.url', $this->tempDir);
+        $client = new \ImportClient('http://fake.url', $this->tempDir, $this->tempDir . '/docroot');
 
         $reflection = new \ReflectionClass($client);
         $method = $reflection->getMethod('handle_symlink_chunk');
@@ -98,7 +98,7 @@ class ImportSymlinkTest extends TestCase
 
         $method->invoke($client, $chunk);
 
-        $symlinkPath = $this->tempDir . '/filesystem-root/a/link';
+        $symlinkPath = $this->tempDir . '/docroot/a/link';
         $this->assertFalse(is_link($symlinkPath), 'Symlink escaping root should not be created');
     }
 
@@ -109,7 +109,7 @@ class ImportSymlinkTest extends TestCase
      */
     public function testChainedSymlinksEscapingRootRejected()
     {
-        $client = new \ImportClient('http://fake.url', $this->tempDir);
+        $client = new \ImportClient('http://fake.url', $this->tempDir, $this->tempDir . '/docroot');
 
         $reflection = new \ReflectionClass($client);
         $method = $reflection->getMethod('handle_symlink_chunk');
@@ -127,7 +127,7 @@ class ImportSymlinkTest extends TestCase
         ];
         $method->invoke($client, $chunk1);
 
-        $link1 = $this->tempDir . '/filesystem-root/site/__wp__';
+        $link1 = $this->tempDir . '/docroot/site/__wp__';
         $this->assertFalse(is_link($link1), 'Symlink escaping root should not be created');
 
         // Second symlink references a path within root — should succeed
@@ -140,7 +140,7 @@ class ImportSymlinkTest extends TestCase
         ];
         $method->invoke($client, $chunk2);
 
-        $link2 = $this->tempDir . '/filesystem-root/site/wp-load.php';
+        $link2 = $this->tempDir . '/docroot/site/wp-load.php';
         $this->assertTrue(is_link($link2), 'Symlink staying within root should be created');
         $this->assertEquals('__wp__/wp-load.php', readlink($link2));
     }
@@ -151,7 +151,7 @@ class ImportSymlinkTest extends TestCase
      */
     public function testAbsoluteSymlinkOutsideRootRejected()
     {
-        $client = new \ImportClient('http://fake.url', $this->tempDir);
+        $client = new \ImportClient('http://fake.url', $this->tempDir, $this->tempDir . '/docroot');
 
         $reflection = new \ReflectionClass($client);
         $method = $reflection->getMethod('handle_symlink_chunk');
@@ -166,7 +166,7 @@ class ImportSymlinkTest extends TestCase
 
         $method->invoke($client, $chunk);
 
-        $symlinkPath = $this->tempDir . '/filesystem-root/bin-link';
+        $symlinkPath = $this->tempDir . '/docroot/bin-link';
         $this->assertFalse(is_link($symlinkPath), 'Absolute symlink outside root should not be created');
     }
 
@@ -176,7 +176,7 @@ class ImportSymlinkTest extends TestCase
      */
     public function testRelativeSymlinkWithinRootCreated()
     {
-        $client = new \ImportClient('http://fake.url', $this->tempDir);
+        $client = new \ImportClient('http://fake.url', $this->tempDir, $this->tempDir . '/docroot');
 
         $reflection = new \ReflectionClass($client);
         $method = $reflection->getMethod('handle_symlink_chunk');
@@ -191,7 +191,7 @@ class ImportSymlinkTest extends TestCase
 
         $method->invoke($client, $chunk);
 
-        $symlinkPath = $this->tempDir . '/filesystem-root/wp-content/link';
+        $symlinkPath = $this->tempDir . '/docroot/wp-content/link';
         $this->assertTrue(is_link($symlinkPath), 'Symlink within root should be created');
         $this->assertEquals('../uploads/file.txt', readlink($symlinkPath));
     }
@@ -202,8 +202,8 @@ class ImportSymlinkTest extends TestCase
      */
     public function testAbsoluteSymlinkWithinRootCreated()
     {
-        $client = new \ImportClient('http://fake.url', $this->tempDir);
-        $root = realpath($this->tempDir . '/filesystem-root');
+        $client = new \ImportClient('http://fake.url', $this->tempDir, $this->tempDir . '/docroot');
+        $root = realpath($this->tempDir . '/docroot');
 
         $reflection = new \ReflectionClass($client);
         $method = $reflection->getMethod('handle_symlink_chunk');
@@ -225,7 +225,7 @@ class ImportSymlinkTest extends TestCase
 
     public function testSymlinkWithMissingDataSkipped()
     {
-        $client = new \ImportClient('http://fake.url', $this->tempDir);
+        $client = new \ImportClient('http://fake.url', $this->tempDir, $this->tempDir . '/docroot');
 
         $reflection = new \ReflectionClass($client);
         $method = $reflection->getMethod('handle_symlink_chunk');
@@ -263,10 +263,10 @@ class ImportSymlinkTest extends TestCase
 
     public function testSymlinkReplacesExistingFile()
     {
-        $client = new \ImportClient('http://fake.url', $this->tempDir);
+        $client = new \ImportClient('http://fake.url', $this->tempDir, $this->tempDir . '/docroot');
 
         // Create a regular file
-        $filePath = $this->tempDir . '/filesystem-root/test/link';
+        $filePath = $this->tempDir . '/docroot/test/link';
         mkdir(dirname($filePath), 0755, true);
         file_put_contents($filePath, 'content');
         $this->assertTrue(is_file($filePath));

--- a/tests/Import/TypeSwapTest.php
+++ b/tests/Import/TypeSwapTest.php
@@ -21,7 +21,7 @@ class TypeSwapTest extends TestCase
         parent::setUp();
         $this->tempDir = sys_get_temp_dir() . '/import-typeswap-test-' . uniqid();
         mkdir($this->tempDir, 0755, true);
-        mkdir($this->tempDir . '/filesystem-root', 0755, true);
+        mkdir($this->tempDir . '/docroot', 0755, true);
     }
 
     protected function tearDown(): void
@@ -61,14 +61,14 @@ class TypeSwapTest extends TestCase
      */
     public function testEnsureDirectoryPathRemovesBlockingSymlink()
     {
-        $client = new \ImportClient('http://fake.url', $this->tempDir);
+        $client = new \ImportClient('http://fake.url', $this->tempDir, $this->tempDir . '/docroot');
 
         $reflection = new \ReflectionClass($client);
         $method = $reflection->getMethod('ensure_directory_path');
 
-        // Resolve the filesystem-root path so it matches the realpath() check
+        // Resolve the docroot path so it matches the realpath() check
         // inside ensure_directory_path (on macOS, /var -> /private/var).
-        $fsRoot = realpath($this->tempDir . '/filesystem-root');
+        $fsRoot = realpath($this->tempDir . '/docroot');
 
         // Create a symlink at a path where we want a real directory
         $symlinkPath = $fsRoot . '/some-dir';
@@ -90,9 +90,9 @@ class TypeSwapTest extends TestCase
      */
     public function testFileChunkReplacesSymlinkToDirectory()
     {
-        $client = new \ImportClient('http://fake.url', $this->tempDir);
+        $client = new \ImportClient('http://fake.url', $this->tempDir, $this->tempDir . '/docroot');
 
-        $fsRoot = $this->tempDir . '/filesystem-root';
+        $fsRoot = $this->tempDir . '/docroot';
 
         // Create a real directory and a symlink pointing to it
         $realDir = $fsRoot . '/real-target-dir';
@@ -134,9 +134,9 @@ class TypeSwapTest extends TestCase
      */
     public function testDirectoryChunkReplacesSymlinkToFile()
     {
-        $client = new \ImportClient('http://fake.url', $this->tempDir);
+        $client = new \ImportClient('http://fake.url', $this->tempDir, $this->tempDir . '/docroot');
 
-        $fsRoot = $this->tempDir . '/filesystem-root';
+        $fsRoot = $this->tempDir . '/docroot';
 
         // Create a real file and a symlink pointing to it
         $realFile = $fsRoot . '/real-target-file';
@@ -170,9 +170,9 @@ class TypeSwapTest extends TestCase
      */
     public function testFileChunkUnderFormerSymlink()
     {
-        $client = new \ImportClient('http://fake.url', $this->tempDir);
+        $client = new \ImportClient('http://fake.url', $this->tempDir, $this->tempDir . '/docroot');
 
-        $fsRoot = $this->tempDir . '/filesystem-root';
+        $fsRoot = $this->tempDir . '/docroot';
 
         // Create a symlink at the path
         $realFile = $fsRoot . '/target-file';
@@ -223,11 +223,11 @@ class TypeSwapTest extends TestCase
      */
     public function testNestedFileUnderExistingSymlinkViaEnsureDirectory()
     {
-        $client = new \ImportClient('http://fake.url', $this->tempDir);
+        $client = new \ImportClient('http://fake.url', $this->tempDir, $this->tempDir . '/docroot');
 
-        // Resolve the filesystem-root path so it matches the realpath() check
+        // Resolve the docroot path so it matches the realpath() check
         // inside ensure_directory_path (on macOS, /var -> /private/var).
-        $fsRoot = realpath($this->tempDir . '/filesystem-root');
+        $fsRoot = realpath($this->tempDir . '/docroot');
 
         // Create a symlink at the top-level path component
         $targetDir = $fsRoot . '/real-target';

--- a/tests/e2e/lib/test-helpers.js
+++ b/tests/e2e/lib/test-helpers.js
@@ -211,9 +211,17 @@ function parseMultipart(body, boundary) {
 }
 
 /**
+ * Return the docroot path for a given output directory.
+ * By convention, E2E tests place downloaded files in outputDir/docroot.
+ */
+export function docrootDir(outputDir) {
+    return join(outputDir, 'docroot');
+}
+
+/**
  * Run the importer CLI.
  * @param {string} url - Export URL
- * @param {string} outputDir - Local output directory
+ * @param {string} outputDir - Local output directory (state files live here; docroot is outputDir/docroot)
  * @param {string} command - Import command (files-sync, db-sync, etc.)
  * @param {Object} options - Additional options
  * @returns {Object} { stdout, stderr, exitCode }
@@ -228,7 +236,8 @@ export function runImporter(url, outputDir, command, options = {}) {
             IMPORTER_PATH,
             cmd,
             url,
-            outputDir,
+            `--state-dir=${outputDir}`,
+            `--docroot=${docrootDir(outputDir)}`,
         ];
         if (secret) {
             args.push(`--secret=${secret}`);

--- a/tests/e2e/site-registry.json
+++ b/tests/e2e/site-registry.json
@@ -27,6 +27,9 @@
     "import-failures":   { "port": 8100 },
     "follow-symlinks":   { "port": 8101 },
     "sqlite":            { "port": 8102 },
-    "large-single-file": { "port": 8103 }
+    "large-single-file": { "port": 8103 },
+    "file-deletions":    { "port": 8104 },
+    "file-type-swaps":   { "port": 8105 },
+    "file-type-cache":   { "port": 8106 }
   }
 }

--- a/tests/e2e/tests/import-01-basic-file-sync.test.js
+++ b/tests/e2e/tests/import-01-basic-file-sync.test.js
@@ -11,6 +11,7 @@ import {
     getSiteUrl, getSiteSecret, getSiteDir,
     assertTreesMatch,
     assertFileCount, assertSiteMirror,
+    docrootDir,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -46,10 +47,10 @@ describe('Import: Basic File Sync', () => {
         assert.equal(state.status, 'complete');
     });
 
-    it('filesystem-root file hashes match source site directory', () => {
-        // The importer stores files at filesystem-root/<absolute-path>,
-        // so the site dir content ends up at filesystem-root/srv/e2e-sites/<site>/
-        const importedRoot = join(tempDir, 'filesystem-root', getSiteDir(site));
+    it('docroot file hashes match source site directory', () => {
+        // The importer stores files at docroot/<absolute-path>,
+        // so the site dir content ends up at docroot/srv/e2e-sites/<site>/
+        const importedRoot = join(docrootDir(tempDir), getSiteDir(site));
         assert.ok(existsSync(importedRoot), `Expected ${importedRoot} to exist`);
 
         assertTreesMatch(getSiteDir(site), importedRoot);
@@ -67,7 +68,7 @@ describe('Import: Basic File Sync', () => {
     });
 
     it('imported files form a valid WordPress site mirror', () => {
-        assertSiteMirror(join(tempDir, 'filesystem-root', getSiteDir(site)));
+        assertSiteMirror(join(docrootDir(tempDir), getSiteDir(site)));
     });
 
     it('re-running after completion triggers a delta sync', () => {

--- a/tests/e2e/tests/import-03-delta-sync.test.js
+++ b/tests/e2e/tests/import-03-delta-sync.test.js
@@ -12,6 +12,7 @@ import {
     getSiteUrl, getSiteSecret, getSiteDir,
     assertTreesMatch,
     assertFileCount, assertSiteMirror,
+    docrootDir,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -48,7 +49,7 @@ describe('Import: Delta Sync', () => {
     });
 
     it('imported files form a valid WordPress site mirror', () => {
-        assertSiteMirror(join(tempDir, 'filesystem-root', getSiteDir(site)));
+        assertSiteMirror(join(docrootDir(tempDir), getSiteDir(site)));
     });
 
     it('files-sync with no changes completes', () => {
@@ -58,7 +59,7 @@ describe('Import: Delta Sync', () => {
         assert.equal(result.exitCode, 0, `Expected exit 0\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);
 
         // Hashes should still match
-        assertTreesMatch(getSiteDir(site), join(tempDir, 'filesystem-root', getSiteDir(site)));
+        assertTreesMatch(getSiteDir(site), join(docrootDir(tempDir), getSiteDir(site)));
     });
 
     it('files-sync picks up new file via delta', () => {
@@ -73,7 +74,7 @@ describe('Import: Delta Sync', () => {
         assert.equal(result.exitCode, 0, `Expected exit 0\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);
 
         // The new file should appear in the output
-        const importedPath = join(tempDir, 'filesystem-root', getSiteDir(site), 'test-data', 'delta-test-added.txt');
+        const importedPath = join(docrootDir(tempDir), getSiteDir(site), 'test-data', 'delta-test-added.txt');
         assert.ok(existsSync(importedPath), 'Expected delta-test-added.txt in output');
 
         // Clean up added file

--- a/tests/e2e/tests/import-05-unicode-paths.test.js
+++ b/tests/e2e/tests/import-05-unicode-paths.test.js
@@ -11,6 +11,7 @@ import {
     getSiteUrl, getSiteSecret, getSiteDir,
     hashDirectory, assertTreesMatch,
     assertFileCount, assertSiteMirror,
+    docrootDir,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -61,7 +62,7 @@ describe('Import: Unicode Paths', () => {
     });
 
     it('files with emoji, accented chars, spaces, and Chinese chars exist', () => {
-        const importedRoot = join(tempDir, 'filesystem-root', getSiteDir(site));
+        const importedRoot = join(docrootDir(tempDir), getSiteDir(site));
         assert.ok(existsSync(importedRoot), `Expected ${importedRoot} to exist`);
 
         // Check for files with special names
@@ -91,7 +92,7 @@ describe('Import: Unicode Paths', () => {
     });
 
     it('file hashes match source', () => {
-        const importedRoot = join(tempDir, 'filesystem-root', getSiteDir(site));
+        const importedRoot = join(docrootDir(tempDir), getSiteDir(site));
         assertTreesMatch(getSiteDir(site), importedRoot);
     });
 
@@ -100,7 +101,7 @@ describe('Import: Unicode Paths', () => {
     });
 
     it('imported files form a valid WordPress site mirror', () => {
-        assertSiteMirror(join(tempDir, 'filesystem-root', getSiteDir(site)));
+        assertSiteMirror(join(docrootDir(tempDir), getSiteDir(site)));
     });
 
     it('db-sync completes with valid dump', () => {

--- a/tests/e2e/tests/import-06-symlinks.test.js
+++ b/tests/e2e/tests/import-06-symlinks.test.js
@@ -12,6 +12,7 @@ import {
     getSiteUrl, getSiteSecret, getSiteDir,
     assertTreesMatch,
     assertFileCount, assertSiteMirror,
+    docrootDir,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -52,7 +53,7 @@ describe('Import: Symlinks', () => {
         });
 
         it('regular files are downloaded and match source', () => {
-            const importedRoot = join(tempDir, 'filesystem-root', getSiteDir(site));
+            const importedRoot = join(docrootDir(tempDir), getSiteDir(site));
             assertTreesMatch(getSiteDir(site), importedRoot);
         });
 
@@ -61,7 +62,7 @@ describe('Import: Symlinks', () => {
         });
 
         it('imported files form a valid WordPress site mirror', () => {
-            assertSiteMirror(join(tempDir, 'filesystem-root', getSiteDir(site)));
+            assertSiteMirror(join(docrootDir(tempDir), getSiteDir(site)));
         });
 
         it('sync completed without error despite symlinks', () => {
@@ -105,7 +106,7 @@ describe('Import: Symlinks', () => {
         });
 
         it('regular files are downloaded and match source', () => {
-            const importedRoot = join(tempDir, 'filesystem-root', getSiteDir(site));
+            const importedRoot = join(docrootDir(tempDir), getSiteDir(site));
             assertTreesMatch(getSiteDir(site), importedRoot);
         });
     });

--- a/tests/e2e/tests/import-07-permission-errors.test.js
+++ b/tests/e2e/tests/import-07-permission-errors.test.js
@@ -12,6 +12,7 @@ import {
     runImporter, createTempDir, cleanupTempDir,
     getSiteUrl, getSiteSecret, getSiteDir,
     assertTreesMatch, readAuditLog,
+    docrootDir,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -54,7 +55,7 @@ describe('Import: Permission Errors', () => {
         it('readable files are downloaded and match source', () => {
             // hashDirectory skips unreadable files on both sides,
             // so this verifies all readable files match exactly
-            const importedRoot = join(tempDir, 'filesystem-root', getSiteDir(site));
+            const importedRoot = join(docrootDir(tempDir), getSiteDir(site));
             assertTreesMatch(getSiteDir(site), importedRoot);
         });
 

--- a/tests/e2e/tests/import-08-large-directory.test.js
+++ b/tests/e2e/tests/import-08-large-directory.test.js
@@ -11,6 +11,7 @@ import {
     getSiteUrl, getSiteSecret, getSiteDir,
     hashDirectory, assertTreesMatch,
     assertFileCount, assertSiteMirror,
+    docrootDir,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -49,8 +50,8 @@ describe('Import: Large Directory', () => {
         assert.equal(result.exitCode, 0, `Expected exit 0\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);
     });
 
-    it('filesystem-root has 2000+ files', () => {
-        const importedRoot = join(tempDir, 'filesystem-root', getSiteDir(site));
+    it('docroot has 2000+ files', () => {
+        const importedRoot = join(docrootDir(tempDir), getSiteDir(site));
         assert.ok(existsSync(importedRoot), `Expected ${importedRoot} to exist`);
 
         const hashes = hashDirectory(importedRoot);
@@ -62,16 +63,16 @@ describe('Import: Large Directory', () => {
     });
 
     it('imported files form a valid WordPress site mirror', () => {
-        assertSiteMirror(join(tempDir, 'filesystem-root', getSiteDir(site)));
+        assertSiteMirror(join(docrootDir(tempDir), getSiteDir(site)));
     });
 
     it('all file hashes match source', () => {
-        const importedRoot = join(tempDir, 'filesystem-root', getSiteDir(site));
+        const importedRoot = join(docrootDir(tempDir), getSiteDir(site));
         assertTreesMatch(getSiteDir(site), importedRoot);
     });
 
     it('spot-check file content matches content-NNNN pattern', () => {
-        const importedRoot = join(tempDir, 'filesystem-root', getSiteDir(site));
+        const importedRoot = join(docrootDir(tempDir), getSiteDir(site));
         // Check a few specific files
         for (const num of ['0001', '0500', '1000', '1999']) {
             const filePath = join(importedRoot, 'test-data', 'many-files', `file-${num}.txt`);

--- a/tests/e2e/tests/import-10-resume-files.test.js
+++ b/tests/e2e/tests/import-10-resume-files.test.js
@@ -12,6 +12,7 @@ import {
     getSiteUrl, getSiteSecret, getSiteDir,
     assertTreesMatch,
     assertFileCount, assertSiteMirror,
+    docrootDir,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -67,11 +68,11 @@ describe('Import: Resume Files', { timeout: 180000 }, () => {
     });
 
     it('imported files form a valid WordPress site mirror', () => {
-        assertSiteMirror(join(tempDir, 'filesystem-root', getSiteDir(site)));
+        assertSiteMirror(join(docrootDir(tempDir), getSiteDir(site)));
     });
 
     it('all files present and correct after multi-request sync', () => {
-        const importedRoot = join(tempDir, 'filesystem-root', getSiteDir(site));
+        const importedRoot = join(docrootDir(tempDir), getSiteDir(site));
         assertTreesMatch(getSiteDir(site), importedRoot);
     });
 });

--- a/tests/e2e/tests/import-13-sha1-integrity.test.js
+++ b/tests/e2e/tests/import-13-sha1-integrity.test.js
@@ -12,6 +12,7 @@ import {
     getSiteUrl, getSiteSecret, getSiteDir,
     hashDirectory, assertTreesMatch, sha1File,
     assertFileCount, assertSiteMirror,
+    docrootDir,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -51,7 +52,7 @@ describe('Import: SHA1 Integrity', () => {
     });
 
     it('all file hashes match source', () => {
-        const importedRoot = join(tempDir, 'filesystem-root', getSiteDir(site));
+        const importedRoot = join(docrootDir(tempDir), getSiteDir(site));
         assertTreesMatch(getSiteDir(site), importedRoot);
     });
 
@@ -60,18 +61,18 @@ describe('Import: SHA1 Integrity', () => {
     });
 
     it('imported files form a valid WordPress site mirror', () => {
-        assertSiteMirror(join(tempDir, 'filesystem-root', getSiteDir(site)));
+        assertSiteMirror(join(docrootDir(tempDir), getSiteDir(site)));
     });
 
     it('at least 20 files with correct hashes', () => {
-        const importedRoot = join(tempDir, 'filesystem-root', getSiteDir(site));
+        const importedRoot = join(docrootDir(tempDir), getSiteDir(site));
         const importedHashes = hashDirectory(importedRoot);
         assert.ok(importedHashes.size >= 20, `Expected at least 20 files, got ${importedHashes.size}`);
     });
 
     it('large binary file (256KB) hash matches', () => {
         const sourcePath = join(getSiteDir(site), 'test-data', 'large-binary.bin');
-        const importedPath = join(tempDir, 'filesystem-root', getSiteDir(site), 'test-data', 'large-binary.bin');
+        const importedPath = join(docrootDir(tempDir), getSiteDir(site), 'test-data', 'large-binary.bin');
 
         assert.ok(existsSync(sourcePath), 'Expected source large-binary.bin to exist');
         assert.ok(existsSync(importedPath), 'Expected imported large-binary.bin to exist');

--- a/tests/e2e/tests/import-14-buffered-response.test.js
+++ b/tests/e2e/tests/import-14-buffered-response.test.js
@@ -11,6 +11,7 @@ import {
     getSiteUrl, getSiteSecret, getSiteDir,
     assertTreesMatch,
     assertFileCount, assertSiteMirror,
+    docrootDir,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -39,7 +40,7 @@ describe('Import: Buffered Response', () => {
     });
 
     it('files are correct', () => {
-        const importedRoot = join(tempDir, 'filesystem-root', getSiteDir(site));
+        const importedRoot = join(docrootDir(tempDir), getSiteDir(site));
         assertTreesMatch(getSiteDir(site), importedRoot);
     });
 
@@ -48,7 +49,7 @@ describe('Import: Buffered Response', () => {
     });
 
     it('imported files form a valid WordPress site mirror', () => {
-        assertSiteMirror(join(tempDir, 'filesystem-root', getSiteDir(site)));
+        assertSiteMirror(join(docrootDir(tempDir), getSiteDir(site)));
     });
 
     it('db-sync through buffered proxy completes', () => {

--- a/tests/e2e/tests/import-15-volatile-files.test.js
+++ b/tests/e2e/tests/import-15-volatile-files.test.js
@@ -14,6 +14,7 @@ import {
     hashDirectory, assertTreesMatch, readAuditLog,
     writeTestHooks, removeTestHooks,
     writeHookState, readHookState, clearHookState,
+    docrootDir,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -83,7 +84,7 @@ describe('Import: Volatile Files', () => {
 
         it('downloaded files have correct hashes (no corruption)', () => {
             const siteDir = getSiteDir(site);
-            const importedRoot = join(tempDir, 'filesystem-root', siteDir);
+            const importedRoot = join(docrootDir(tempDir), siteDir);
             // allowMissing: hook's sleep(1) slows export, so sync may be incomplete
             assertTreesMatch(siteDir, importedRoot, { exclude: ['large-volatile.bin'], allowMissing: true });
         });
@@ -159,7 +160,7 @@ describe('Import: Volatile Files', () => {
         });
 
         it('readable files are still downloaded', () => {
-            const importedRoot = join(tempDir, 'filesystem-root', getSiteDir(site));
+            const importedRoot = join(docrootDir(tempDir), getSiteDir(site));
             const hashes = hashDirectory(importedRoot);
             assert.ok(hashes.size > 0, 'Expected at least some files downloaded');
 
@@ -173,7 +174,7 @@ describe('Import: Volatile Files', () => {
             // The hook deleted test-data/subdir during the directory scan.
             // The scanner silently skips entries that no longer stat, so
             // files from subdir should not be indexed or downloaded.
-            const importedRoot = join(tempDir, 'filesystem-root', getSiteDir(site));
+            const importedRoot = join(docrootDir(tempDir), getSiteDir(site));
             const allFiles = [...hashDirectory(importedRoot).keys()];
             const subdirFiles = allFiles.filter(p => p.includes('subdir'));
             assert.equal(

--- a/tests/e2e/tests/import-16-custom-wp-content.test.js
+++ b/tests/e2e/tests/import-16-custom-wp-content.test.js
@@ -11,6 +11,7 @@ import {
     getSiteUrl, getSiteSecret, getSiteDir,
     assertTreesMatch,
     assertFileCount, assertSiteMirror,
+    docrootDir,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -50,7 +51,7 @@ describe('Import: Custom WP Content', () => {
     });
 
     it('files downloaded correctly', () => {
-        const importedRoot = join(tempDir, 'filesystem-root', getSiteDir(site));
+        const importedRoot = join(docrootDir(tempDir), getSiteDir(site));
         assert.ok(existsSync(importedRoot), `Expected ${importedRoot} to exist`);
 
         assertTreesMatch(getSiteDir(site), importedRoot);
@@ -61,7 +62,7 @@ describe('Import: Custom WP Content', () => {
     });
 
     it('imported files form a valid WordPress site mirror', () => {
-        assertSiteMirror(join(tempDir, 'filesystem-root', getSiteDir(site)));
+        assertSiteMirror(join(docrootDir(tempDir), getSiteDir(site)));
     });
 
     it('db-sync completes with valid dump', () => {

--- a/tests/e2e/tests/import-18-full-import-render.test.js
+++ b/tests/e2e/tests/import-18-full-import-render.test.js
@@ -15,6 +15,7 @@ import {
     assertTreesMatch,
     assertSiteMirror, createMysqlConnection,
     compareDatabases, getDbName,
+    docrootDir,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -72,12 +73,12 @@ describe('Import: Full Round-Trip', () => {
     });
 
     it('imported files form a valid WordPress site', () => {
-        const importedRoot = join(tempDir, 'filesystem-root', getSiteDir(site));
+        const importedRoot = join(docrootDir(tempDir), getSiteDir(site));
         assertSiteMirror(importedRoot);
     });
 
     it('imported files match source site', () => {
-        const importedRoot = join(tempDir, 'filesystem-root', getSiteDir(site));
+        const importedRoot = join(docrootDir(tempDir), getSiteDir(site));
         assertTreesMatch(getSiteDir(site), importedRoot);
     });
 

--- a/tests/e2e/tests/import-19-error-chunks.test.js
+++ b/tests/e2e/tests/import-19-error-chunks.test.js
@@ -20,6 +20,7 @@ import {
     readAuditLog,
     writeTestHooks, removeTestHooks,
     writeHookState, readHookState, clearHookState,
+    docrootDir,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -64,7 +65,7 @@ describe('Import: Error Chunks', () => {
 
         it('downloaded files have correct hashes (no corruption)', () => {
             const siteDir = getSiteDir(site);
-            const importedRoot = join(tempDir, 'filesystem-root', siteDir);
+            const importedRoot = join(docrootDir(tempDir), siteDir);
             assertTreesMatch(siteDir, importedRoot);
         });
     });
@@ -137,7 +138,7 @@ describe('Import: Error Chunks', () => {
 
         it('downloaded files have correct hashes (no corruption)', () => {
             const siteDir = getSiteDir(site);
-            const importedRoot = join(tempDir, 'filesystem-root', siteDir);
+            const importedRoot = join(docrootDir(tempDir), siteDir);
             // allowMissing: hook's sleep(1) slows export, so sync may be incomplete
             assertTreesMatch(siteDir, importedRoot, { exclude: ['large-volatile.bin'], allowMissing: true });
         });
@@ -207,7 +208,7 @@ describe('Import: Error Chunks', () => {
 
         it('downloaded files have correct hashes (no corruption)', () => {
             const siteDir = getSiteDir(site);
-            const importedRoot = join(tempDir, 'filesystem-root', siteDir);
+            const importedRoot = join(docrootDir(tempDir), siteDir);
             // allowMissing: hook deletes file mid-stream, which can cause incomplete sync
             assertTreesMatch(siteDir, importedRoot, { exclude: ['large-deletable.bin'], allowMissing: true });
         });

--- a/tests/e2e/tests/import-20-request-cutoff.test.js
+++ b/tests/e2e/tests/import-20-request-cutoff.test.js
@@ -15,6 +15,7 @@ import {
     readAuditLog,
     writeTestHooks, removeTestHooks,
     writeHookState, readHookState, clearHookState,
+    docrootDir,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -86,7 +87,7 @@ describe('Import: Request Cutoff', () => {
     });
 
     it('all file hashes match source after resume', () => {
-        const importedRoot = join(tempDir, 'filesystem-root', getSiteDir(site));
+        const importedRoot = join(docrootDir(tempDir), getSiteDir(site));
         assertTreesMatch(getSiteDir(site), importedRoot);
     });
 

--- a/tests/e2e/tests/import-22-delta-with-deletions.test.js
+++ b/tests/e2e/tests/import-22-delta-with-deletions.test.js
@@ -17,7 +17,7 @@ import {
 import { ensureSite } from '../lib/site-setup.js';
 
 describe('Import: Delta Sync with Deletions', () => {
-    const site = 'file-changes';
+    const site = 'file-deletions';
     let tempDir;
     const extraFile1 = join(getSiteDir(site), 'test-data', 'will-be-deleted-1.txt');
     const extraFile2 = join(getSiteDir(site), 'test-data', 'will-be-deleted-2.txt');

--- a/tests/e2e/tests/import-22-delta-with-deletions.test.js
+++ b/tests/e2e/tests/import-22-delta-with-deletions.test.js
@@ -12,6 +12,7 @@ import {
     runImporter, createTempDir, cleanupTempDir,
     getSiteUrl, getSiteSecret, getSiteDir,
     hashDirectory, assertTreesMatch,
+    docrootDir,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -47,7 +48,7 @@ describe('Import: Delta Sync with Deletions', () => {
         });
         assert.equal(result.exitCode, 0, `Expected exit 0\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);
 
-        const importedRoot = join(tempDir, 'filesystem-root', getSiteDir(site));
+        const importedRoot = join(docrootDir(tempDir), getSiteDir(site));
         const hashes = hashDirectory(importedRoot);
         assert.ok(
             [...hashes.keys()].some(p => p.includes('will-be-deleted-1.txt')),
@@ -60,7 +61,7 @@ describe('Import: Delta Sync with Deletions', () => {
     });
 
     it('initial sync hashes match source', () => {
-        const importedRoot = join(tempDir, 'filesystem-root', getSiteDir(site));
+        const importedRoot = join(docrootDir(tempDir), getSiteDir(site));
         assertTreesMatch(getSiteDir(site), importedRoot);
     });
 

--- a/tests/e2e/tests/import-24-large-single-file.test.js
+++ b/tests/e2e/tests/import-24-large-single-file.test.js
@@ -13,6 +13,7 @@ import {
     runImporter, createTempDir, cleanupTempDir,
     getSiteUrl, getSiteSecret, getSiteDir,
     assertTreesMatch, sha1File,
+    docrootDir,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -50,7 +51,7 @@ describe('Import: Large Single File', { timeout: 180000 }, () => {
     });
 
     it('large file exists in import output', () => {
-        const importedPath = join(tempDir, 'filesystem-root', getSiteDir(site), largeName);
+        const importedPath = join(docrootDir(tempDir), getSiteDir(site), largeName);
         assert.ok(existsSync(importedPath), `Expected ${largeName} in output`);
 
         const stat = statSync(importedPath);
@@ -59,7 +60,7 @@ describe('Import: Large Single File', { timeout: 180000 }, () => {
 
     it('large file SHA1 matches source', () => {
         const sourcePath = join(getSiteDir(site), largeName);
-        const importedPath = join(tempDir, 'filesystem-root', getSiteDir(site), largeName);
+        const importedPath = join(docrootDir(tempDir), getSiteDir(site), largeName);
 
         const sourceHash = sha1File(sourcePath);
         const importedHash = sha1File(importedPath);
@@ -67,7 +68,7 @@ describe('Import: Large Single File', { timeout: 180000 }, () => {
     });
 
     it('all downloaded files have correct hashes', () => {
-        const importedRoot = join(tempDir, 'filesystem-root', getSiteDir(site));
+        const importedRoot = join(docrootDir(tempDir), getSiteDir(site));
         // allowMissing: large 12MB file transfer may leave sync incomplete
         assertTreesMatch(getSiteDir(site), importedRoot, { allowMissing: true });
     });

--- a/tests/e2e/tests/import-25-state-corruption.test.js
+++ b/tests/e2e/tests/import-25-state-corruption.test.js
@@ -11,6 +11,7 @@ import {
     runImporter, createTempDir, cleanupTempDir,
     getSiteUrl, getSiteSecret, getSiteDir,
     assertTreesMatch, readAuditLog,
+    docrootDir,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -65,7 +66,7 @@ describe('Import: State Corruption', () => {
         });
 
         it('files match source after recovery', () => {
-            const importedRoot = join(tempDir, 'filesystem-root', getSiteDir(site));
+            const importedRoot = join(docrootDir(tempDir), getSiteDir(site));
             assertTreesMatch(getSiteDir(site), importedRoot);
         });
     });
@@ -142,7 +143,7 @@ describe('Import: State Corruption', () => {
         });
 
         it('files match source after restart', () => {
-            const importedRoot = join(tempDir, 'filesystem-root', getSiteDir(site));
+            const importedRoot = join(docrootDir(tempDir), getSiteDir(site));
             assertTreesMatch(getSiteDir(site), importedRoot);
         });
     });

--- a/tests/e2e/tests/import-28-concurrent-errors.test.js
+++ b/tests/e2e/tests/import-28-concurrent-errors.test.js
@@ -17,6 +17,7 @@ import {
     assertTreesMatch, readAuditLog,
     writeTestHooks, removeTestHooks,
     writeHookState, readHookState, clearHookState,
+    docrootDir,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -118,7 +119,7 @@ describe('Import: Concurrent Errors', { timeout: 180000 }, () => {
     });
 
     it('non-error files are still downloaded correctly', () => {
-        const importedRoot = join(tempDir, 'filesystem-root', getSiteDir(site));
+        const importedRoot = join(docrootDir(tempDir), getSiteDir(site));
         // allowMissing: multiple hooks with sleep(1) slow export, so sync may be incomplete
         assertTreesMatch(getSiteDir(site), importedRoot, {
             exclude: ['concurrent-unreadable.txt', 'concurrent-volatile.bin', 'concurrent-deletable.bin'],

--- a/tests/e2e/tests/import-30-symlink-manifest.test.js
+++ b/tests/e2e/tests/import-30-symlink-manifest.test.js
@@ -16,6 +16,7 @@ import {
     getSiteUrl, getSiteSecret, getSiteDir,
     assertTreesMatch, readAuditLog,
     assertSiteMirror,
+    docrootDir,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -55,7 +56,7 @@ describe('Import: Symlink Handling', () => {
     });
 
     it('regular files are still downloaded correctly', () => {
-        const importedRoot = join(tempDir, 'filesystem-root', getSiteDir(site));
+        const importedRoot = join(docrootDir(tempDir), getSiteDir(site));
         assertTreesMatch(getSiteDir(site), importedRoot);
     });
 
@@ -70,7 +71,7 @@ describe('Import: Symlink Handling', () => {
     });
 
     it('external-link symlink is handled in the import', () => {
-        const importedRoot = join(tempDir, 'filesystem-root', getSiteDir(site));
+        const importedRoot = join(docrootDir(tempDir), getSiteDir(site));
         const externalLinkPath = join(importedRoot, 'test-data', 'external-link');
 
         if (existsSync(externalLinkPath)) {

--- a/tests/e2e/tests/import-31-follow-symlinks.test.js
+++ b/tests/e2e/tests/import-31-follow-symlinks.test.js
@@ -10,7 +10,7 @@
  * - Chained symlinks (target dir contains more symlinks) are followed recursively
  * - Circular symlinks don't cause infinite loops
  * - Multiple symlinks to the same target don't cause duplicate downloads
- * - The local filesystem-root mirrors the server's directory layout
+ * - The local docroot mirrors the server's directory layout
  */
 import { describe, it, beforeAll, afterAll } from 'vitest';
 import assert from 'node:assert/strict';
@@ -25,6 +25,7 @@ import {
     runImporter, createTempDir, cleanupTempDir,
     getSiteUrl, getSiteSecret, getSiteDir,
     readAuditLog,
+    docrootDir,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -179,7 +180,7 @@ describe('Import: Follow Symlinks', () => {
     }
 
     function fsRoot() {
-        return join(tempDir, 'filesystem-root');
+        return docrootDir(tempDir);
     }
 
     function lstatIfExists(path) {
@@ -351,13 +352,13 @@ describe('Import: Follow Symlinks', () => {
 
     // ─── Layout correctness ────────────────────────────────────────
 
-    it('filesystem-root mirrors the server directory layout', () => {
-        // The site root should be under filesystem-root/<site-dir>
+    it('docroot mirrors the server directory layout', () => {
+        // The site root should be under docroot/<site-dir>
         const siteRoot = join(fsRoot(), getSiteDir(site));
         assert.ok(existsSync(siteRoot),
             `Expected site root at ${siteRoot}`);
 
-        // External content should be under filesystem-root/<external-root>
+        // External content should be under docroot/<external-root>
         const externalRoot = join(fsRoot(), EXTERNAL_ROOT);
         assert.ok(existsSync(externalRoot),
             `Expected external root at ${externalRoot}`);
@@ -365,7 +366,7 @@ describe('Import: Follow Symlinks', () => {
         // Both should share the same top-level prefix (/srv)
         const srvDir = join(fsRoot(), 'srv');
         assert.ok(existsSync(srvDir),
-            `Expected /srv directory in filesystem-root`);
+            `Expected /srv directory in docroot`);
     });
 
     it('WordPress core files are present alongside symlink targets', () => {

--- a/tests/e2e/tests/import-32-delta-deletions-and-type-swaps.test.js
+++ b/tests/e2e/tests/import-32-delta-deletions-and-type-swaps.test.js
@@ -20,7 +20,7 @@ import {
 import { ensureSite } from '../lib/site-setup.js';
 
 describe('Import: Delta deletions and type swaps', () => {
-    const site = 'file-changes';
+    const site = 'file-type-swaps';
     const scenarioName = 'delta-rigorous';
     const preserveName = 'delta-rigorous-preserve';
     const remoteScenarioRoot = join(getSiteDir(site), 'test-data', scenarioName);

--- a/tests/e2e/tests/import-32-delta-deletions-and-type-swaps.test.js
+++ b/tests/e2e/tests/import-32-delta-deletions-and-type-swaps.test.js
@@ -15,6 +15,7 @@ import { join } from 'node:path';
 import {
     runImporter, createTempDir, cleanupTempDir,
     getSiteUrl, getSiteSecret, getSiteDir,
+    docrootDir,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -44,11 +45,11 @@ describe('Import: Delta deletions and type swaps', () => {
     }
 
     function localScenarioRoot() {
-        return join(tempDir, 'filesystem-root', getSiteDir(site), 'test-data', scenarioName);
+        return join(docrootDir(tempDir), getSiteDir(site), 'test-data', scenarioName);
     }
 
     function localPreserveFile() {
-        return join(tempDir, 'filesystem-root', getSiteDir(site), 'test-data', preserveName, 'keep.txt');
+        return join(docrootDir(tempDir), getSiteDir(site), 'test-data', preserveName, 'keep.txt');
     }
 
     function lstatIfExists(path) {

--- a/tests/e2e/tests/import-34-delta-type-swap-cache-invalidation.test.js
+++ b/tests/e2e/tests/import-34-delta-type-swap-cache-invalidation.test.js
@@ -15,6 +15,7 @@ import { setTimeout as sleep } from 'node:timers/promises';
 import {
     runImporter, createTempDir, cleanupTempDir,
     getSiteSecret, getSiteDir,
+    docrootDir,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -127,7 +128,7 @@ chown -R nginx:nginx ${sh(remoteRoot)}
     it('delta keeps symlink->file transition', () => {
         const tempDir = runScenarioOnce('e2e-delta-cache-type-swaps-file');
         try {
-            const root = join(tempDir, 'filesystem-root', remoteRoot);
+            const root = join(docrootDir(tempDir), remoteRoot);
             const symlinkToDirToFile = join(root, 'symlink-to-dir-to-file');
             assert.ok(lstatSync(symlinkToDirToFile).isFile(), 'Expected symlink-to-dir-to-file to become a regular file');
             assert.equal(readFileSync(symlinkToDirToFile, 'utf-8'), 'became-file\n');
@@ -139,7 +140,7 @@ chown -R nginx:nginx ${sh(remoteRoot)}
     it('delta keeps symlink->directory transition with nested data', () => {
         const tempDir = runScenarioOnce('e2e-delta-cache-type-swaps-dir');
         try {
-            const root = join(tempDir, 'filesystem-root', remoteRoot);
+            const root = join(docrootDir(tempDir), remoteRoot);
             const nestedFile = join(root, 'symlink-to-file-to-dir', 'x', 'y', 'z', 'value.txt');
             assert.ok(existsSync(nestedFile), `Expected nested file at ${nestedFile}`);
             assert.equal(readFileSync(nestedFile, 'utf-8'), 'became-directory\n');

--- a/tests/e2e/tests/import-34-delta-type-swap-cache-invalidation.test.js
+++ b/tests/e2e/tests/import-34-delta-type-swap-cache-invalidation.test.js
@@ -20,7 +20,7 @@ import {
 import { ensureSite } from '../lib/site-setup.js';
 
 describe('Import: Delta type swaps cache invalidation', () => {
-    const site = 'file-changes';
+    const site = 'file-type-cache';
     const port = 8112;
     const scenarioName = 'delta-cache-type-swaps';
     const remoteRoot = join(getSiteDir(site), 'test-data', scenarioName);


### PR DESCRIPTION
## Summary

The CLI importer now requires two explicit paths: `--state-dir` for transient import state (cursors, indexes, audit logs, `db.sql`) and `--docroot` for the actual site files.

Why?

Before this PR, the migration state files and the downloaded site files in a single directory with the `state/` and `filesystem-root/` subdirectories. This was inconvenient for syncing the remote site into the pre-determined local document root.

## Test plan

- [x] `php importer/import.php --help` shows the new usage syntax with `--state-dir=DIR --docroot=DIR`
- [x] Missing `--state-dir` or `--docroot` produces a clear error message
- [x] All 106 non-DB unit tests pass (DB tests require a running MySQL server)
- [ ] E2E tests pass with the new two-directory layout (`cd tests/e2e && ./run-all-tests.sh`)