### PR TITLE
Deploy plugin to WordPress.org on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
         run: ./bin/build-importer-phar.sh
 
       - name: Package wordpress-plugin.zip
-        run: cd wordpress-plugin && zip -r ../wordpress-plugin.zip . -x '*/secret.php'
+        run: cd wordpress-plugin && zip -r ../wordpress-plugin.zip . -x '*/secret.php' -x '*/.gitignore'
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
@@ -38,3 +38,25 @@ jobs:
             importer.phar
             wordpress-plugin.zip
           generate_release_notes: true
+
+  deploy-to-wporg:
+    name: Deploy plugin to WordPress.org
+    runs-on: ubuntu-latest
+    environment: WordPress.org Plugin
+    needs: release
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Extract version from tag
+        id: version
+        run: echo "value=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - name: WordPress Plugin Deploy
+        uses: 10up/action-wordpress-plugin-deploy@stable
+        env:
+          SVN_USERNAME: ${{ secrets.WPORG_SVN_USERNAME }}
+          SVN_PASSWORD: ${{ secrets.WPORG_SVN_PASSWORD }}
+          SLUG: site-export
+          VERSION: ${{ steps.version.outputs.value }}
+          BUILD_DIR: wordpress-plugin

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -78,8 +78,19 @@ jobs:
             exit 1
           fi
 
-      - name: Create and push tag
+      - name: Bump version in plugin files
         run: |
-          git tag "v${{ steps.version.outputs.value }}"
-          git push origin "v${{ steps.version.outputs.value }}"
-          echo "Tagged and pushed v${{ steps.version.outputs.value }}"
+          VERSION="${{ steps.version.outputs.value }}"
+          perl -i -pe "s/Version:(\s+)[0-9.]+/Version:\${1}$VERSION/" wordpress-plugin/index.php
+          perl -i -pe "s/define\('SITE_EXPORT_VERSION', '[0-9.]+'\)/define('SITE_EXPORT_VERSION', '$VERSION')/" wordpress-plugin/index.php
+          perl -i -pe "s/Stable tag:(\s+)[0-9.]+/Stable tag:\${1}$VERSION/" wordpress-plugin/readme.txt
+
+      - name: Commit version bump and tag
+        run: |
+          VERSION="${{ steps.version.outputs.value }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git commit -a -m "Bump version to $VERSION"
+          git tag "v$VERSION"
+          git push origin HEAD:${{ github.ref_name }} --follow-tags
+          echo "Committed version bump and tagged v$VERSION"

--- a/wordpress-plugin/.distignore
+++ b/wordpress-plugin/.distignore
@@ -1,0 +1,4 @@
+.distignore
+.gitignore
+secret.php
+README.md

--- a/wordpress-plugin/readme.txt
+++ b/wordpress-plugin/readme.txt
@@ -1,0 +1,69 @@
+=== Site Export ===
+Contributors: flavor
+Tags: export, migration, sync, backup, database
+Requires at least: 6.0
+Tested up to: 6.8
+Stable tag: 1.0.0
+Requires PHP: 7.4
+License: GPLv2 or later
+License URI: https://www.gnu.org/licenses/gpl-2.0.html
+
+Exposes a site export API for resumable, cursor-based synchronization of database and files over HTTP.
+
+== Description ==
+
+Site Export turns your WordPress site into a streaming export server. An external import tool connects to the API, authenticates via HMAC, and downloads your database and files in resumable chunks.
+
+The plugin is designed for resource-constrained shared hosting environments. It carefully manages memory and execution time, pausing and resuming via cursors so it never hits host limits.
+
+**Features:**
+
+* Cursor-based resumable exports — never loses progress
+* HMAC-authenticated API — no passwords transmitted
+* Streaming multipart transport — handles files of any size
+* Memory and execution time budgeting — works on shared hosts
+* Full database export with batched INSERT statements
+* File tree synchronization with symlink support
+* Delta sync — only transfers what changed
+
+**How it works:**
+
+1. Install and activate the plugin
+2. Your import tool generates a connection token
+3. Paste the token into the plugin settings (Tools > Site Export)
+4. The import tool connects and downloads everything over HTTP
+
+== Installation ==
+
+1. Upload the `site-export` directory to `/wp-content/plugins/`
+2. Activate the plugin through the 'Plugins' menu in WordPress
+3. Go to the Site Export page in the admin menu
+4. Paste the connection token from your import tool
+
+== Frequently Asked Questions ==
+
+= Does this plugin export my site automatically? =
+
+No. The plugin only exposes an API endpoint. An external import tool must connect to it and initiate the transfer.
+
+= Is the API secure? =
+
+Yes. All requests are authenticated using HMAC signatures with a shared secret, nonce, and timestamp. Requests expire after 5 minutes to prevent replay attacks.
+
+= Will this slow down my site? =
+
+No. The export API only runs when explicitly called with the `?site-export-api` query parameter. Normal page loads are not affected.
+
+= Does it work on shared hosting? =
+
+Yes. The plugin is specifically designed for shared hosting. It tracks memory usage and execution time, gracefully pausing before hitting host limits and resuming where it left off.
+
+== Changelog ==
+
+= 1.0.0 =
+* Initial release
+
+== Upgrade Notice ==
+
+= 1.0.0 =
+Initial release.


