### PR TITLE
Accept string post_data in download_file_fetch to prevent TypeError

### DIFF
--- a/importer/import.php
+++ b/importer/import.php
@@ -3317,13 +3317,36 @@ class ImportClient
     /**
      * Download file content for a prepared file list (file_fetch).
      *
-     * @param array|null $post_data Optional POST data
+     * @param array|string|null $post_data POST data — normally an array with
+     *        a 'file_list' CURLFile entry, but also accepts a raw JSON string
+     *        (the file list content) which is auto-converted to a CURLFile upload.
      * @param string|null $cursor Cursor for resumption within the current batch
      */
     private function download_file_fetch(
-        ?array $post_data,
+        $post_data,
         ?string $cursor
     ): bool {
+        // If a raw JSON string was passed (e.g. the file list content read
+        // via file_get_contents), write it to a temp file and wrap it in a
+        // CURLFile array so the server receives it as a file upload.
+        $inline_tmp = null;
+        if (is_string($post_data)) {
+            $inline_tmp = tempnam(sys_get_temp_dir(), "file-fetch-inline-");
+            if ($inline_tmp === false) {
+                throw new RuntimeException(
+                    "Failed to create temp file for inline file list",
+                );
+            }
+            file_put_contents($inline_tmp, $post_data);
+            $post_data = [
+                "file_list" => new CURLFile(
+                    $inline_tmp,
+                    "application/json",
+                    "file-list.json",
+                ),
+            ];
+        }
+
         $cursor = $cursor ?? ($this->state["fetch"]["cursor"] ?? null);
         $complete = false;
         $this->chunks_since_save = 0;
@@ -3501,6 +3524,11 @@ class ImportClient
             $this->state["current_file_bytes"] = null;
         }
         $this->save_state($this->state);
+
+        // Clean up the temp file created for inline string post_data.
+        if ($inline_tmp !== null && file_exists($inline_tmp)) {
+            @unlink($inline_tmp);
+        }
 
         return $complete;
     }

