### PR TITLE
Deduplicate file counts in files-stats

### DIFF
--- a/importer/import.php
+++ b/importer/import.php
@@ -2913,10 +2913,10 @@ class ImportClient
         $remote_index = $this->remote_index_file;
         $download_list = $this->download_list_file;
 
-        // Single pass over the remote index: count, sum sizes, and build
-        // a path→size map for resolving download list entries.
-        $indexed_count = 0;
-        $indexed_bytes = 0;
+        // Single pass over the remote index to build a path→size map.
+        // Duplicates (from overlapping symlink targets) are collapsed
+        // automatically because later entries overwrite earlier ones in
+        // the map, so the counts we derive are always deduplicated.
         $size_by_path = [];
 
         if (is_file($remote_index)) {
@@ -2927,13 +2927,14 @@ class ImportClient
                     if ($entry === null) {
                         continue;
                     }
-                    $indexed_count++;
-                    $indexed_bytes += $entry["size"];
                     $size_by_path[$entry["path"]] = $entry["size"];
                 }
                 fclose($handle);
             }
         }
+
+        $indexed_count = count($size_by_path);
+        $indexed_bytes = array_sum($size_by_path);
 
         // Walk the download list to count pending files. The download
         // list only stores paths, so look up sizes from the map above.


### PR DESCRIPTION
## Summary

When the remote server follows symlinks, overlapping targets cause the same files to appear multiple times in the raw remote index. The sort step deduplicates them after indexing completes, but `files-stats` was counting raw lines — so during indexing it reported inflated totals (e.g. 36,995) that dropped after the sort (to 23,306), making the progress bar jump backwards.

Now `files-stats` builds a path→size map (which naturally collapses duplicates) and derives counts from that map, so the reported numbers are consistent whether the index has been sorted yet or not.

## Test plan

- [ ] Import a site whose remote has symlinks that cause overlapping index entries
- [ ] Call `files-stats` during the index stage and after the sort — counts should match
- [ ] Verify progress no longer jumps backwards when transitioning from indexing to fetching