### PR TITLE
Don't accept brotli content encoding

### DIFF
--- a/importer/import.php
+++ b/importer/import.php
@@ -6383,7 +6383,7 @@ class ImportClient
             "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36",
             "Accept: {$accept}",
             "Accept-Language: en-US,en;q=0.9",
-            "Accept-Encoding: gzip, deflate, br",
+            "Accept-Encoding: gzip, deflate",
             "Cache-Control: no-cache",
             "Pragma: no-cache",
             "Connection: keep-alive",
@@ -6475,7 +6475,7 @@ class ImportClient
         curl_setopt_array($ch, [
             CURLOPT_FOLLOWLOCATION => false,
             CURLOPT_TIMEOUT => 30,
-            CURLOPT_ENCODING => "",
+            CURLOPT_ENCODING => "gzip, deflate",
             CURLOPT_HTTPHEADER => $headers,
             CURLOPT_RETURNTRANSFER => true,
         ]);
@@ -6627,7 +6627,7 @@ class ImportClient
         curl_setopt_array($ch, [
             CURLOPT_FOLLOWLOCATION => false,
             CURLOPT_TIMEOUT => 300,
-            CURLOPT_ENCODING => "", // Auto-decompress gzip/deflate/br responses
+            CURLOPT_ENCODING => "gzip, deflate",
             CURLOPT_HTTPHEADER => $headers,
             CURLOPT_HEADERFUNCTION => function ($ch, $header_line) use (
                 &$parser,

--- a/tests/Import/AcceptEncodingTest.php
+++ b/tests/Import/AcceptEncodingTest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace ImportTests;
+
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+
+require_once __DIR__ . '/../../importer/import.php';
+
+/**
+ * Verify that HTTP requests never advertise brotli (br) encoding.
+ *
+ * Not every curl build ships with brotli support. When the client sends
+ * "Accept-Encoding: …, br" but curl can't decode it, the transfer fails
+ * with "Unrecognized content encoding type."  We must only advertise
+ * encodings that every curl build supports: gzip and deflate.
+ */
+class AcceptEncodingTest extends TestCase
+{
+    private $tempDir;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->tempDir = sys_get_temp_dir() . '/import-encoding-test-' . uniqid();
+        mkdir($this->tempDir . '/state', 0755, true);
+        mkdir($this->tempDir . '/docroot', 0755, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->recursiveDelete($this->tempDir);
+        parent::tearDown();
+    }
+
+    private function recursiveDelete(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        foreach (scandir($dir) as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $path = $dir . '/' . $item;
+            if (is_link($path)) {
+                unlink($path);
+            } elseif (is_dir($path)) {
+                $this->recursiveDelete($path);
+            } else {
+                unlink($path);
+            }
+        }
+        rmdir($dir);
+    }
+
+    /**
+     * The Accept-Encoding header must not include "br" (brotli),
+     * because curl may not have brotli support compiled in.
+     */
+    public function testAcceptEncodingExcludesBrotli(): void
+    {
+        $client = new \ImportClient(
+            'http://fake.url',
+            $this->tempDir . '/state',
+            $this->tempDir . '/docroot'
+        );
+
+        $method = new ReflectionMethod($client, 'get_base_headers');
+        $method->setAccessible(true);
+
+        $headers = $method->invoke($client, 'application/json');
+
+        $encoding_header = null;
+        foreach ($headers as $header) {
+            if (stripos($header, 'Accept-Encoding:') === 0) {
+                $encoding_header = $header;
+                break;
+            }
+        }
+
+        $this->assertNotNull($encoding_header, 'Accept-Encoding header must be present');
+        $this->assertStringNotContainsString(
+            'br',
+            $encoding_header,
+            'Accept-Encoding must not include brotli (br) — curl may lack brotli support'
+        );
+        $this->assertStringContainsString('gzip', $encoding_header);
+        $this->assertStringContainsString('deflate', $encoding_header);
+    }
+}


### PR DESCRIPTION
## Summary

The importer advertised brotli (`br`) in its `Accept-Encoding` header, but not all curl builds ship with brotli support. On systems like Playground CLI, curl fails with "Unrecognized content encoding type" when the server responds with brotli. This removes brotli from the accepted encodings and pins `CURLOPT_ENCODING` to `gzip, deflate` — the two encodings every curl build supports.

## Test plan

- Added `AcceptEncodingTest` that verifies the `Accept-Encoding` header excludes `br`
- All 85 Import tests pass