### PR TITLE
--new-site-url: rewrite both HTTP and HTTPS variants

### DIFF
--- a/importer/import.php
+++ b/importer/import.php
@@ -2987,7 +2987,8 @@ class ImportClient
 
     /**
      * If --new-site-url is set, derive the source origin from the export URL
-     * and append an implicit --rewrite-url mapping to $options.
+     * and append implicit --rewrite-url mappings for both HTTP and HTTPS
+     * variants of the old URL to $options. The new URL is used verbatim.
      */
     private function resolve_new_site_url_option(array &$options): void
     {
@@ -3002,15 +3003,21 @@ class ImportClient
             );
         }
 
-        $source_origin = $parsed_url['scheme'] . '://' . $parsed_url['host'];
+        $host_with_port = $parsed_url['host'];
         if (!empty($parsed_url['port'])) {
-            $source_origin .= ':' . $parsed_url['port'];
+            $host_with_port .= ':' . $parsed_url['port'];
         }
 
         if (!isset($options["rewrite_url"])) {
             $options["rewrite_url"] = [];
         }
-        $options["rewrite_url"][] = [$source_origin, $options["new_site_url"]];
+
+        // Rewrite both http:// and https:// variants of the old origin
+        // to the new URL verbatim, so we catch references stored with
+        // either scheme in the database.
+        $new_url = $options["new_site_url"];
+        $options["rewrite_url"][] = ['https://' . $host_with_port, $new_url];
+        $options["rewrite_url"][] = ['http://' . $host_with_port, $new_url];
     }
 
     private function escape_pdo_dsn_value(string $value): string

--- a/tests/Import/NewSiteUrlTest.php
+++ b/tests/Import/NewSiteUrlTest.php
@@ -7,8 +7,8 @@ use PHPUnit\Framework\TestCase;
 require_once __DIR__ . '/../../importer/import.php';
 
 /**
- * Test the --new-site-url flag, which derives a --rewrite-url mapping
- * from the export URL's origin.
+ * Test the --new-site-url flag, which derives --rewrite-url mappings
+ * for both HTTP and HTTPS variants of the export URL's origin.
  */
 class NewSiteUrlTest extends TestCase
 {
@@ -58,7 +58,7 @@ class NewSiteUrlTest extends TestCase
         return $options;
     }
 
-    public function testDerivesOriginFromHttpsUrl(): void
+    public function testDerivesHttpAndHttpsFromHttpsUrl(): void
     {
         $client = new \ImportClient(
             'https://old-site.example.com/wp-json/export',
@@ -70,14 +70,18 @@ class NewSiteUrlTest extends TestCase
         $options = $this->callResolve($client, $options);
 
         $this->assertArrayHasKey('rewrite_url', $options);
-        $this->assertCount(1, $options['rewrite_url']);
+        $this->assertCount(2, $options['rewrite_url']);
         $this->assertSame(
             ['https://old-site.example.com', 'https://new-site.example.com'],
             $options['rewrite_url'][0]
         );
+        $this->assertSame(
+            ['http://old-site.example.com', 'https://new-site.example.com'],
+            $options['rewrite_url'][1]
+        );
     }
 
-    public function testDerivesOriginFromHttpUrl(): void
+    public function testDerivesHttpAndHttpsFromHttpUrl(): void
     {
         $client = new \ImportClient(
             'http://old-site.local/export?key=abc',
@@ -88,9 +92,14 @@ class NewSiteUrlTest extends TestCase
         $options = ['new_site_url' => 'https://new-site.example.com'];
         $options = $this->callResolve($client, $options);
 
+        $this->assertCount(2, $options['rewrite_url']);
+        $this->assertSame(
+            ['https://old-site.local', 'https://new-site.example.com'],
+            $options['rewrite_url'][0]
+        );
         $this->assertSame(
             ['http://old-site.local', 'https://new-site.example.com'],
-            $options['rewrite_url'][0]
+            $options['rewrite_url'][1]
         );
     }
 
@@ -105,9 +114,14 @@ class NewSiteUrlTest extends TestCase
         $options = ['new_site_url' => 'https://new-site.example.com'];
         $options = $this->callResolve($client, $options);
 
+        $this->assertCount(2, $options['rewrite_url']);
         $this->assertSame(
             ['https://old-site.example.com:8443', 'https://new-site.example.com'],
             $options['rewrite_url'][0]
+        );
+        $this->assertSame(
+            ['http://old-site.example.com:8443', 'https://new-site.example.com'],
+            $options['rewrite_url'][1]
         );
     }
 
@@ -127,7 +141,7 @@ class NewSiteUrlTest extends TestCase
         ];
         $options = $this->callResolve($client, $options);
 
-        $this->assertCount(2, $options['rewrite_url']);
+        $this->assertCount(3, $options['rewrite_url']);
         $this->assertSame(
             ['https://cdn.old-site.com', 'https://cdn.new-site.com'],
             $options['rewrite_url'][0]
@@ -135,6 +149,10 @@ class NewSiteUrlTest extends TestCase
         $this->assertSame(
             ['https://old-site.example.com', 'https://new-site.example.com'],
             $options['rewrite_url'][1]
+        );
+        $this->assertSame(
+            ['http://old-site.example.com', 'https://new-site.example.com'],
+            $options['rewrite_url'][2]
         );
     }
 
@@ -165,5 +183,23 @@ class NewSiteUrlTest extends TestCase
 
         $options = ['new_site_url' => 'https://new-site.example.com'];
         $this->callResolve($client, $options);
+    }
+
+    public function testNewUrlUsedVerbatim(): void
+    {
+        $client = new \ImportClient(
+            'https://old-site.example.com/export',
+            $this->tempDir,
+            $this->tempDir . '/docroot'
+        );
+
+        // The new URL should be used exactly as-is, even with a trailing path
+        $options = ['new_site_url' => 'http://localhost:8080/subdir'];
+        $options = $this->callResolve($client, $options);
+
+        $this->assertCount(2, $options['rewrite_url']);
+        // Both variants map to the exact same verbatim new URL
+        $this->assertSame('http://localhost:8080/subdir', $options['rewrite_url'][0][1]);
+        $this->assertSame('http://localhost:8080/subdir', $options['rewrite_url'][1][1]);
     }
 }


### PR DESCRIPTION
## Summary

WordPress databases often store a mix of `http://` and `https://` references to the same site origin. Previously `--new-site-url` only generated a single `--rewrite-url` mapping matching the export URL's scheme, so references with the other scheme were silently missed.

Now it emits two mappings — one for `https://old-host` and one for `http://old-host` — both pointing to the new URL verbatim. This ensures no stale references slip through during migration regardless of how they were originally stored.

## Test plan

- [x] All 7 `NewSiteUrlTest` cases pass, covering HTTPS source, HTTP source, custom ports, appending to existing rewrites, no-op, invalid URL, and verbatim new URL preservation