### PR TITLE
Capture more WordPress constants in preflight

### DIFF
--- a/wordpress-plugin/generic/export.php
+++ b/wordpress-plugin/generic/export.php
@@ -1774,6 +1774,19 @@ function endpoint_preflight(array $config): array
                             "SITE_ID_CURRENT_SITE",
                             "BLOG_ID_CURRENT_SITE",
                             "SUBDOMAIN_INSTALL",
+                            "TEMPLATEPATH",
+                            "STYLESHEETPATH",
+                            "WP_HOME",
+                            "WP_SITEURL",
+                            "FORCE_SSL_LOGIN",
+                            "FORCE_SSL_ADMIN",
+                            "WP_CACHE",
+                            "WP_DEBUG",
+                            "WP_DEBUG_LOG",
+                            "WP_DEBUG_DISPLAY",
+                            "SAVEQUERIES",
+                            "WP_MEMORY_LIMIT",
+                            "WP_MAX_MEMORY_LIMIT",
                         ];
                         $constant_values = [];
                         foreach ($constants as $name) {


### PR DESCRIPTION
## Summary

The preflight response already captures path and multisite constants (ABSPATH, WP_CONTENT_DIR, etc.), but was missing several that matter for understanding the remote site's configuration. This adds:

- **Theme paths**: TEMPLATEPATH, STYLESHEETPATH
- **URL overrides**: WP_HOME, WP_SITEURL
- **SSL settings**: FORCE_SSL_LOGIN, FORCE_SSL_ADMIN
- **Debug flags**: WP_DEBUG, WP_DEBUG_LOG, WP_DEBUG_DISPLAY, SAVEQUERIES
- **Caching**: WP_CACHE
- **Memory limits**: WP_MEMORY_LIMIT, WP_MAX_MEMORY_LIMIT

No import-side changes needed — the importer already stores whatever constants the exporter sends via the existing `preflight.data.database.wp.constants` path.

## Test plan

- [ ] Run preflight against a WordPress site and verify the new constants appear in the response
- [ ] Confirm existing constants are still present and unchanged