### PR TITLE
Default --target-sqlite-path to wp-content/database/.ht.sqlite

### DIFF
--- a/importer/import.php
+++ b/importer/import.php
@@ -3102,9 +3102,15 @@ class ImportClient
             $target_db = $options["target_db"] ?? "sqlite_database";
 
             if (!$target_path) {
-                throw new InvalidArgumentException(
-                    "db-apply with --target-engine=sqlite requires --target-sqlite-path.",
+                $content_dir = rtrim(
+                    $this->state["preflight"]["data"]["database"]["wp"]["paths_urls"]["content_dir"] ?? "",
+                    "/",
                 );
+                if ($content_dir === "") {
+                    $content_dir = "/wp-content";
+                }
+                $target_path = $this->get_filesystem_root_path() . $content_dir . '/database/.ht.sqlite';
+                fwrite(STDERR, "[db-apply] No --target-sqlite-path specified, defaulting to: $target_path\n");
             }
 
             return [
@@ -8021,7 +8027,7 @@ if (
                 "  --target-user=USER         Target MySQL user (required for mysql)\n" .
                 "  --target-pass=PASS         Target MySQL password\n" .
                 "  --target-db=NAME           Target DB name (required for mysql, optional for sqlite)\n" .
-                "  --target-sqlite-path=PATH  Target SQLite database file (required for sqlite)\n" .
+                "  --target-sqlite-path=PATH  Target SQLite database file (default: <wp-content>/database/.ht.sqlite)\n" .
                 "  --rewrite-url FROM TO      Rewrite FROM to TO (repeatable)\n" .
                 "  --abort                    Clear state and exit\n" .
                 "  --verbose, -v              Show detailed logs\n" .

--- a/importer/import.php
+++ b/importer/import.php
@@ -3102,12 +3102,15 @@ class ImportClient
             $target_db = $options["target_db"] ?? "sqlite_database";
 
             if (!$target_path) {
+                fwrite(STDERR, "[db-apply] No --target-sqlite-path specified");
                 $content_dir = rtrim(
                     $this->state["preflight"]["data"]["database"]["wp"]["paths_urls"]["content_dir"] ?? "",
                     "/",
                 );
-                if ($content_dir === "") {
-                    $content_dir = "/wp-content";
+                if(!$content_dir) {
+                    throw new InvalidArgumentException(
+                        "--target-sqlite-path option is required but was missing.",
+                    );
                 }
                 $target_path = $this->get_filesystem_root_path() . $content_dir . '/database/.ht.sqlite';
                 fwrite(STDERR, "[db-apply] No --target-sqlite-path specified, defaulting to: $target_path\n");


### PR DESCRIPTION
## Summary

When running `db-apply` with `--target-engine=sqlite`, users previously had to always specify `--target-sqlite-path` or get an error. Since `wp-content/database/.ht.sqlite` is the standard SQLite database location in WordPress, the importer now defaults to `<docroot>/wp-content/database/.ht.sqlite` when the flag is omitted. The resolved path is logged to stderr so it's always clear where the database is being written.

## Test plan

- [ ] Run `db-apply` with `--target-engine=sqlite` but without `--target-sqlite-path` — confirm it uses `<docroot>/wp-content/database/.ht.sqlite` and logs the path
- [ ] Run `db-apply` with both `--target-engine=sqlite` and `--target-sqlite-path=/custom/path` — confirm the explicit path is used
- [ ] Verify `--help` output shows the new default instead of "(required for sqlite)"

🤖 Generated with [Claude Code](https://claude.com/claude-code)