### PR TITLE
Persist partial SQL buffer to disk in mysql output mode

### DIFF
--- a/importer/import.php
+++ b/importer/import.php
@@ -4093,6 +4093,18 @@ class ImportClient
                 "SQL OUTPUT mysql | connected via multi_query(): {$user}@{$host}:{$port}/{$name}",
                 true,
             );
+
+            // Crash recovery: reload any partial query that was buffered to disk
+            // before the previous run ended. Without this, the cursor points past
+            // bytes the server won't re-send, and we'd execute a truncated query.
+            $buffer_file = $this->state_dir . "/.sql-buffer";
+            if (file_exists($buffer_file)) {
+                $sql_buffer = file_get_contents($buffer_file);
+                $this->audit_log(
+                    sprintf("CRASH RECOVERY | Restored %d bytes from .sql-buffer", strlen($sql_buffer)),
+                    true,
+                );
+            }
         }
 
         // Log current progress at start of request
@@ -4261,6 +4273,19 @@ class ImportClient
                 if ($sql_handle) {
                     fflush($sql_handle);
                 }
+
+                // In mysql mode, persist any partial query to disk before saving
+                // the cursor. If we crash between requests, the next run loads
+                // this file so the partial query isn't lost.
+                if ($mysql_conn) {
+                    $buffer_file = $this->state_dir . "/.sql-buffer";
+                    if ($sql_buffer !== "") {
+                        file_put_contents($buffer_file, $sql_buffer);
+                    } elseif (file_exists($buffer_file)) {
+                        unlink($buffer_file);
+                    }
+                }
+
                 $this->state["cursor"] = $cursor;
                 // Clear sql_bytes when complete, otherwise save current position
                 $this->state["sql_bytes"] = $complete ? null : $sql_bytes_written;
@@ -4274,6 +4299,12 @@ class ImportClient
                 $pending = $sql_buffer;
                 $mysql_conn->close();
                 $mysql_conn = null;
+                // Clean up buffer file — if we got here with an empty buffer,
+                // all queries were executed successfully.
+                $buffer_file = $this->state_dir . "/.sql-buffer";
+                if ($pending === "" && file_exists($buffer_file)) {
+                    unlink($buffer_file);
+                }
                 if ($pending !== "") {
                     throw new RuntimeException(
                         "Buffered SQL was never executed (" . strlen($pending) .

--- a/importer/import.php
+++ b/importer/import.php
@@ -4022,6 +4022,7 @@ class ImportClient
 
         $sql_handle = null;
         $mysql_conn = null;
+        $buffer_handle = null;
         $sql_bytes_written = 0;
         $sql_buffer = "";
 
@@ -4206,8 +4207,10 @@ class ImportClient
                             case "mysql":
                                 // Append to disk immediately so the buffer survives
                                 // even if the process is killed mid-chunk.
-                                fwrite($buffer_handle, $data);
-                                fflush($buffer_handle);
+                                if ($buffer_handle) {
+                                    fwrite($buffer_handle, $data);
+                                    fflush($buffer_handle);
+                                }
 
                                 $sql_buffer .= $data;
                                 $sql_bytes_written += strlen($data);
@@ -4227,8 +4230,10 @@ class ImportClient
                                     } while ($mysql_conn->more_results() && $mysql_conn->next_result());
 
                                     // Query executed — truncate the buffer file and reset.
-                                    ftruncate($buffer_handle, 0);
-                                    rewind($buffer_handle);
+                                    if ($buffer_handle) {
+                                        ftruncate($buffer_handle, 0);
+                                        rewind($buffer_handle);
+                                    }
                                     $sql_buffer = "";
                                 }
                                 break;
@@ -4299,7 +4304,7 @@ class ImportClient
             if ($sql_handle) {
                 fclose($sql_handle);
             }
-            if (isset($buffer_handle) && $buffer_handle) {
+            if ($buffer_handle) {
                 fclose($buffer_handle);
                 $buffer_handle = null;
             }

--- a/importer/import.php
+++ b/importer/import.php
@@ -4094,9 +4094,10 @@ class ImportClient
                 true,
             );
 
-            // Crash recovery: reload any partial query that was buffered to disk
-            // before the previous run ended. Without this, the cursor points past
-            // bytes the server won't re-send, and we'd execute a truncated query.
+            // Open a persistent buffer file so partial queries survive crashes.
+            // Each SQL chunk is appended to this file as it arrives; when the
+            // query completes and executes, the file is truncated. If the process
+            // dies at any point, the next run reloads whatever was accumulated.
             $buffer_file = $this->state_dir . "/.sql-buffer";
             if (file_exists($buffer_file)) {
                 $sql_buffer = file_get_contents($buffer_file);
@@ -4104,6 +4105,12 @@ class ImportClient
                     sprintf("CRASH RECOVERY | Restored %d bytes from .sql-buffer", strlen($sql_buffer)),
                     true,
                 );
