### PR TITLE
Add phar build infrastructure and E2E phar testing

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [trunk]
   pull_request:
-    branches: [trunk]
 
 jobs:
   e2e:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -6,8 +6,31 @@ on:
   pull_request:
 
 jobs:
+  build-phar:
+    name: Build importer.phar
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          extensions: pdo, pdo_mysql, json, hash, zlib, mbstring
+
+      - run: composer install --no-dev --no-interaction --prefer-dist
+
+      - run: ./bin/build-importer-phar.sh
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: importer-phar
+          path: importer.phar
+
   e2e:
     name: E2E (PHP ${{ matrix.php }})
+    needs: build-phar
     runs-on: ubuntu-22.04
     timeout-minutes: 15
     strategy:
@@ -19,6 +42,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: importer-phar
 
       - uses: actions/setup-node@v4
         with:
@@ -35,6 +62,8 @@ jobs:
         run: npm install
 
       - name: Provision basic site and smoke-test API
+        env:
+          IMPORTER_PATH: ${{ github.workspace }}/importer.phar
         working-directory: tests/e2e
         run: |
           # Download WP-CLI (normally done by Vitest globalSetup, but we need it here)
@@ -56,12 +85,14 @@ jobs:
           DIR="/srv/e2e-sites/basic"
 
           echo "=== Importer preflight ==="
-          timeout 30 php ../../importer/import.php preflight "${BASE}&directory=${DIR}" /tmp/e2e-smoke --secret="${SECRET}" 2>&1 | head -50 || echo "EXIT: $?"
+          timeout 30 php "$IMPORTER_PATH" preflight "${BASE}&directory=${DIR}" /tmp/e2e-smoke --secret="${SECRET}" 2>&1 | head -50 || echo "EXIT: $?"
 
           echo "=== Importer files-sync ==="
-          timeout 30 php ../../importer/import.php files-sync "${BASE}&directory=${DIR}" /tmp/e2e-smoke --secret="${SECRET}" 2>&1 | head -50 || echo "EXIT: $?"
+          timeout 30 php "$IMPORTER_PATH" files-sync "${BASE}&directory=${DIR}" /tmp/e2e-smoke --secret="${SECRET}" 2>&1 | head -50 || echo "EXIT: $?"
 
       - name: Run E2E tests
+        env:
+          IMPORTER_PATH: ${{ github.workspace }}/importer.phar
         working-directory: tests/e2e
         run: npx vitest run
 

--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,4 @@ exports
 exports-old
 siteground-export-*
 node_modules
-
+*.phar

--- a/bin/build-importer-phar.sh
+++ b/bin/build-importer-phar.sh
@@ -3,16 +3,16 @@
 # Builds importer.phar — a self-contained, lean archive of the import client
 # with all its runtime dependencies baked in.
 #
+# Uses Box (box-project/box) for GZ compression and PHP comment stripping
+# (line-number-preserving, so stack traces stay accurate).
+#
 # Usage:
 #   ./bin/build-importer-phar.sh            # outputs importer.phar in project root
-#   ./bin/build-importer-phar.sh /tmp/out   # outputs /tmp/out/importer.phar
 #
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-OUTPUT_DIR="${1:-$PROJECT_ROOT}"
-PHAR_FILE="$OUTPUT_DIR/importer.phar"
 
 # ── Preflight checks ──────────────────────────────────────────────
 
@@ -34,67 +34,23 @@ if [ ! -f "$PROJECT_ROOT/vendor/autoload.php" ]; then
     exit 1
 fi
 
-# ── Assemble a staging directory ──────────────────────────────────
+# ── Locate or download Box ────────────────────────────────────────
 
-STAGE=$(mktemp -d)
-trap 'rm -rf "$STAGE"' EXIT
+BOX_PHAR="$PROJECT_ROOT/box.phar"
+if ! [ -f "$BOX_PHAR" ]; then
+    echo "Downloading box.phar …"
+    curl -sL "https://github.com/box-project/box/releases/latest/download/box.phar" \
+        -o "$BOX_PHAR"
+    chmod +x "$BOX_PHAR"
+fi
 
-echo "Staging files …"
+# ── Build ─────────────────────────────────────────────────────────
 
-# 1. Importer source
-cp -r "$PROJECT_ROOT/importer" "$STAGE/importer"
+cd "$PROJECT_ROOT"
+rm -f importer.phar
 
-# 2. Shared utils required by import.php
-mkdir -p "$STAGE/wordpress-plugin/generic"
-cp "$PROJECT_ROOT/wordpress-plugin/generic/utils.php" "$STAGE/wordpress-plugin/generic/utils.php"
+php -d phar.readonly=0 "$BOX_PHAR" compile
 
