### PR TITLE
Rename --db-* to --mysql-*, add --mysql-port, document output modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,11 +95,36 @@ Which is to say, you'll need to wrap it in a loop that runs until failure or ful
 
 #### Step 3 — Download the database.
 
-This streams a SQL dump into `db.sql`:
+By default, this streams a SQL dump into `$STATE_DIR/db.sql`:
 
 ```bash
 php importer/import.php db-sync "$URL" --state-dir="$STATE_DIR" --docroot="$DOCROOT" --secret="$SECRET"
 ```
+
+You can also pipe the SQL directly to stdout or stream it into a MySQL server
+without writing a file to disk. Use `--sql-output` to choose the mode:
+
+```bash
+# Pipe to stdout — useful for feeding into mysql CLI or another tool
+php importer/import.php db-sync "$URL" --state-dir="$STATE_DIR" --docroot="$DOCROOT" --secret="$SECRET" \
+    --sql-output=stdout | mysql -u root my_database
+
+# Stream directly into MySQL — no intermediate file, no pipe
+php importer/import.php db-sync "$URL" --state-dir="$STATE_DIR" --docroot="$DOCROOT" --secret="$SECRET" \
+    --sql-output=mysql --db-name=my_database --db-host=127.0.0.1 --db-user=root --db-pass=secret
+```
+
+The three modes:
+
+| Mode | What happens | Output file |
+|------|-------------|-------------|
+| `file` (default) | Writes SQL to `$STATE_DIR/db.sql` | `db.sql` |
+| `stdout` | Streams SQL to stdout, progress/status goes to stderr | none |
+| `mysql` | Connects via `mysqli::multi_query()` and executes statements as they arrive | none |
+
+The `mysql` mode requires `--db-name` and accepts `--db-host`, `--db-user`, and
+`--db-pass` (or the `DB_PASS` environment variable). The host string supports
+the same `host:port` and `host:/path/to/socket` formats as WordPress `DB_HOST`.
 
 The command returns one of three exit codes:
 
@@ -140,15 +165,14 @@ to run that on your platform.
 
 The `db.sql` file will contain the relevant `DELETE TABLE IF EXISTS`
 statements to make sure it can always succeed. You might want to,
-before the first run, clean up any tables that may have been already 
+before the first run, clean up any tables that may have been already
 created by your environment. We won't need them. Furthermore, they may
 not get deleted during the database import if the site doesn't use
 the same table prefix as your environment.
 
-At the moment, there is no convenient way of piping the downloaded
-SQL straight into MySQL while it's still being downloaded. This would
-be a useful feature that will likely be added later on. Today, though,
-you just need to download the entire SQL dump and only pipe it then.
+If you used `--sql-output=mysql`, the SQL was already executed — there's
+no `db.sql` to import. For `--sql-output=stdout`, the SQL was piped to
+whatever tool was reading stdout (typically `mysql` CLI).
 
 ### Status files
 
@@ -245,6 +269,7 @@ If the JSON is invalid on load, the importer renames it to
   "current_file": "wp-content/uploads/photo.jpg",
   "current_file_bytes": 1048576,  // expected size after last complete write
   "sql_bytes": 524288,            // expected db.sql size