+            }
+            // Open in write mode (truncate) if we loaded nothing, append if we
+            // have a partial query to continue accumulating into.
+            $buffer_handle = fopen($buffer_file, $sql_buffer !== "" ? "a" : "w");
+            if (!$buffer_handle) {
+                throw new RuntimeException("Cannot open SQL buffer file: {$buffer_file}");
             }
         }
 
@@ -4132,6 +4139,7 @@ class ImportClient
                     &$complete,
                     &$sql_handle,
                     $mysql_conn,
+                    &$buffer_handle,
                     &$sql_buffer,
                     &$sql_bytes_written,
                     $context
@@ -4196,6 +4204,11 @@ class ImportClient
                                 break;
 
                             case "mysql":
+                                // Append to disk immediately so the buffer survives
+                                // even if the process is killed mid-chunk.
+                                fwrite($buffer_handle, $data);
+                                fflush($buffer_handle);
+
                                 $sql_buffer .= $data;
                                 $sql_bytes_written += strlen($data);
 
@@ -4213,6 +4226,9 @@ class ImportClient
                                         }
                                     } while ($mysql_conn->more_results() && $mysql_conn->next_result());
 
+                                    // Query executed — truncate the buffer file and reset.
+                                    ftruncate($buffer_handle, 0);
+                                    rewind($buffer_handle);
                                     $sql_buffer = "";
                                 }
                                 break;
@@ -4274,18 +4290,6 @@ class ImportClient
                     fflush($sql_handle);
                 }
 
-                // In mysql mode, persist any partial query to disk before saving
-                // the cursor. If we crash between requests, the next run loads
-                // this file so the partial query isn't lost.
-                if ($mysql_conn) {
-                    $buffer_file = $this->state_dir . "/.sql-buffer";
-                    if ($sql_buffer !== "") {
-                        file_put_contents($buffer_file, $sql_buffer);
-                    } elseif (file_exists($buffer_file)) {
-                        unlink($buffer_file);
-                    }
-                }
-
                 $this->state["cursor"] = $cursor;
                 // Clear sql_bytes when complete, otherwise save current position
                 $this->state["sql_bytes"] = $complete ? null : $sql_bytes_written;