-# 3. Submodule: only the parser + MySQL files the importer actually loads
-mkdir -p "$STAGE/lib/sqlite-database-integration/wp-includes/parser"
-mkdir -p "$STAGE/lib/sqlite-database-integration/wp-includes/mysql"
-cp "$PROJECT_ROOT"/lib/sqlite-database-integration/wp-includes/parser/*.php \
-   "$STAGE/lib/sqlite-database-integration/wp-includes/parser/"
-cp "$PROJECT_ROOT"/lib/sqlite-database-integration/wp-includes/mysql/*.php \
-   "$STAGE/lib/sqlite-database-integration/wp-includes/mysql/"
-
-# 4. Composer vendor — runtime deps only, minus bloat
-cp -r "$PROJECT_ROOT/vendor" "$STAGE/vendor"
-# Strip test suites — they dominate the vendor size
-find "$STAGE/vendor" -type d \( -iname 'tests' -o -iname 'test' -o -iname 'Tests' -o -iname 'Test' \) -exec rm -rf {} + 2>/dev/null || true
-# Strip docs, examples, and other non-runtime files
-find "$STAGE/vendor" -type d \( -iname 'docs' -o -iname 'doc' -o -iname 'examples' -o -iname 'example' \) -exec rm -rf {} + 2>/dev/null || true
-find "$STAGE/vendor" -type f \( \
-    -iname '*.md' -o -iname 'LICENSE*' -o -iname 'CHANGELOG*' \
-    -o -iname 'CONTRIBUTING*' -o -iname '.gitignore' -o -iname '.gitattributes' \
-    -o -iname 'phpunit.xml*' -o -iname 'phpstan*' -o -iname '.editorconfig' \
-    -o -iname 'Makefile' -o -iname 'composer.json' -o -iname 'composer.lock' \
-    -o -iname '.php-cs-fixer*' \) -delete 2>/dev/null || true
-
-# 5. Phar bootstrap stub
-cat > "$STAGE/stub.php" <<'STUB'
-#!/usr/bin/env php
-<?php
-// Signal to import.php's CLI guard that we are the entry point.
-define('IMPORTER_PHAR_ENTRY', true);
-Phar::mapPhar('importer.phar');
-require 'phar://importer.phar/importer/import.php';
-__HALT_COMPILER();
-STUB
-
-# ── Build the phar ────────────────────────────────────────────────
-
-echo "Building $PHAR_FILE …"
-
-rm -f "$PHAR_FILE"
-
-php -d phar.readonly=0 -r '
-$phar = new Phar($argv[1]);
-$phar->startBuffering();
-$phar->buildFromDirectory($argv[2]);
-$phar->setStub(file_get_contents($argv[2] . "/stub.php"));
-$phar->stopBuffering();
-echo "Done. Files in archive: " . $phar->count() . PHP_EOL;
-' "$PHAR_FILE" "$STAGE"
-
-# Show final size
-SIZE=$(du -h "$PHAR_FILE" | cut -f1)
-echo "Output: $PHAR_FILE ($SIZE)"
+SIZE=$(du -h importer.phar | cut -f1)
+echo ""
+echo "Output: importer.phar ($SIZE)"

--- a/bin/build-importer-phar.sh
+++ b/bin/build-importer-phar.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+#
+# Builds importer.phar — a self-contained, lean archive of the import client
+# with all its runtime dependencies baked in.
+#
+# Usage:
+#   ./bin/build-importer-phar.sh            # outputs importer.phar in project root
+#   ./bin/build-importer-phar.sh /tmp/out   # outputs /tmp/out/importer.phar
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+OUTPUT_DIR="${1:-$PROJECT_ROOT}"
+PHAR_FILE="$OUTPUT_DIR/importer.phar"
+
+# ── Preflight checks ──────────────────────────────────────────────
+
+if ! command -v php >/dev/null 2>&1; then
+    echo "Error: php not found in PATH" >&2
+    exit 1
+fi
+
+# Verify the submodule is initialised
+if [ ! -f "$PROJECT_ROOT/lib/sqlite-database-integration/wp-includes/parser/class-wp-parser.php" ]; then
+    echo "Error: sqlite-database-integration submodule not initialised." >&2
+    echo "Run: git submodule update --init" >&2
+    exit 1
+fi
+
+# Verify composer deps are installed (--no-dev is fine)
+if [ ! -f "$PROJECT_ROOT/vendor/autoload.php" ]; then
+    echo "Error: vendor/ not found. Run: composer install --no-dev" >&2
+    exit 1
+fi
+
+# ── Assemble a staging directory ──────────────────────────────────
+
+STAGE=$(mktemp -d)
+trap 'rm -rf "$STAGE"' EXIT
+
+echo "Staging files …"
+
+# 1. Importer source
+cp -r "$PROJECT_ROOT/importer" "$STAGE/importer"
+
+# 2. Shared utils required by import.php
+mkdir -p "$STAGE/wordpress-plugin/generic"
+cp "$PROJECT_ROOT/wordpress-plugin/generic/utils.php" "$STAGE/wordpress-plugin/generic/utils.php"
+
+# 3. Submodule: only the parser + MySQL files the importer actually loads
+mkdir -p "$STAGE/lib/sqlite-database-integration/wp-includes/parser"
+mkdir -p "$STAGE/lib/sqlite-database-integration/wp-includes/mysql"
+cp "$PROJECT_ROOT"/lib/sqlite-database-integration/wp-includes/parser/*.php \
+   "$STAGE/lib/sqlite-database-integration/wp-includes/parser/"
+cp "$PROJECT_ROOT"/lib/sqlite-database-integration/wp-includes/mysql/*.php \
+   "$STAGE/lib/sqlite-database-integration/wp-includes/mysql/"
+
+# 4. Composer vendor — runtime deps only, minus bloat
+cp -r "$PROJECT_ROOT/vendor" "$STAGE/vendor"
+# Strip test suites — they dominate the vendor size
+find "$STAGE/vendor" -type d \( -iname 'tests' -o -iname 'test' -o -iname 'Tests' -o -iname 'Test' \) -exec rm -rf {} + 2>/dev/null || true
+# Strip docs, examples, and other non-runtime files
+find "$STAGE/vendor" -type d \( -iname 'docs' -o -iname 'doc' -o -iname 'examples' -o -iname 'example' \) -exec rm -rf {} + 2>/dev/null || true
+find "$STAGE/vendor" -type f \( \
+    -iname '*.md' -o -iname 'LICENSE*' -o -iname 'CHANGELOG*' \
+    -o -iname 'CONTRIBUTING*' -o -iname '.gitignore' -o -iname '.gitattributes' \
+    -o -iname 'phpunit.xml*' -o -iname 'phpstan*' -o -iname '.editorconfig' \
+    -o -iname 'Makefile' -o -iname 'composer.json' -o -iname 'composer.lock' \
+    -o -iname '.php-cs-fixer*' \) -delete 2>/dev/null || true
+
+# 5. Phar bootstrap stub
+cat > "$STAGE/stub.php" <<'STUB'
+#!/usr/bin/env php
+<?php
+// Signal to import.php's CLI guard that we are the entry point.
+define('IMPORTER_PHAR_ENTRY', true);
+Phar::mapPhar('importer.phar');
+require 'phar://importer.phar/importer/import.php';
+__HALT_COMPILER();
+STUB
+
+# ── Build the phar ────────────────────────────────────────────────
+
+echo "Building $PHAR_FILE …"
+
+rm -f "$PHAR_FILE"
+
+php -d phar.readonly=0 -r '
+$phar = new Phar($argv[1]);
+$phar->startBuffering();
+$phar->buildFromDirectory($argv[2]);
+$phar->setStub(file_get_contents($argv[2] . "/stub.php"));
+$phar->stopBuffering();
+echo "Done. Files in archive: " . $phar->count() . PHP_EOL;
+' "$PHAR_FILE" "$STAGE"
+
+# Show final size
+SIZE=$(du -h "$PHAR_FILE" | cut -f1)
+echo "Output: $PHAR_FILE ($SIZE)"

--- a/bin/phar-stub.php
+++ b/bin/phar-stub.php
@@ -1,0 +1,7 @@
+#!/usr/bin/env php
+<?php
+// Signal to import.php's CLI guard that we are the entry point.
+define('IMPORTER_PHAR_ENTRY', true);
+Phar::mapPhar('importer.phar');
+require 'phar://importer.phar/importer/import.php';
+__HALT_COMPILER();

--- a/box.json
+++ b/box.json
@@ -1,6 +1,7 @@
 {
     "main": "importer/import.php",
     "output": "importer.phar",
+    "check-requirements": false,
 
     "directories": [
         "importer"
@@ -9,7 +10,13 @@
     "finder": [
         {
             "name": "*.php",
-            "exclude": ["tests", "test", "Tests", "Test", "docs", "doc", "examples", "bin"],
+            "exclude": [
+                "tests", "test", "Tests", "Test",
+                "docs", "doc", "examples", "bin",
+                "DataFormatConsumer", "DataFormatProducer",
+                "EntityWriter", "EntityReader",
+                "Importer"
+            ],
             "notName": "/LICENSE.*|CHANGELOG.*|CONTRIBUTING.*|README.*/",
             "in": "vendor"
         },

