### PR TITLE
Add webhost detection and flatten-docroot command

### DIFF
--- a/importer/import.php
+++ b/importer/import.php
@@ -3070,9 +3070,14 @@ class ImportClient
      *
      * Creates a directory at the specified --flatten-to path that mirrors
      * a vanilla WordPress installation layout by symlinking entries from
-     * the import docroot. This is useful when the source site uses a
-     * non-standard layout (e.g. WP Cloud with __wp__) and the target
-     * needs a conventional wp-admin/, wp-includes/, wp-load.php structure.
+     * the import docroot. Uses preflight data (paths_urls) to determine
+     * where each WordPress component actually lives, rather than blindly
+     * scanning docroot top-level entries.
+     *
+     * This is essential when the source site uses a non-standard layout
+     * (e.g. WP Cloud with ABSPATH=/srv/htdocs and WP_CONTENT_DIR=/tmp/__wp__/wp-content)
+     * and the target needs a conventional wp-admin/, wp-includes/,
+     * wp-content/, wp-load.php structure.
      *
      * The command is idempotent: re-running refreshes all symlinks.
      * If a path that should be a symlink is a regular file/directory,
@@ -3097,6 +3102,85 @@ class ImportClient
             );
         }
 
+        // Require preflight data so we know where WP components live
+        $this->require_preflight();
+        $preflight = $this->state["preflight"]["data"] ?? [];
+
+        // Extract WordPress directory paths from preflight
+        $paths_urls = $preflight["database"]["wp"]["paths_urls"] ?? null;
+        $abspath = null;
+        $content_dir = null;
+        $plugins_dir = null;
+        $mu_plugins_dir = null;
+        $uploads_basedir = null;
+
+        if (is_array($paths_urls)) {
+            $abspath = $this->flatten_clean_path($paths_urls["abspath"] ?? null);
+            $content_dir = $this->flatten_clean_path($paths_urls["content_dir"] ?? null);
+            $plugins_dir = $this->flatten_clean_path($paths_urls["plugins_dir"] ?? null);
+            $mu_plugins_dir = $this->flatten_clean_path($paths_urls["mu_plugins_dir"] ?? null);
+            $uploads_basedir = $this->flatten_clean_path(
+                $paths_urls["uploads"]["basedir"] ?? null,
+            );
+        }
+
+        // Fall back to wp_detect roots if abspath not available
+        if ($abspath === null) {
+            $roots = $preflight["wp_detect"]["roots"] ?? [];
+            if (!empty($roots)) {
+                $abspath = $this->flatten_clean_path($roots[0]["path"] ?? null);
+            }
+        }
+
+        if ($abspath === null) {
+            throw new RuntimeException(
+                "Cannot determine WordPress ABSPATH from preflight data. " .
+                    "Run preflight first to detect the WordPress installation.",
+            );
+        }
+
+        // Map remote paths to local paths within docroot
+        $local_abspath = $this->docroot . $abspath;
+        if (!is_dir($local_abspath)) {
+            throw new RuntimeException(
+                "WordPress ABSPATH directory not found in docroot: {$local_abspath} " .
+                    "(remote ABSPATH: {$abspath}). Has the file sync completed?",
+            );
+        }
+
+        $local_content_dir = $content_dir !== null
+            ? $this->docroot . $content_dir
+            : null;
+        $local_plugins_dir = $plugins_dir !== null
+            ? $this->docroot . $plugins_dir
+            : null;
+        $local_mu_plugins_dir = $mu_plugins_dir !== null
+            ? $this->docroot . $mu_plugins_dir
+            : null;
+        $local_uploads_basedir = $uploads_basedir !== null
+            ? $this->docroot . $uploads_basedir
+            : null;
+
+        // Determine which components are "detached" — located outside
+        // their conventional parent directory on the source server.
+        $content_detached = $content_dir !== null
+            && strpos($content_dir, $abspath . "/") !== 0;
+        $plugins_detached = $plugins_dir !== null
+            && $content_dir !== null
+            && strpos($plugins_dir, $content_dir . "/") !== 0;
+        $mu_plugins_detached = $mu_plugins_dir !== null
+            && $content_dir !== null
+            && strpos($mu_plugins_dir, $content_dir . "/") !== 0;
+        $uploads_detached = $uploads_basedir !== null
+            && $content_dir !== null
+            && strpos($uploads_basedir, $content_dir . "/") !== 0;
+
+        // If any sub-component is detached from content_dir, we need to
+        // "explode" wp-content into a real directory with individual symlinks
+        // rather than symlinking the content_dir wholesale.
+        $need_exploded_content =
+            $plugins_detached || $mu_plugins_detached || $uploads_detached;
+
         // Create the target directory if it doesn't exist
         if (!is_dir($flatten_to)) {
             if (!mkdir($flatten_to, 0755, true)) {
@@ -3104,88 +3188,170 @@ class ImportClient
                     "Failed to create flatten-to directory: {$flatten_to}",
                 );
             }