+  "sql_output": "file",           // "file" | "stdout" | "mysql"
 
   "tuning": {
     "config": { ... },            // AIMD parameters
@@ -309,7 +334,7 @@ php importer/import.php <command> <URL> --state-dir=DIR --docroot=DIR [options]
 * `files-sync` — Sync files. Auto-detects initial vs delta based on state: downloads the full tree on first run, only changes on subsequent runs.
 * `files-index` — Optional. It's a standalone command to index the full remote file index without fetching file contents. `files-sync` does it implicitly
                   so this is mostly useful for testing and diagnostics.
-* `db-sync` — Downloads the database as a SQL dump to `db.sql`.
+* `db-sync` — Downloads the database as a SQL dump. Defaults to writing `db.sql`; use `--sql-output=stdout` or `--sql-output=mysql` to stream elsewhere.
 * `db-index` — Indexes database tables and their statistics (name, row count, size) to `db-tables.jsonl`.
 
 All commands except `preflight-assert` support `--abort` to abort the current sync and exit. For `files-sync`, this clears sync progress but keeps the local index and downloaded files — the next run performs a delta sync. For `db-sync` and `db-index`, it clears the output file so the next run starts from scratch. Interrupted commands automatically resume from the last saved cursor.

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ php importer/import.php db-sync "$URL" --state-dir="$STATE_DIR" --docroot="$DOCR
 
 # Stream directly into MySQL — no intermediate file, no pipe
 php importer/import.php db-sync "$URL" --state-dir="$STATE_DIR" --docroot="$DOCROOT" --secret="$SECRET" \
-    --sql-output=mysql --db-name=my_database --db-host=127.0.0.1 --db-user=root --db-pass=secret
+    --sql-output=mysql --mysql-database=my_database --mysql-host=127.0.0.1 --mysql-user=root --mysql-password=secret
 ```
 
 The three modes:
@@ -122,9 +122,11 @@ The three modes:
 | `stdout` | Streams SQL to stdout, progress/status goes to stderr | none |
 | `mysql` | Connects via `mysqli::multi_query()` and executes statements as they arrive | none |
 
-The `mysql` mode requires `--db-name` and accepts `--db-host`, `--db-user`, and
-`--db-pass` (or the `DB_PASS` environment variable). The host string supports
-the same `host:port` and `host:/path/to/socket` formats as WordPress `DB_HOST`.
+The `mysql` mode requires `--mysql-database` and accepts `--mysql-host`,
+`--mysql-port`, `--mysql-user`, and `--mysql-password` (or the `MYSQL_PASSWORD`
+environment variable). The host string also supports `host:port` and
+`host:/path/to/socket` formats (same as WordPress `DB_HOST`), but
+`--mysql-port` takes precedence when both are specified.
 
 The command returns one of three exit codes:
 

--- a/importer/import.php
+++ b/importer/import.php
@@ -927,16 +927,19 @@ class ImportClient
     private $sql_output_mode = 'file';
 
     /** @var string|null MySQL host for --sql-output=mysql. */
-    private $sql_db_host;
+    private $mysql_host;
+
+    /** @var int|null MySQL port for --sql-output=mysql. */
+    private $mysql_port;
 
     /** @var string|null MySQL user for --sql-output=mysql. */
-    private $sql_db_user;
+    private $mysql_user;
 
     /** @var string|null MySQL password for --sql-output=mysql. */
-    private $sql_db_pass;
+    private $mysql_password;
 
     /** @var string|null MySQL database for --sql-output=mysql. */
-    private $sql_db_name;
+    private $mysql_database;
 
     /** @var resource File descriptor for progress output — STDOUT normally, STDERR in stdout mode. */
     private $progress_fd;
@@ -1269,7 +1272,7 @@ class ImportClient
 
         // Persist sql_output_mode in state so it survives across resume invocations.
         // The password is NOT persisted — it must be supplied on every run (or via
-        // the DB_PASS environment variable).
+        // the MYSQL_PASSWORD environment variable).
         if (isset($options["sql_output"])) {
             $mode = $options["sql_output"];
             if (!in_array($mode, ["file", "stdout", "mysql"])) {
@@ -1291,40 +1294,47 @@ class ImportClient
         }
 
         // MySQL connection parameters for --sql-output=mysql.
-        if (isset($options["sql_db_host"])) {
-            $this->sql_db_host = $options["sql_db_host"];
-            $this->state["sql_db_host"] = $this->sql_db_host;
-        } elseif (isset($this->state["sql_db_host"])) {
-            $this->sql_db_host = $this->state["sql_db_host"];
+        if (isset($options["mysql_host"])) {
+            $this->mysql_host = $options["mysql_host"];
+            $this->state["mysql_host"] = $this->mysql_host;
+        } elseif (isset($this->state["mysql_host"])) {
+            $this->mysql_host = $this->state["mysql_host"];
         }
 
-        if (isset($options["sql_db_user"])) {
-            $this->sql_db_user = $options["sql_db_user"];
-            $this->state["sql_db_user"] = $this->sql_db_user;
-        } elseif (isset($this->state["sql_db_user"])) {
-            $this->sql_db_user = $this->state["sql_db_user"];
+        if (isset($options["mysql_port"])) {
+            $this->mysql_port = (int) $options["mysql_port"];
+            $this->state["mysql_port"] = $this->mysql_port;
+        } elseif (isset($this->state["mysql_port"])) {
+            $this->mysql_port = (int) $this->state["mysql_port"];
         }
 
-        if (isset($options["sql_db_name"])) {
-            $this->sql_db_name = $options["sql_db_name"];
-            $this->state["sql_db_name"] = $this->sql_db_name;
-        } elseif (isset($this->state["sql_db_name"])) {
-            $this->sql_db_name = $this->state["sql_db_name"];
+        if (isset($options["mysql_user"])) {
+            $this->mysql_user = $options["mysql_user"];
+            $this->state["mysql_user"] = $this->mysql_user;
+        } elseif (isset($this->state["mysql_user"])) {
+            $this->mysql_user = $this->state["mysql_user"];
+        }
+
+        if (isset($options["mysql_database"])) {
+            $this->mysql_database = $options["mysql_database"];
+            $this->state["mysql_database"] = $this->mysql_database;
+        } elseif (isset($this->state["mysql_database"])) {
+            $this->mysql_database = $this->state["mysql_database"];
         }
 
         $this->save_state($this->state);
 
         // Password is never persisted — must be supplied each run or via env.
-        if (isset($options["sql_db_pass"])) {
-            $this->sql_db_pass = $options["sql_db_pass"];
-        } elseif (getenv("DB_PASS") !== false) {
-            $this->sql_db_pass = getenv("DB_PASS");
+        if (isset($options["mysql_password"])) {
+            $this->mysql_password = $options["mysql_password"];
+        } elseif (getenv("MYSQL_PASSWORD") !== false) {
+            $this->mysql_password = getenv("MYSQL_PASSWORD");
         }
 
         // Validate mysql mode requirements.
-        if ($this->sql_output_mode === "mysql" && empty($this->sql_db_name)) {
+        if ($this->sql_output_mode === "mysql" && empty($this->mysql_database)) {
             throw new InvalidArgumentException(
-                "--db-name is required when using --sql-output=mysql",
+                "--mysql-database is required when using --sql-output=mysql",
             );
         }
 
@@ -2727,7 +2737,7 @@ class ImportClient
             } elseif ($this->sql_output_mode === "stdout") {
                 fwrite($this->progress_fd, "SQL written to stdout\n");
             } elseif ($this->sql_output_mode === "mysql") {
-                fwrite($this->progress_fd, "SQL imported into {$this->sql_db_name}\n");
+                fwrite($this->progress_fd, "SQL imported into {$this->mysql_database}\n");
             }
             fwrite($this->progress_fd, "Audit log: {$this->audit_log}\n");
         }
@@ -4054,19 +4064,21 @@ class ImportClient
         } elseif ($mode === "mysql") {
             $sql_bytes_written = $this->state["sql_bytes"] ?? 0;
 
-            $host = $this->sql_db_host ?? "127.0.0.1";
-            $user = $this->sql_db_user ?? "root";
-            $pass = $this->sql_db_pass ?? "";
-            $name = $this->sql_db_name;
+            $host = $this->mysql_host ?? "127.0.0.1";
+            $user = $this->mysql_user ?? "root";
+            $pass = $this->mysql_password ?? "";
+            $name = $this->mysql_database;
 
-            // Parse host for port/socket (same format as WordPress DB_HOST)
-            $port = 3306;
+            // Parse host for port/socket (same format as WordPress DB_HOST).
+            // An explicit --mysql-port takes precedence over a port embedded
+            // in the host string.
+            $port = $this->mysql_port ?? 3306;
             $socket = null;
             if (strpos($host, ":") !== false) {
                 list($host, $port_or_socket) = explode(":", $host, 2);
                 if ($port_or_socket[0] === "/") {
                     $socket = $port_or_socket;
-                } else {
+                } elseif ($this->mysql_port === null) {
                     $port = (int) $port_or_socket;
                 }
             }
@@ -5921,6 +5933,11 @@ class ImportClient
             "sql_bytes" => null,           // Expected SQL file size
             // SQL output mode (file, stdout, mysql) — persisted for resume
             "sql_output" => null,
+            // MySQL connection parameters — persisted for resume (password excluded)
+            "mysql_host" => null,
+            "mysql_port" => null,
+            "mysql_user" => null,
+            "mysql_database" => null,
             // Adaptive tuning state/config
             "tuning" => [
                 "config" => [],
@@ -6534,10 +6551,11 @@ if (
                 "  --verbose, -v               Show detailed request/response logs\n" .
                 "  --max-allowed-packet=SIZE   Client max_allowed_packet (e.g. 16M, 64M)\n" .
                 "  --sql-output=MODE           Output mode: file (default), stdout, mysql\n" .
-                "  --db-host=HOST              MySQL host (default: 127.0.0.1, for --sql-output=mysql)\n" .
-                "  --db-user=USER              MySQL user (default: root, for --sql-output=mysql)\n" .
-                "  --db-pass=PASS              MySQL password (for --sql-output=mysql; or set DB_PASS env)\n" .
-                "  --db-name=DB                MySQL database (required for --sql-output=mysql)\n" .
+                "  --mysql-host=HOST           MySQL host (default: 127.0.0.1, for --sql-output=mysql)\n" .
+                "  --mysql-port=PORT           MySQL port (default: 3306, for --sql-output=mysql)\n" .
+                "  --mysql-user=USER           MySQL user (default: root, for --sql-output=mysql)\n" .
+                "  --mysql-password=PASS       MySQL password (or set MYSQL_PASSWORD env)\n" .
+                "  --mysql-database=DB         MySQL database (required for --sql-output=mysql)\n" .
                 "\n" .
                 "Output modes:\n" .
                 "  file    Write to --state-dir/db.sql (default)\n" .
@@ -6844,14 +6862,16 @@ if (
             $options["pipeline_steps"] = (int) substr($argv[$i], strlen("--steps="));
         } elseif (strpos($argv[$i], "--sql-output=") === 0) {
             $options["sql_output"] = substr($argv[$i], strlen("--sql-output="));
-        } elseif (strpos($argv[$i], "--db-host=") === 0) {
-            $options["sql_db_host"] = substr($argv[$i], strlen("--db-host="));
-        } elseif (strpos($argv[$i], "--db-user=") === 0) {
-            $options["sql_db_user"] = substr($argv[$i], strlen("--db-user="));
-        } elseif (strpos($argv[$i], "--db-pass=") === 0) {
-            $options["sql_db_pass"] = substr($argv[$i], strlen("--db-pass="));
-        } elseif (strpos($argv[$i], "--db-name=") === 0) {
-            $options["sql_db_name"] = substr($argv[$i], strlen("--db-name="));
+        } elseif (strpos($argv[$i], "--mysql-host=") === 0) {
+            $options["mysql_host"] = substr($argv[$i], strlen("--mysql-host="));
+        } elseif (strpos($argv[$i], "--mysql-port=") === 0) {
+            $options["mysql_port"] = substr($argv[$i], strlen("--mysql-port="));
+        } elseif (strpos($argv[$i], "--mysql-user=") === 0) {
+            $options["mysql_user"] = substr($argv[$i], strlen("--mysql-user="));
+        } elseif (strpos($argv[$i], "--mysql-password=") === 0) {
+            $options["mysql_password"] = substr($argv[$i], strlen("--mysql-password="));
+        } elseif (strpos($argv[$i], "--mysql-database=") === 0) {
+            $options["mysql_database"] = substr($argv[$i], strlen("--mysql-database="));
         } else {
             fwrite(STDERR, "Unknown option: {$argv[$i]}\n");
             exit(1);

--- a/tests/e2e/tests/import-35-sql-output-modes.test.js
+++ b/tests/e2e/tests/import-35-sql-output-modes.test.js
@@ -92,10 +92,10 @@ describe('Import: SQL Output Modes', () => {
                     secret: getSiteSecret(site),
                     extraArgs: [
                         '--sql-output=mysql',
-                        `--db-name=${importDb}`,
-                        '--db-host=127.0.0.1',
-                        '--db-user=e2e_admin',
-                        '--db-pass=e2e_password',
+                        `--mysql-database=${importDb}`,
+                        '--mysql-host=127.0.0.1',
+                        '--mysql-user=e2e_admin',
+                        '--mysql-password=e2e_password',
                     ],
                 },
             );


### PR DESCRIPTION
## Summary

Renames the `db-sync` MySQL connection flags to be more explicit and consistent:

| Old | New |
|-----|-----|
| `--db-host` | `--mysql-host` |
| `--db-user` | `--mysql-user` |
| `--db-pass` | `--mysql-password` |
| `--db-name` | `--mysql-database` |
| `DB_PASS` env | `MYSQL_PASSWORD` env |

Adds `--mysql-port` so non-standard ports can be specified without embedding them in the host string. When both `--mysql-port` and a `host:port` value are given, the explicit flag wins.

Also adds the MySQL connection parameters and `sql_output` to `default_state()` so they survive `normalize_state()` across resume cycles, and documents the three `--sql-output` modes in the README with usage examples and a comparison table.

## Test plan

- [ ] `php -l importer/import.php` passes
- [ ] Unit tests pass (`composer test:fast`)
- [ ] E2E: `import-35-sql-output-modes.test.js` uses the new flag names