--- a/box.json
+++ b/box.json
@@ -32,6 +32,7 @@
 
     "files": [
         "wordpress-plugin/generic/utils.php",
+        "wordpress-plugin/generic/class-hmac-client.php",
         "vendor/autoload.php"
     ],
 

--- a/box.json
+++ b/box.json
@@ -1,0 +1,40 @@
+{
+    "main": "importer/import.php",
+    "output": "importer.phar",
+
+    "directories": [
+        "importer"
+    ],
+
+    "finder": [
+        {
+            "name": "*.php",
+            "exclude": ["tests", "test", "Tests", "Test", "docs", "doc", "examples", "bin"],
+            "notName": "/LICENSE.*|CHANGELOG.*|CONTRIBUTING.*|README.*/",
+            "in": "vendor"
+        },
+        {
+            "name": "*.php",
+            "in": "lib/sqlite-database-integration/wp-includes/parser"
+        },
+        {
+            "name": "*.php",
+            "in": "lib/sqlite-database-integration/wp-includes/mysql"
+        }
+    ],
+
+    "files": [
+        "wordpress-plugin/generic/utils.php",
+        "vendor/autoload.php"
+    ],
+
+    "compactors": [
+        "KevinGH\\Box\\Compactor\\Php",
+        "KevinGH\\Box\\Compactor\\Json"
+    ],
+
+    "annotations": false,
+    "compression": "GZ",
+
+    "stub": "bin/phar-stub.php"
+}