### PR DESCRIPTION
## Summary

Wires up the release workflow to publish the WordPress plugin to WordPress.org after each tagged release.

The tag-release workflow now bumps version strings in three places — the `Version:` plugin header, the `SITE_EXPORT_VERSION` constant, and the `Stable tag` in `readme.txt` — then commits and tags in one push. The release workflow gains a `deploy-to-wporg` job that uses [10up/action-wordpress-plugin-deploy](https://github.com/10up/action-wordpress-plugin-deploy) to handle the SVN plumbing.

Also adds the WordPress.org `readme.txt` (plugin description, FAQ, changelog) and `.distignore` (excludes `secret.php`, `.gitignore`, `README.md` from the SVN deploy).

## Setup required before first deploy

1. Register the plugin slug on WordPress.org (currently using `site-export` — update `SLUG` in `release.yml` if the actual slug differs)
2. Create a GitHub environment called **"WordPress.org Plugin"**
3. Add `WPORG_SVN_USERNAME` and `WPORG_SVN_PASSWORD` secrets to that environment

## Dry-run testing

You can verify each piece locally without actually publishing anything:

**1. Test version bumping (tag-release workflow logic):**

```bash
# Simulate bumping to 1.2.3
VERSION=1.2.3
perl -pe "s/Version:(\s+)[0-9.]+/Version:\${1}$VERSION/" wordpress-plugin/index.php | grep 'Version:'
perl -pe "s/define\('SITE_EXPORT_VERSION', '[0-9.]+'\)/define('SITE_EXPORT_VERSION', '$VERSION')/" wordpress-plugin/index.php | grep SITE_EXPORT_VERSION
perl -pe "s/Stable tag:(\s+)[0-9.]+/Stable tag:\${1}$VERSION/" wordpress-plugin/readme.txt | grep 'Stable tag:'
```

All three should show `1.2.3`. No files are modified (no `-i` flag).

**2. Test .distignore excludes the right files:**

```bash
# Build the zip the same way the workflow does, then list contents
cd wordpress-plugin
rsync -r --exclude-from=.distignore . /tmp/site-export-test/
ls -la /tmp/site-export-test/
# Should contain: index.php, generic/, wordpress/, readme.txt
# Should NOT contain: secret.php, .gitignore, .distignore, README.md
rm -rf /tmp/site-export-test
```

**3. Test the 10up deploy action in dry-run mode:**

```bash
# The action supports DRY_RUN — add this to the workflow env temporarily:
#   DRY_RUN: true
# Then trigger a release. It will do everything except the final svn commit.
```

**4. Test the full flow end-to-end on a fork:**

1. Fork the repo
2. Create a `v0.0.1-test` tag and push it
3. The release workflow will run — the GitHub Release job will succeed; the deploy-to-wporg job will fail (no secrets/slug) but you can verify the version extraction and checkout steps pass

## Test plan

- [ ] Verify version bump regexes match all three locations (`Version:`, `SITE_EXPORT_VERSION`, `Stable tag:`)
- [ ] Verify `.distignore` excludes `secret.php`, `.gitignore`, `.distignore`, `README.md`
- [ ] Verify `readme.txt` passes the [WordPress readme validator](https://wordpress.org/plugins/developers/readme-validator/)
- [ ] Once the WordPress.org slug is registered, do a dry-run deploy with `DRY_RUN: true`