--- a/tests/Import/DownloadFileFetchTypeTest.php
+++ b/tests/Import/DownloadFileFetchTypeTest.php
@@ -1,0 +1,157 @@
+<?php
+
+namespace ImportTests;
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../importer/import.php';
+
+/**
+ * Regression test for TypeError when download_file_fetch receives a string
+ * instead of an array for $post_data.
+ *
+ * This can happen when the file list JSON content is passed inline as a
+ * string (e.g. from file_get_contents($batch_file)) rather than wrapped
+ * in a ['file_list' => new CURLFile(...)] array.
+ *
+ * The function should handle string input gracefully by converting it to
+ * the expected CURLFile array format, rather than throwing a TypeError.
+ */
+class DownloadFileFetchTypeTest extends TestCase
+{
+    private $tempDir;
+    private $stateDir;
+    private $docroot;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->tempDir = sys_get_temp_dir() . '/import-fetch-type-test-' . uniqid();
+        $this->stateDir = $this->tempDir . '/state';
+        $this->docroot = $this->tempDir . '/docroot';
+        mkdir($this->stateDir, 0755, true);
+        mkdir($this->docroot, 0755, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->recursiveDelete($this->tempDir);
+        parent::tearDown();
+    }
+
+    private function recursiveDelete(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        foreach (scandir($dir) as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $path = $dir . '/' . $item;
+            if (is_link($path)) {
+                unlink($path);
+            } elseif (is_dir($path)) {
+                $this->recursiveDelete($path);
+            } else {
+                unlink($path);
+            }
+        }
+        rmdir($dir);
+    }
+
+    /**
+     * Calling download_file_fetch with a JSON string (the file list content)
+     * instead of an array should NOT throw a TypeError.
+     *
+     * It will throw a RuntimeException because there's no server to connect
+     * to — that's expected. The important thing is that the function accepts
+     * the string and converts it internally.
+     */
+    public function testStringPostDataDoesNotThrowTypeError(): void
+    {
+        // Use a port that nothing listens on to get a quick connection-refused error.
+        $client = new \ImportClient(
+            'http://127.0.0.1:1',
+            $this->stateDir,
+            $this->docroot,
+        );
+
+        $method = new \ReflectionMethod($client, 'download_file_fetch');
+        $method->setAccessible(true);
+
+        // This is the scenario that triggers the bug: a raw JSON string
+        // is passed as $post_data instead of an array with CURLFile.
+        $json_file_list = '["/wp-content/uploads/photo.jpg"]';
+
+        try {
+            $method->invoke($client, $json_file_list, null);
+            // If we reach here, the function completed without error
+            // (unlikely without a real server, but not a TypeError).
+        } catch (\TypeError $e) {
+            $this->fail(
+                "download_file_fetch should accept string post_data without " .
+                "TypeError, but got: " . $e->getMessage()
+            );
+        } catch (\RuntimeException $e) {
+            // Expected: HTTP connection fails because there's no server.
+            // The important thing is we got past the type check.
+            $this->assertTrue(true, "Function accepted string and failed on HTTP (expected)");
+        }
+    }
+
+    /**
+     * Null post_data should still work (used for non-file-list fetches).
+     */
+    public function testNullPostDataStillWorks(): void
+    {
+        $client = new \ImportClient(
+            'http://127.0.0.1:1',
+            $this->stateDir,
+            $this->docroot,
+        );
+
+        $method = new \ReflectionMethod($client, 'download_file_fetch');
+        $method->setAccessible(true);
+
+        try {
+            $method->invoke($client, null, null);
+        } catch (\TypeError $e) {
+            $this->fail("Null post_data should not throw TypeError: " . $e->getMessage());
+        } catch (\RuntimeException $e) {
+            $this->assertTrue(true);
+        }
+    }
+
+    /**
+     * Array post_data (the normal CURLFile case) should still work.
+     */
+    public function testArrayPostDataStillWorks(): void
+    {
+        $client = new \ImportClient(
+            'http://127.0.0.1:1',
+            $this->stateDir,
+            $this->docroot,
+        );
+
+        $method = new \ReflectionMethod($client, 'download_file_fetch');
+        $method->setAccessible(true);
+
+        $tmp = tempnam(sys_get_temp_dir(), 'test-file-list-');
+        file_put_contents($tmp, '["/wp-content/uploads/photo.jpg"]');
+
+        $post_data = [
+            'file_list' => new \CURLFile($tmp, 'application/json', 'file-list.json'),
+        ];
+
+        try {
+            $method->invoke($client, $post_data, null);
+        } catch (\TypeError $e) {
+            $this->fail("Array post_data should not throw TypeError: " . $e->getMessage());
+        } catch (\RuntimeException $e) {
+            $this->assertTrue(true);
+        } finally {
+            @unlink($tmp);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

In production, `download_file_fetch()` threw a TypeError:

```
ImportClient::download_file_fetch(): Argument #1 ($post_data) must be of type ?array, string given
```

### What we know

The only call to `download_file_fetch` is in `download_files_from_list()`, which always constructs `$post_data` as a fresh array literal:

```php
$post_data = [
    "file_list" => new CURLFile($batch_file, "application/json", "file-list.json"),
];
$complete = $this->download_file_fetch($post_data, $cursor);
```

There's no code path in trunk that passes a string. I've verified: no dynamic dispatch, no CURLFile polyfills, no signal handler that could modify the variable, no state corruption that reaches `$post_data`. The phar built from trunk matches the source.

### Root cause: unknown

I cannot identify how `$post_data` ends up as a string in the current trunk code. The fix is defensive — it makes `download_file_fetch` handle string input gracefully instead of crashing, regardless of how the string arrives.

### The fix

Removes the strict `?array` type hint from `$post_data` and adds conversion logic: when a string is received (presumably the raw JSON file list content), it writes it to a temp file, wraps it in a `['file_list' => new CURLFile(...)]` array matching the server's expected file upload format, and cleans up the temp file afterward.

## Test plan

- [ ] `testStringPostDataDoesNotThrowTypeError` — passes a raw JSON string to `download_file_fetch` via reflection, asserts no TypeError
- [ ] `testNullPostDataStillWorks` — null input still accepted
- [ ] `testArrayPostDataStillWorks` — normal CURLFile array still works
- [ ] All 87 existing Import tests pass without regressions