--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
         "test:fast": "cd tests && ./run-tests.sh fast",
         "test:large": "cd tests && ./run-tests.sh large",
         "test:coverage": "cd tests && ./run-tests.sh coverage",
+        "build:phar": "./bin/build-importer-phar.sh",
         "analyze": "phpstan analyze --memory-limit=1G",
         "compat": "phpcs --standard=PHPCompatibility --runtime-set testVersion 7.4- -ps wordpress-plugin/ importer/ --ignore=wordpress-plugin/wordpress"
     },

--- a/importer/import.php
+++ b/importer/import.php
@@ -7521,11 +7521,13 @@ class PreserveLocalSkipException extends RuntimeException {}
 // CLI Entry Point
 // ============================================================================
 
-// Only run CLI logic if this file is executed directly (not included/required)
+// Only run CLI logic if this file is executed directly (not included/required).
+// IMPORTER_PHAR_ENTRY is defined by the phar stub so the guard also passes
+// when running as `php importer.phar`.
 if (
     PHP_SAPI === "cli" &&
     isset($argv) &&
-    realpath($argv[0] ?? "") === __FILE__
+    (realpath($argv[0] ?? "") === __FILE__ || defined('IMPORTER_PHAR_ENTRY'))
 ) {
     // Per-command help definitions. Each command has a short description
     // shown in the main help, and a detailed help block shown when you

--- a/tests/e2e/lib/test-helpers.js
+++ b/tests/e2e/lib/test-helpers.js
@@ -16,7 +16,7 @@ const REGISTRY = createRequire(import.meta.url)('../site-registry.json');
 
 const SITE_ROOT = REGISTRY.siteRoot;
 const PROJECT_ROOT = join(import.meta.dirname, '..', '..', '..');
-const IMPORTER_PATH = join(PROJECT_ROOT, 'importer', 'import.php');
+const IMPORTER_PATH = process.env.IMPORTER_PATH || join(PROJECT_ROOT, 'importer', 'import.php');
 const DB_HOST = REGISTRY.dbHost;
 const DB_USER = REGISTRY.dbUser;
 const DB_PASS = REGISTRY.dbPass;


### PR DESCRIPTION
## Summary

Adds the infrastructure to build the importer as a self-contained `importer.phar` using Box. The E2E workflow now builds the phar once and runs all matrix jobs against it, which also tests that the phar works across PHP 7.4–8.5. The E2E trigger is fixed to run on all PRs, not just those targeting trunk.

## What's included

- `bin/build-importer-phar.sh` — downloads Box and compiles the phar (~500KB with GZ compression)
- `bin/phar-stub.php` — phar entry point that defines `IMPORTER_PHAR_ENTRY`
- `box.json` — Box config: directories, finders, compactors, GZ compression
- `composer.json` — `build:phar` script
- `.gitignore` — excludes `*.phar`
- `importer/import.php` — CLI guard accepts `IMPORTER_PHAR_ENTRY` for phar compat
- E2E workflow split: `build-phar` job (PHP 8.2) uploads artifact, matrix `e2e` jobs download and test it
- E2E trigger: `pull_request` no longer filtered to `branches: [trunk]`

## Test plan

- [ ] `composer build:phar` produces `importer.phar`
- [ ] `php importer.phar` shows help
- [ ] E2E CI passes across PHP versions