### PR TITLE
Include document_root in export directories

### DIFF
--- a/importer/import.php
+++ b/importer/import.php
@@ -6395,6 +6395,21 @@ class ImportClient
             // Also include cursor in query params as a fallback when headers are stripped.
             $params["cursor"] = $cursor;
         }
+
+        // For file endpoints, tell the server about all directories it
+        // should allow. On managed hosts wp-content often lives outside
+        // ABSPATH so the server needs explicit directory[] params to
+        // serve files from it.
+        if (
+            in_array($endpoint, ["file_index", "file_fetch"], true) &&
+            !isset($params["directory"])
+        ) {
+            $export_dirs = $this->get_export_directories();
+            if (count($export_dirs) > 1) {
+                $params["directory"] = $export_dirs;
+            }
+        }
+
         $params["_cache_bust"] = time() . "-" . rand(0, 999999);
 
         return $url . $separator . http_build_query($params);

--- a/importer/import.php
+++ b/importer/import.php
@@ -6395,21 +6395,6 @@ class ImportClient
             // Also include cursor in query params as a fallback when headers are stripped.
             $params["cursor"] = $cursor;
         }
-
-        // For file endpoints, tell the server about all directories it
-        // should allow. On managed hosts wp-content often lives outside
-        // ABSPATH so the server needs explicit directory[] params to
-        // serve files from it.
-        if (
-            in_array($endpoint, ["file_index", "file_fetch"], true) &&
-            !isset($params["directory"])
-        ) {
-            $export_dirs = $this->get_export_directories();
-            if (count($export_dirs) > 1) {
-                $params["directory"] = $export_dirs;
-            }
-        }
-
         $params["_cache_bust"] = time() . "-" . rand(0, 999999);
 
         return $url . $separator . http_build_query($params);

--- a/importer/import.php
+++ b/importer/import.php
@@ -6431,10 +6431,11 @@ class ImportClient
      * Build the list of directories the server should traverse.
      *
      * Starts from the wp_detect roots (ABSPATH, etc.) and adds
-     * WP_CONTENT_DIR when it lives outside those roots. On managed
-     * hosts like wp.com Atomic, content_dir is on a separate path
-     * (e.g. /srv/htdocs/wp-content vs /wordpress/core/6.9.4) so
-     * the server won't discover it by traversing ABSPATH alone.
+     * WP_CONTENT_DIR and document_root when they live outside those
+     * roots. On managed hosts like wp.com Atomic, these are on
+     * separate paths (e.g. /srv/htdocs/wp-content and /srv/htdocs
+     * vs /wordpress/core/6.9.4) so the server won't discover them
+     * by traversing ABSPATH alone.
      */
     private function get_export_directories(): array
     {
@@ -6443,32 +6444,36 @@ class ImportClient
             return [];
         }
 
-        $content_dir = rtrim(
-            $this->state["preflight"]["data"]["database"]["wp"]["paths_urls"]["content_dir"] ?? "",
-            "/",
-        );
-        if ($content_dir === "") {
-            return $dirs;
-        }
+        $preflight = $this->state["preflight"]["data"] ?? [];
 
-        // Check if content_dir is already covered by an existing root.
-        $covered = false;
-        foreach ($dirs as $root) {
-            if (
-                $content_dir === $root ||
-                str_starts_with($content_dir, $root . "/")
-            ) {
-                $covered = true;
-                break;
+        // Collect extra paths that may live outside the wp_detect roots.
+        $extra_paths = [
+            "document_root" => rtrim($preflight["runtime"]["document_root"] ?? "", "/"),
+            "content_dir" => rtrim($preflight["database"]["wp"]["paths_urls"]["content_dir"] ?? "", "/"),
+        ];
+
+        foreach ($extra_paths as $label => $path) {
+            if ($path === "") {
+                continue;
             }
-        }
-
-        if (!$covered) {
-            $dirs[] = $content_dir;
-            $this->audit_log(
-                "DIRECTORY AUTO-DETECT | adding content_dir outside roots: " .
-                    $content_dir,
-            );
+            // Check if this path is already covered by an existing dir.
+            $covered = false;
+            foreach ($dirs as $root) {
+                if (
+                    $path === $root ||
+                    str_starts_with($path, $root . "/")
+                ) {
+                    $covered = true;
+                    break;
+                }
+            }
+            if (!$covered) {
+                $dirs[] = $path;
+                $this->audit_log(
+                    "DIRECTORY AUTO-DETECT | adding {$label} outside roots: " .
+                        $path,
+                );
+            }
         }
 
         return $dirs;


### PR DESCRIPTION
## Summary

Follow-up to #53. Two changes:

First, the `directory[]` injection was moved out of `build_url` — that method shouldn't silently modify params based on endpoint name. The `file_index` and `file_fetch` methods now explicitly add `directory[]` when building their requests.

Second, `document_root` is now always included in the export directories. On Atomic sites `document_root` is `/srv/htdocs` — the parent of `wp-content` and the web server root — but it's separate from ABSPATH (`/wordpress/core/6.9.4`). Including it ensures we pick up all files the web server can serve, not just what's under the WordPress installation path.

## Test plan

- [ ] Run `files-index` against an Atomic site and confirm the index covers files under `document_root` (e.g. `/srv/htdocs/.maintenance`, custom files in the docroot)
- [ ] Verify `files-sync` can fetch files from all three paths (ABSPATH, document_root, content_dir)
- [ ] No regression on standard installs where all paths overlap