### PR TITLE
Add CORS headers to the export API for Playground integration

### DIFF
--- a/wordpress-plugin/index.php
+++ b/wordpress-plugin/index.php
@@ -52,6 +52,17 @@ function _site_export_handle_api_request(): void {
         ob_end_clean();
     }
 
+    // Allow CORS requests for WordPress Playground integration.
+    header('Access-Control-Allow-Origin: *');
+    header('Access-Control-Allow-Credentials: true');
+    header('Access-Control-Allow-Methods: GET, POST, OPTIONS');
+    header('Access-Control-Allow-Headers: *');
+
+    if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
+        header("Allow: GET, POST, OPTIONS");
+        exit;
+    }
+
     // Buffer output so stray warnings don't corrupt the JSON response.
     ob_start();
 


### PR DESCRIPTION
## Summary

The export API endpoint now sends permissive CORS headers and handles OPTIONS preflight requests. This enables WordPress Playground — running in a browser context — to call the export API directly via `fetch()`, which triggers cross-origin requests that browsers block by default.

The headers are set early in the request lifecycle, before authentication, so the OPTIONS preflight can succeed without HMAC credentials.

## Test plan

- [ ] Verify that a cross-origin `fetch()` from a Playground instance to the export API succeeds
- [ ] Verify that OPTIONS preflight returns 200 with the correct Allow header
- [ ] Verify that same-origin requests continue to work as before