### PR TITLE
Add SQLite support to db-apply

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ On the **migration target** side:
  - ext-json — JSON encoding/decoding
  - ext-hash — hash_hmac, hash_equals
  - ext-zlib — deflate_init/deflate_add for gzip streaming
+ - ext-pdo + ext-pdo_mysql — for MySQL targets
+ - ext-pdo + ext-pdo_sqlite — for SQLite targets via sqlite-database-integration
 
 ## Integrating with a hosting platform
 
@@ -171,11 +173,22 @@ The command returns one of three exit codes:
 
 If the site's domain is changing (e.g. migrating from `https://old-site.com`
 to `https://new-site.com`), use `db-apply` with `--rewrite-url` to import
-the SQL dump into a target MySQL database while rewriting all URLs in one pass:
+the SQL dump into a target database while rewriting all URLs in one pass.
+
+MySQL target:
 
 ```bash
 php importer.phar db-apply "$URL" --state-dir="$STATE_DIR" --docroot="$DOCROOT" --secret="$SECRET" \
     --target-user=root --target-db=wp_new \
+    --rewrite-url https://old-site.com https://new-site.com
+```
+
+SQLite target:
+
+```bash
+php importer.phar db-apply "$URL" --state-dir="$STATE_DIR" --docroot="$DOCROOT" --secret="$SECRET" \
+    --target-engine=sqlite --target-sqlite-path="$STATE_DIR/wordpress.sqlite" \
+    --target-db=wp_new \
     --rewrite-url https://old-site.com https://new-site.com
 ```
 