-            $this->audit_log("FLATTEN-DOCROOT | Created directory: {$flatten_to}");
-        }
-
-        // Enumerate all top-level entries in the docroot
-        $entries = @scandir($this->docroot);
-        if ($entries === false) {
-            throw new RuntimeException(
-                "Failed to scan docroot: {$this->docroot}",
+            $this->audit_log(
+                "FLATTEN-DOCROOT | Created directory: {$flatten_to}",
             );
         }
+
+        $this->audit_log(
+            sprintf(
+                "FLATTEN-DOCROOT | abspath=%s content_dir=%s " .
+                    "content_detached=%s plugins_detached=%s " .
+                    "mu_plugins_detached=%s uploads_detached=%s",
+                $abspath,
+                $content_dir ?? "(not set)",
+                $content_detached ? "yes" : "no",
+                $plugins_detached ? "yes" : "no",
+                $mu_plugins_detached ? "yes" : "no",
+                $uploads_detached ? "yes" : "no",
+            ),
+        );
 
         $created = 0;
         $refreshed = 0;
         $forced = 0;
 
+        // Determine what to skip from ABSPATH enumeration.
+        // If content_dir is detached (or needs exploding), skip any
+        // wp-content entry from ABSPATH since we'll handle it separately.
+        $skip_from_abspath = [];
+        if ($content_detached || $need_exploded_content) {
+            $skip_from_abspath["wp-content"] = true;
+        }
+
+        // Phase 1: Symlink all entries from ABSPATH into flatten-to.
+        // This covers wp-admin, wp-includes, wp-load.php, index.php, etc.
+        $entries = @scandir($local_abspath);
+        if ($entries === false) {
+            throw new RuntimeException(
+                "Failed to scan ABSPATH directory: {$local_abspath}",
+            );
+        }
+
         foreach ($entries as $entry) {
             if ($entry === "." || $entry === "..") {
                 continue;
             }
-
-            $source = $this->docroot . "/" . $entry;
-            $target = $flatten_to . "/" . $entry;
-
-            // If the target is already a symlink, remove it and recreate
-            // (refresh) to ensure it points to the right place.
-            if (is_link($target)) {
-                $current_link_target = readlink($target);
-                if ($current_link_target === $source) {
-                    // Already correct — still count as refreshed
-                    $refreshed++;
-                    continue;
-                }
-                // Points elsewhere — remove and recreate
-                unlink($target);
+            if (isset($skip_from_abspath[$entry])) {
                 $this->audit_log(
-                    "FLATTEN-DOCROOT | Refreshed symlink: {$target} (was -> {$current_link_target})",
+                    "FLATTEN-DOCROOT | Skipping '{$entry}' from ABSPATH " .
+                        "(will be handled from detached location)",
                 );
-                if (!symlink($source, $target)) {
-                    throw new RuntimeException(
-                        "Failed to create symlink: {$target} -> {$source}",
-                    );
-                }
-                $refreshed++;
                 continue;
             }
 
-            // If something exists at the target path that is not a symlink,
-            // this is a conflict.
-            if (file_exists($target)) {
-                if (!$force) {
-                    throw new RuntimeException(
-                        "Cannot create symlink at {$target}: a non-symlink " .
-                        (is_dir($target) ? "directory" : "file") .
-                        " already exists. Use --force to remove it and replace with a symlink.",
+            $source = $local_abspath . "/" . $entry;
+            $target = $flatten_to . "/" . $entry;
+            $this->flatten_place_symlink(
+                $source,
+                $target,
+                $force,
+                $created,
+                $refreshed,
+                $forced,
+            );
+        }
+
+        // Phase 2: Handle wp-content when it's outside ABSPATH
+        if ($need_exploded_content && $local_content_dir !== null) {
+            // wp-content must be a real directory because some sub-components
+            // (plugins, mu-plugins, or uploads) live outside content_dir.
+            $wp_content_target = $flatten_to . "/wp-content";
+            $this->flatten_ensure_real_directory(
+                $wp_content_target,
+                $force,
+                $forced,
+            );
+
+            // Symlink all entries from content_dir into the real wp-content dir
+            if (is_dir($local_content_dir)) {
+                $content_entries = @scandir($local_content_dir) ?: [];
+                // Determine which sub-entries to skip (will be overridden)
+                $skip_from_content = [];
+                if ($plugins_detached) {
+                    $skip_from_content["plugins"] = true;
+                }
+                if ($mu_plugins_detached) {
+                    $skip_from_content["mu-plugins"] = true;
+                }
+                if ($uploads_detached) {
+                    $skip_from_content["uploads"] = true;
+                }
+
+                foreach ($content_entries as $entry) {
+                    if ($entry === "." || $entry === "..") {
+                        continue;
+                    }
+                    if (isset($skip_from_content[$entry])) {
+                        continue;
+                    }
+                    $source = $local_content_dir . "/" . $entry;
+                    $target = $wp_content_target . "/" . $entry;
+                    $this->flatten_place_symlink(
+                        $source,
+                        $target,
+                        $force,
+                        $created,
+                        $refreshed,
+                        $forced,
                     );
                 }
+            }
 
-                // --force: remove the conflicting entry and replace with symlink
-                $type = is_dir($target) ? "directory" : "file";
+            // Symlink detached sub-components into wp-content
+            if ($plugins_detached && is_dir($local_plugins_dir)) {
+                $target = $wp_content_target . "/plugins";
+                $this->flatten_place_symlink(
+                    $local_plugins_dir,
+                    $target,
+                    $force,
+                    $created,
+                    $refreshed,
+                    $forced,
+                );
+            }
+            if ($mu_plugins_detached && is_dir($local_mu_plugins_dir)) {
+                $target = $wp_content_target . "/mu-plugins";
+                $this->flatten_place_symlink(
+                    $local_mu_plugins_dir,
+                    $target,
+                    $force,
+                    $created,
+                    $refreshed,
+                    $forced,
+                );
+            }
+            if ($uploads_detached && is_dir($local_uploads_basedir)) {
+                $target = $wp_content_target . "/uploads";
+                $this->flatten_place_symlink(
+                    $local_uploads_basedir,
+                    $target,
+                    $force,
+                    $created,
+                    $refreshed,
+                    $forced,
+                );
+            }
+        } elseif ($content_detached && $local_content_dir !== null) {
+            // Content dir is outside ABSPATH but sub-components are inside it.
+            // Simple case: just symlink the whole content_dir as wp-content.
+            if (is_dir($local_content_dir)) {
+                $target = $flatten_to . "/wp-content";
+                $this->flatten_place_symlink(
+                    $local_content_dir,
+                    $target,
+                    $force,
+                    $created,
+                    $refreshed,
+                    $forced,
+                );
+            } else {
                 $this->audit_log(
-                    "FLATTEN-DOCROOT FORCE | Removing conflicting {$type}: {$target}",
+                    "FLATTEN-DOCROOT | Warning: content_dir not found in docroot: " .
+                        "{$local_content_dir} (remote: {$content_dir})",
                     true,
                 );
-
-                if (is_dir($target) && !is_link($target)) {
-                    $this->remove_directory_recursive($target);
-                } else {
-                    unlink($target);
-                }
-                $forced++;
             }
-
-            // Create the symlink
-            if (!symlink($source, $target)) {
-                throw new RuntimeException(
-                    "Failed to create symlink: {$target} -> {$source}",
-                );
-            }
-            $this->audit_log(
-                "FLATTEN-DOCROOT | Created symlink: {$target} -> {$source}",
-            );
-            $created++;
         }
 
         $this->audit_log(
@@ -3202,11 +3368,134 @@ class ImportClient
             "status" => "complete",
             "flatten_to" => $flatten_to,
             "docroot" => $this->docroot,
+            "abspath" => $abspath,
+            "content_dir" => $content_dir,
+            "content_detached" => $content_detached,
             "created" => $created,
             "refreshed" => $refreshed,
             "force_replaced" => $forced,
         ];
         fwrite($this->progress_fd, json_encode($result) . "\n");
+    }
+
+    /**
+     * Clean a path value from preflight data: trim, strip trailing slash.
+     * Returns null if the value is not a non-empty string.
+     */
+    private function flatten_clean_path($value): ?string
+    {
+        if (!is_string($value) || trim($value) === "") {
+            return null;
+        }
+        return rtrim($value, "/");
+    }
+
+    /**
+     * Create or refresh a symlink at $target pointing to $source.
+     * Handles conflicts (existing non-symlinks) based on --force flag.
+     */
+    private function flatten_place_symlink(
+        string $source,
+        string $target,
+        bool $force,
+        int &$created,
+        int &$refreshed,
+        int &$forced
+    ): void {
+        // If the target is already a symlink, check if it points to the
+        // right place. Refresh if not, skip if already correct.
+        if (is_link($target)) {
+            $current_link_target = readlink($target);
+            if ($current_link_target === $source) {
+                $refreshed++;
+                return;
+            }
+            // Points elsewhere — remove and recreate
+            unlink($target);
+            $this->audit_log(
+                "FLATTEN-DOCROOT | Refreshed symlink: {$target} (was -> {$current_link_target})",
+            );
+            if (!symlink($source, $target)) {
+                throw new RuntimeException(
+                    "Failed to create symlink: {$target} -> {$source}",
+                );
+            }
+            $refreshed++;
+            return;
+        }
+
+        // If something exists at the target path that is not a symlink,
+        // this is a conflict.
+        if (file_exists($target)) {
+            if (!$force) {
+                throw new RuntimeException(
+                    "Cannot create symlink at {$target}: a non-symlink " .
+                        (is_dir($target) ? "directory" : "file") .
+                        " already exists. Use --force to remove it and replace with a symlink.",
+                );
+            }
+
+            $type = is_dir($target) ? "directory" : "file";
+            $this->audit_log(
+                "FLATTEN-DOCROOT FORCE | Removing conflicting {$type}: {$target}",
+                true,
+            );
+
+            if (is_dir($target) && !is_link($target)) {
+                $this->remove_directory_recursive($target);
+            } else {
+                unlink($target);
+            }
+            $forced++;
+        }
+
+        // Create the symlink
+        if (!symlink($source, $target)) {
+            throw new RuntimeException(
+                "Failed to create symlink: {$target} -> {$source}",
+            );
+        }
+        $this->audit_log(
+            "FLATTEN-DOCROOT | Created symlink: {$target} -> {$source}",
+        );
+        $created++;
+    }
+
+    /**
+     * Ensure a path is a real directory (not a symlink).
+     * If it's a symlink, remove it (or error without --force).
+     * If it doesn't exist, create it.
+     */
+    private function flatten_ensure_real_directory(
+        string $path,
+        bool $force,
+        int &$forced
+    ): void {
+        if (is_link($path)) {
+            if (!$force) {
+                throw new RuntimeException(
+                    "Cannot create real directory at {$path}: a symlink already " .
+                        "exists. Use --force to remove it.",
+                );
+            }
+            $this->audit_log(
+                "FLATTEN-DOCROOT FORCE | Replacing symlink with real directory: {$path}",
+                true,
+            );
+            unlink($path);
+            $forced++;
+        }
+
+        if (!is_dir($path)) {
+            if (!mkdir($path, 0755, true)) {
+                throw new RuntimeException(
+                    "Failed to create directory: {$path}",
+                );
+            }
+            $this->audit_log(
+                "FLATTEN-DOCROOT | Created directory: {$path}",
+            );
+        }
     }
 
     /**
@@ -8267,11 +8556,16 @@ if (
             "short" => "Create a vanilla WordPress directory layout using symlinks",
             "detail" =>
                 "Creates a directory at --flatten-to that mirrors the standard\n" .
-                "WordPress directory structure (wp-admin/, wp-includes/, wp-content/,\n" .
-                "wp-load.php, etc.) by symlinking each entry from the import docroot.\n" .
+                "WordPress directory structure by analyzing preflight path data\n" .
+                "and symlinking each component from where it actually lives.\n" .
                 "\n" .
-                "Useful when the source site uses a non-standard layout (e.g. WP Cloud\n" .
-                "with __wp__ symlinks) and the target needs conventional paths.\n" .
+                "Uses preflight paths_urls (ABSPATH, WP_CONTENT_DIR, WP_PLUGIN_DIR,\n" .
+                "WPMU_PLUGIN_DIR, uploads basedir) to locate each WordPress component\n" .
+                "within the import docroot, even when they reside in different parent\n" .
+                "directories on the source server (e.g. WP Cloud with ABSPATH at\n" .
+                "/srv/htdocs and WP_CONTENT_DIR at /tmp/__wp__/wp-content).\n" .
+                "\n" .
+                "Requires a prior preflight run to detect the WordPress directory layout.\n" .
                 "\n" .
                 "The command is idempotent: re-running refreshes all symlinks.\n" .
                 "If a path that should be a symlink is a regular file or directory,\n" .
@@ -8281,9 +8575,7 @@ if (
                 "  --flatten-to=PATH  Target directory for the flattened layout (required)\n" .
                 "  --force            Remove conflicting non-symlink files and replace\n" .
                 "                     with symlinks (logged to audit log)\n" .
-                "  --verbose, -v      Show detailed operation logs\n" .
-                "\n" .
-                "The <remote-url> parameter is kept for CLI consistency but ignored.\n",
+                "  --verbose, -v      Show detailed operation logs\n",
         ],
     ];
 

--- a/importer/import.php
+++ b/importer/import.php
@@ -3441,8 +3441,42 @@ class ImportClient
     }
 
     /**
+     * Compute a relative path from $from to $to.
+     *
+     * Both paths must be absolute. Returns a relative path such that
+     * a symlink at $from/$name pointing to the result will resolve to $to.
+     *
+     * Example: relative_path('/a/b/c', '/a/d/e') => '../../d/e'
+     */
+    private static function compute_relative_path(
+        string $from,
+        string $to
+    ): string {
+        $from_parts = explode("/", trim($from, "/"));
+        $to_parts = explode("/", trim($to, "/"));
+
+        // Find common prefix length
+        $common = 0;
+        $max = min(count($from_parts), count($to_parts));
+        while ($common < $max && $from_parts[$common] === $to_parts[$common]) {
+            $common++;
+        }
+
+        // Go up from $from to the common ancestor, then down to $to
+        $up = count($from_parts) - $common;
+        $down = array_slice($to_parts, $common);
+
+        $parts = array_merge(array_fill(0, $up, ".."), $down);
+        return implode("/", $parts) ?: ".";
+    }
+
+    /**
      * Create or refresh a symlink at $target pointing to $source.
      * Handles conflicts (existing non-symlinks) based on --force flag.
+     *
+     * The symlink value is computed as a relative path from the symlink's
+     * parent directory to the source, so it works regardless of CWD and
+     * survives directory moves.
      */
     private function flatten_place_symlink(
         string $source,
@@ -3452,11 +3486,37 @@ class ImportClient
         int &$refreshed,
         int &$forced
     ): void {
-        // If the target is already a symlink, check if it points to the
-        // right place. Refresh if not, skip if already correct.
+        // Resolve both paths to absolute so we can compute a correct
+        // relative symlink value.  The source may not have a realpath()
+        // (e.g. broken symlink), but its parent directory should exist.
+        $abs_source = realpath($source);
+        if ($abs_source === false) {
+            // Source itself may be a symlink or not exist yet — try
+            // resolving the parent and appending the basename.
+            $parent_real = realpath(dirname($source));
+            if ($parent_real === false) {
+                throw new RuntimeException(
+                    "Cannot resolve source path for symlink: {$source}",
+                );
+            }
+            $abs_source = $parent_real . "/" . basename($source);
+        }
+
+        // The target's parent must exist (we create flatten-to before calling this).
+        $target_parent_real = realpath(dirname($target));
+        if ($target_parent_real === false) {
+            throw new RuntimeException(
+                "Cannot resolve target parent directory: " . dirname($target),
+            );
+        }
+
+        $link_value = self::compute_relative_path($target_parent_real, $abs_source);
+
+        // If the target is already a symlink, check if it resolves to the
+        // same place. Refresh if not, skip if already correct.
         if (is_link($target)) {
             $current_link_target = readlink($target);
-            if ($current_link_target === $source) {
+            if ($current_link_target === $link_value) {
                 $refreshed++;
                 return;
             }
@@ -3465,9 +3525,9 @@ class ImportClient
             $this->audit_log(
                 "FLATTEN-DOCROOT | Refreshed symlink: {$target} (was -> {$current_link_target})",
             );
-            if (!symlink($source, $target)) {
+            if (!symlink($link_value, $target)) {
                 throw new RuntimeException(
-                    "Failed to create symlink: {$target} -> {$source}",
+                    "Failed to create symlink: {$target} -> {$link_value}",
                 );
             }
             $refreshed++;
@@ -3500,13 +3560,13 @@ class ImportClient
         }
 
         // Create the symlink
-        if (!symlink($source, $target)) {
+        if (!symlink($link_value, $target)) {
             throw new RuntimeException(
-                "Failed to create symlink: {$target} -> {$source}",
+                "Failed to create symlink: {$target} -> {$link_value}",
             );
         }
         $this->audit_log(
-            "FLATTEN-DOCROOT | Created symlink: {$target} -> {$source}",
+            "FLATTEN-DOCROOT | Created symlink: {$target} -> {$link_value}",
         );
         $created++;
     }

--- a/importer/import.php
+++ b/importer/import.php
@@ -3551,7 +3551,10 @@ class ImportClient
                 true,
             );
 
-            if (is_dir($target) && !is_link($target)) {
+            // At this point, we know $target is not a symlink (symlinks
+            // are handled above and return early). So we only need to
+            // distinguish between directories and regular files.
+            if (is_dir($target)) {
                 $this->remove_directory_recursive($target);
             } else {
                 unlink($target);

--- a/importer/import.php
+++ b/importer/import.php
@@ -1286,7 +1286,7 @@ class ImportClient
 
         if (!$command) {
             throw new InvalidArgumentException(
-                "Command is required. Valid commands: files-sync, files-index, files-stats, db-sync, db-index, db-domains, db-apply, preflight, preflight-assert",
+                "Command is required. Valid commands: files-sync, files-index, files-stats, db-sync, db-index, db-domains, db-apply, preflight, preflight-assert, flatten-docroot",
             );
         }
 
@@ -1301,10 +1301,11 @@ class ImportClient
                 "files-stats",
                 "preflight",
                 "preflight-assert",
+                "flatten-docroot",
             ])
         ) {
             throw new InvalidArgumentException(
-                "Invalid command: {$command}. Valid commands: files-sync, files-index, files-stats, db-sync, db-index, db-domains, db-apply, preflight, preflight-assert",
+                "Invalid command: {$command}. Valid commands: files-sync, files-index, files-stats, db-sync, db-index, db-domains, db-apply, preflight, preflight-assert, flatten-docroot",
             );
         }
 
@@ -1436,6 +1437,10 @@ class ImportClient
         }
         if ($command === "files-stats") {
             $this->run_files_stats();
+            return;
+        }
+        if ($command === "flatten-docroot") {
+            $this->run_flatten_docroot($options);
             return;
         }
         if ($command === "db-apply") {
@@ -1710,6 +1715,13 @@ class ImportClient
             $this->state["remote_protocol_min_version"] = (int) $payload["protocol_min_version"];
         }
 
+        // Detect webhost environment from preflight data
+        $detected_webhost = $this->detect_webhost($payload);
+        if ($detected_webhost !== null) {
+            $this->state["webhost"] = $detected_webhost;
+            $this->audit_log("WEBHOST DETECTED | {$detected_webhost}", true);
+        }
+
         $this->save_state($this->state);
 
         $this->audit_log(
@@ -1747,6 +1759,74 @@ class ImportClient
                 );
             }
         }
+    }
+
+    /**
+     * Detect the webhost environment from preflight data.
+     *
+     * - SiteGround: has plugins prefixed with "sg-" (e.g. sg-cachepress, sg-security)
+     * - WP Cloud: has a __wp__ symlink in the document root
+     *
+     * @param array|null $preflight_data The preflight response payload
+     * @return string|null "siteground", "wpcloud", or null if unknown
+     */
+    private function detect_webhost(?array $preflight_data): ?string
+    {
+        if (!is_array($preflight_data)) {
+            return null;
+        }
+
+        // Check for SiteGround: look for plugins prefixed with "sg-"
+        $roots = $preflight_data["wp_content"]["roots"] ?? [];
+        $sg_count = 0;
+        foreach ($roots as $root) {
+            $plugins = $root["plugins"] ?? [];
+            foreach ($plugins as $plugin) {
+                $name = $plugin["name"] ?? "";
+                if (strpos($name, "sg-") === 0) {
+                    $sg_count++;
+                }
+            }
+        }
+        if ($sg_count >= 2) {
+            return "siteground";
+        }
+
+        // Check for WP Cloud: look for __wp__ in the filesystem directories
+        // WP Cloud sites have a __wp__ symlink in the document root pointing
+        // to the WordPress core installation.
+        $doc_root = $preflight_data["runtime"]["document_root"] ?? null;
+        if (is_string($doc_root) && $doc_root !== "") {
+            $wp_dir = rtrim($doc_root, "/") . "/__wp__";
+            // Check if __wp__ appears in the filesystem directory checks
+            $dir_checks = $preflight_data["filesystem"]["directories"] ?? [];
+            foreach ($dir_checks as $check) {
+                $path = $check["path"] ?? "";
+                if ($path === $wp_dir && ($check["exists"] ?? false)) {
+                    return "wpcloud";
+                }
+            }
+        }
+
+        // Also check wp_detect roots: WP Cloud typically has WordPress
+        // detected at __wp__ inside the document root
+        $wp_roots = $preflight_data["wp_detect"]["roots"] ?? [];
+        if (is_string($doc_root) && $doc_root !== "") {
+            $wp_subdir = rtrim($doc_root, "/") . "/__wp__";
+            foreach ($wp_roots as $root) {
+                $path = $root["path"] ?? "";
+                if ($path === $wp_subdir) {
+                    return "wpcloud";
+                }
+            }
+        }
+
+        // Fallback: check the local docroot for a __wp__ symlink
+        if (is_link($this->docroot . "/__wp__")) {
+            return "wpcloud";
+        }
+
+        return null;
     }
 
     /**
@@ -2983,6 +3063,173 @@ class ImportClient
                 "bytes" => $pending_bytes,
             ],
         ], JSON_PRETTY_PRINT) . "\n";
+    }
+
+    /**
+     * Command: flatten-docroot
+     *
+     * Creates a directory at the specified --flatten-to path that mirrors
+     * a vanilla WordPress installation layout by symlinking entries from
+     * the import docroot. This is useful when the source site uses a
+     * non-standard layout (e.g. WP Cloud with __wp__) and the target
+     * needs a conventional wp-admin/, wp-includes/, wp-load.php structure.
+     *
+     * The command is idempotent: re-running refreshes all symlinks.
+     * If a path that should be a symlink is a regular file/directory,
+     * the command stops with an error unless --force is specified.
+     */
+    private function run_flatten_docroot(array $options): void
+    {
+        $flatten_to = $options["flatten_to"] ?? null;
+        if (empty($flatten_to)) {
+            throw new InvalidArgumentException(
+                "flatten-docroot requires --flatten-to=PATH",
+            );
+        }
+
+        $flatten_to = rtrim($flatten_to, "/");
+        $force = $options["force"] ?? false;
+
+        // Ensure the docroot exists
+        if (!is_dir($this->docroot)) {
+            throw new RuntimeException(
+                "Docroot does not exist: {$this->docroot}",
+            );
+        }
+
+        // Create the target directory if it doesn't exist
+        if (!is_dir($flatten_to)) {
+            if (!mkdir($flatten_to, 0755, true)) {
+                throw new RuntimeException(
+                    "Failed to create flatten-to directory: {$flatten_to}",
+                );
+            }
+            $this->audit_log("FLATTEN-DOCROOT | Created directory: {$flatten_to}");
+        }
+
+        // Enumerate all top-level entries in the docroot
+        $entries = @scandir($this->docroot);
+        if ($entries === false) {
+            throw new RuntimeException(
+                "Failed to scan docroot: {$this->docroot}",
+            );
+        }
+
+        $created = 0;
+        $refreshed = 0;
+        $forced = 0;
+
+        foreach ($entries as $entry) {
+            if ($entry === "." || $entry === "..") {
+                continue;
+            }
+
+            $source = $this->docroot . "/" . $entry;
+            $target = $flatten_to . "/" . $entry;
+
+            // If the target is already a symlink, remove it and recreate
+            // (refresh) to ensure it points to the right place.
+            if (is_link($target)) {
+                $current_link_target = readlink($target);
+                if ($current_link_target === $source) {
+                    // Already correct — still count as refreshed
+                    $refreshed++;
+                    continue;
+                }
+                // Points elsewhere — remove and recreate
+                unlink($target);
+                $this->audit_log(
+                    "FLATTEN-DOCROOT | Refreshed symlink: {$target} (was -> {$current_link_target})",
+                );
+                if (!symlink($source, $target)) {
+                    throw new RuntimeException(
+                        "Failed to create symlink: {$target} -> {$source}",
+                    );
+                }
+                $refreshed++;
+                continue;
+            }
+
+            // If something exists at the target path that is not a symlink,
+            // this is a conflict.
+            if (file_exists($target)) {
+                if (!$force) {
+                    throw new RuntimeException(
+                        "Cannot create symlink at {$target}: a non-symlink " .
+                        (is_dir($target) ? "directory" : "file") .
+                        " already exists. Use --force to remove it and replace with a symlink.",
+                    );
+                }
+
+                // --force: remove the conflicting entry and replace with symlink
+                $type = is_dir($target) ? "directory" : "file";
+                $this->audit_log(
+                    "FLATTEN-DOCROOT FORCE | Removing conflicting {$type}: {$target}",
+                    true,
+                );
+
+                if (is_dir($target) && !is_link($target)) {
+                    $this->remove_directory_recursive($target);
+                } else {
+                    unlink($target);
+                }
+                $forced++;
+            }
+
+            // Create the symlink
+            if (!symlink($source, $target)) {
+                throw new RuntimeException(
+                    "Failed to create symlink: {$target} -> {$source}",
+                );
+            }
+            $this->audit_log(
+                "FLATTEN-DOCROOT | Created symlink: {$target} -> {$source}",
+            );
+            $created++;
+        }
+
+        $this->audit_log(
+            sprintf(
+                "FLATTEN-DOCROOT | Complete: %d created, %d refreshed, %d force-replaced",
+                $created,
+                $refreshed,
+                $forced,
+            ),
+            true,
+        );
+
+        $result = [
+            "status" => "complete",
+            "flatten_to" => $flatten_to,
+            "docroot" => $this->docroot,
+            "created" => $created,
+            "refreshed" => $refreshed,
+            "force_replaced" => $forced,
+        ];
+        fwrite($this->progress_fd, json_encode($result) . "\n");
+    }
+
+    /**
+     * Recursively remove a directory and all its contents.
+     */
+    private function remove_directory_recursive(string $dir): void
+    {
+        $entries = @scandir($dir);
+        if ($entries === false) {
+            throw new RuntimeException("Failed to scan directory for removal: {$dir}");
+        }
+        foreach ($entries as $entry) {
+            if ($entry === "." || $entry === "..") {
+                continue;
+            }
+            $path = $dir . "/" . $entry;
+            if (is_dir($path) && !is_link($path)) {
+                $this->remove_directory_recursive($path);
+            } else {
+                unlink($path);
+            }
+        }
+        rmdir($dir);
     }
 
     /**
@@ -7182,12 +7429,14 @@ class ImportClient
     {
         $preflight = $this->state["preflight"] ?? null;
         $version = $this->state["version"] ?? null;
+        $webhost = $this->state["webhost"] ?? null;
         $follow = $this->state["follow_symlinks"] ?? false;
         $nonempty = $this->state["docroot_nonempty_behavior"] ?? "error";
         $max_packet = $this->state["max_allowed_packet"] ?? null;
         $this->state = $this->default_state();
         $this->state["preflight"] = $preflight;
         $this->state["version"] = $version;
+        $this->state["webhost"] = $webhost;
         $this->state["follow_symlinks"] = $follow;
         $this->state["docroot_nonempty_behavior"] = $nonempty;
         $this->state["max_allowed_packet"] = $max_packet;
@@ -7204,6 +7453,7 @@ class ImportClient
             "remote_protocol_version" => null,
             "remote_protocol_min_version" => null,
             "version" => null,
+            "webhost" => null,
             "follow_symlinks" => true,
             "docroot_nonempty_behavior" => "error",
             "max_allowed_packet" => null,
@@ -8013,6 +8263,28 @@ if (
                 "Options:\n" .
                 "  --secret=TOKEN   HMAC shared secret for export API authentication\n",
         ],
+        "flatten-docroot" => [
+            "short" => "Create a vanilla WordPress directory layout using symlinks",
+            "detail" =>
+                "Creates a directory at --flatten-to that mirrors the standard\n" .
+                "WordPress directory structure (wp-admin/, wp-includes/, wp-content/,\n" .
+                "wp-load.php, etc.) by symlinking each entry from the import docroot.\n" .
+                "\n" .
+                "Useful when the source site uses a non-standard layout (e.g. WP Cloud\n" .
+                "with __wp__ symlinks) and the target needs conventional paths.\n" .
+                "\n" .
+                "The command is idempotent: re-running refreshes all symlinks.\n" .
+                "If a path that should be a symlink is a regular file or directory,\n" .
+                "the command stops with an error unless --force is specified.\n" .
+                "\n" .
+                "Options:\n" .
+                "  --flatten-to=PATH  Target directory for the flattened layout (required)\n" .
+                "  --force            Remove conflicting non-symlink files and replace\n" .
+                "                     with symlinks (logged to audit log)\n" .
+                "  --verbose, -v      Show detailed operation logs\n" .
+                "\n" .
+                "The <remote-url> parameter is kept for CLI consistency but ignored.\n",
+        ],
     ];
 
     // Show main help when invoked with no arguments or just --help
@@ -8325,6 +8597,10 @@ if (
             }
             $options["new_site_url"] = $argv[$i + 1];
             $i += 1;
+        } elseif (strpos($argv[$i], "--flatten-to=") === 0) {
+            $options["flatten_to"] = substr($argv[$i], strlen("--flatten-to="));
+        } elseif ($argv[$i] === "--force") {
+            $options["force"] = true;
         } else {
             fwrite(STDERR, "Unknown option: {$argv[$i]}\n");
             exit(1);

--- a/importer/import.php
+++ b/importer/import.php
@@ -3109,6 +3109,8 @@ class ImportClient
         // Extract WordPress directory paths from preflight
         $paths_urls = $preflight["database"]["wp"]["paths_urls"] ?? null;
         $abspath = null;
+        $wp_admin_path = null;
+        $wp_includes_path = null;
         $content_dir = null;
         $plugins_dir = null;
         $mu_plugins_dir = null;
@@ -3116,6 +3118,8 @@ class ImportClient
 
         if (is_array($paths_urls)) {
             $abspath = $this->flatten_clean_path($paths_urls["abspath"] ?? null);
+            $wp_admin_path = $this->flatten_clean_path($paths_urls["wp_admin_path"] ?? null);
+            $wp_includes_path = $this->flatten_clean_path($paths_urls["wp_includes_path"] ?? null);
             $content_dir = $this->flatten_clean_path($paths_urls["content_dir"] ?? null);
             $plugins_dir = $this->flatten_clean_path($paths_urls["plugins_dir"] ?? null);
             $mu_plugins_dir = $this->flatten_clean_path($paths_urls["mu_plugins_dir"] ?? null);
@@ -3148,6 +3152,12 @@ class ImportClient
             );
         }
 
+        $local_wp_admin = $wp_admin_path !== null
+            ? $this->docroot . $wp_admin_path
+            : null;
+        $local_wp_includes = $wp_includes_path !== null
+            ? $this->docroot . $wp_includes_path
+            : null;
         $local_content_dir = $content_dir !== null
             ? $this->docroot . $content_dir
             : null;
@@ -3163,6 +3173,13 @@ class ImportClient
 
         // Determine which components are "detached" — located outside
         // their conventional parent directory on the source server.
+        // wp-admin and wp-includes are detached when their resolved path
+        // differs from the ABSPATH/wp-admin or ABSPATH/wp-includes path
+        // (e.g. WP Cloud where they live behind __wp__/).
+        $wp_admin_detached = $wp_admin_path !== null
+            && $wp_admin_path !== $abspath . "/wp-admin";
+        $wp_includes_detached = $wp_includes_path !== null
+            && $wp_includes_path !== $abspath . "/wp-includes";
         $content_detached = $content_dir !== null
             && strpos($content_dir, $abspath . "/") !== 0;
         $plugins_detached = $plugins_dir !== null
@@ -3195,10 +3212,12 @@ class ImportClient
 
         $this->audit_log(
             sprintf(
-                "FLATTEN-DOCROOT | abspath=%s content_dir=%s " .
-                    "content_detached=%s plugins_detached=%s " .
-                    "mu_plugins_detached=%s uploads_detached=%s",
+                "FLATTEN-DOCROOT | abspath=%s wp_admin=%s wp_includes=%s " .
+                    "content_dir=%s content_detached=%s " .
+                    "plugins_detached=%s mu_plugins_detached=%s uploads_detached=%s",
                 $abspath,
+                $wp_admin_path ?? "(from abspath)",
+                $wp_includes_path ?? "(from abspath)",
                 $content_dir ?? "(not set)",
                 $content_detached ? "yes" : "no",
                 $plugins_detached ? "yes" : "no",
@@ -3212,15 +3231,21 @@ class ImportClient
         $forced = 0;
 
         // Determine what to skip from ABSPATH enumeration.
-        // If content_dir is detached (or needs exploding), skip any
-        // wp-content entry from ABSPATH since we'll handle it separately.
+        // Components with known detached locations are handled separately.
         $skip_from_abspath = [];
         if ($content_detached || $need_exploded_content) {
             $skip_from_abspath["wp-content"] = true;
         }
+        if ($wp_admin_detached) {
+            $skip_from_abspath["wp-admin"] = true;
+        }
+        if ($wp_includes_detached) {
+            $skip_from_abspath["wp-includes"] = true;
+        }
 
         // Phase 1: Symlink all entries from ABSPATH into flatten-to.
-        // This covers wp-admin, wp-includes, wp-load.php, index.php, etc.
+        // This covers core files (index.php, wp-load.php, wp-config.php, etc.)
+        // and wp-admin/wp-includes when they're directly under ABSPATH.
         $entries = @scandir($local_abspath);
         if ($entries === false) {
             throw new RuntimeException(
@@ -3235,7 +3260,7 @@ class ImportClient
             if (isset($skip_from_abspath[$entry])) {
                 $this->audit_log(
                     "FLATTEN-DOCROOT | Skipping '{$entry}' from ABSPATH " .
-                        "(will be handled from detached location)",
+                        "(will be sourced from resolved location)",
                 );
                 continue;
             }
@@ -3245,6 +3270,29 @@ class ImportClient
             $this->flatten_place_symlink(
                 $source,
                 $target,
+                $force,
+                $created,
+                $refreshed,
+                $forced,
+            );
+        }
+
+        // Phase 1b: Symlink detached wp-admin and wp-includes from their
+        // resolved physical locations (e.g. /wordpress/wp-admin on WP Cloud).
+        if ($wp_admin_detached && $local_wp_admin !== null && is_dir($local_wp_admin)) {
+            $this->flatten_place_symlink(
+                $local_wp_admin,
+                $flatten_to . "/wp-admin",
+                $force,
+                $created,
+                $refreshed,
+                $forced,
+            );
+        }
+        if ($wp_includes_detached && $local_wp_includes !== null && is_dir($local_wp_includes)) {
+            $this->flatten_place_symlink(
+                $local_wp_includes,
+                $flatten_to . "/wp-includes",
                 $force,
                 $created,
                 $refreshed,
@@ -3369,6 +3417,8 @@ class ImportClient
             "flatten_to" => $flatten_to,
             "docroot" => $this->docroot,
             "abspath" => $abspath,
+            "wp_admin_path" => $wp_admin_path,
+            "wp_includes_path" => $wp_includes_path,
             "content_dir" => $content_dir,
             "content_detached" => $content_detached,
             "created" => $created,

--- a/tests/e2e/site-registry.json
+++ b/tests/e2e/site-registry.json
@@ -32,6 +32,7 @@
     "file-type-swaps":   { "port": 8105 },
     "file-type-cache":   { "port": 8106 },
     "preserve-local":    { "port": 8107 },
-    "url-rewriting":     { "port": 8108 }
+    "url-rewriting":     { "port": 8108 },
+    "wpcloud-flatten":   { "port": 8109 }
   }
 }

--- a/tests/e2e/tests/import-38-flatten-wpcloud.test.js
+++ b/tests/e2e/tests/import-38-flatten-wpcloud.test.js
@@ -1,0 +1,284 @@
+/**
+ * Test 38: flatten-docroot with WP Cloud-like directory layout
+ *
+ * Simulates a WP Cloud hosting environment where:
+ * - ABSPATH is the document root (/srv/e2e-sites/wpcloud-flatten/)
+ * - wp-admin and wp-includes are behind a __wp__ symlink pointing to
+ *   a separate core directory (/tmp/e2e-wpcloud-core/)
+ * - wp-content is in a separate location (/tmp/e2e-wpcloud-wpcontent/)
+ *
+ * Tests that:
+ * 1. Preflight correctly resolves wp_admin_path / wp_includes_path via realpath()
+ * 2. files-sync with --follow-symlinks downloads files at their resolved locations
+ * 3. flatten-docroot creates a standard WP layout by sourcing each component
+ *    from where it physically lives
+ */
+import { describe, it, beforeAll, afterAll } from 'vitest';
+import assert from 'node:assert/strict';
+import {
+    existsSync, readFileSync, readlinkSync,
+    mkdirSync, writeFileSync, symlinkSync, lstatSync,
+} from 'node:fs';
+import { execSync } from 'node:child_process';
+import { join } from 'node:path';
+import {
+    runImporter, createTempDir, cleanupTempDir,
+    getSiteUrl, getSiteSecret, getSiteDir,
+    docrootDir,
+} from '../lib/test-helpers.js';
+import { ensureSite } from '../lib/site-setup.js';
+
+const CORE_DIR = '/tmp/e2e-wpcloud-core';
+const CONTENT_DIR = '/tmp/e2e-wpcloud-wpcontent';
+
+describe('Import: Flatten Docroot (WP Cloud-like layout)', () => {
+    const site = 'wpcloud-flatten';
+    let tempDir;
+
+    beforeAll(async () => {
+        // Clean up previous external dirs (may be nginx-owned from prior run)
+        execSync(`sudo rm -rf ${CORE_DIR} ${CONTENT_DIR}`);
+
+        await ensureSite(site, {
+            afterCreate: async (siteDir) => {
+                // Simulate WP Cloud layout:
+                //   wp-admin and wp-includes live behind __wp__ in a separate dir
+                //   wp-content lives in a completely separate dir
+                mkdirSync(CORE_DIR, { recursive: true });
+                mkdirSync(CONTENT_DIR, { recursive: true });
+
+                // Move wp-admin and wp-includes to the core directory
+                execSync(`mv "${join(siteDir, 'wp-admin')}" "${CORE_DIR}/wp-admin"`);
+                execSync(`mv "${join(siteDir, 'wp-includes')}" "${CORE_DIR}/wp-includes"`);
+
+                // Create __wp__ symlink -> core dir
+                symlinkSync(CORE_DIR, join(siteDir, '__wp__'));
+
+                // Symlink wp-admin and wp-includes through __wp__ (relative)
+                symlinkSync('__wp__/wp-admin', join(siteDir, 'wp-admin'));
+                symlinkSync('__wp__/wp-includes', join(siteDir, 'wp-includes'));
+
+                // Move wp-content to separate location
+                execSync(`cp -a "${join(siteDir, 'wp-content')}" "${CONTENT_DIR}/wp-content"`);
+                execSync(`rm -rf "${join(siteDir, 'wp-content')}"`);
+                symlinkSync(CONTENT_DIR + '/wp-content', join(siteDir, 'wp-content'));
+
+                // Rewrite wp-config.php to define WP_CONTENT_DIR
+                writeFileSync(join(siteDir, 'wp-config.php'), `<?php
+define('DB_HOST', '127.0.0.1');
+define('DB_NAME', 'e2e_wpcloud_flatten');
+define('DB_USER', 'e2e_admin');
+define('DB_PASSWORD', 'e2e_password');
+define('DB_CHARSET', 'utf8mb4');
+define('DB_COLLATE', '');
+define('AUTH_KEY',         'e2e-test-key-1');
+define('SECURE_AUTH_KEY',  'e2e-test-key-2');
+define('LOGGED_IN_KEY',    'e2e-test-key-3');
+define('NONCE_KEY',        'e2e-test-key-4');
+define('AUTH_SALT',        'e2e-test-salt-1');
+define('SECURE_AUTH_SALT', 'e2e-test-salt-2');
+define('LOGGED_IN_SALT',   'e2e-test-salt-3');
+define('NONCE_SALT',       'e2e-test-salt-4');
+define('WP_CONTENT_DIR', '${CONTENT_DIR}/wp-content');
+$table_prefix = 'wp_';
+if ( ! defined( 'ABSPATH' ) ) {
+    define( 'ABSPATH', __DIR__ . '/' );
+}
+require_once ABSPATH . 'wp-settings.php';
+`);
+            },
+            afterPermissions: async () => {
+                execSync(`sudo chown -R nginx:nginx ${CORE_DIR} ${CONTENT_DIR}`);
+            },
+        });
+
+        tempDir = createTempDir('e2e-flatten-wpcloud');
+    });
+
+    afterAll(() => {
+        cleanupTempDir(tempDir);
+    });
+
+    function importUrl() {
+        return `${getSiteUrl(site)}&directory=${getSiteDir(site)}`;
+    }
+
+    it('preflight reports resolved wp_admin_path and wp_includes_path', () => {
+        const result = runImporter(importUrl(), tempDir, 'preflight', {
+            secret: getSiteSecret(site),
+        });
+        assert.equal(result.exitCode, 0, `preflight failed:\n${result.stderr}`);
+
+        const state = JSON.parse(readFileSync(join(tempDir, '.import-state.json'), 'utf-8'));
+        const pathsUrls = state.preflight?.data?.database?.wp?.paths_urls;
+        assert.ok(pathsUrls, 'Expected paths_urls in preflight data');
+
+        // ABSPATH should be the site directory
+        assert.ok(
+            pathsUrls.abspath?.includes('wpcloud-flatten'),
+            `Expected abspath to contain 'wpcloud-flatten', got: ${pathsUrls.abspath}`,
+        );
+
+        // wp_admin_path should resolve through __wp__ to the core directory
+        assert.ok(
+            pathsUrls.wp_admin_path?.includes('e2e-wpcloud-core'),
+            `Expected wp_admin_path to resolve to core dir, got: ${pathsUrls.wp_admin_path}`,
+        );
+
+        // wp_includes_path should also resolve to the core directory
+        assert.ok(
+            pathsUrls.wp_includes_path?.includes('e2e-wpcloud-core'),
+            `Expected wp_includes_path to resolve to core dir, got: ${pathsUrls.wp_includes_path}`,
+        );
+
+        // content_dir should be the separate content directory
+        assert.ok(
+            pathsUrls.content_dir?.includes('e2e-wpcloud-wpcontent'),
+            `Expected content_dir in separate location, got: ${pathsUrls.content_dir}`,
+        );
+    });
+
+    it('files-sync completes with follow_symlinks', () => {
+        const result = runImporter(importUrl(), tempDir, 'files-sync', {
+            secret: getSiteSecret(site),
+            extraArgs: ['--follow-symlinks'],
+        });
+        assert.equal(result.exitCode, 0, `files-sync failed:\n${result.stderr}`);
+    });
+
+    it('wp-admin files exist at the resolved core path in docroot', () => {
+        const state = JSON.parse(readFileSync(join(tempDir, '.import-state.json'), 'utf-8'));
+        const wpAdminPath = state.preflight?.data?.database?.wp?.paths_urls?.wp_admin_path;
+        assert.ok(wpAdminPath, 'wp_admin_path not found in state');
+
+        const localWpAdmin = join(docrootDir(tempDir), wpAdminPath);
+        assert.ok(
+            existsSync(localWpAdmin),
+            `wp-admin should exist at resolved path: ${localWpAdmin}`,
+        );
+        assert.ok(
+            existsSync(join(localWpAdmin, 'admin.php')),
+            'wp-admin/admin.php should exist at resolved path',
+        );
+    });
+
+    it('wp-content files exist at the separate content path in docroot', () => {
+        const state = JSON.parse(readFileSync(join(tempDir, '.import-state.json'), 'utf-8'));
+        const contentDir = state.preflight?.data?.database?.wp?.paths_urls?.content_dir;
+        assert.ok(contentDir, 'content_dir not found in state');
+
+        const localContent = join(docrootDir(tempDir), contentDir);
+        assert.ok(
+            existsSync(localContent),
+            `wp-content should exist at: ${localContent}`,
+        );
+        assert.ok(
+            existsSync(join(localContent, 'plugins')),
+            'wp-content/plugins should exist',
+        );
+    });
+
+    describe('flatten-docroot', () => {
+        let flattenTo;
+
+        beforeAll(() => {
+            flattenTo = join(tempDir, 'flattened');
+            const result = runImporter(importUrl(), tempDir, 'flatten-docroot', {
+                secret: getSiteSecret(site),
+                extraArgs: [`--flatten-to=${flattenTo}`],
+            });
+            assert.equal(
+                result.exitCode, 0,
+                `flatten-docroot failed:\n${result.stderr}\n${result.stdout}`,
+            );
+        });
+
+        it('creates wp-admin symlink pointing to resolved core location', () => {
+            const wpAdminLink = join(flattenTo, 'wp-admin');
+            assert.ok(existsSync(wpAdminLink), 'flatten-to/wp-admin should exist');
+            assert.ok(
+                lstatSync(wpAdminLink).isSymbolicLink(),
+                'wp-admin should be a symlink',
+            );
+
+            // The symlink target should point into the core directory, not ABSPATH
+            const target = readlinkSync(wpAdminLink);
+            assert.ok(
+                target.includes('e2e-wpcloud-core'),
+                `wp-admin symlink should point to core dir, got: ${target}`,
+            );
+        });
+
+        it('creates wp-includes symlink pointing to resolved core location', () => {
+            const wpIncludesLink = join(flattenTo, 'wp-includes');
+            assert.ok(existsSync(wpIncludesLink), 'flatten-to/wp-includes should exist');
+            assert.ok(
+                lstatSync(wpIncludesLink).isSymbolicLink(),
+                'wp-includes should be a symlink',
+            );
+
+            const target = readlinkSync(wpIncludesLink);
+            assert.ok(
+                target.includes('e2e-wpcloud-core'),
+                `wp-includes symlink should point to core dir, got: ${target}`,
+            );
+        });
+
+        it('creates wp-content symlink pointing to separate content location', () => {
+            const wpContentLink = join(flattenTo, 'wp-content');
+            assert.ok(existsSync(wpContentLink), 'flatten-to/wp-content should exist');
+            assert.ok(
+                lstatSync(wpContentLink).isSymbolicLink(),
+                'wp-content should be a symlink',
+            );
+
+            const target = readlinkSync(wpContentLink);
+            assert.ok(
+                target.includes('e2e-wpcloud-wpcontent'),
+                `wp-content symlink should point to content dir, got: ${target}`,
+            );
+        });
+
+        it('symlinks core files from ABSPATH', () => {
+            assert.ok(existsSync(join(flattenTo, 'wp-load.php')), 'wp-load.php should exist');
+            assert.ok(existsSync(join(flattenTo, 'wp-config.php')), 'wp-config.php should exist');
+            assert.ok(existsSync(join(flattenTo, 'index.php')), 'index.php should exist');
+        });
+
+        it('wp-admin is traversable and contains real files', () => {
+            assert.ok(
+                existsSync(join(flattenTo, 'wp-admin', 'admin.php')),
+                'wp-admin/admin.php should be accessible through flatten-to',
+            );
+            assert.ok(
+                existsSync(join(flattenTo, 'wp-admin', 'index.php')),
+                'wp-admin/index.php should be accessible through flatten-to',
+            );
+        });
+
+        it('wp-includes is traversable and contains real files', () => {
+            assert.ok(
+                existsSync(join(flattenTo, 'wp-includes', 'version.php')),
+                'wp-includes/version.php should be accessible through flatten-to',
+            );
+        });
+
+        it('wp-content is traversable and contains plugins', () => {
+            assert.ok(
+                existsSync(join(flattenTo, 'wp-content', 'plugins')),
+                'wp-content/plugins should be accessible through flatten-to',
+            );
+        });
+
+        it('does NOT contain __wp__ (implementation detail, not part of standard layout)', () => {
+            // __wp__ is an intermediate symlink from the source - it may or may not
+            // appear in the flattened dir depending on what was in ABSPATH. If it does
+            // appear it's fine, but wp-admin and wp-includes should NOT point through it.
+            const wpAdminTarget = readlinkSync(join(flattenTo, 'wp-admin'));
+            assert.ok(
+                !wpAdminTarget.includes('__wp__'),
+                `wp-admin should point directly to core, not through __wp__: ${wpAdminTarget}`,
+            );
+        });
+    });
+});

--- a/tests/e2e/tests/import-38-flatten-wpcloud.test.js
+++ b/tests/e2e/tests/import-38-flatten-wpcloud.test.js
@@ -201,8 +201,13 @@ require_once ABSPATH . 'wp-settings.php';
                 'wp-admin should be a symlink',
             );
 
