### PR TITLE
Include wp-content in file index when outside ABSPATH

### DIFF
--- a/importer/import.php
+++ b/importer/import.php
@@ -6387,14 +6387,26 @@ class ImportClient
             // Also include cursor in query params as a fallback when headers are stripped.
             $params["cursor"] = $cursor;
         }
+
+        // For file endpoints, tell the server about all directories it
+        // should allow. On managed hosts wp-content often lives outside
+        // ABSPATH so the server needs explicit directory[] params to
+        // serve files from it.
+        if (
+            in_array($endpoint, ["file_index", "file_fetch"], true) &&
+            !isset($params["directory"])
+        ) {
+            $export_dirs = $this->get_export_directories();
+            if (count($export_dirs) > 1) {
+                $params["directory"] = $export_dirs;
+            }
+        }
+
         $params["_cache_bust"] = time() . "-" . rand(0, 999999);
 
         return $url . $separator . http_build_query($params);
     }
 
-    /**
-     * Extract root directories from the remote URL query.
-     */
     /**
      * Extract root directories from preflight wp_detect data.
      * Falls back to this when the URL doesn't contain directory[] params.
@@ -6419,6 +6431,53 @@ class ImportClient
                     implode(", ", $dirs),
             );
         }
+        return $dirs;
+    }
+
+    /**
+     * Build the list of directories the server should traverse.
+     *
+     * Starts from the wp_detect roots (ABSPATH, etc.) and adds
+     * WP_CONTENT_DIR when it lives outside those roots. On managed
+     * hosts like wp.com Atomic, content_dir is on a separate path
+     * (e.g. /srv/htdocs/wp-content vs /wordpress/core/6.9.4) so
+     * the server won't discover it by traversing ABSPATH alone.
+     */
+    private function get_export_directories(): array
+    {
+        $dirs = $this->get_root_directories_from_preflight();
+        if (empty($dirs)) {
+            return [];
+        }
+
+        $content_dir = rtrim(
+            $this->state["preflight"]["data"]["database"]["wp"]["paths_urls"]["content_dir"] ?? "",
+            "/",
+        );
+        if ($content_dir === "") {
+            return $dirs;
+        }
+
+        // Check if content_dir is already covered by an existing root.
+        $covered = false;
+        foreach ($dirs as $root) {
+            if (
+                $content_dir === $root ||
+                str_starts_with($content_dir, $root . "/")
+            ) {
+                $covered = true;
+                break;
+            }
+        }
+
+        if (!$covered) {
+            $dirs[] = $content_dir;
+            $this->audit_log(
+                "DIRECTORY AUTO-DETECT | adding content_dir outside roots: " .
+                    $content_dir,
+            );
+        }
+
         return $dirs;
     }
 

--- a/importer/import.php
+++ b/importer/import.php
@@ -3624,6 +3624,10 @@ class ImportClient
         }
 
         $params = $this->get_tuned_params("file_fetch");
+        $export_dirs = $this->get_export_directories();
+        if (count($export_dirs) > 1) {
+            $params["directory"] = $export_dirs;
+        }
         $url = $this->build_url("file_fetch", $cursor, $params);
         $this->audit_log("Downloading file fetch from {$url}");
         $this->audit_log("POST data: " . json_encode($post_data));
@@ -3814,6 +3818,10 @@ class ImportClient
         }
         if ($this->follow_symlinks) {
             $params["follow_symlinks"] = "1";
+        }
+        $export_dirs = $this->get_export_directories();
+        if (count($export_dirs) > 1) {
+            $params["directory"] = $export_dirs;
         }
         $url = $this->build_url("file_index", $cursor, $params);
         $context = new StreamingContext();
@@ -6387,21 +6395,6 @@ class ImportClient
             // Also include cursor in query params as a fallback when headers are stripped.
             $params["cursor"] = $cursor;
         }
-
-        // For file endpoints, tell the server about all directories it
-        // should allow. On managed hosts wp-content often lives outside
-        // ABSPATH so the server needs explicit directory[] params to
-        // serve files from it.
-        if (
-            in_array($endpoint, ["file_index", "file_fetch"], true) &&
-            !isset($params["directory"])
-        ) {
-            $export_dirs = $this->get_export_directories();
-            if (count($export_dirs) > 1) {
-                $params["directory"] = $export_dirs;
-            }
-        }
-
         $params["_cache_bust"] = time() . "-" . rand(0, 999999);
 
         return $url . $separator . http_build_query($params);


### PR DESCRIPTION
## Summary

On managed hosts like wp.com Atomic, `WP_CONTENT_DIR` lives on a completely different filesystem path from `ABSPATH` (e.g. `/srv/htdocs/wp-content` vs `/wordpress/core/6.9.4`). The importer was only telling the server to traverse ABSPATH, so `files-index` returned ~3,700 WordPress core files and missed the entire wp-content tree — plugins, themes, uploads, mu-plugins — which is where the actual site content lives.

The importer now reads `content_dir` from preflight data and, when it falls outside the known roots, passes it as an additional `directory[]` parameter on `file_index` and `file_fetch` requests. The server's `resolve_directories()` and traversal stack already support multiple directories, so no server-side changes are needed.

The `directory[]` params are added explicitly at each call site (`download_remote_index` and the file fetch method) rather than implicitly in `build_url`, keeping URL construction a straightforward pass-through.

## Test plan

- [ ] Run `files-index` against a wp.com Atomic site (e.g. adamadam.blog) and verify the index now includes files from `/srv/htdocs/wp-content` (should be ~20k+ entries instead of ~3,700)
- [ ] Run `files-sync` end-to-end to verify `file_fetch` also works for files under the content directory
- [ ] Verify no regression on a standard WordPress install where `WP_CONTENT_DIR` is inside ABSPATH