@@ -196,7 +209,8 @@ php importer.phar db-apply "$URL" --state-dir="$STATE_DIR" --docroot="$DOCROOT" 
 ```
 
 If the domain isn't changing, you can skip `db-apply` and import `db.sql`
-directly with any MySQL tool.
+directly with a MySQL tool, or use `db-apply --target-engine=sqlite` to load it
+into SQLite through the bundled `sqlite-database-integration` driver.
 
 #### Shoehorning the site onto your platform
 
@@ -376,7 +390,7 @@ php importer.phar <command> <URL> --state-dir=DIR --docroot=DIR [options]
 * `files-index` — Optional. It's a standalone command to index the full remote file index without fetching file contents. `files-sync` does it implicitly
                   so this is mostly useful for testing and diagnostics.
 * `db-sync` — Downloads the database as a SQL dump. Defaults to writing `db.sql`; use `--sql-output=stdout` or `--sql-output=mysql` to stream elsewhere.
-* `db-apply` — Applies `db.sql` to a target MySQL database. Accepts `--rewrite-url FROM TO` (repeatable) to rewrite domains during import.
+* `db-apply` — Applies `db.sql` to a target MySQL or SQLite database. Accepts `--rewrite-url FROM TO` (repeatable) to rewrite domains during import.
 * `db-domains` — Lists domains discovered in the SQL dump. Reads `.import-domains.json` if available (written by `db-sync`), otherwise scans `db.sql`.
 * `db-index` — Indexes database tables and their statistics (name, row count, size) to `db-tables.jsonl`.
 

--- a/box.json
+++ b/box.json
@@ -27,10 +27,20 @@
         {
             "name": "*.php",
             "in": "lib/sqlite-database-integration/wp-includes/mysql"
+        },
+        {
+            "name": "*.php",
+            "in": "lib/sqlite-database-integration/wp-includes/sqlite"
+        },
+        {
+            "name": "*.php",
+            "in": "lib/sqlite-database-integration/wp-includes/sqlite-ast"
         }
     ],
 
     "files": [
+        "lib/sqlite-database-integration/wp-pdo-mysql-on-sqlite.php",
+        "lib/sqlite-database-integration/version.php",
         "wordpress-plugin/generic/utils.php",
         "wordpress-plugin/generic/class-hmac-client.php",
         "vendor/autoload.php"

--- a/box.json
+++ b/box.json
@@ -39,6 +39,7 @@
     ],
 
     "files": [
+        "lib/sqlite-database-integration/php-polyfills.php",
         "lib/sqlite-database-integration/wp-pdo-mysql-on-sqlite.php",
         "lib/sqlite-database-integration/version.php",
         "wordpress-plugin/generic/utils.php",

--- a/importer/import.php
+++ b/importer/import.php
@@ -3026,6 +3026,7 @@ class ImportClient
         }
 
         $driver_loader = dirname(__DIR__) . "/lib/sqlite-database-integration/wp-pdo-mysql-on-sqlite.php";
+        $polyfills = dirname(__DIR__) . "/lib/sqlite-database-integration/php-polyfills.php";
         if (!file_exists($driver_loader)) {
             throw new RuntimeException(
                 "SQLite target support requires lib/sqlite-database-integration to be initialized.",
@@ -3043,6 +3044,7 @@ class ImportClient
             }
         }
 
+        require_once $polyfills;
         require_once $driver_loader;
 
         $dsn = sprintf(

--- a/importer/import.php
+++ b/importer/import.php
@@ -3012,16 +3012,88 @@ class ImportClient
         $options["rewrite_url"][] = [$source_origin, $options["new_site_url"]];
     }
 
-    private function run_db_apply(array $options): void
+    private function escape_pdo_dsn_value(string $value): string
     {
-        $sql_file = $this->state_dir . "/db.sql";
-        if (!file_exists($sql_file)) {
+        return str_replace(';', ';;', $value);
+    }
+
+    private function create_sqlite_target_pdo(string $target_path, string $target_db): PDO
+    {
+        if (!extension_loaded("pdo_sqlite")) {
             throw new RuntimeException(
-                "db.sql not found in {$this->state_dir}. Run db-sync first.",
+                "SQLite target support requires the pdo_sqlite extension.",
             );
         }
 
-        // Parse target database options
+        $driver_loader = dirname(__DIR__) . "/lib/sqlite-database-integration/wp-pdo-mysql-on-sqlite.php";
+        if (!file_exists($driver_loader)) {
+            throw new RuntimeException(
+                "SQLite target support requires lib/sqlite-database-integration to be initialized.",
+            );
+        }
+
+        if ($target_path !== ':memory:') {
+            $target_dir = dirname($target_path);
+            if ($target_dir !== '' && $target_dir !== '.' && !is_dir($target_dir)) {
+                if (!mkdir($target_dir, 0777, true) && !is_dir($target_dir)) {
+                    throw new RuntimeException(
+                        "Cannot create SQLite directory: {$target_dir}",
+                    );
+                }
+            }
+        }
+
+        require_once $driver_loader;
+
+        $dsn = sprintf(
+            "mysql-on-sqlite:path=%s;dbname=%s",
+            $this->escape_pdo_dsn_value($target_path),
+            $this->escape_pdo_dsn_value($target_db),
+        );
+
+        try {
+            return new WP_PDO_MySQL_On_SQLite($dsn, null, null, [
+                PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+                PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+            ]);
+        } catch (PDOException $e) {
+            throw new RuntimeException(
+                "Cannot connect to target SQLite database: " . $e->getMessage(),
+                0,
+                $e,
+            );
+        }
+    }
+
+    private function create_target_db_apply_connection(array $options): array
+    {
+        $target_engine = strtolower((string) ($options["target_engine"] ?? "mysql"));
+        if (!in_array($target_engine, ["mysql", "sqlite"], true)) {
+            throw new InvalidArgumentException(
+                "Invalid --target-engine value: {$target_engine}. Valid engines: mysql, sqlite.",
+            );
+        }
+
+        if ($target_engine === "sqlite") {
+            $target_path = $options["target_sqlite_path"] ?? null;
+            $target_db = $options["target_db"] ?? "sqlite_database";
+
+            if (!$target_path) {
+                throw new InvalidArgumentException(
+                    "db-apply with --target-engine=sqlite requires --target-sqlite-path.",
+                );
+            }
+
+            return [
+                $this->create_sqlite_target_pdo($target_path, $target_db),
+                sprintf(
+                    "engine=sqlite path=%s db=%s",
+                    $target_path,
+                    $target_db,
+                ),
+            ];
+        }
+
         $target_host = $options["target_host"] ?? "127.0.0.1";
         $target_port = (int) ($options["target_port"] ?? 3306);
         $target_user = $options["target_user"] ?? null;
@@ -3030,7 +3102,43 @@ class ImportClient
 
         if (!$target_user || !$target_db) {
             throw new InvalidArgumentException(
-                "db-apply requires --target-user and --target-db options.",
+                "db-apply with --target-engine=mysql requires --target-user and --target-db.",
+            );
+        }
+
+        $dsn = "mysql:host={$target_host};port={$target_port};dbname={$target_db};charset=utf8mb4";
+        try {
+            $pdo = new PDO($dsn, $target_user, $target_pass, [
+                PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+                PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+                PDO::MYSQL_ATTR_LOCAL_INFILE => false,
+            ]);
+        } catch (PDOException $e) {
+            throw new RuntimeException(
+                "Cannot connect to target MySQL database: " . $e->getMessage(),
+                0,
+                $e,
+            );
+        }
+
+        return [
+            $pdo,
+            sprintf(
+                "engine=mysql host=%s port=%d db=%s user=%s",
+                $target_host,
+                $target_port,
+                $target_db,
+                $target_user,
+            ),
+        ];
+    }
+
+    private function run_db_apply(array $options): void
+    {
+        $sql_file = $this->state_dir . "/db.sql";
+        if (!file_exists($sql_file)) {
+            throw new RuntimeException(
+                "db.sql not found in {$this->state_dir}. Run db-sync first.",
             );
         }
 
@@ -3137,28 +3245,10 @@ class ImportClient
             );
         }
 
-        // Connect to target MySQL
-        $dsn = "mysql:host={$target_host};port={$target_port};dbname={$target_db};charset=utf8mb4";
-        try {
-            $pdo = new PDO($dsn, $target_user, $target_pass, [
-                PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
-                PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
-                PDO::MYSQL_ATTR_LOCAL_INFILE => false,
-            ]);
-        } catch (PDOException $e) {
-            throw new RuntimeException(
-                "Cannot connect to target database: " . $e->getMessage(),
-            );
-        }
+        [$pdo, $connection_label] = $this->create_target_db_apply_connection($options);
 
         $this->audit_log(
-            sprintf(
-                "CONNECTED | host=%s port=%d db=%s user=%s",
-                $target_host,
-                $target_port,
-                $target_db,
-                $target_user,
-            ),
+            "CONNECTED | {$connection_label}",
             false,
         );
 
@@ -7757,26 +7847,33 @@ if (
                 "  php import.php db-domains - --state-dir=/path/to/state\n",
         ],
         "db-apply" => [
-            "short" => "Apply SQL dump to a target MySQL database with URL rewriting",
+            "short" => "Apply SQL dump to a target MySQL or SQLite database with URL rewriting",
             "detail" =>
                 "Reads <local-path>/db.sql, optionally rewrites URLs, and executes\n" .
-                "all statements against a target MySQL database. Resumable.\n" .
+                "all statements against a target MySQL or SQLite database. Resumable.\n" .
                 "\n" .
                 "The <remote-url> parameter is kept for CLI consistency but ignored.\n" .
                 "\n" .
                 "Options:\n" .
+                "  --target-engine=ENGINE     Target database engine: mysql (default) or sqlite\n" .
                 "  --target-host=HOST         Target MySQL host (default: 127.0.0.1)\n" .
                 "  --target-port=PORT         Target MySQL port (default: 3306)\n" .
-                "  --target-user=USER         Target MySQL user (required)\n" .
+                "  --target-user=USER         Target MySQL user (required for mysql)\n" .
                 "  --target-pass=PASS         Target MySQL password\n" .
-                "  --target-db=NAME           Target MySQL database (required)\n" .
+                "  --target-db=NAME           Target DB name (required for mysql, optional for sqlite)\n" .
+                "  --target-sqlite-path=PATH  Target SQLite database file (required for sqlite)\n" .
                 "  --rewrite-url FROM TO      Rewrite FROM to TO (repeatable)\n" .
                 "  --abort                    Clear state and exit\n" .
                 "  --verbose, -v              Show detailed logs\n" .
                 "\n" .
-                "Example:\n" .
+                "MySQL example:\n" .
                 "  php import.php db-apply - /path/to/import \\\n" .
                 "    --target-user=root --target-db=wp_new \\\n" .
+                "    --rewrite-url https://old.com https://new.com\n" .
+                "\n" .
+                "SQLite example:\n" .
+                "  php import.php db-apply - /path/to/import \\\n" .
+                "    --target-engine=sqlite --target-sqlite-path=/path/to/db.sqlite \\\n" .
                 "    --rewrite-url https://old.com https://new.com\n",
         ],
         "preflight" => [
@@ -8088,12 +8185,16 @@ if (
             $options["target_host"] = substr($argv[$i], strlen("--target-host="));
         } elseif (strpos($argv[$i], "--target-port=") === 0) {
             $options["target_port"] = (int) substr($argv[$i], strlen("--target-port="));
+        } elseif (strpos($argv[$i], "--target-engine=") === 0) {
+            $options["target_engine"] = substr($argv[$i], strlen("--target-engine="));
         } elseif (strpos($argv[$i], "--target-user=") === 0) {
             $options["target_user"] = substr($argv[$i], strlen("--target-user="));
         } elseif (strpos($argv[$i], "--target-pass=") === 0) {
             $options["target_pass"] = substr($argv[$i], strlen("--target-pass="));
         } elseif (strpos($argv[$i], "--target-db=") === 0) {
             $options["target_db"] = substr($argv[$i], strlen("--target-db="));
+        } elseif (strpos($argv[$i], "--target-sqlite-path=") === 0) {
+            $options["target_sqlite_path"] = substr($argv[$i], strlen("--target-sqlite-path="));
         } elseif ($argv[$i] === "--rewrite-url") {
             if (!isset($argv[$i + 1]) || !isset($argv[$i + 2])) {
                 fwrite(STDERR, "--rewrite-url requires two arguments: FROM TO\n");

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -46,16 +46,6 @@ parameters:
 			path: wordpress-plugin/generic/class-file-tree-producer.php
 
 		-
-			message: "#^Class WP_SQLite_Driver not found\\.$#"
-			count: 1
-			path: wordpress-plugin/generic/export.php
-
-		-
-			message: "#^Call to method get_connection\\(\\) on an unknown class WP_SQLite_Driver\\.$#"
-			count: 1
-			path: wordpress-plugin/generic/export.php
-
-		-
 			message: "#^Instantiated class SqliteDriverPDO not found\\.$#"
 			count: 1
 			path: wordpress-plugin/generic/export.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -20,3 +20,5 @@ parameters:
         - wordpress-plugin/generic
         - lib/sqlite-database-integration/wp-includes/parser
         - lib/sqlite-database-integration/wp-includes/mysql
+        - lib/sqlite-database-integration/wp-includes/sqlite
+        - lib/sqlite-database-integration/wp-includes/sqlite-ast

--- a/tests/e2e/lib/test-helpers.js
+++ b/tests/e2e/lib/test-helpers.js
@@ -439,6 +439,30 @@ export async function createMysqlConnection(dbName = null) {
 }
 
 /**
+ * Query a SQLite database through the upstream MySQL-on-SQLite PDO driver.
+ */
+export function queryMysqlOnSqlite(sqlitePath, sql, dbName = 'sqlite_database') {
+    const script = `
+require_once $argv[1] . '/lib/sqlite-database-integration/wp-pdo-mysql-on-sqlite.php';
+$pdo = new WP_PDO_MySQL_On_SQLite(
+    'mysql-on-sqlite:path=' . str_replace(';', ';;', $argv[2]) . ';dbname=' . str_replace(';', ';;', $argv[3]),
+    null,
+    null,
+    [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION, PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC]
+);
+$stmt = $pdo->query($argv[4]);
+echo json_encode($stmt->fetchAll(PDO::FETCH_ASSOC), JSON_UNESCAPED_SLASHES);
+`;
+
+    const output = execFileSync('php', ['-r', script, PROJECT_ROOT, sqlitePath, dbName, sql], {
+        encoding: 'utf-8',
+        env: { ...process.env },
+    });
+
+    return JSON.parse(output);
+}
+
+/**
  * Get database name for a site.
  */
 export function getDbName(siteName) {

--- a/tests/e2e/lib/test-helpers.js
+++ b/tests/e2e/lib/test-helpers.js
@@ -443,6 +443,7 @@ export async function createMysqlConnection(dbName = null) {
  */
 export function queryMysqlOnSqlite(sqlitePath, sql, dbName = 'sqlite_database') {
     const script = `