-            // The symlink target should point into the core directory, not ABSPATH
+            // The symlink target should be relative (not absolute) and point
+            // into the core directory, not ABSPATH
             const target = readlinkSync(wpAdminLink);
+            assert.ok(
+                !target.startsWith('/'),
+                `wp-admin symlink should be relative, got: ${target}`,
+            );
             assert.ok(
                 target.includes('e2e-wpcloud-core'),
                 `wp-admin symlink should point to core dir, got: ${target}`,
@@ -218,6 +223,10 @@ require_once ABSPATH . 'wp-settings.php';
             );
 
             const target = readlinkSync(wpIncludesLink);
+            assert.ok(
+                !target.startsWith('/'),
+                `wp-includes symlink should be relative, got: ${target}`,
+            );
             assert.ok(
                 target.includes('e2e-wpcloud-core'),
                 `wp-includes symlink should point to core dir, got: ${target}`,

--- a/wordpress-plugin/generic/export.php
+++ b/wordpress-plugin/generic/export.php
@@ -1625,10 +1625,34 @@ function endpoint_preflight(array $config): array
                         $db["wp"]["theme_template"] = get_option("template");
                         $db["wp"]["siteurl"] = get_option("siteurl");
                         $db["wp"]["home"] = get_option("home");
+                        // Resolve wp-admin and wp-includes paths.
+                        // These are always ABSPATH/wp-admin and ABSPATH/WPINC
+                        // by WordPress convention, but on hosts like WP Cloud
+                        // they may be symlinks (e.g. __wp__/wp-admin -> /wordpress/wp-admin).
+                        // Use realpath() to resolve to the physical location so
+                        // the importer knows where the files actually live.
+                        $wp_admin_path = null;
+                        $wp_includes_path = null;
+                        if (defined("ABSPATH")) {
+                            $wp_admin_candidate = ABSPATH . "wp-admin";
+                            $wp_admin_real = realpath($wp_admin_candidate);
+                            if ($wp_admin_real !== false && is_dir($wp_admin_real)) {
+                                $wp_admin_path = $wp_admin_real;
+                            }
+                            $wpinc = defined("WPINC") ? WPINC : "wp-includes";
+                            $wp_includes_candidate = ABSPATH . $wpinc;
+                            $wp_includes_real = realpath($wp_includes_candidate);
+                            if ($wp_includes_real !== false && is_dir($wp_includes_real)) {
+                                $wp_includes_path = $wp_includes_real;
+                            }
+                        }
+
                         $paths_urls = [
                             "abspath" => defined("ABSPATH")
                                 ? rtrim(ABSPATH, "/")
                                 : null,
+                            "wp_admin_path" => $wp_admin_path,
+                            "wp_includes_path" => $wp_includes_path,
                             "content_dir" => defined("WP_CONTENT_DIR")
                                 ? rtrim(WP_CONTENT_DIR, "/")
                                 : null,

--- a/wordpress-plugin/generic/export.php
+++ b/wordpress-plugin/generic/export.php
@@ -1632,13 +1632,16 @@ function endpoint_preflight(array $config): array
                         // Use realpath() to resolve to the physical location so
                         // the importer knows where the files actually live.
                         $wp_admin_path = null;
-                        $wp_includes_path = null;
                         if (defined("ABSPATH")) {
                             $wp_admin_candidate = ABSPATH . "wp-admin";
                             $wp_admin_real = realpath($wp_admin_candidate);
                             if ($wp_admin_real !== false && is_dir($wp_admin_real)) {
                                 $wp_admin_path = $wp_admin_real;
                             }
+                        }
+
+                        $wp_includes_path = null;
+                        if (defined("ABSPATH")) {
                             $wpinc = defined("WPINC") ? WPINC : "wp-includes";
                             $wp_includes_candidate = ABSPATH . $wpinc;
                             $wp_includes_real = realpath($wp_includes_candidate);
@@ -1654,7 +1657,7 @@ function endpoint_preflight(array $config): array
                             "wp_admin_path" => $wp_admin_path,
                             "wp_includes_path" => $wp_includes_path,
                             "content_dir" => defined("WP_CONTENT_DIR")
-                                ? rtrim(WP_CONTENT_DIR, "/")
+                                ? realpath(rtrim(WP_CONTENT_DIR, "/"))
                                 : null,
                             "content_url" => function_exists("content_url")
                                 ? content_url()


### PR DESCRIPTION
Detect the source webhost environment (SiteGround or WP Cloud) during
preflight and persist the result in import state. The detection checks
preflight plugin lists for sg-* prefixed plugins (SiteGround) and
filesystem/docroot for __wp__ symlinks (WP Cloud). The webhost field
survives abort commands so it is never lost once detected.

Add a new "flatten-docroot" command that creates a directory mirroring
a vanilla WordPress layout by symlinking all top-level docroot entries
into a target directory. The command is idempotent — re-running refreshes
symlinks. Non-symlink conflicts cause an error unless --force is used,
which removes conflicting files/directories and logs each removal to the
audit log.

https://claude.ai/code/session_01ANMMmqvcm3ZGm29ajZ64JK