@@ -4294,6 +4298,10 @@ class ImportClient
         } finally {
             if ($sql_handle) {
                 fclose($sql_handle);
+            }
+            if (isset($buffer_handle) && $buffer_handle) {
+                fclose($buffer_handle);
+                $buffer_handle = null;
             }
             if ($mysql_conn) {
                 $pending = $sql_buffer;

--- a/tests/e2e/tests/import-36-mysql-mode-crash-recovery.test.js
+++ b/tests/e2e/tests/import-36-mysql-mode-crash-recovery.test.js
@@ -3,9 +3,9 @@
  *
  * When using --sql-output=mysql with short execution times, the server
  * may pause mid-query (x-query-complete: 0). The importer buffers the
- * partial SQL in memory and persists it to .sql-buffer on disk between
- * requests. If the process dies and restarts, it reloads the buffer so
- * the partial query isn't lost.
+ * partial SQL in memory and persists it to .sql-buffer on disk as each
+ * chunk arrives. If the process dies at any point, the next run reloads
+ * whatever was accumulated.
  *
  * This test forces many resume cycles with --max-exec=1, verifies the
  * database is correct after completion, and confirms .sql-buffer is
@@ -42,7 +42,7 @@ describe('Import: MySQL Mode Crash Recovery', { timeout: 120000 }, () => {
         '--mysql-password=e2e_password',
     ];
 
-    describe('resume after partial run with short --max-exec', () => {
+    describe('resume with short --max-exec completes correctly', () => {
         let tempDir;
         const importDb = 'e2e_basic_import_36_resume';
 
@@ -61,35 +61,12 @@ describe('Import: MySQL Mode Crash Recovery', { timeout: 120000 }, () => {
             await conn.end();
         });
 
-        it('partial run saves state and cursor', () => {
-            // Run with --max-exec=1 and no auto-resume to get a single
-            // partial run that exits with code 2.
+        it('completes via multiple resume cycles and database matches source', async () => {
+            // Use --max-exec=1 to force the server to pause frequently,
+            // creating many resume cycles. auto-resume handles exit code 2.
             const result = runImporter(importUrl(), tempDir, 'db-sync', {
                 secret: getSiteSecret(site),
                 extraArgs: [...mysqlArgs(importDb), '--max-exec=1'],
-                autoResume: false,
-            });
-
-            // Exit code 2 = partial completion, 0 = happened to finish
-            assert.ok(
-                result.exitCode === 0 || result.exitCode === 2,
-                `Expected exit 0 or 2, got ${result.exitCode}\nstderr: ${result.stderr}`,
-            );
-
-            if (result.exitCode === 2) {
-                const state = JSON.parse(
-                    readFileSync(join(tempDir, '.import-state.json'), 'utf-8'),
-                );
-                assert.ok(state.cursor, 'Expected cursor to be saved after partial run');
-            }
-        });
-
-        it('resume completes and database matches source', async () => {
-            // Let auto-resume finish the job (may take many cycles with --max-exec=1)
-            const result = runImporter(importUrl(), tempDir, 'db-sync', {
-                secret: getSiteSecret(site),
-                extraArgs: [...mysqlArgs(importDb), '--max-exec=1'],
-                skipPreflight: true,
                 maxResumeAttempts: 200,
                 wallTimeout: 90000,
             });
@@ -103,8 +80,7 @@ describe('Import: MySQL Mode Crash Recovery', { timeout: 120000 }, () => {
         });
 
         it('.sql-buffer is cleaned up after completion', () => {
-            const bufferFile = join(tempDir, '.sql-buffer');
-            assert.ok(!existsSync(bufferFile),
+            assert.ok(!existsSync(join(tempDir, '.sql-buffer')),
                 'Expected .sql-buffer to be cleaned up after successful completion');
         });
 

--- a/tests/e2e/tests/import-36-mysql-mode-crash-recovery.test.js
+++ b/tests/e2e/tests/import-36-mysql-mode-crash-recovery.test.js
@@ -1,0 +1,167 @@
+/**
+ * Test 36: MySQL Mode Crash Recovery
+ *
+ * When using --sql-output=mysql with short execution times, the server
+ * may pause mid-query (x-query-complete: 0). The importer buffers the
+ * partial SQL in memory and persists it to .sql-buffer on disk between
+ * requests. If the process dies and restarts, it reloads the buffer so
+ * the partial query isn't lost.
+ *
+ * This test forces many resume cycles with --max-exec=1, verifies the
+ * database is correct after completion, and confirms .sql-buffer is
+ * cleaned up.
+ */
+import { describe, it, beforeAll, afterAll } from 'vitest';
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+    runImporter, createTempDir, cleanupTempDir,
+    getSiteUrl, getSiteSecret, getSiteDir,
+    getDbName, compareDatabases, createMysqlConnection,
+    readAuditLog,
+} from '../lib/test-helpers.js';
+import { ensureSite } from '../lib/site-setup.js';
+
+describe('Import: MySQL Mode Crash Recovery', { timeout: 120000 }, () => {
+    const site = 'basic';
+
+    beforeAll(async () => {
+        await ensureSite(site);
+    });
+
+    function importUrl() {
+        return `${getSiteUrl(site)}&directory=${getSiteDir(site)}`;
+    }
+
+    const mysqlArgs = (db) => [
+        '--sql-output=mysql',
+        `--mysql-database=${db}`,
+        '--mysql-host=127.0.0.1',
+        '--mysql-user=e2e_admin',
+        '--mysql-password=e2e_password',
+    ];
+
+    describe('resume after partial run with short --max-exec', () => {
+        let tempDir;
+        const importDb = 'e2e_basic_import_36_resume';
+
+        beforeAll(async () => {
+            tempDir = createTempDir('e2e-mysql-crash-recovery');
+            const conn = await createMysqlConnection();
+            await conn.query(`DROP DATABASE IF EXISTS \`${importDb}\``);
+            await conn.query(`CREATE DATABASE \`${importDb}\``);
+            await conn.end();
+        });
+
+        afterAll(async () => {
+            cleanupTempDir(tempDir);
+            const conn = await createMysqlConnection();
+            await conn.query(`DROP DATABASE IF EXISTS \`${importDb}\``);
+            await conn.end();
+        });
+
+        it('partial run saves state and cursor', () => {
+            // Run with --max-exec=1 and no auto-resume to get a single
+            // partial run that exits with code 2.
+            const result = runImporter(importUrl(), tempDir, 'db-sync', {
+                secret: getSiteSecret(site),
+                extraArgs: [...mysqlArgs(importDb), '--max-exec=1'],
+                autoResume: false,
+            });
+
+            // Exit code 2 = partial completion, 0 = happened to finish
+            assert.ok(
+                result.exitCode === 0 || result.exitCode === 2,
+                `Expected exit 0 or 2, got ${result.exitCode}\nstderr: ${result.stderr}`,
+            );
+
+            if (result.exitCode === 2) {
+                const state = JSON.parse(
+                    readFileSync(join(tempDir, '.import-state.json'), 'utf-8'),
+                );
+                assert.ok(state.cursor, 'Expected cursor to be saved after partial run');
+            }
+        });
+
+        it('resume completes and database matches source', async () => {
+            // Let auto-resume finish the job (may take many cycles with --max-exec=1)
+            const result = runImporter(importUrl(), tempDir, 'db-sync', {
+                secret: getSiteSecret(site),
+                extraArgs: [...mysqlArgs(importDb), '--max-exec=1'],
+                skipPreflight: true,
+                maxResumeAttempts: 200,
+                wallTimeout: 90000,
+            });
+            assert.equal(result.exitCode, 0,
+                `Expected exit 0, got ${result.exitCode}\nstderr: ${result.stderr}`);
+
+            const comparison = await compareDatabases(getDbName(site), importDb);
+            assert.ok(comparison.match,
+                `Database mismatch: missing=${JSON.stringify(comparison.missingTables)}, ` +
+                `counts=${JSON.stringify(comparison.rowCounts)}`);
+        });
+
+        it('.sql-buffer is cleaned up after completion', () => {
+            const bufferFile = join(tempDir, '.sql-buffer');
+            assert.ok(!existsSync(bufferFile),
+                'Expected .sql-buffer to be cleaned up after successful completion');
+        });
+
+        it('no db.sql on disk', () => {
+            assert.ok(!existsSync(join(tempDir, 'db.sql')),
+                'Expected no db.sql file when using --sql-output=mysql');
+        });
+    });
+
+    describe('pre-seeded .sql-buffer is loaded on resume', () => {
+        let tempDir;
+        const importDb = 'e2e_basic_import_36_seeded';
+
+        beforeAll(async () => {
+            tempDir = createTempDir('e2e-mysql-seeded-buffer');
+            const conn = await createMysqlConnection();
+            await conn.query(`DROP DATABASE IF EXISTS \`${importDb}\``);
+            await conn.query(`CREATE DATABASE \`${importDb}\``);
+            await conn.end();
+        });
+
+        afterAll(async () => {
+            cleanupTempDir(tempDir);
+            const conn = await createMysqlConnection();
+            await conn.query(`DROP DATABASE IF EXISTS \`${importDb}\``);
+            await conn.end();
+        });
+
+        it('loads .sql-buffer from disk and logs recovery', () => {
+            // Run preflight so db-sync can proceed
+            runImporter(importUrl(), tempDir, 'preflight', {
+                secret: getSiteSecret(site),
+            });
+
+            // Seed a .sql-buffer file before running db-sync.
+            // The content is a harmless SQL comment that won't affect execution
+            // — the point is to verify the importer reads it and logs recovery.
+            const bufferFile = join(tempDir, '.sql-buffer');
+            writeFileSync(bufferFile, '-- pre-seeded buffer\n');
+
+            // Run a fresh db-sync — the importer should detect the buffer file
+            const result = runImporter(importUrl(), tempDir, 'db-sync', {
+                secret: getSiteSecret(site),
+                extraArgs: mysqlArgs(importDb),
+                skipPreflight: true,
+            });
+            assert.equal(result.exitCode, 0,
+                `Expected exit 0, got ${result.exitCode}\nstderr: ${result.stderr}`);
+
+            // Verify recovery was logged
+            const audit = readAuditLog(tempDir);
+            assert.ok(audit.includes('CRASH RECOVERY') && audit.includes('.sql-buffer'),
+                'Expected audit log to mention .sql-buffer crash recovery');
+
+            // Buffer should be cleaned up
+            assert.ok(!existsSync(bufferFile),
+                'Expected .sql-buffer to be removed after completion');
+        });
+    });
+});


### PR DESCRIPTION
## Summary

When using `--sql-output=mysql`, the server can pause mid-query at its time budget boundary, sending `x-query-complete: 0` on the last chunk. The importer holds the partial SQL in an in-memory buffer until the next request brings the rest. That works fine within the same process, but if the process dies between HTTP requests the buffer is lost. The cursor has already advanced past those bytes, so the server won't re-send them — the next run tries to execute a truncated query against MySQL.

This adds a `.sql-buffer` file in the state directory that mirrors the in-memory buffer to disk:

- On startup in mysql mode, if `.sql-buffer` exists, its contents are loaded back into memory
- After each HTTP request, the buffer is written to disk (or the file is deleted if the buffer is empty)
- On clean shutdown, the file is removed

This is the same crash-recovery pattern that file mode uses with `sql_bytes` and file truncation — just adapted for the case where the "file" is a MySQL connection and the data lives in memory between requests.

## Test plan

- [ ] `php -l importer/import.php` passes
- [ ] E2E: `import-35-sql-output-modes.test.js` still passes
- [ ] Manual: kill the importer mid-export in mysql mode, re-run — the partial query is recovered from `.sql-buffer` and execution continues cleanly