### PR TITLE
Add --new-site-url flag as a shorthand for --rewrite-url

### DIFF
--- a/importer/import.php
+++ b/importer/import.php
@@ -2918,6 +2918,26 @@ class ImportClient
             );
         }
 
+        // If --new-site-url is provided, derive the source origin from the
+        // export URL and add an implicit --rewrite-url mapping.
+        if (!empty($options["new_site_url"])) {
+            $parsed_url = parse_url($this->remote_url);
+            if ($parsed_url && isset($parsed_url['scheme'], $parsed_url['host'])) {
+                $source_origin = $parsed_url['scheme'] . '://' . $parsed_url['host'];
+                if (!empty($parsed_url['port'])) {
+                    $source_origin .= ':' . $parsed_url['port'];
+                }
+                if (!isset($options["rewrite_url"])) {
+                    $options["rewrite_url"] = [];
+                }
+                $options["rewrite_url"][] = [$source_origin, $options["new_site_url"]];
+            } else {
+                throw new InvalidArgumentException(
+                    "--new-site-url requires a valid export URL to derive the source site origin.",
+                );
+            }
+        }
+
         // Parse URL mapping
         $url_mapping = [];
         if (!empty($options["rewrite_url"])) {
@@ -7971,6 +7991,15 @@ if (
             }
             $options["rewrite_url"][] = [$argv[$i + 1], $argv[$i + 2]];
             $i += 2;
+        } elseif (strpos($argv[$i], "--new-site-url=") === 0) {
+            $options["new_site_url"] = substr($argv[$i], strlen("--new-site-url="));
+        } elseif ($argv[$i] === "--new-site-url") {
+            if (!isset($argv[$i + 1])) {
+                fwrite(STDERR, "--new-site-url requires one argument: URL\n");
+                exit(1);
+            }
+            $options["new_site_url"] = $argv[$i + 1];
+            $i += 1;
         } else {
             fwrite(STDERR, "Unknown option: {$argv[$i]}\n");
             exit(1);

--- a/importer/import.php
+++ b/importer/import.php
@@ -2896,6 +2896,34 @@ class ImportClient
         }
     }
 
