### PR TITLE
Add build script to package the importer as a self-contained .phar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,4 @@ exports
 exports-old
 siteground-export-*
 node_modules
-
+*.phar

--- a/bin/build-importer-phar.sh
+++ b/bin/build-importer-phar.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+#
+# Builds importer.phar — a self-contained, lean archive of the import client
+# with all its runtime dependencies baked in.
+#
+# Usage:
+#   ./bin/build-importer-phar.sh            # outputs importer.phar in project root
+#   ./bin/build-importer-phar.sh /tmp/out   # outputs /tmp/out/importer.phar
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+OUTPUT_DIR="${1:-$PROJECT_ROOT}"
+PHAR_FILE="$OUTPUT_DIR/importer.phar"
+
+# ── Preflight checks ──────────────────────────────────────────────
+
+if ! command -v php >/dev/null 2>&1; then
+    echo "Error: php not found in PATH" >&2
+    exit 1
+fi
+
+# Verify the submodule is initialised
+if [ ! -f "$PROJECT_ROOT/lib/sqlite-database-integration/wp-includes/parser/class-wp-parser.php" ]; then
+    echo "Error: sqlite-database-integration submodule not initialised." >&2
+    echo "Run: git submodule update --init" >&2
+    exit 1
+fi
+
+# Verify composer deps are installed (--no-dev is fine)
+if [ ! -f "$PROJECT_ROOT/vendor/autoload.php" ]; then
+    echo "Error: vendor/ not found. Run: composer install --no-dev" >&2
+    exit 1
+fi
+
+# ── Assemble a staging directory ──────────────────────────────────
+
+STAGE=$(mktemp -d)
+trap 'rm -rf "$STAGE"' EXIT
+
+echo "Staging files …"
+
+# 1. Importer source
+cp -r "$PROJECT_ROOT/importer" "$STAGE/importer"
+
+# 2. Shared utils required by import.php
+mkdir -p "$STAGE/wordpress-plugin/generic"
+cp "$PROJECT_ROOT/wordpress-plugin/generic/utils.php" "$STAGE/wordpress-plugin/generic/utils.php"
+
+# 3. Submodule: only the parser + MySQL files the importer actually loads
+mkdir -p "$STAGE/lib/sqlite-database-integration/wp-includes/parser"
+mkdir -p "$STAGE/lib/sqlite-database-integration/wp-includes/mysql"
+cp "$PROJECT_ROOT"/lib/sqlite-database-integration/wp-includes/parser/*.php \
+   "$STAGE/lib/sqlite-database-integration/wp-includes/parser/"
+cp "$PROJECT_ROOT"/lib/sqlite-database-integration/wp-includes/mysql/*.php \
+   "$STAGE/lib/sqlite-database-integration/wp-includes/mysql/"
+
+# 4. Composer vendor — runtime deps only, minus bloat
+cp -r "$PROJECT_ROOT/vendor" "$STAGE/vendor"
+# Strip test suites — they dominate the vendor size
+find "$STAGE/vendor" -type d \( -iname 'tests' -o -iname 'test' -o -iname 'Tests' -o -iname 'Test' \) -exec rm -rf {} + 2>/dev/null || true
+# Strip docs, examples, and other non-runtime files
+find "$STAGE/vendor" -type d \( -iname 'docs' -o -iname 'doc' -o -iname 'examples' -o -iname 'example' \) -exec rm -rf {} + 2>/dev/null || true
+find "$STAGE/vendor" -type f \( \
+    -iname '*.md' -o -iname 'LICENSE*' -o -iname 'CHANGELOG*' \
+    -o -iname 'CONTRIBUTING*' -o -iname '.gitignore' -o -iname '.gitattributes' \
+    -o -iname 'phpunit.xml*' -o -iname 'phpstan*' -o -iname '.editorconfig' \
+    -o -iname 'Makefile' -o -iname 'composer.json' -o -iname 'composer.lock' \
+    -o -iname '.php-cs-fixer*' \) -delete 2>/dev/null || true
+
+# 5. Phar bootstrap stub
+cat > "$STAGE/stub.php" <<'STUB'
+#!/usr/bin/env php
+<?php
+// Signal to import.php's CLI guard that we are the entry point.
+define('IMPORTER_PHAR_ENTRY', true);
+Phar::mapPhar('importer.phar');
+require 'phar://importer.phar/importer/import.php';
+__HALT_COMPILER();
+STUB
+
+# ── Build the phar ────────────────────────────────────────────────
+
+echo "Building $PHAR_FILE …"
+
+rm -f "$PHAR_FILE"
+
+php -d phar.readonly=0 -r '
+$phar = new Phar($argv[1]);
+$phar->startBuffering();
+$phar->buildFromDirectory($argv[2]);
+$phar->setStub(file_get_contents($argv[2] . "/stub.php"));
+$phar->stopBuffering();
+echo "Done. Files in archive: " . $phar->count() . PHP_EOL;
+' "$PHAR_FILE" "$STAGE"
+
+# Show final size
+SIZE=$(du -h "$PHAR_FILE" | cut -f1)
+echo "Output: $PHAR_FILE ($SIZE)"

--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
         "test:fast": "cd tests && ./run-tests.sh fast",
         "test:large": "cd tests && ./run-tests.sh large",
         "test:coverage": "cd tests && ./run-tests.sh coverage",
+        "build:phar": "./bin/build-importer-phar.sh",
         "analyze": "phpstan analyze --memory-limit=1G",
         "compat": "phpcs --standard=PHPCompatibility --runtime-set testVersion 7.4- -ps wordpress-plugin/ importer/ --ignore=wordpress-plugin/wordpress"
     },

--- a/importer/import.php
+++ b/importer/import.php
@@ -7276,11 +7276,13 @@ class StreamingContext
 // CLI Entry Point
 // ============================================================================
 
-// Only run CLI logic if this file is executed directly (not included/required)
+// Only run CLI logic if this file is executed directly (not included/required).
+// IMPORTER_PHAR_ENTRY is defined by the phar stub so the guard also passes
+// when running as `php importer.phar`.
 if (
     PHP_SAPI === "cli" &&
     isset($argv) &&
-    realpath($argv[0] ?? "") === __FILE__
+    (realpath($argv[0] ?? "") === __FILE__ || defined('IMPORTER_PHAR_ENTRY'))
 ) {
     // Per-command help definitions. Each command has a short description
     // shown in the main help, and a detailed help block shown when you


### PR DESCRIPTION
##  Summary

This adds bin/build-importer-phar.sh, a build script that produces a directly-executable importer.phar (~2.8 MB) containing everything the import CLI needs to run.

The script stages only the runtime-critical files into a temp directory, strips test suites and docs from vendor packages (~30 MB), and compiles the result into a single phar archive. I think it could be made even smaller

##  What's bundled

  - importer/ — CLI entry point and all lib/ helpers
  - wordpress-plugin/generic/utils.php — shared polyfills and utilities
  - 8 PHP files from lib/sqlite-database-integration/ (264K out of the 8.1M submodule)


##  What's excluded

  - All test suites, markdown docs, READMEs, LICENSE files
  - Export-side plugin code (except utils.php)
  - Dev dependencies, phpstan/phpunit configs, git metadata
  - Composer vendor packages with Tests/, docs, and metadata stripped

##  Usage

```
  composer build:phar          # or: ./bin/build-importer-phar.sh
  php importer.phar --help     # or just: ./importer.phar
```

##  Test plan

  - Run ./bin/build-importer-phar.sh and verify it produces importer.phar
  - Run php importer.phar and confirm help output appears
  - Run php importer.phar preflight <url> --state-dir=... --docroot=... against a live export endpoint
  - Verify the phar works on a machine with no checkout (copy just the .phar file)

