### PR TITLE
Add $wpdb-based SQL import for SQLite support

### DIFF
--- a/importer/import.php
+++ b/importer/import.php
@@ -5183,7 +5183,7 @@ class ImportClient
                 }
             }
             // wpdb mode: same buffer cleanup logic as mysql mode.
-            if ($wpdb && !$mysql_conn) {
+            if ($wpdb) {
                 $pending = $sql_buffer;
                 $buffer_file = $this->state_dir . "/.sql-buffer";
                 if ($pending === "" && file_exists($buffer_file)) {

--- a/importer/import.php
+++ b/importer/import.php
@@ -978,6 +978,9 @@ class ImportClient
     /** @var string|null MySQL database for --sql-output=mysql. */
     private $mysql_database;
 
+    /** @var string|null Path to WordPress wp-load.php for $wpdb-based import. */
+    private $wp_load_path;
+
     /** @var resource File descriptor for progress output — STDOUT normally, STDERR in stdout mode. */
     private $progress_fd;
 
@@ -1345,9 +1348,9 @@ class ImportClient
         // the MYSQL_PASSWORD environment variable).
         if (isset($options["sql_output"])) {
             $mode = $options["sql_output"];
-            if (!in_array($mode, ["file", "stdout", "mysql"])) {
+            if (!in_array($mode, ["file", "stdout", "mysql", "wpdb"])) {
                 throw new InvalidArgumentException(
-                    "Invalid --sql-output mode: {$mode}. Valid modes: file, stdout, mysql",
+                    "Invalid --sql-output mode: {$mode}. Valid modes: file, stdout, mysql, wpdb",
                 );
             }
             $this->sql_output_mode = $mode;
@@ -1392,6 +1395,21 @@ class ImportClient
             $this->mysql_database = $this->state["mysql_database"];
         }
 
+        // WordPress wp-load.php path for $wpdb-based import (used by
+        // --sql-output=wpdb and db-apply --wp-load).
+        if (isset($options["wp_load"])) {
+            $path = $options["wp_load"];
+            if (!file_exists($path)) {
+                throw new InvalidArgumentException(
+                    "wp-load.php not found at: {$path}",
+                );
+            }
+            $this->wp_load_path = realpath($path);
+            $this->state["wp_load"] = $this->wp_load_path;
+        } elseif (isset($this->state["wp_load"])) {
+            $this->wp_load_path = $this->state["wp_load"];
+        }
+
         $this->save_state($this->state);
 
         // Password is never persisted — must be supplied each run or via env.
@@ -1405,6 +1423,13 @@ class ImportClient
         if ($this->sql_output_mode === "mysql" && empty($this->mysql_database)) {
             throw new InvalidArgumentException(
                 "--mysql-database is required when using --sql-output=mysql",
+            );
+        }
+
+        // Validate wpdb mode requirements.
+        if ($this->sql_output_mode === "wpdb" && empty($this->wp_load_path)) {
+            throw new InvalidArgumentException(
+                "--wp-load is required when using --sql-output=wpdb",
             );
         }
 
@@ -2820,6 +2845,8 @@ class ImportClient
                 fwrite($this->progress_fd, "SQL written to stdout\n");
             } elseif ($this->sql_output_mode === "mysql") {
                 fwrite($this->progress_fd, "SQL imported into {$this->mysql_database}\n");
+            } elseif ($this->sql_output_mode === "wpdb") {
+                fwrite($this->progress_fd, "SQL imported via \$wpdb\n");
             }
             fwrite($this->progress_fd, "Audit log: {$this->audit_log}\n");
         }
@@ -3021,16 +3048,21 @@ class ImportClient
             );
         }
 
-        // Parse target database options
+        // Determine which database backend to use: either direct MySQL via
+        // PDO, or WordPress's $wpdb (which may be backed by MySQL or SQLite
+        // via the sqlite-database-integration plugin).
+        $use_wpdb = !empty($this->wp_load_path) || !empty($options["wp_load"]);
+
+        // Parse target database options (only needed for direct MySQL mode)
         $target_host = $options["target_host"] ?? "127.0.0.1";
         $target_port = (int) ($options["target_port"] ?? 3306);
         $target_user = $options["target_user"] ?? null;
         $target_pass = $options["target_pass"] ?? "";
         $target_db = $options["target_db"] ?? null;
 
-        if (!$target_user || !$target_db) {
+        if (!$use_wpdb && (!$target_user || !$target_db)) {
             throw new InvalidArgumentException(
-                "db-apply requires --target-user and --target-db options.",
+                "db-apply requires --target-user and --target-db, or --wp-load.",
             );
         }
 
@@ -3137,30 +3169,54 @@ class ImportClient
             );
         }
 