+    /**
+     * If --new-site-url is set, derive the source origin from the export URL
+     * and append an implicit --rewrite-url mapping to $options.
+     */
+    private function resolve_new_site_url_option(array &$options): void
+    {
+        if (empty($options["new_site_url"])) {
+            return;
+        }
+
+        $parsed_url = parse_url($this->remote_url);
+        if (!$parsed_url || !isset($parsed_url['scheme'], $parsed_url['host'])) {
+            throw new InvalidArgumentException(
+                "--new-site-url requires a valid export URL to derive the source site origin.",
+            );
+        }
+
+        $source_origin = $parsed_url['scheme'] . '://' . $parsed_url['host'];
+        if (!empty($parsed_url['port'])) {
+            $source_origin .= ':' . $parsed_url['port'];
+        }
+
+        if (!isset($options["rewrite_url"])) {
+            $options["rewrite_url"] = [];
+        }
+        $options["rewrite_url"][] = [$source_origin, $options["new_site_url"]];
+    }
+
     private function run_db_apply(array $options): void
     {
         $sql_file = $this->state_dir . "/db.sql";
@@ -2920,23 +2948,7 @@ class ImportClient
 
         // If --new-site-url is provided, derive the source origin from the
         // export URL and add an implicit --rewrite-url mapping.
-        if (!empty($options["new_site_url"])) {
-            $parsed_url = parse_url($this->remote_url);
-            if ($parsed_url && isset($parsed_url['scheme'], $parsed_url['host'])) {
-                $source_origin = $parsed_url['scheme'] . '://' . $parsed_url['host'];
-                if (!empty($parsed_url['port'])) {
-                    $source_origin .= ':' . $parsed_url['port'];
-                }
-                if (!isset($options["rewrite_url"])) {
-                    $options["rewrite_url"] = [];
-                }
-                $options["rewrite_url"][] = [$source_origin, $options["new_site_url"]];
-            } else {
-                throw new InvalidArgumentException(
-                    "--new-site-url requires a valid export URL to derive the source site origin.",
-                );
-            }
-        }
+        $this->resolve_new_site_url_option($options);
 
         // Parse URL mapping
         $url_mapping = [];

--- a/tests/Import/NewSiteUrlTest.php
+++ b/tests/Import/NewSiteUrlTest.php
@@ -1,0 +1,169 @@
+<?php
+
+namespace ImportTests;
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../importer/import.php';
+
+/**
+ * Test the --new-site-url flag, which derives a --rewrite-url mapping
+ * from the export URL's origin.
+ */
+class NewSiteUrlTest extends TestCase
+{
+    private $tempDir;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->tempDir = sys_get_temp_dir() . '/import-new-site-url-test-' . uniqid();
+        mkdir($this->tempDir, 0755, true);
+        mkdir($this->tempDir . '/docroot', 0755, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->recursiveDelete($this->tempDir);
+        parent::tearDown();
+    }
+
+    private function recursiveDelete(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        $items = scandir($dir);
+        foreach ($items as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $path = $dir . '/' . $item;
+            if (is_link($path)) {
+                unlink($path);
+            } elseif (is_dir($path)) {
+                $this->recursiveDelete($path);
+            } else {
+                unlink($path);
+            }
+        }
+        rmdir($dir);
+    }
+
+    private function callResolve(\ImportClient $client, array $options): array
+    {
+        $reflection = new \ReflectionClass($client);
+        $method = $reflection->getMethod('resolve_new_site_url_option');
+        $method->invokeArgs($client, [&$options]);
+        return $options;
+    }
+
+    public function testDerivesOriginFromHttpsUrl(): void
+    {
+        $client = new \ImportClient(
+            'https://old-site.example.com/wp-json/export',
+            $this->tempDir,
+            $this->tempDir . '/docroot'
+        );
+
+        $options = ['new_site_url' => 'https://new-site.example.com'];
+        $options = $this->callResolve($client, $options);
+
+        $this->assertArrayHasKey('rewrite_url', $options);
+        $this->assertCount(1, $options['rewrite_url']);
+        $this->assertSame(
+            ['https://old-site.example.com', 'https://new-site.example.com'],
+            $options['rewrite_url'][0]
+        );
+    }
+
+    public function testDerivesOriginFromHttpUrl(): void
+    {
+        $client = new \ImportClient(
+            'http://old-site.local/export?key=abc',
+            $this->tempDir,
+            $this->tempDir . '/docroot'
+        );
+
+        $options = ['new_site_url' => 'https://new-site.example.com'];
+        $options = $this->callResolve($client, $options);
+
+        $this->assertSame(
+            ['http://old-site.local', 'https://new-site.example.com'],
+            $options['rewrite_url'][0]
+        );
+    }
+
+    public function testPreservesPort(): void
+    {
+        $client = new \ImportClient(
+            'https://old-site.example.com:8443/export',
+            $this->tempDir,
+            $this->tempDir . '/docroot'
+        );
+
+        $options = ['new_site_url' => 'https://new-site.example.com'];
+        $options = $this->callResolve($client, $options);
+
+        $this->assertSame(
+            ['https://old-site.example.com:8443', 'https://new-site.example.com'],
+            $options['rewrite_url'][0]
+        );
+    }
+
+    public function testAppendsToExistingRewriteUrlEntries(): void
+    {
+        $client = new \ImportClient(
+            'https://old-site.example.com/export',
+            $this->tempDir,
+            $this->tempDir . '/docroot'
+        );
+
+        $options = [
+            'new_site_url' => 'https://new-site.example.com',
+            'rewrite_url' => [
+                ['https://cdn.old-site.com', 'https://cdn.new-site.com'],
+            ],
+        ];
+        $options = $this->callResolve($client, $options);
+
+        $this->assertCount(2, $options['rewrite_url']);
+        $this->assertSame(
+            ['https://cdn.old-site.com', 'https://cdn.new-site.com'],
+            $options['rewrite_url'][0]
+        );
+        $this->assertSame(
+            ['https://old-site.example.com', 'https://new-site.example.com'],
+            $options['rewrite_url'][1]
+        );
+    }
+
+    public function testNoOpWhenNewSiteUrlNotSet(): void
+    {
+        $client = new \ImportClient(
+            'https://old-site.example.com/export',
+            $this->tempDir,
+            $this->tempDir . '/docroot'
+        );
+
+        $options = [];
+        $options = $this->callResolve($client, $options);
+
+        $this->assertArrayNotHasKey('rewrite_url', $options);
+    }
+
+    public function testThrowsOnUnparseableExportUrl(): void
+    {
+        $client = new \ImportClient(
+            '://not-a-url',
+            $this->tempDir,
+            $this->tempDir . '/docroot'
+        );
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('--new-site-url requires a valid export URL');
+
+        $options = ['new_site_url' => 'https://new-site.example.com'];
+        $this->callResolve($client, $options);
+    }
+}


### PR DESCRIPTION
## Summary

When migrating a site to a new domain, users currently have to manually figure out the source origin and pass `--rewrite-url https://old.example.com https://new.example.com`. The new `--new-site-url` flag simplifies this by automatically deriving the source origin from the export URL.

Before: `php import.php db-apply https://old.example.com/export --rewrite-url https://old.example.com https://new.example.com`
After: `php import.php db-apply https://old.example.com/export --new-site-url https://new.example.com`

The flag works by parsing the export URL to extract the scheme, host, and optional port, then adding an implicit `--rewrite-url` entry. It integrates with the existing `StructuredDataUrlRewriter` pipeline — no new rewriting logic was needed.

## Test plan

- [ ] Run `db-apply` with `--new-site-url https://new.example.com` and verify URLs in the imported database are rewritten
- [ ] Verify `--new-site-url` combined with explicit `--rewrite-url` entries works (both mappings should apply)
- [ ] Verify error is thrown when export URL can't be parsed
- [ ] Verify both CLI forms work: `--new-site-url=URL` and `--new-site-url URL`