+require_once $argv[1] . '/lib/sqlite-database-integration/php-polyfills.php';
 require_once $argv[1] . '/lib/sqlite-database-integration/wp-pdo-mysql-on-sqlite.php';
 $pdo = new WP_PDO_MySQL_On_SQLite(
     'mysql-on-sqlite:path=' . str_replace(';', ';;', $argv[2]) . ';dbname=' . str_replace(';', ';;', $argv[3]),

--- a/tests/e2e/tests/import-38-db-apply-sqlite-target.test.js
+++ b/tests/e2e/tests/import-38-db-apply-sqlite-target.test.js
@@ -1,0 +1,86 @@
+import { describe, it, beforeAll, afterAll } from 'vitest';
+import assert from 'node:assert/strict';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+    runImporter, createTempDir, cleanupTempDir,
+    getSiteUrl, getSiteSecret, getSiteDir,
+    queryMysqlOnSqlite,
+} from '../lib/test-helpers.js';
+import { ensureSite } from '../lib/site-setup.js';
+
+describe('Import: SQLite db-apply target', () => {
+    const site = 'basic';
+    const targetDb = 'wp_sqlite_import';
+    const targetDomain = 'https://sqlite-target.example.com';
+    const sourceDomain = new URL(getSiteUrl(site)).origin;
+    let tempDir;
+    let sqlitePath;
+
+    beforeAll(async () => {
+        await ensureSite(site, {
+            db: 'sample',
+            files: 'sample',
+        });
+
+        tempDir = createTempDir('e2e-db-apply-sqlite');
+        sqlitePath = join(tempDir, 'target', 'wordpress.sqlite');
+    }, 120000);
+
+    afterAll(() => {
+        cleanupTempDir(tempDir);
+    });
+
+    function importUrl() {
+        return `${getSiteUrl(site)}&directory=${getSiteDir(site)}`;
+    }
+
+    it('applies db.sql into SQLite via the upstream PDO-compatible driver', () => {
+        const syncResult = runImporter(importUrl(), tempDir, 'db-sync', {
+            secret: getSiteSecret(site),
+        });
+        assert.equal(syncResult.exitCode, 0,
+            `Expected db-sync exit 0, got ${syncResult.exitCode}\nstderr: ${syncResult.stderr}\nstdout: ${syncResult.stdout}`);
+
+        const applyResult = runImporter(importUrl(), tempDir, 'db-apply', {
+            secret: getSiteSecret(site),
+            extraArgs: [
+                '--target-engine=sqlite',
+                `--target-sqlite-path=${sqlitePath}`,
+                `--target-db=${targetDb}`,
+                '--rewrite-url', sourceDomain, targetDomain,
+            ],
+        });
+
+        assert.equal(applyResult.exitCode, 0,
+            `Expected db-apply exit 0, got ${applyResult.exitCode}\nstderr: ${applyResult.stderr}\nstdout: ${applyResult.stdout}`);
+        assert.ok(existsSync(sqlitePath), `Expected SQLite database file at ${sqlitePath}`);
+
+        const tables = queryMysqlOnSqlite(sqlitePath, 'SHOW TABLES', targetDb);
+        const tableNames = tables.map(row => Object.values(row)[0]);
+        for (const table of ['wp_options', 'wp_posts', 'wp_users']) {
+            assert.ok(
+                tableNames.includes(table),
+                `Expected ${table} in SQLite import, got: ${tableNames.join(', ')}`,
+            );
+        }
+
+        const options = queryMysqlOnSqlite(
+            sqlitePath,
+            "SELECT option_name, option_value FROM wp_options WHERE option_name IN ('siteurl', 'home') ORDER BY option_name",
+            targetDb,
+        );
+
+        assert.equal(options.length, 2, `Expected siteurl/home rows, got: ${JSON.stringify(options)}`);
+        for (const row of options) {
+            assert.ok(
+                row.option_value.includes(targetDomain),
+                `Expected rewritten target domain in ${row.option_name}, got: ${row.option_value}`,
+            );
+            assert.ok(
+                !row.option_value.includes(sourceDomain),
+                `Expected source domain to be removed from ${row.option_name}, got: ${row.option_value}`,
+            );
+        }
+    });
+});


### PR DESCRIPTION
## Summary
- update the sqlite-database-integration submodule to a trunk commit that exposes the PDO-compatible MySQL-on-SQLite driver
- add `db-apply` target-engine support for SQLite via `WP_PDO_MySQL_On_SQLite`, while keeping MySQL as the default path
- document the new CLI options, include the extra driver files in the PHAR build, and add focused SQLite-target E2E coverage

## Testing
- `php -l importer/import.php`
- direct smoke test: apply a handcrafted `db.sql` into SQLite via `php importer/import.php db-apply ... --target-engine=sqlite` and query the resulting database through `WP_PDO_MySQL_On_SQLite`
- `./tests/e2e/node_modules/.bin/vitest run tests/import-38-db-apply-sqlite-target.test.js` *(blocked locally: `ensureSite()` requires passworded `sudo` to manage `/srv/e2e-sites`)*