-        // Connect to target MySQL
-        $dsn = "mysql:host={$target_host};port={$target_port};dbname={$target_db};charset=utf8mb4";
-        try {
-            $pdo = new PDO($dsn, $target_user, $target_pass, [
-                PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
-                PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
-                PDO::MYSQL_ATTR_LOCAL_INFILE => false,
-            ]);
-        } catch (PDOException $e) {
-            throw new RuntimeException(
-                "Cannot connect to target database: " . $e->getMessage(),
+        // Set up the database executor — a closure that takes a SQL string
+        // and throws RuntimeException on failure.  This lets the streaming
+        // loop work identically regardless of the backend.
+        if ($use_wpdb) {
+            $wpdb = $this->load_wordpress();
+
+            // Suppress errors so $wpdb->query() returns false instead of
+            // calling wp_die().  We inspect $wpdb->last_error ourselves.
+            $wpdb->suppress_errors(true);
+            $wpdb->show_errors(false);
+
+            $exec_query = function (string $sql) use ($wpdb): void {
+                $result = $wpdb->query($sql);
+                if ($result === false && $wpdb->last_error) {
+                    throw new RuntimeException($wpdb->last_error);
+                }
+            };
+
+            $this->audit_log("CONNECTED | via \$wpdb (wp-load: {$this->wp_load_path})", false);
+        } else {
+            $dsn = "mysql:host={$target_host};port={$target_port};dbname={$target_db};charset=utf8mb4";
+            try {
+                $pdo = new PDO($dsn, $target_user, $target_pass, [
+                    PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+                    PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+                    PDO::MYSQL_ATTR_LOCAL_INFILE => false,
+                ]);
+            } catch (PDOException $e) {
+                throw new RuntimeException(
+                    "Cannot connect to target database: " . $e->getMessage(),
+                );
+            }
+
+            $exec_query = function (string $sql) use ($pdo): void {
+                $pdo->exec($sql);
+            };
+
+            $this->audit_log(
+                sprintf(
+                    "CONNECTED | host=%s port=%d db=%s user=%s",
+                    $target_host,
+                    $target_port,
+                    $target_db,
+                    $target_user,
+                ),
+                false,
             );
         }
-
-        $this->audit_log(
-            sprintf(
-                "CONNECTED | host=%s port=%d db=%s user=%s",
-                $target_host,
-                $target_port,
-                $target_db,
-                $target_user,
-            ),
-            false,
-        );
 
         // Stream db.sql through the query stream and execute
         $query_stream = new \WP_MySQL_Naive_Query_Stream();
@@ -3233,8 +3289,8 @@ class ImportClient
 
                     // Execute against target database
                     try {
-                        $pdo->exec($query);
-                    } catch (PDOException $e) {
+                        $exec_query($query);
+                    } catch (\Exception $e) {
                         $this->audit_log(
                             sprintf(
                                 "SQL ERROR | stmt=%d | %s | query=%.200s",
@@ -3295,8 +3351,8 @@ class ImportClient
                 }
 
                 try {
-                    $pdo->exec($query);
-                } catch (PDOException $e) {
+                    $exec_query($query);
+                } catch (\Exception $e) {
                     $this->audit_log(
                         sprintf(
                             "SQL ERROR | stmt=%d | %s | query=%.200s",
@@ -3350,6 +3406,41 @@ class ImportClient
         } finally {
             fclose($sql_handle);
         }
+    }
+
+    /**
+     * Load WordPress via wp-load.php and return the global $wpdb instance.
+     *
+     * Uses SHORTINIT to skip plugins/themes — only the database layer
+     * (including the db.php drop-in for SQLite) is bootstrapped.  This
+     * lets the importer route SQL through $wpdb whether WordPress is
+     * running on MySQL or SQLite (via sqlite-database-integration).
+     *
+     * @return \wpdb The global WordPress database object.
+     */
+    private function load_wordpress(): object
+    {
+        $wp_load = $this->wp_load_path;
+        if (empty($wp_load)) {
+            throw new RuntimeException("--wp-load path is not set.");
+        }
+
+        // SHORTINIT tells WordPress to stop after the database layer,
+        // skipping plugins, themes, and the rest of the bootstrap.
+        if (!defined('SHORTINIT')) {
+            define('SHORTINIT', true);
+        }
+
+        require_once $wp_load;
+
+        if (!isset($GLOBALS['wpdb'])) {
+            throw new RuntimeException(
+                "WordPress loaded from {$wp_load} but \$wpdb is not available. " .
+                "Check that wp-config.php and the database layer are working."
+            );
+        }
+
+        return $GLOBALS['wpdb'];
     }
 
     /**
@@ -4641,6 +4732,7 @@ class ImportClient
 
         $sql_handle = null;
         $mysql_conn = null;
+        $wpdb = null;
         $buffer_handle = null;
         $sql_bytes_written = 0;
         $sql_buffer = "";
@@ -4732,6 +4824,32 @@ class ImportClient
             if (!$buffer_handle) {
                 throw new RuntimeException("Cannot open SQL buffer file: {$buffer_file}");
             }
+
+        } elseif ($mode === "wpdb") {
+            $sql_bytes_written = $this->state["sql_bytes"] ?? 0;
+
+            $wpdb = $this->load_wordpress();
+            $wpdb->suppress_errors(true);
+            $wpdb->show_errors(false);
+
+            $this->audit_log(
+                "SQL OUTPUT wpdb | connected via \$wpdb (wp-load: {$this->wp_load_path})",
+                true,
+            );
+
+            // Use the same persistent buffer/crash-recovery strategy as mysql mode.
+            $buffer_file = $this->state_dir . "/.sql-buffer";
+            if (file_exists($buffer_file)) {
+                $sql_buffer = file_get_contents($buffer_file);
+                $this->audit_log(
+                    sprintf("CRASH RECOVERY | Restored %d bytes from .sql-buffer", strlen($sql_buffer)),
+                    true,
+                );
+            }
+            $buffer_handle = fopen($buffer_file, $sql_buffer !== "" ? "a" : "w");
+            if (!$buffer_handle) {
+                throw new RuntimeException("Cannot open SQL buffer file: {$buffer_file}");
+            }
         }
 
         // Domain discovery: scan SQL for URLs during download
@@ -4790,6 +4908,7 @@ class ImportClient
                     &$complete,
                     &$sql_handle,
                     $mysql_conn,
+                    $wpdb,
                     &$buffer_handle,
                     &$sql_buffer,
                     &$sql_bytes_written,
@@ -4897,6 +5016,43 @@ class ImportClient
                                     } while ($mysql_conn->more_results() && $mysql_conn->next_result());
 
                                     // Query executed — truncate the buffer file and reset.
+                                    if ($buffer_handle) {
+                                        ftruncate($buffer_handle, 0);
+                                        rewind($buffer_handle);
+                                    }
+                                    $sql_buffer = "";
+                                }
+                                break;
+
+                            case "wpdb":
+                                // Same buffer/crash-recovery strategy as mysql mode,
+                                // but execute through $wpdb->query() which routes
+                                // through whatever database backend WordPress uses
+                                // (MySQL or SQLite via sqlite-database-integration).
+                                if ($buffer_handle) {
+                                    fwrite($buffer_handle, $data);
+                                    fflush($buffer_handle);
+                                }
+
+                                $sql_buffer .= $data;
+                                $sql_bytes_written += strlen($data);
+
+                                if ($query_complete && $sql_buffer !== "") {
+                                    // $wpdb->query() handles one statement at a time,
+                                    // so split the buffer using the query stream.
+                                    $buf_stream = new \WP_MySQL_Naive_Query_Stream();
+                                    $buf_stream->append_sql($sql_buffer);
+                                    $buf_stream->mark_input_complete();
+                                    while ($buf_stream->next_query()) {
+                                        $q = $buf_stream->get_query();
+                                        $result = $wpdb->query($q);
+                                        if ($result === false && $wpdb->last_error) {
+                                            throw new RuntimeException(
+                                                "wpdb execution failed: " . $wpdb->last_error
+                                            );
+                                        }
+                                    }
+
                                     if ($buffer_handle) {
                                         ftruncate($buffer_handle, 0);
                                         rewind($buffer_handle);
@@ -5015,6 +5171,20 @@ class ImportClient
                 $mysql_conn = null;
                 // Clean up buffer file — if we got here with an empty buffer,
                 // all queries were executed successfully.
+                $buffer_file = $this->state_dir . "/.sql-buffer";
+                if ($pending === "" && file_exists($buffer_file)) {
+                    unlink($buffer_file);
+                }
+                if ($pending !== "") {
+                    throw new RuntimeException(
+                        "Buffered SQL was never executed (" . strlen($pending) .
+                        " bytes) — incomplete export?"
+                    );
+                }
+            }
+            // wpdb mode: same buffer cleanup logic as mysql mode.
+            if ($wpdb && !$mysql_conn) {
+                $pending = $sql_buffer;
                 $buffer_file = $this->state_dir . "/.sql-buffer";
                 if ($pending === "" && file_exists($buffer_file)) {
                     unlink($buffer_file);
@@ -7065,13 +7235,15 @@ class ImportClient
                 "bytes_read" => 0,
                 "rewrite_url" => null,
             ],
-            // SQL output mode (file, stdout, mysql) — persisted for resume
+            // SQL output mode (file, stdout, mysql, wpdb) — persisted for resume
             "sql_output" => null,
             // MySQL connection parameters — persisted for resume (password excluded)
             "mysql_host" => null,
             "mysql_port" => null,
             "mysql_user" => null,
             "mysql_database" => null,
+            // WordPress wp-load.php path — persisted for resume
+            "wp_load" => null,
             // Adaptive tuning state/config
             "tuning" => [
                 "config" => [],
@@ -7716,17 +7888,19 @@ if (
                 "  --secret=TOKEN              HMAC shared secret for export API authentication\n" .
                 "  --verbose, -v               Show detailed request/response logs\n" .
                 "  --max-allowed-packet=SIZE   Client max_allowed_packet (e.g. 16M, 64M)\n" .
-                "  --sql-output=MODE           Output mode: file (default), stdout, mysql\n" .
+                "  --sql-output=MODE           Output mode: file (default), stdout, mysql, wpdb\n" .
                 "  --mysql-host=HOST           MySQL host (default: 127.0.0.1, for --sql-output=mysql)\n" .
                 "  --mysql-port=PORT           MySQL port (default: 3306, for --sql-output=mysql)\n" .
                 "  --mysql-user=USER           MySQL user (default: root, for --sql-output=mysql)\n" .
                 "  --mysql-password=PASS       MySQL password (or set MYSQL_PASSWORD env)\n" .
                 "  --mysql-database=DB         MySQL database (required for --sql-output=mysql)\n" .
+                "  --wp-load=PATH              Path to wp-load.php (required for --sql-output=wpdb)\n" .
                 "\n" .
                 "Output modes:\n" .
                 "  file    Write to --state-dir/db.sql (default)\n" .
                 "  stdout  Write raw SQL to stdout; progress goes to stderr\n" .
-                "  mysql   Stream directly into a MySQL connection\n",
+                "  mysql   Stream directly into a MySQL connection\n" .
+                "  wpdb    Stream through WordPress \$wpdb (supports MySQL and SQLite)\n",
         ],
         "db-index" => [
             "short" => "Index database tables and their statistics",
@@ -7757,26 +7931,37 @@ if (
                 "  php import.php db-domains - --state-dir=/path/to/state\n",
         ],
         "db-apply" => [
-            "short" => "Apply SQL dump to a target MySQL database with URL rewriting",
+            "short" => "Apply SQL dump to a target database with URL rewriting",
             "detail" =>
                 "Reads <local-path>/db.sql, optionally rewrites URLs, and executes\n" .
-                "all statements against a target MySQL database. Resumable.\n" .
+                "all statements against a target database. Resumable.\n" .
+                "\n" .
+                "Supports two backends:\n" .
+                "  1. Direct MySQL via --target-* options (default)\n" .
+                "  2. WordPress \$wpdb via --wp-load (works with MySQL and SQLite)\n" .
                 "\n" .
                 "The <remote-url> parameter is kept for CLI consistency but ignored.\n" .
                 "\n" .
                 "Options:\n" .
                 "  --target-host=HOST         Target MySQL host (default: 127.0.0.1)\n" .
                 "  --target-port=PORT         Target MySQL port (default: 3306)\n" .
-                "  --target-user=USER         Target MySQL user (required)\n" .
+                "  --target-user=USER         Target MySQL user (required without --wp-load)\n" .
                 "  --target-pass=PASS         Target MySQL password\n" .
-                "  --target-db=NAME           Target MySQL database (required)\n" .
+                "  --target-db=NAME           Target MySQL database (required without --wp-load)\n" .
+                "  --wp-load=PATH             Path to wp-load.php (uses \$wpdb instead of direct MySQL)\n" .
                 "  --rewrite-url FROM TO      Rewrite FROM to TO (repeatable)\n" .
                 "  --abort                    Clear state and exit\n" .
                 "  --verbose, -v              Show detailed logs\n" .
                 "\n" .
-                "Example:\n" .
+                "Examples:\n" .
+                "  # Direct MySQL:\n" .
                 "  php import.php db-apply - /path/to/import \\\n" .
                 "    --target-user=root --target-db=wp_new \\\n" .
+                "    --rewrite-url https://old.com https://new.com\n" .
+                "\n" .
+                "  # Via WordPress \$wpdb (MySQL or SQLite):\n" .
+                "  php import.php db-apply - /path/to/import \\\n" .
+                "    --wp-load=/path/to/wordpress/wp-load.php \\\n" .
                 "    --rewrite-url https://old.com https://new.com\n",
         ],
         "preflight" => [
@@ -8094,6 +8279,8 @@ if (
             $options["target_pass"] = substr($argv[$i], strlen("--target-pass="));
         } elseif (strpos($argv[$i], "--target-db=") === 0) {
             $options["target_db"] = substr($argv[$i], strlen("--target-db="));
+        } elseif (strpos($argv[$i], "--wp-load=") === 0) {
+            $options["wp_load"] = substr($argv[$i], strlen("--wp-load="));
         } elseif ($argv[$i] === "--rewrite-url") {
             if (!isset($argv[$i + 1]) || !isset($argv[$i + 2])) {
                 fwrite(STDERR, "--rewrite-url requires two arguments: FROM TO\n");

--- a/importer/lib/wp-stubs.php
+++ b/importer/lib/wp-stubs.php
@@ -92,3 +92,33 @@ if(!class_exists('WP_Error')) {
         }
     }
 }
+
+if (!class_exists('wpdb')) {
+    /**
+     * Minimal wpdb stub so PHPStan can resolve the type when the real
+     * WordPress isn't available.  Only the methods/properties used by
+     * the importer's $wpdb integration are declared here.
+     */
+    class wpdb {
+        /** @var string */
+        public $last_error = '';
+
+        /**
+         * @param string $query
+         * @return int|bool
+         */
+        public function query($query) { return 0; }
+
+        /**
+         * @param bool $suppress
+         * @return bool
+         */
+        public function suppress_errors($suppress = true) { return false; }
+
+        /**
+         * @param bool $show
+         * @return void
+         */
+        public function show_errors($show = true) {}
+    }
+}

--- a/tests/Import/WpdbImportTest.php
+++ b/tests/Import/WpdbImportTest.php
@@ -1,0 +1,498 @@
+<?php
+
+namespace ImportTests;
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../importer/import.php';
+
+/**
+ * Minimal $wpdb stand-in for testing.
+ *
+ * Records every query that passes through query(), and can be told to
+ * simulate an error for a specific statement number.  Only the methods
+ * actually called by ImportClient are implemented.
+ */
+class FakeWpdb
+{
+    /** @var string[] All queries executed via query(). */
+    public $queries = [];
+
+    /** @var string Last error message (empty = no error). */
+    public $last_error = '';
+
+    /** @var int|null 1-indexed statement number to fail on, or null. */
+    public $fail_on_statement = null;
+
+    /** @var string Error message to use when failing. */
+    public $fail_message = 'Simulated wpdb error';
+
+    /** @var bool Current suppress_errors state. */
+    private $suppress = false;
+
+    /**
+     * Execute a SQL query and record it.
+     *
+     * @return int|false Number of affected rows, or false on error.
+     */
+    public function query(string $sql)
+    {
+        $this->queries[] = $sql;
+        $this->last_error = '';
+
+        if (
+            $this->fail_on_statement !== null
+            && count($this->queries) === $this->fail_on_statement
+        ) {
+            $this->last_error = $this->fail_message;
+            return false;
+        }
+
+        return 1;
+    }
+
+    public function suppress_errors(bool $suppress = true): bool
+    {
+        $old = $this->suppress;
+        $this->suppress = $suppress;
+        return $old;
+    }
+
+    public function show_errors(bool $show = true): void
+    {
+        // no-op
+    }
+}
+
+
+/**
+ * Tests for the $wpdb-based SQL import paths:
+ *   - db-apply --wp-load=...
+ *   - --sql-output=wpdb
+ *
+ * These tests use a FakeWpdb that records queries so we can verify
+ * the importer feeds the right SQL through $wpdb->query() without
+ * needing a real WordPress installation or database.
+ */
+class WpdbImportTest extends TestCase
+{
+    private $tempDir;
+    private $stateDir;
+    private $docroot;
+
+    /**
+     * Path to a no-op wp-load.php that allows load_wordpress() to
+     * succeed.  Created once per test class because require_once
+     * only loads a file once per process.
+     */
+    private static $fakeWpLoad;
+
+    public static function setUpBeforeClass(): void
+    {
+        // The fake wp-load.php is intentionally empty — it doesn't
+        // touch $GLOBALS['wpdb'].  Each test pre-sets that global
+        // before invoking any code that calls load_wordpress().
+        self::$fakeWpLoad = sys_get_temp_dir()
+            . '/fake-wp-load-' . uniqid() . '.php';
+        file_put_contents(
+            self::$fakeWpLoad,
+            "<?php\n// Fake wp-load.php for WpdbImportTest\n",
+        );
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        if (self::$fakeWpLoad && file_exists(self::$fakeWpLoad)) {
+            unlink(self::$fakeWpLoad);
+        }
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->tempDir = sys_get_temp_dir() . '/wpdb-import-test-' . uniqid();
+        $this->stateDir = $this->tempDir . '/state';
+        $this->docroot = $this->tempDir . '/docroot';
+        mkdir($this->stateDir, 0755, true);
+        mkdir($this->docroot, 0755, true);
+    }
+
+    protected function tearDown(): void
+    {
+        unset($GLOBALS['wpdb']);
+        $this->recursiveDelete($this->tempDir);
+        parent::tearDown();
+    }
+
+    private function recursiveDelete(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        foreach (scandir($dir) as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $path = $dir . '/' . $item;
+            if (is_link($path)) {
+                unlink($path);
+            } elseif (is_dir($path)) {
+                $this->recursiveDelete($path);
+            } else {
+                unlink($path);
+            }
+        }
+        rmdir($dir);
+    }
+
+    private function makeClient(): \ImportClient
+    {
+        return new \ImportClient(
+            'http://fake.url',
+            $this->stateDir,
+            $this->docroot,
+        );
+    }
+
+    /**
+     * Write a db.sql file in the state directory.
+     */
+    private function writeSqlFile(string $sql): void
+    {
+        file_put_contents($this->stateDir . '/db.sql', $sql);
+    }
+
+    /**
+     * Write a state file directly.
+     */
+    private function writeState(array $state): void
+    {
+        $defaults = [
+            "command" => null,
+            "status" => null,
+            "cursor" => null,
+            "stage" => null,
+            "preflight" => ["data" => ["ok" => true], "http_code" => 200],
+            "remote_protocol_version" => null,
+            "remote_protocol_min_version" => null,
+            "version" => null,
+            "follow_symlinks" => false,
+            "docroot_nonempty_behavior" => "error",
+            "max_allowed_packet" => null,
+        ];
+        file_put_contents(
+            $this->stateDir . '/.import-state.json',
+            json_encode(array_merge($defaults, $state), JSON_PRETTY_PRINT),
+        );
+    }
+
+    /**
+     * Read the current state file.
+     */
+    private function readState(): array
+    {
+        $path = $this->stateDir . '/.import-state.json';
+        return json_decode(file_get_contents($path), true);
+    }
+
+
+    // ── Validation tests ────────────────────────────────────────────
+
+    /**
+     * db-apply without --target-* or --wp-load should produce a
+     * helpful error mentioning both alternatives.
+     */
+    public function testDbApplyRequiresTargetOrWpLoad(): void
+    {
+        $this->writeSqlFile("SELECT 1;\n");
+
+        $client = $this->makeClient();
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('--target-user and --target-db, or --wp-load');
+
+        $client->run(['command' => 'db-apply']);
+    }
+
+    /**
+     * --wp-load pointing to a nonexistent file should fail early
+     * with a clear message.
+     */
+    public function testWpLoadRejectsNonexistentPath(): void
+    {
+        $this->writeSqlFile("SELECT 1;\n");
+
+        $client = $this->makeClient();
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('wp-load.php not found');
+
+        $client->run([
+            'command' => 'db-apply',
+            'wp_load' => '/nonexistent/wp-load.php',
+        ]);
+    }
+
+    /**
+     * --sql-output=wpdb without --wp-load should fail with a clear error.
+     */
+    public function testSqlOutputWpdbRequiresWpLoad(): void
+    {
+        $client = $this->makeClient();
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('--wp-load is required');
+
+        $client->run([
+            'command' => 'db-sync',
+            'sql_output' => 'wpdb',
+        ]);
+    }
+
+    /**
+     * sql_output validation accepts the new "wpdb" mode.
+     */
+    public function testSqlOutputAcceptsWpdbMode(): void
+    {
+        // Pre-set wpdb so load_wordpress() succeeds when db-sync
+        // actually runs (it will fail on the HTTP request, but we
+        // only care that the mode was accepted during validation).
+        $GLOBALS['wpdb'] = new FakeWpdb();
+
+        $client = $this->makeClient();
+        try {
+            $client->run([
+                'command' => 'db-sync',
+                'sql_output' => 'wpdb',
+                'wp_load' => self::$fakeWpLoad,
+            ]);
+        } catch (\RuntimeException $e) {
+            // Expected — db-sync will fail because there's no real
+            // server, but we got past mode validation.
+            $this->assertStringNotContainsString(
+                'Invalid --sql-output mode',
+                $e->getMessage(),
+            );
+            return;
+        }
+        // If it didn't throw, that's fine too (unlikely but acceptable).
+    }
+
+
+    // ── load_wordpress() tests ──────────────────────────────────────
+
+    /**
+     * load_wordpress() should throw when $GLOBALS['wpdb'] is not set
+     * after loading wp-load.php.
+     */
+    public function testLoadWordpressThrowsWhenWpdbMissing(): void
+    {
+        unset($GLOBALS['wpdb']);
+
+        $client = $this->makeClient();
+
+        // Set wp_load_path via reflection so load_wordpress() has a
+        // file to load.
+        $ref = new \ReflectionClass($client);
+        $prop = $ref->getProperty('wp_load_path');
+        $prop->setValue($client, self::$fakeWpLoad);
+
+        $method = $ref->getMethod('load_wordpress');
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('$wpdb is not available');
+
+        $method->invoke($client);
+    }
+
+    /**
+     * load_wordpress() returns whatever is in $GLOBALS['wpdb'].
+     */
+    public function testLoadWordpressReturnsWpdb(): void
+    {
+        $mock = new FakeWpdb();
+        $GLOBALS['wpdb'] = $mock;
+
+        $client = $this->makeClient();
+
+        $ref = new \ReflectionClass($client);
+        $prop = $ref->getProperty('wp_load_path');
+        $prop->setValue($client, self::$fakeWpLoad);
+
+        $method = $ref->getMethod('load_wordpress');
+        $result = $method->invoke($client);
+
+        $this->assertSame($mock, $result);
+    }
+
+
+    // ── db-apply execution tests ────────────────────────────────────
+
+    /**
+     * db-apply --wp-load should feed every SQL statement from db.sql
+     * through $wpdb->query() in order.
+     */
+    public function testDbApplyWithWpLoadExecutesAllStatements(): void
+    {
+        $sql = implode("\n", [
+            "DROP TABLE IF EXISTS `test_table`;",
+            "CREATE TABLE `test_table` (id INT);",
+            "INSERT INTO `test_table` VALUES (1);",
+            "INSERT INTO `test_table` VALUES (2);",
+        ]);
+        $this->writeSqlFile($sql);
+
+        $mock = new FakeWpdb();
+        $GLOBALS['wpdb'] = $mock;
+
+        $client = $this->makeClient();
+        $client->run([
+            'command' => 'db-apply',
+            'wp_load' => self::$fakeWpLoad,
+        ]);
+
+        // All four statements should have been executed via $wpdb.
+        // Trim queries because the query stream may preserve leading
+        // whitespace from the SQL file.
+        $this->assertCount(4, $mock->queries);
+        $this->assertStringStartsWith('DROP TABLE', trim($mock->queries[0]));
+        $this->assertStringStartsWith('CREATE TABLE', trim($mock->queries[1]));
+        $this->assertStringContainsString('VALUES (1)', $mock->queries[2]);
+        $this->assertStringContainsString('VALUES (2)', $mock->queries[3]);
+
+        // State should be marked complete
+        $state = $this->readState();
+        $this->assertSame('complete', $state['status']);
+        $this->assertSame(4, $state['apply']['statements_executed']);
+    }
+
+    /**
+     * When $wpdb->query() returns false with a last_error, db-apply
+     * should report the error with the statement number and a snippet
+     * of the failing query.
+     */
+    public function testDbApplyWithWpLoadReportsErrors(): void
+    {
+        $sql = "INSERT INTO `ok_table` VALUES (1);\nINSERT INTO `bad_table` VALUES (2);\n";
+        $this->writeSqlFile($sql);
+
+        $mock = new FakeWpdb();
+        $mock->fail_on_statement = 2;
+        $mock->fail_message = 'no such table: bad_table';
+        $GLOBALS['wpdb'] = $mock;
+
+        $client = $this->makeClient();
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('SQL execution error at statement 2');
+
+        $client->run([
+            'command' => 'db-apply',
+            'wp_load' => self::$fakeWpLoad,
+        ]);
+    }
+
+    /**
+     * db-apply with --wp-load persists the wp_load path and statement
+     * count in state, and marks the run complete.
+     */
+    public function testWpLoadPathPersistedInState(): void
+    {
+        $this->writeSqlFile("SELECT 1;\n");
+
+        $GLOBALS['wpdb'] = new FakeWpdb();
+
+        $client = $this->makeClient();
+        $client->run([
+            'command' => 'db-apply',
+            'wp_load' => self::$fakeWpLoad,
+        ]);
+
+        $state = $this->readState();
+        $this->assertSame(
+            realpath(self::$fakeWpLoad),
+            $state['wp_load'],
+        );
+    }
+
+    /**
+     * db-apply with --wp-load correctly resumes from a partially
+     * completed run by skipping already-executed statements.
+     */
+    public function testDbApplyWithWpLoadResumes(): void
+    {
+        // 4 statements, pretend 2 were already executed
+        $sql = implode("\n", [
+            "INSERT INTO t VALUES (1);",
+            "INSERT INTO t VALUES (2);",
+            "INSERT INTO t VALUES (3);",
+            "INSERT INTO t VALUES (4);",
+        ]);
+        $this->writeSqlFile($sql);
+
+        // Write state showing 2 statements already executed
+        $this->writeState([
+            'command' => 'db-apply',
+            'status' => 'in_progress',
+            'apply' => [
+                'statements_executed' => 2,
+                'bytes_read' => 0,  // forces statement-skipping path
+                'rewrite_url' => null,
+            ],
+            'wp_load' => self::$fakeWpLoad,
+        ]);
+
+        $mock = new FakeWpdb();
+        $GLOBALS['wpdb'] = $mock;
+
+        $client = $this->makeClient();
+        $client->run([
+            'command' => 'db-apply',
+            'wp_load' => self::$fakeWpLoad,
+        ]);
+
+        // Only the last 2 statements should have been executed
+        $this->assertCount(2, $mock->queries);
+        $this->assertStringContainsString('VALUES (3)', $mock->queries[0]);
+        $this->assertStringContainsString('VALUES (4)', $mock->queries[1]);
+
+        $state = $this->readState();
+        $this->assertSame('complete', $state['status']);
+        $this->assertSame(4, $state['apply']['statements_executed']);
+    }
+
+    /**
+     * When --wp-load is provided, the --target-* MySQL options are
+     * not required — the importer skips the PDO connection entirely.
+     */
+    public function testDbApplyWithWpLoadSkipsTargetValidation(): void
+    {
+        $this->writeSqlFile("SELECT 1;\n");
+        $GLOBALS['wpdb'] = new FakeWpdb();
+
+        $client = $this->makeClient();
+        // Should NOT throw "requires --target-user and --target-db"
+        $client->run([
+            'command' => 'db-apply',
+            'wp_load' => self::$fakeWpLoad,
+            // Intentionally omitting target_user and target_db
+        ]);
+
+        $this->assertSame('complete', $this->readState()['status']);
+    }
+
+    /**
+     * Existing direct-MySQL db-apply path still works: when --wp-load
+     * is NOT provided, the old --target-* validation fires.
+     */
+    public function testDbApplyWithoutWpLoadStillRequiresTarget(): void
+    {
+        $this->writeSqlFile("SELECT 1;\n");
+
+        $client = $this->makeClient();
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('--target-user and --target-db, or --wp-load');
+
+        $client->run([
+            'command' => 'db-apply',
+            // No wp_load, no target_user/target_db
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary

The importer can now route SQL through WordPress's `$wpdb` instead of requiring a direct MySQL connection. This enables importing into SQLite databases via the sqlite-database-integration plugin — `$wpdb` handles the MySQL-to-SQLite translation transparently.

Two new integration points, both using the new `--wp-load` flag:

- **`db-apply --wp-load=...`** applies a downloaded `db.sql` through `$wpdb`. The `--target-*` MySQL options become unnecessary.
- **`db-sync --sql-output=wpdb --wp-load=...`** streams SQL directly through `$wpdb` as it downloads, same pattern as `--sql-output=mysql`.

WordPress is loaded with `SHORTINIT` so only the database layer (including the `db.php` drop-in for SQLite) gets bootstrapped — no plugins, themes, or hooks. The `--wp-load` path persists in state for resume support.

Internally, `db-apply` uses an `$exec_query` closure that abstracts the backend, so the streaming loop, resume logic, and URL rewriting work identically for both PDO/MySQL and `$wpdb`. The `db-sync` wpdb mode reuses the same `.sql-buffer` crash-recovery strategy as the mysql mode, splitting the buffer into individual statements via `WP_MySQL_Naive_Query_Stream` since `$wpdb->query()` handles one statement at a time.

## Test plan

- [ ] `db-apply --wp-load=...` with a MySQL-backed WordPress site
- [ ] `db-apply --wp-load=...` with a SQLite-backed WordPress site (sqlite-database-integration)
- [ ] `db-sync --sql-output=wpdb --wp-load=...` streaming mode
- [ ] Resume after interruption preserves `wp_load` state
- [ ] Validation: `--wp-load` with nonexistent path errors clearly
- [ ] Validation: `--sql-output=wpdb` without `--wp-load` errors clearly
- [ ] `db-apply` without `--wp-load` or `--target-*` gives helpful error message
- [ ] Existing `db-apply --target-*` MySQL path still works unchanged