### PR TITLE
Suppress curl_close() deprecation on PHP 8.5+

### DIFF
--- a/importer/import.php
+++ b/importer/import.php
@@ -6699,7 +6699,7 @@ class ImportClient
         try {
             $this->check_curl_error($ch);
         } catch (RuntimeException $e) {
-            curl_close($ch);
+            @curl_close($ch);
             return [
                 "ok" => false,
                 "http_code" => 0,
@@ -6713,7 +6713,7 @@ class ImportClient
         }
 
         $http_code = (int) curl_getinfo($ch, CURLINFO_HTTP_CODE);
-        curl_close($ch);
+        @curl_close($ch);
 
         if ($http_code !== 200) {
             return [
@@ -7019,7 +7019,7 @@ class ImportClient
             $ttfb = (float) curl_getinfo($ch, CURLINFO_STARTTRANSFER_TIME);
             $total_time = (float) curl_getinfo($ch, CURLINFO_TOTAL_TIME);
         } finally {
-            curl_close($ch);
+            @curl_close($ch);
         }
 
         if (!isset($context->response_stats) || !is_array($context->response_stats)) {


### PR DESCRIPTION
## Summary

- Silences the `curl_close()` deprecation warning introduced in PHP 8.5. The function has been a no-op since PHP 8.0, so prefixing with `@` changes nothing except suppressing the noise.

## Test plan

- Run the importer on PHP 8.5+ and verify no deprecation warnings appear for `curl_close()`