### PR TITLE
Make --follow-symlinks the default, add --no-follow-symlinks to opt out

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ If the JSON is invalid on load, the importer renames it to
   "stage": "streaming",           // current phase within the command
   "preflight": { ... },           // cached preflight response
   "version": "...",               // importer version
-  "follow_symlinks": false,
+  "follow_symlinks": true,
   "max_allowed_packet": null,     // client-side MySQL packet limit
 
   // Per-command state sections:
@@ -489,12 +489,13 @@ export stream and calls `symlink()` to recreate them locally. This is safe becau
 constrained to the `--docroot` directory.
 
 Some symlinks may point to places on the remote filesystem that are
-outside of the requested directory root. When that happens, they're
-not recreated unless you use the `--follow-symlinks` option.
+outside of the requested directory root. By default, the importer
+follows these symlinks — it asks the server to expand them into real
+files and recreates the symlink structure locally, constrained within
+the `--docroot`.
 
-With the `--follow-symlinks`, the importer will create local
-symlinks even if they point ourside of the directory root. They're
-still constrained within the confines of the `--docroot`
+To disable this behavior, pass `--no-follow-symlinks`. Symlinks pointing
+outside the directory root will then be skipped instead of followed.
 
 ## Database synchronization
 

--- a/importer/import.php
+++ b/importer/import.php
@@ -906,10 +906,11 @@ class ImportClient
 
     /**
      * @var bool When true, tell the server to follow symlinks that point outside
-     * the document root (expanding them into real files). Set via --follow-symlinks,
-     * persisted in state so it survives across invocations.
+     * the document root (expanding them into real files). Enabled by default,
+     * disable with --no-follow-symlinks. Persisted in state so it survives
+     * across invocations.
      */
-    private $follow_symlinks = false;
+    private $follow_symlinks = true;
 
     /**
      * @var string Controls behavior when the docroot is non-empty at import start.
@@ -1268,7 +1269,7 @@ class ImportClient
     public function run(array $options = []): void
     {
         $this->verbose_mode = $options["verbose"] ?? false;
-        $this->follow_symlinks = $options["follow_symlinks"] ?? false;
+        $this->follow_symlinks = $options["follow_symlinks"] ?? true;
         if (isset($options["docroot_nonempty_behavior"])) {
             $this->docroot_nonempty_behavior = $options["docroot_nonempty_behavior"];
             if (!in_array($this->docroot_nonempty_behavior, ['error', 'preserve-local'])) {
@@ -1309,12 +1310,12 @@ class ImportClient
         $this->state = $this->load_state();
 
         // Persist follow_symlinks in state so it survives across invocations.
-        // If passed on CLI, store it.  Otherwise, restore from persisted state.
-        if ($this->follow_symlinks) {
-            $this->state["follow_symlinks"] = true;
+        // If explicitly set on CLI, store it.  Otherwise, restore from persisted state.
+        if (isset($options["follow_symlinks"])) {
+            $this->state["follow_symlinks"] = $this->follow_symlinks;
             $this->save_state($this->state);
-        } elseif ($this->state["follow_symlinks"] ?? false) {
-            $this->follow_symlinks = true;
+        } elseif (isset($this->state["follow_symlinks"])) {
+            $this->follow_symlinks = $this->state["follow_symlinks"];
         }
 
         // Persist docroot_nonempty_behavior in state so it survives across invocations.
@@ -6909,7 +6910,7 @@ class ImportClient
             "remote_protocol_version" => null,
             "remote_protocol_min_version" => null,
             "version" => null,
-            "follow_symlinks" => false,
+            "follow_symlinks" => true,
             "docroot_nonempty_behavior" => "error",
             "max_allowed_packet" => null,
             "db_index" => [
@@ -7545,7 +7546,7 @@ if (
                 "\n" .
                 "Options:\n" .
                 "  --abort              Abort current sync and exit (keeps files and index)\n" .
-                "  --follow-symlinks    Follow symlinks pointing outside root directories\n" .
+                "  --no-follow-symlinks Do not follow symlinks pointing outside root directories\n" .
                 "  --on-docroot-nonempty=MODE\n" .
                 "                       What to do when docroot is non-empty (error|preserve-local)\n" .
                 "  --secret=TOKEN       HMAC shared secret for export API authentication\n" .
@@ -7695,7 +7696,7 @@ if (
         echo "Global options:\n";
         echo "  --secret=TOKEN       HMAC shared secret for export API authentication\n";
         echo "  --abort            Abort current sync and exit (preserves downloaded files)\n";
-        echo "  --follow-symlinks    Follow symlinks pointing outside root directories\n";
+        echo "  --no-follow-symlinks Do not follow symlinks pointing outside root directories\n";
         echo "  --on-docroot-nonempty=MODE\n";
         echo "                       What to do when docroot is non-empty (error|preserve-local)\n";
         echo "  --verbose, -v        Show detailed request/response logs\n";
@@ -7760,6 +7761,8 @@ if (
             $options["verbose"] = true;
         } elseif ($argv[$i] === "--follow-symlinks") {
             $options["follow_symlinks"] = true;
+        } elseif ($argv[$i] === "--no-follow-symlinks") {
+            $options["follow_symlinks"] = false;
         } elseif (strpos($argv[$i], "--on-docroot-nonempty=") === 0) {
             $options["docroot_nonempty_behavior"] = substr(
                 $argv[$i],


### PR DESCRIPTION
## Summary

Most real-world migrations need symlinks followed — hosting environments commonly symlink WP core, plugins, and drop-ins from shared locations. Requiring an explicit `--follow-symlinks` flag meant most callers had to remember to pass it, and forgetting it led to incomplete migrations.

Now symlinks are followed by default. Callers who specifically want to skip external symlinks can pass `--no-follow-symlinks`. The old `--follow-symlinks` flag still works for backward compatibility.

### What changed

- Default for `$follow_symlinks` flipped from `false` to `true`
- Added `--no-follow-symlinks` CLI flag to opt out
- State persistence updated to store both `true` and `false` explicitly (previously only stored `true`)
- Help text and README updated to document the new default

## Test plan

- [ ] Run `files-sync` without any symlink flag — symlinks should be followed
- [ ] Run `files-sync --no-follow-symlinks` — symlinks outside root should be skipped
- [ ] Run `files-sync --follow-symlinks` — still works (backward compat)
- [ ] All existing Import tests pass (84 tests, 184 assertions)