### PR TITLE
Import PHP runtime configuration on preflight

### DIFF
--- a/importer/import.php
+++ b/importer/import.php
@@ -1752,38 +1752,25 @@ class ImportClient
     }
 
     /**
-     * Collect the filesystem paths of PHP runtime config files reported
-     * in the preflight response: the main php.ini and any scanned .ini
-     * files.  Values like auto_prepend_file and auto_append_file are
-     * already captured in ini_get_all so they don't need separate
-     * file downloads.
+     * Collect auto_prepend_file and auto_append_file paths from ini_get_all.
      *
      * @return array{files: string[], directories: string[]}
-     *   - files: absolute paths of individual files to fetch
+     *   - files: absolute paths to download
      *   - directories: their parent directories (for the export allow-list)
      */
     private function collect_runtime_file_paths(): array
     {
         $preflight = $this->state["preflight"]["data"] ?? [];
-        $runtime = $preflight["runtime"] ?? [];
+        $ini_all = $preflight["runtime"]["ini_get_all"] ?? [];
 
         $files = [];
-
-        $php_ini = $runtime["php_ini"] ?? "";
-        if (is_string($php_ini) && $php_ini !== "") {
-            $files[] = $php_ini;
-        }
-
-        $scanned = $runtime["php_ini_scanned_files"] ?? "";
-        if (is_string($scanned) && $scanned !== "") {
-            foreach (array_map("trim", explode(",", $scanned)) as $ini_path) {
-                if ($ini_path !== "") {
-                    $files[] = $ini_path;
-                }
+        foreach (["auto_prepend_file", "auto_append_file"] as $key) {
+            $path = $ini_all[$key] ?? "";
+            if (is_string($path) && $path !== "") {
+                $files[] = $path;
             }
         }
 
-        // Deduplicate and compute parent directories for the export allow-list.
         $files = array_values(array_unique($files));
         $dirs = [];
         foreach ($files as $f) {
@@ -1800,23 +1787,16 @@ class ImportClient
     }
 
     /**
-     * Download PHP runtime configuration files (php.ini and scanned .ini
-     * files) into the state
-     * directory under runtime_files/.
+     * Save ini_get_all data and download auto_prepend/append scripts
+     * into state_dir/runtime_files/.
      *
-     * Uses the file_fetch endpoint with the parent directories of
-     * these files as allowed roots.  The server may reject some
-     * directories (e.g. system paths not accessible to the web
-     * process), so failures are tolerated and logged.
-     *
-     * Called on every preflight: the runtime_files/ directory is deleted
-     * and re-created so it always reflects the current server state.
+     * Called on every preflight: the directory is wiped and recreated
+     * so it always reflects the current server state.  Download
+     * failures are tolerated since the scripts may live on paths not
+     * accessible to the web server process.
      */
     private function download_runtime_files(): void
     {
-        $info = $this->collect_runtime_file_paths();
-        $files = $info["files"];
-
         $runtime_dir = $this->state_dir . "/runtime_files";
 
         // Always wipe and recreate so the directory reflects current state.
@@ -1831,8 +1811,6 @@ class ImportClient
         }
 
         // Write the full computed INI configuration from ini_get_all().
-        // This is always available in the preflight response regardless of
-        // whether the actual .ini files are readable on disk.
         $preflight = $this->state["preflight"]["data"] ?? [];
         $runtime = $preflight["runtime"] ?? [];
         $ini_all = $runtime["ini_get_all"] ?? null;
@@ -1842,28 +1820,27 @@ class ImportClient
             $this->audit_log("RUNTIME FILES | wrote ini_get_all.json (" . count($ini_all) . " directives)");
         }
 
+        // Download auto_prepend_file and auto_append_file scripts.
+        $info = $this->collect_runtime_file_paths();
+        $files = $info["files"];
         if (empty($files)) {
-            $this->audit_log("RUNTIME FILES | no runtime files to download");
+            $this->audit_log("RUNTIME FILES | no prepend/append scripts to download");
             return;
         }
 
         $this->audit_log(
-            "RUNTIME FILES | downloading " . count($files) . " file(s): " .
+            "RUNTIME FILES | downloading " . count($files) . " script(s): " .
                 implode(", ", $files),
         );
 
-        // Group files by parent directory.  The file_fetch endpoint validates
-        // all directories via realpath() up front, so if any single directory
-        // is inaccessible the whole request fails.  By issuing one request per
-        // directory we ensure that accessible directories succeed independently.
+        // Issue one file_fetch request per parent directory so that
+        // an inaccessible directory doesn't block the other.
         $by_dir = [];
         foreach ($files as $f) {
             $parent = dirname($f);
-            if ($parent === "" || $parent === ".") {
-                continue;
+            if ($parent !== "" && $parent !== ".") {
+                $by_dir[rtrim($parent, "/")][] = $f;
             }
-            $parent = rtrim($parent, "/");
-            $by_dir[$parent][] = $f;
         }
 
         $downloaded = 0;
@@ -1872,7 +1849,6 @@ class ImportClient
         foreach ($by_dir as $directory => $dir_files) {
             $tmp = tempnam(sys_get_temp_dir(), "runtime-fetch-");
             if ($tmp === false) {
-                $this->audit_log("RUNTIME FILES | failed to create temp file for {$directory}", true);
                 continue;
             }
             file_put_contents($tmp, json_encode($dir_files, JSON_UNESCAPED_SLASHES));
@@ -1880,9 +1856,7 @@ class ImportClient
             $post_data = [
                 "file_list" => new \CURLFile($tmp, "application/json", "file_list"),
             ];
-
-            $params = ["directory" => [$directory]];
-            $url = $this->build_url("file_fetch", null, $params);
+            $url = $this->build_url("file_fetch", null, ["directory" => [$directory]]);
 
             $context = new StreamingContext();
             $context->file_handle = null;
@@ -1923,12 +1897,6 @@ class ImportClient
                     if ($is_last && $context->file_handle) {
                         fclose($context->file_handle);
                         $context->file_handle = null;
-
-                        $ctime = $chunk["headers"]["x-file-ctime"] ?? null;
-                        if ($ctime !== null) {
-                            @touch($local_path, (int) $ctime);
-                        }
-
                         $downloaded++;
                         $this->audit_log("RUNTIME FILES | saved {$path} → {$local_path}");
                     }
@@ -1943,8 +1911,6 @@ class ImportClient
             try {
                 $this->fetch_streaming($url, null, $context, $post_data, "file_fetch");
             } catch (\RuntimeException $e) {
-                // Tolerate failures — these are system paths that may not be
-                // accessible to the web server process.
                 $this->audit_log(
                     "RUNTIME FILES | fetch failed for {$directory} (non-fatal): " .
                         substr($e->getMessage(), 0, 200),
@@ -1958,7 +1924,7 @@ class ImportClient
             }
         }
 
-        $this->audit_log("RUNTIME FILES | downloaded {$downloaded}/{$total} file(s)");
+        $this->audit_log("RUNTIME FILES | downloaded {$downloaded}/{$total} script(s)");
     }
 
     /**
@@ -7711,21 +7677,10 @@ class ImportClient
         }
 
         if (isset($data["runtime"]) && is_array($data["runtime"])) {
-            foreach (["php_ini", "temp_dir", "document_root", "script_filename", "cwd"] as $key) {
+            foreach (["temp_dir", "document_root", "script_filename", "cwd"] as $key) {
                 if (array_key_exists($key, $data["runtime"])) {
                     $data["runtime"][$key] = $this->encode_state_path_value($data["runtime"][$key]);
                 }
-            }
-            // php_ini_scanned_files is a comma-separated string of paths
-            if (array_key_exists("php_ini_scanned_files", $data["runtime"]) && is_string($data["runtime"]["php_ini_scanned_files"])) {
-                $files = array_map("trim", explode(",", $data["runtime"]["php_ini_scanned_files"]));
-                $encoded = [];
-                foreach ($files as $f) {
-                    if ($f !== "") {
-                        $encoded[] = $this->encode_state_path_value($f);
-                    }
-                }
-                $data["runtime"]["php_ini_scanned_files"] = implode(",", $encoded);
             }
         }
 
@@ -7788,21 +7743,10 @@ class ImportClient
         }
 
         if (isset($data["runtime"]) && is_array($data["runtime"])) {
-            foreach (["php_ini", "temp_dir", "document_root", "script_filename", "cwd"] as $key) {
+            foreach (["temp_dir", "document_root", "script_filename", "cwd"] as $key) {
                 if (array_key_exists($key, $data["runtime"])) {
                     $data["runtime"][$key] = $this->decode_state_path_value($data["runtime"][$key]);
                 }
-            }
-            // php_ini_scanned_files is a comma-separated string of paths
-            if (array_key_exists("php_ini_scanned_files", $data["runtime"]) && is_string($data["runtime"]["php_ini_scanned_files"])) {
-                $files = array_map("trim", explode(",", $data["runtime"]["php_ini_scanned_files"]));
-                $decoded = [];
-                foreach ($files as $f) {
-                    if ($f !== "") {
-                        $decoded[] = $this->decode_state_path_value($f);
-                    }
-                }
-                $data["runtime"]["php_ini_scanned_files"] = implode(",", $decoded);
             }
         }
 

--- a/importer/import.php
+++ b/importer/import.php
@@ -1752,43 +1752,8 @@ class ImportClient
     }
 
     /**
-     * Collect auto_prepend_file and auto_append_file paths from ini_get_all.
-     *
-     * @return array{files: string[], directories: string[]}
-     *   - files: absolute paths to download
-     *   - directories: their parent directories (for the export allow-list)
-     */
-    private function collect_runtime_file_paths(): array
-    {
-        $preflight = $this->state["preflight"]["data"] ?? [];
-        $ini_all = $preflight["runtime"]["ini_get_all"] ?? [];
-
-        $files = [];
-        foreach (["auto_prepend_file", "auto_append_file"] as $key) {
-            $path = $ini_all[$key] ?? "";
-            if (is_string($path) && $path !== "") {
-                $files[] = $path;
-            }
-        }
-
-        $files = array_values(array_unique($files));
-        $dirs = [];
-        foreach ($files as $f) {
-            $parent = dirname($f);
-            if ($parent !== "" && $parent !== ".") {
-                $dirs[rtrim($parent, "/")] = true;
-            }
-        }
-
-        return [
-            "files" => $files,
-            "directories" => array_keys($dirs),
-        ];
-    }
-
-    /**
-     * Save ini_get_all data and download auto_prepend/append scripts
-     * into state_dir/runtime_files/.
+     * Download auto_prepend_file and auto_append_file scripts into
+     * state_dir/runtime_files/.
      *
      * Called on every preflight: the directory is wiped and recreated
      * so it always reflects the current server state.  Download
@@ -1801,40 +1766,48 @@ class ImportClient
 
         // Always wipe and recreate so the directory reflects current state.
         if (is_dir($runtime_dir)) {
-            $this->recursive_rmdir($runtime_dir);
+            self::rmdir_recursive($runtime_dir);
             $this->audit_log("RUNTIME FILES | deleted {$runtime_dir}");
         }
 
-        if (!mkdir($runtime_dir, 0755, true)) {
-            $this->audit_log("RUNTIME FILES | failed to create {$runtime_dir}", true);
-            return;
+        $ini_all = $this->state["preflight"]["data"]["runtime"]["ini_get_all"] ?? [];
+        $files = [];
+        foreach (["auto_prepend_file", "auto_append_file"] as $key) {
+            $path = $ini_all[$key] ?? "";
+            if (is_string($path) && $path !== "") {
+                $files[] = $path;
+            }
         }
+        $files = array_values(array_unique($files));
 
-        // Write the full computed INI configuration from ini_get_all().
-        $preflight = $this->state["preflight"]["data"] ?? [];
-        $runtime = $preflight["runtime"] ?? [];
-        $ini_all = $runtime["ini_get_all"] ?? null;
-        if (is_array($ini_all) && !empty($ini_all)) {
-            $json = json_encode($ini_all, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
-            file_put_contents($runtime_dir . "/ini_get_all.json", $json);
-            $this->audit_log("RUNTIME FILES | wrote ini_get_all.json (" . count($ini_all) . " directives)");
-        }
-
-        // Download auto_prepend_file and auto_append_file scripts.
-        $info = $this->collect_runtime_file_paths();
-        $files = $info["files"];
         if (empty($files)) {
             $this->audit_log("RUNTIME FILES | no prepend/append scripts to download");
             return;
         }
+
+        mkdir($runtime_dir, 0755, true);
 
         $this->audit_log(
             "RUNTIME FILES | downloading " . count($files) . " script(s): " .
                 implode(", ", $files),
         );
 
-        // Issue one file_fetch request per parent directory so that
-        // an inaccessible directory doesn't block the other.
+        $downloaded = $this->fetch_files_into($runtime_dir, $files);
+        $this->audit_log("RUNTIME FILES | downloaded {$downloaded}/" . count($files) . " script(s)");
+    }
+
+    /**
+     * Download a list of absolute remote paths into $target_dir,
+     * preserving their directory structure.
+     *
+     * Issues one file_fetch request per parent directory so that an
+     * inaccessible directory doesn't block the others.  All errors
+     * are caught and logged as non-fatal.
+     *
+     * @return int Number of files successfully downloaded.
+     */
+    private function fetch_files_into(string $target_dir, array $files): int
+    {
         $by_dir = [];
         foreach ($files as $f) {
             $parent = dirname($f);
@@ -1844,10 +1817,9 @@ class ImportClient
         }
 
         $downloaded = 0;
-        $total = count($files);
 
         foreach ($by_dir as $directory => $dir_files) {
-            $tmp = tempnam(sys_get_temp_dir(), "runtime-fetch-");
+            $tmp = tempnam(sys_get_temp_dir(), "fetch-into-");
             if ($tmp === false) {
                 continue;
             }
@@ -1863,19 +1835,19 @@ class ImportClient
             $context->file_path = null;
             $context->file_ctime = null;
 
-            $context->on_chunk = function ($chunk) use ($runtime_dir, $context, &$downloaded) {
+            $context->on_chunk = function ($chunk) use ($target_dir, $context, &$downloaded) {
                 $chunk_type = $chunk["headers"]["x-chunk-type"] ?? "";
 
                 if ($chunk_type === "file") {
-                    $raw_header = $chunk["headers"]["x-file-path"] ?? "";
-                    $path = base64_decode($raw_header, true);
+                    $raw = $chunk["headers"]["x-file-path"] ?? "";
+                    $path = base64_decode($raw, true);
                     if ($path === false || $path === "") {
                         return;
                     }
 
                     $is_first = ($chunk["headers"]["x-first-chunk"] ?? "0") === "1";
                     $is_last = ($chunk["headers"]["x-last-chunk"] ?? "0") === "1";
-                    $local_path = $runtime_dir . $path;
+                    $local_path = $target_dir . $path;
 
                     if ($is_first) {
                         if ($context->file_handle) {
@@ -1898,13 +1870,12 @@ class ImportClient
                         fclose($context->file_handle);
                         $context->file_handle = null;
                         $downloaded++;
-                        $this->audit_log("RUNTIME FILES | saved {$path} → {$local_path}");
+                        $this->audit_log("Saved {$path} → {$local_path}");
                     }
                 } elseif ($chunk_type === "error") {
                     $body = json_decode($chunk["body"] ?? "{}", true);
                     $error_path = isset($body["path"]) ? base64_decode($body["path"]) : "unknown";
-                    $message = $body["message"] ?? "unknown error";
-                    $this->audit_log("RUNTIME FILES | error for {$error_path}: {$message}");
+                    $this->audit_log("Fetch error for {$error_path}: " . ($body["message"] ?? "unknown"));
                 }
             };
 
@@ -1912,7 +1883,7 @@ class ImportClient
                 $this->fetch_streaming($url, null, $context, $post_data, "file_fetch");
             } catch (\RuntimeException $e) {
                 $this->audit_log(
-                    "RUNTIME FILES | fetch failed for {$directory} (non-fatal): " .
+                    "Fetch failed for directory {$directory} (non-fatal): " .
                         substr($e->getMessage(), 0, 200),
                 );
             }
@@ -1924,13 +1895,13 @@ class ImportClient
             }
         }
 
-        $this->audit_log("RUNTIME FILES | downloaded {$downloaded}/{$total} script(s)");
+        return $downloaded;
     }
 
     /**
      * Recursively remove a directory and all its contents.
      */
-    private function recursive_rmdir(string $dir): void
+    private static function rmdir_recursive(string $dir): void
     {
         if (!is_dir($dir)) {
             return;
@@ -1945,7 +1916,7 @@ class ImportClient
             }
             $path = $dir . "/" . $entry;
             if (is_dir($path) && !is_link($path)) {
-                $this->recursive_rmdir($path);
+                self::rmdir_recursive($path);
             } else {
                 @unlink($path);
             }

--- a/importer/import.php
+++ b/importer/import.php
@@ -1752,18 +1752,72 @@ class ImportClient
     }
 
     /**
-     * Write PHP runtime configuration files (php.ini, scanned .ini
+     * Collect the filesystem paths of PHP runtime config files reported
+     * in the preflight response: the main php.ini, any scanned .ini
+     * files, and auto_prepend_file / auto_append_file.
+     *
+     * @return array{files: string[], directories: string[]}
+     *   - files: absolute paths of individual files to fetch
+     *   - directories: their parent directories (for the export allow-list)
+     */
+    private function collect_runtime_file_paths(): array
+    {
+        $preflight = $this->state["preflight"]["data"] ?? [];
+        $runtime = $preflight["runtime"] ?? [];
+
+        $files = [];
+
+        foreach (["php_ini", "auto_prepend_file", "auto_append_file"] as $key) {
+            $path = $runtime[$key] ?? "";
+            if (is_string($path) && $path !== "") {
+                $files[] = $path;
+            }
+        }
+
+        $scanned = $runtime["php_ini_scanned_files"] ?? "";
+        if (is_string($scanned) && $scanned !== "") {
+            foreach (array_map("trim", explode(",", $scanned)) as $ini_path) {
+                if ($ini_path !== "") {
+                    $files[] = $ini_path;
+                }
+            }
+        }
+
+        // Deduplicate and compute parent directories for the export allow-list.
+        $files = array_values(array_unique($files));
+        $dirs = [];
+        foreach ($files as $f) {
+            $parent = dirname($f);
+            if ($parent !== "" && $parent !== ".") {
+                $dirs[rtrim($parent, "/")] = true;
+            }
+        }
+
+        return [
+            "files" => $files,
+            "directories" => array_keys($dirs),
+        ];
+    }
+
+    /**
+     * Download PHP runtime configuration files (php.ini, scanned .ini
      * files, auto_prepend_file, auto_append_file) into the state
      * directory under runtime_files/.
      *
-     * The file contents are already included in the preflight response
-     * (base64-encoded), so no additional HTTP request is needed.
+     * Uses the file_fetch endpoint with the parent directories of
+     * these files as allowed roots.  The server may reject some
+     * directories (e.g. system paths not accessible to the web
+     * process), so failures are tolerated and logged.
      *
      * Called on every preflight: the runtime_files/ directory is deleted
      * and re-created so it always reflects the current server state.
      */
     private function download_runtime_files(): void
     {
+        $info = $this->collect_runtime_file_paths();
+        $files = $info["files"];
+        $directories = $info["directories"];
+
         $runtime_dir = $this->state_dir . "/runtime_files";
 
         // Always wipe and recreate so the directory reflects current state.
@@ -1772,57 +1826,110 @@ class ImportClient
             $this->audit_log("RUNTIME FILES | deleted {$runtime_dir}");
         }
 
-        $entries = $this->state["preflight"]["data"]["runtime_files"] ?? [];
-        if (!is_array($entries) || empty($entries)) {
-            $this->audit_log("RUNTIME FILES | no runtime files in preflight");
+        if (empty($files)) {
+            $this->audit_log("RUNTIME FILES | no runtime files to download");
             return;
         }
 
-        $written = 0;
-        foreach ($entries as $entry) {
-            if (!is_array($entry)) {
-                continue;
-            }
-            $path = $entry["path"] ?? "";
-            $content_b64 = $entry["content"] ?? null;
-            $error = $entry["error"] ?? null;
-
-            if (!is_string($path) || $path === "") {
-                continue;
-            }
-            if ($error !== null) {
-                $this->audit_log("RUNTIME FILES | skip {$path}: {$error}");
-                continue;
-            }
-            if ($content_b64 === null) {
-                continue;
-            }
-
-            $content = base64_decode($content_b64, true);
-            if ($content === false) {
-                $this->audit_log("RUNTIME FILES | skip {$path}: base64 decode failed");
-                continue;
-            }
-
-            $local_path = $runtime_dir . $path;
-            $dir = dirname($local_path);
-            if (!is_dir($dir) && !mkdir($dir, 0755, true)) {
-                $this->audit_log("RUNTIME FILES | skip {$path}: mkdir failed for {$dir}");
-                continue;
-            }
-
-            if (file_put_contents($local_path, $content) === false) {
-                $this->audit_log("RUNTIME FILES | skip {$path}: write failed");
-                continue;
-            }
-
-            $written++;
-            $this->audit_log("RUNTIME FILES | saved {$path} → {$local_path}");
+        if (!mkdir($runtime_dir, 0755, true)) {
+            $this->audit_log("RUNTIME FILES | failed to create {$runtime_dir}", true);
+            return;
         }
 
         $this->audit_log(
-            "RUNTIME FILES | wrote {$written}/" . count($entries) . " file(s)",
+            "RUNTIME FILES | downloading " . count($files) . " file(s): " .
+                implode(", ", $files),
         );
+
+        // Build a JSON file list for the file_fetch endpoint.
+        $tmp = tempnam(sys_get_temp_dir(), "runtime-fetch-");
+        if ($tmp === false) {
+            $this->audit_log("RUNTIME FILES | failed to create temp file", true);
+            return;
+        }
+        file_put_contents($tmp, json_encode($files, JSON_UNESCAPED_SLASHES));
+
+        $post_data = [
+            "file_list" => new \CURLFile($tmp, "application/json", "file_list"),
+        ];
+
+        $params = ["directory" => $directories];
+        $url = $this->build_url("file_fetch", null, $params);
+
+        $context = new StreamingContext();
+        $context->file_handle = null;
+        $context->file_path = null;
+        $context->file_ctime = null;
+        $downloaded = 0;
+
+        $context->on_chunk = function ($chunk) use ($runtime_dir, $context, &$downloaded) {
+            $chunk_type = $chunk["headers"]["x-chunk-type"] ?? "";
+
+            if ($chunk_type === "file") {
+                $raw_header = $chunk["headers"]["x-file-path"] ?? "";
+                $path = base64_decode($raw_header, true);
+                if ($path === false || $path === "") {
+                    return;
+                }
+
+                $is_first = ($chunk["headers"]["x-first-chunk"] ?? "0") === "1";
+                $is_last = ($chunk["headers"]["x-last-chunk"] ?? "0") === "1";
+                $local_path = $runtime_dir . $path;
+
+                if ($is_first) {
+                    if ($context->file_handle) {
+                        fclose($context->file_handle);
+                        $context->file_handle = null;
+                    }
+                    $dir = dirname($local_path);
+                    if (!is_dir($dir)) {
+                        @mkdir($dir, 0755, true);
+                    }
+                    $context->file_handle = @fopen($local_path, "wb");
+                    $context->file_path = $local_path;
+                }
+
+                if ($context->file_handle && isset($chunk["body"])) {
+                    fwrite($context->file_handle, $chunk["body"]);
+                }
+
+                if ($is_last && $context->file_handle) {
+                    fclose($context->file_handle);
+                    $context->file_handle = null;
+
+                    $ctime = $chunk["headers"]["x-file-ctime"] ?? null;
+                    if ($ctime !== null) {
+                        @touch($local_path, (int) $ctime);
+                    }
+
+                    $downloaded++;
+                    $this->audit_log("RUNTIME FILES | saved {$path} → {$local_path}");
+                }
+            } elseif ($chunk_type === "error") {
+                $body = json_decode($chunk["body"] ?? "{}", true);
+                $error_path = isset($body["path"]) ? base64_decode($body["path"]) : "unknown";
+                $message = $body["message"] ?? "unknown error";
+                $this->audit_log("RUNTIME FILES | error for {$error_path}: {$message}");
+            }
+        };
+
+        try {
+            $this->fetch_streaming($url, null, $context, $post_data, "file_fetch");
+        } catch (\RuntimeException $e) {
+            // Tolerate failures — these are system paths that may not be
+            // accessible to the web server process.
+            $this->audit_log(
+                "RUNTIME FILES | fetch failed (non-fatal): " . substr($e->getMessage(), 0, 200),
+            );
+        }
+
+        @unlink($tmp);
+
+        if ($context->file_handle) {
+            fclose($context->file_handle);
+        }
+
+        $this->audit_log("RUNTIME FILES | downloaded {$downloaded}/" . count($files) . " file(s)");
     }
 
     /**
@@ -7624,15 +7731,6 @@ class ImportClient
             }
         }
 
-        if (isset($data["runtime_files"]) && is_array($data["runtime_files"])) {
-            foreach ($data["runtime_files"] as $idx => $entry) {
-                if (!is_array($entry) || !array_key_exists("path", $entry)) {
-                    continue;
-                }
-                $data["runtime_files"][$idx]["path"] = $this->encode_state_path_value($entry["path"]);
-            }
-        }
-
         return $data;
     }
 
@@ -7707,15 +7805,6 @@ class ImportClient
                         $data["wp_content"]["roots"][$idx][$key] = $this->decode_state_path_value($root_entry[$key]);
                     }
                 }
-            }
-        }
-
-        if (isset($data["runtime_files"]) && is_array($data["runtime_files"])) {
-            foreach ($data["runtime_files"] as $idx => $entry) {
-                if (!is_array($entry) || !array_key_exists("path", $entry)) {
-                    continue;
-                }
-                $data["runtime_files"][$idx]["path"] = $this->decode_state_path_value($entry["path"]);
             }
         }
 

--- a/importer/import.php
+++ b/importer/import.php
@@ -1848,61 +1848,21 @@ class ImportClient
             "file_list" => new CURLFile($tmp, "application/json", "file_list"),
         ];
 
-        $params = [];
-        $params["directory"] = $directories;
+        $params = ["directory" => $directories];
         $url = $this->build_url("file_fetch", null, $params);
 
+        // Reuse the standard file chunk handler by setting target_base_dir
+        // on the context — handle_file_chunk will write files there instead
+        // of the import docroot and skip index/state updates.
         $context = new StreamingContext();
-        $context->file_handle = null;
-        $context->file_path = null;
-        $context->file_ctime = null;
-        $downloaded = 0;
+        $context->target_base_dir = $runtime_dir;
 
-        $context->on_chunk = function ($chunk) use ($runtime_dir, $context, &$downloaded) {
+        $context->on_chunk = function ($chunk) use ($context) {
             $chunk_type = $chunk["headers"]["x-chunk-type"] ?? "";
-
             if ($chunk_type === "file") {
-                $raw_header = $chunk["headers"]["x-file-path"] ?? "";
-                $path = base64_decode($raw_header, true);
-                if ($path === false || $path === "") {
-                    return;
-                }
-
-                $is_first = ($chunk["headers"]["x-first-chunk"] ?? "0") === "1";
-                $is_last = ($chunk["headers"]["x-last-chunk"] ?? "0") === "1";
-                $local_path = $runtime_dir . $path;
-
-                if ($is_first) {
-                    $dir = dirname($local_path);
-                    if (!is_dir($dir)) {
-                        @mkdir($dir, 0755, true);
-                    }
-                    $context->file_handle = fopen($local_path, "wb");
-                    $context->file_path = $local_path;
-                }
-
-                if ($context->file_handle) {
-                    fwrite($context->file_handle, $chunk["body"] ?? "");
-                }
-
-                if ($is_last && $context->file_handle) {
-                    fclose($context->file_handle);
-                    $context->file_handle = null;
-                    $context->file_path = null;
-
-                    $ctime = $chunk["headers"]["x-file-ctime"] ?? null;
-                    if ($ctime !== null) {
-                        @touch($local_path, (int) $ctime);
-                    }
-
-                    $downloaded++;
-                    $this->audit_log("RUNTIME FILES | saved {$path} → {$local_path}");
-                }
+                $this->handle_file_chunk($chunk, $context);
             } elseif ($chunk_type === "error") {
-                $body = json_decode($chunk["body"] ?? "{}", true);
-                $error_path = isset($body["path"]) ? base64_decode($body["path"]) : "unknown";
-                $message = $body["message"] ?? "unknown error";
-                $this->audit_log("RUNTIME FILES | error fetching {$error_path}: {$message}", true);
+                $this->handle_error_chunk($chunk, "runtime_files", $context);
             }
         };
 
@@ -1920,8 +1880,6 @@ class ImportClient
         if ($context->file_handle) {
             fclose($context->file_handle);
         }
-
-        $this->audit_log("RUNTIME FILES | downloaded {$downloaded}/" . count($files) . " file(s)");
     }
 
     /**
@@ -5922,7 +5880,13 @@ class ImportClient
             return;
         }
 
-        $local_path = $this->remote_path_to_local_path_within_import_root($path);
+        // When target_base_dir is set on the context, write files there
+        // instead of the import docroot.  This is used by download_runtime_files()
+        // to store php.ini / auto_prepend / auto_append files in the state dir.
+        $custom_target = $context->target_base_dir !== null;
+        $local_path = $custom_target
+            ? $context->target_base_dir . $path
+            : $this->remote_path_to_local_path_within_import_root($path);
 
         // Open file on first chunk
         if ($is_first) {
@@ -5930,6 +5894,7 @@ class ImportClient
             $context->skip_current_file = false;
 
             if (
+                !$custom_target &&
                 (file_exists($local_path) || is_link($local_path)) &&
                 (!is_file($local_path) || is_link($local_path))
             ) {
@@ -5962,9 +5927,11 @@ class ImportClient
                 false,
             );
 
-            $this->show_progress_line(
-                sprintf("[%d files] %s", $this->files_imported, $this->display_path($path)),
-            );
+            if (!$custom_target) {
+                $this->show_progress_line(
+                    sprintf("[%d files] %s", $this->files_imported, $this->display_path($path)),
+                );
+            }
         }
 
         // Skip body/close for files being preserved
@@ -5985,14 +5952,18 @@ class ImportClient
             // Create parent directory if needed
             $dir = dirname($local_path);
             if (!is_dir($dir)) {
-                // Check if any component of the path exists as a file and remove it
-                try {
-                    $this->ensure_directory_path($dir);
-                } catch (PreserveLocalSkipException $e) {
-                    $context->skip_current_file = true;
-                    $this->audit_log($e->getMessage(), true);
-                    $this->show_progress_line("[skip] " . $this->display_path($path));
-                    return;
+                if ($custom_target) {
+                    @mkdir($dir, 0755, true);
+                } else {
+                    // Check if any component of the path exists as a file and remove it
+                    try {
+                        $this->ensure_directory_path($dir);
+                    } catch (PreserveLocalSkipException $e) {
+                        $context->skip_current_file = true;
+                        $this->audit_log($e->getMessage(), true);
+                        $this->show_progress_line("[skip] " . $this->display_path($path));
+                        return;
+                    }
                 }
             }
 
@@ -6040,41 +6011,44 @@ class ImportClient
                 touch($context->file_path, $context->file_ctime);
             }
 
-            // Index update (JSON lines)
-            $file_size = (int) ($headers["x-file-size"] ?? 0);
-            $final_size = file_exists($context->file_path)
-                ? filesize($context->file_path)
-                : 0;
+            if (!$custom_target) {
+                // Index update (JSON lines)
+                $file_size = (int) ($headers["x-file-size"] ?? 0);
+                $final_size = file_exists($context->file_path)
+                    ? filesize($context->file_path)
+                    : 0;
 
-            $file_changed = ($headers["x-file-changed"] ?? "0") === "1";
+                $file_changed = ($headers["x-file-changed"] ?? "0") === "1";
 
-            if ($context->file_ctime && !$file_changed) {
-                $this->upsert_index_entry(
-                    $path,
-                    $context->file_ctime,
-                    $file_size,
-                    "file",
-                );
-                $this->files_imported++; // Count completed files only
-                $this->clear_volatile_file($path);
-                $this->audit_log(
-                    sprintf("  Indexed (wrote %d bytes)", $final_size),
-                    false,
-                );
-            } elseif ($file_changed) {
-                $this->audit_log(
-                    "  File changed during stream; index not updated",
-                    true,
-                );
+                if ($context->file_ctime && !$file_changed) {
+                    $this->upsert_index_entry(
+                        $path,
+                        $context->file_ctime,
+                        $file_size,
+                        "file",
+                    );
+                    $this->files_imported++; // Count completed files only
+                    $this->clear_volatile_file($path);
+                    $this->audit_log(
+                        sprintf("  Indexed (wrote %d bytes)", $final_size),
+                        false,
+                    );
+                } elseif ($file_changed) {
+                    $this->audit_log(
+                        "  File changed during stream; index not updated",
+                        true,
+                    );
+                }
+
+                // Clear crash recovery tracking - file is complete
+                $this->state["current_file"] = null;
+                $this->state["current_file_bytes"] = null;
             }
 
             $context->file_handle = null;
             $context->file_path = null;
             $context->file_ctime = null;
             $context->file_bytes_written = 0;
-            // Clear crash recovery tracking - file is complete
-            $this->state["current_file"] = null;
-            $this->state["current_file_bytes"] = null;
         }
     }
 
@@ -8099,6 +8073,9 @@ class StreamingContext
     public $saw_completion = false;
     // When true, skip writing the current file (preserve-local mode)
     public $skip_current_file = false;
+    // When set, file chunks are written under this directory instead of
+    // the import docroot, and index/state updates are skipped.
+    public $target_base_dir = null;
 }
 
 /**

--- a/importer/import.php
+++ b/importer/import.php
@@ -1825,13 +1825,25 @@ class ImportClient
             $this->audit_log("RUNTIME FILES | deleted {$runtime_dir}");
         }
 
-        if (empty($files)) {
-            $this->audit_log("RUNTIME FILES | no runtime files to download");
+        if (!mkdir($runtime_dir, 0755, true)) {
+            $this->audit_log("RUNTIME FILES | failed to create {$runtime_dir}", true);
             return;
         }
 
-        if (!mkdir($runtime_dir, 0755, true)) {
-            $this->audit_log("RUNTIME FILES | failed to create {$runtime_dir}", true);
+        // Write the full computed INI configuration from ini_get_all().
+        // This is always available in the preflight response regardless of
+        // whether the actual .ini files are readable on disk.
+        $preflight = $this->state["preflight"]["data"] ?? [];
+        $runtime = $preflight["runtime"] ?? [];
+        $ini_all = $runtime["ini_get_all"] ?? null;
+        if (is_array($ini_all) && !empty($ini_all)) {
+            $json = json_encode($ini_all, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+            file_put_contents($runtime_dir . "/ini_get_all.json", $json);
+            $this->audit_log("RUNTIME FILES | wrote ini_get_all.json (" . count($ini_all) . " directives)");
+        }
+
+        if (empty($files)) {
+            $this->audit_log("RUNTIME FILES | no runtime files to download");
             return;
         }
 

--- a/importer/import.php
+++ b/importer/import.php
@@ -1747,6 +1747,207 @@ class ImportClient
                 );
             }
         }
+
+        $this->download_runtime_files();
+    }
+
+    /**
+     * Collect the filesystem paths of PHP runtime config files reported
+     * in the preflight response: the main php.ini, any scanned .ini
+     * files, and auto_prepend_file / auto_append_file.
+     *
+     * @return array{files: string[], directories: string[]}
+     *   - files: absolute paths of individual files to fetch
+     *   - directories: their parent directories (for the export allow-list)
+     */
+    private function collect_runtime_file_paths(): array
+    {
+        $preflight = $this->state["preflight"]["data"] ?? [];
+        $runtime = $preflight["runtime"] ?? [];
+
+        $files = [];
+
+        foreach (["php_ini", "auto_prepend_file", "auto_append_file"] as $key) {
+            $path = $runtime[$key] ?? "";
+            if (is_string($path) && $path !== "") {
+                $files[] = $path;
+            }
+        }
+
+        $scanned = $runtime["php_ini_scanned_files"] ?? "";
+        if (is_string($scanned) && $scanned !== "") {
+            foreach (array_map("trim", explode(",", $scanned)) as $ini_path) {
+                if ($ini_path !== "") {
+                    $files[] = $ini_path;
+                }
+            }
+        }
+
+        // Deduplicate and compute parent directories for the export allow-list.
+        $files = array_values(array_unique($files));
+        $dirs = [];
+        foreach ($files as $f) {
+            $parent = dirname($f);
+            if ($parent !== "" && $parent !== ".") {
+                $dirs[rtrim($parent, "/")] = true;
+            }
+        }
+
+        return [
+            "files" => $files,
+            "directories" => array_keys($dirs),
+        ];
+    }
+
+    /**
+     * Download PHP runtime configuration files (php.ini, scanned .ini
+     * files, auto_prepend_file, auto_append_file) into the state
+     * directory under runtime_files/.
+     *
+     * Called on every preflight: the runtime_files/ directory is deleted
+     * and re-created so it always reflects the current server state.
+     */
+    private function download_runtime_files(): void
+    {
+        $info = $this->collect_runtime_file_paths();
+        $files = $info["files"];
+        $directories = $info["directories"];
+
+        $runtime_dir = $this->state_dir . "/runtime_files";
+
+        // Always wipe and recreate so the directory reflects current state.
+        if (is_dir($runtime_dir)) {
+            $this->recursive_rmdir($runtime_dir);
+            $this->audit_log("RUNTIME FILES | deleted {$runtime_dir}");
+        }
+
+        if (empty($files)) {
+            $this->audit_log("RUNTIME FILES | no runtime files to download");
+            return;
+        }
+
+        if (!mkdir($runtime_dir, 0755, true)) {
+            $this->audit_log("RUNTIME FILES | failed to create {$runtime_dir}", true);
+            return;
+        }
+
+        $this->audit_log(
+            "RUNTIME FILES | downloading " . count($files) . " file(s): " .
+                implode(", ", $files),
+        );
+
+        // Build a JSON file list for the file_fetch endpoint.
+        $tmp = tempnam(sys_get_temp_dir(), "runtime-fetch-");
+        if ($tmp === false) {
+            $this->audit_log("RUNTIME FILES | failed to create temp file", true);
+            return;
+        }
+        file_put_contents($tmp, json_encode($files, JSON_UNESCAPED_SLASHES));
+
+        $post_data = [
+            "file_list" => new CURLFile($tmp, "application/json", "file_list"),
+        ];
+
+        $params = [];
+        $params["directory"] = $directories;
+        $url = $this->build_url("file_fetch", null, $params);
+
+        $context = new StreamingContext();
+        $context->file_handle = null;
+        $context->file_path = null;
+        $context->file_ctime = null;
+        $downloaded = 0;
+
+        $context->on_chunk = function ($chunk) use ($runtime_dir, $context, &$downloaded) {
+            $chunk_type = $chunk["headers"]["x-chunk-type"] ?? "";
+
+            if ($chunk_type === "file") {
+                $raw_header = $chunk["headers"]["x-file-path"] ?? "";
+                $path = base64_decode($raw_header, true);
+                if ($path === false || $path === "") {
+                    return;
+                }
+
+                $is_first = ($chunk["headers"]["x-first-chunk"] ?? "0") === "1";
+                $is_last = ($chunk["headers"]["x-last-chunk"] ?? "0") === "1";
+                $local_path = $runtime_dir . $path;
+
+                if ($is_first) {
+                    $dir = dirname($local_path);
+                    if (!is_dir($dir)) {
+                        @mkdir($dir, 0755, true);
+                    }
+                    $context->file_handle = fopen($local_path, "wb");
+                    $context->file_path = $local_path;
+                }
+
+                if ($context->file_handle) {
+                    fwrite($context->file_handle, $chunk["body"] ?? "");
+                }
+
+                if ($is_last && $context->file_handle) {
+                    fclose($context->file_handle);
+                    $context->file_handle = null;
+                    $context->file_path = null;
+
+                    $ctime = $chunk["headers"]["x-file-ctime"] ?? null;
+                    if ($ctime !== null) {
+                        @touch($local_path, (int) $ctime);
+                    }
+
+                    $downloaded++;
+                    $this->audit_log("RUNTIME FILES | saved {$path} → {$local_path}");
+                }
+            } elseif ($chunk_type === "error") {
+                $body = json_decode($chunk["body"] ?? "{}", true);
+                $error_path = isset($body["path"]) ? base64_decode($body["path"]) : "unknown";
+                $message = $body["message"] ?? "unknown error";
+                $this->audit_log("RUNTIME FILES | error fetching {$error_path}: {$message}", true);
+            }
+        };
+
+        try {
+            $this->fetch_streaming($url, null, $context, $post_data, "file_fetch");
+        } catch (RuntimeException $e) {
+            $this->audit_log(
+                "RUNTIME FILES | fetch failed: " . substr($e->getMessage(), 0, 200),
+                true,
+            );
+        }
+
+        @unlink($tmp);
+
+        if ($context->file_handle) {
+            fclose($context->file_handle);
+        }
+
+        $this->audit_log("RUNTIME FILES | downloaded {$downloaded}/" . count($files) . " file(s)");
+    }
+
+    /**
+     * Recursively remove a directory and all its contents.
+     */
+    private function recursive_rmdir(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        $entries = scandir($dir);
+        if ($entries === false) {
+            return;
+        }
+        foreach ($entries as $entry) {
+            if ($entry === "." || $entry === "..") {
+                continue;
+            }
+            $path = $dir . "/" . $entry;
+            if (is_dir($path) && !is_link($path)) {
+                $this->recursive_rmdir($path);
+            } else {
+                @unlink($path);
+            }
+        }
+        @rmdir($dir);
     }
 
     /**
@@ -7473,10 +7674,21 @@ class ImportClient
         }
 
         if (isset($data["runtime"]) && is_array($data["runtime"])) {
-            foreach (["php_ini", "temp_dir", "document_root", "script_filename", "cwd"] as $key) {
+            foreach (["php_ini", "auto_prepend_file", "auto_append_file", "temp_dir", "document_root", "script_filename", "cwd"] as $key) {
                 if (array_key_exists($key, $data["runtime"])) {
                     $data["runtime"][$key] = $this->encode_state_path_value($data["runtime"][$key]);
                 }
+            }
+            // php_ini_scanned_files is a comma-separated string of paths
+            if (array_key_exists("php_ini_scanned_files", $data["runtime"]) && is_string($data["runtime"]["php_ini_scanned_files"])) {
+                $files = array_map("trim", explode(",", $data["runtime"]["php_ini_scanned_files"]));
+                $encoded = [];
+                foreach ($files as $f) {
+                    if ($f !== "") {
+                        $encoded[] = $this->encode_state_path_value($f);
+                    }
+                }
+                $data["runtime"]["php_ini_scanned_files"] = implode(",", $encoded);
             }
         }
 
@@ -7539,10 +7751,21 @@ class ImportClient
         }
 
         if (isset($data["runtime"]) && is_array($data["runtime"])) {
-            foreach (["php_ini", "temp_dir", "document_root", "script_filename", "cwd"] as $key) {
+            foreach (["php_ini", "auto_prepend_file", "auto_append_file", "temp_dir", "document_root", "script_filename", "cwd"] as $key) {
                 if (array_key_exists($key, $data["runtime"])) {
                     $data["runtime"][$key] = $this->decode_state_path_value($data["runtime"][$key]);
                 }
+            }
+            // php_ini_scanned_files is a comma-separated string of paths
+            if (array_key_exists("php_ini_scanned_files", $data["runtime"]) && is_string($data["runtime"]["php_ini_scanned_files"])) {
+                $files = array_map("trim", explode(",", $data["runtime"]["php_ini_scanned_files"]));
+                $decoded = [];
+                foreach ($files as $f) {
+                    if ($f !== "") {
+                        $decoded[] = $this->decode_state_path_value($f);
+                    }
+                }
+                $data["runtime"]["php_ini_scanned_files"] = implode(",", $decoded);
             }
         }
 

--- a/importer/import.php
+++ b/importer/import.php
@@ -1816,7 +1816,6 @@ class ImportClient
     {
         $info = $this->collect_runtime_file_paths();
         $files = $info["files"];
-        $directories = $info["directories"];
 
         $runtime_dir = $this->state_dir . "/runtime_files";
 
@@ -1841,95 +1840,113 @@ class ImportClient
                 implode(", ", $files),
         );
 
-        // Build a JSON file list for the file_fetch endpoint.
-        $tmp = tempnam(sys_get_temp_dir(), "runtime-fetch-");
-        if ($tmp === false) {
-            $this->audit_log("RUNTIME FILES | failed to create temp file", true);
-            return;
+        // Group files by parent directory.  The file_fetch endpoint validates
+        // all directories via realpath() up front, so if any single directory
+        // is inaccessible the whole request fails.  By issuing one request per
+        // directory we ensure that accessible directories succeed independently.
+        $by_dir = [];
+        foreach ($files as $f) {
+            $parent = dirname($f);
+            if ($parent === "" || $parent === ".") {
+                continue;
+            }
+            $parent = rtrim($parent, "/");
+            $by_dir[$parent][] = $f;
         }
-        file_put_contents($tmp, json_encode($files, JSON_UNESCAPED_SLASHES));
 
-        $post_data = [
-            "file_list" => new \CURLFile($tmp, "application/json", "file_list"),
-        ];
-
-        $params = ["directory" => $directories];
-        $url = $this->build_url("file_fetch", null, $params);
-
-        $context = new StreamingContext();
-        $context->file_handle = null;
-        $context->file_path = null;
-        $context->file_ctime = null;
         $downloaded = 0;
+        $total = count($files);
 
-        $context->on_chunk = function ($chunk) use ($runtime_dir, $context, &$downloaded) {
-            $chunk_type = $chunk["headers"]["x-chunk-type"] ?? "";
+        foreach ($by_dir as $directory => $dir_files) {
+            $tmp = tempnam(sys_get_temp_dir(), "runtime-fetch-");
+            if ($tmp === false) {
+                $this->audit_log("RUNTIME FILES | failed to create temp file for {$directory}", true);
+                continue;
+            }
+            file_put_contents($tmp, json_encode($dir_files, JSON_UNESCAPED_SLASHES));
 
-            if ($chunk_type === "file") {
-                $raw_header = $chunk["headers"]["x-file-path"] ?? "";
-                $path = base64_decode($raw_header, true);
-                if ($path === false || $path === "") {
-                    return;
-                }
+            $post_data = [
+                "file_list" => new \CURLFile($tmp, "application/json", "file_list"),
+            ];
 
-                $is_first = ($chunk["headers"]["x-first-chunk"] ?? "0") === "1";
-                $is_last = ($chunk["headers"]["x-last-chunk"] ?? "0") === "1";
-                $local_path = $runtime_dir . $path;
+            $params = ["directory" => [$directory]];
+            $url = $this->build_url("file_fetch", null, $params);
 
-                if ($is_first) {
-                    if ($context->file_handle) {
+            $context = new StreamingContext();
+            $context->file_handle = null;
+            $context->file_path = null;
+            $context->file_ctime = null;
+
+            $context->on_chunk = function ($chunk) use ($runtime_dir, $context, &$downloaded) {
+                $chunk_type = $chunk["headers"]["x-chunk-type"] ?? "";
+
+                if ($chunk_type === "file") {
+                    $raw_header = $chunk["headers"]["x-file-path"] ?? "";
+                    $path = base64_decode($raw_header, true);
+                    if ($path === false || $path === "") {
+                        return;
+                    }
+
+                    $is_first = ($chunk["headers"]["x-first-chunk"] ?? "0") === "1";
+                    $is_last = ($chunk["headers"]["x-last-chunk"] ?? "0") === "1";
+                    $local_path = $runtime_dir . $path;
+
+                    if ($is_first) {
+                        if ($context->file_handle) {
+                            fclose($context->file_handle);
+                            $context->file_handle = null;
+                        }
+                        $dir = dirname($local_path);
+                        if (!is_dir($dir)) {
+                            @mkdir($dir, 0755, true);
+                        }
+                        $context->file_handle = @fopen($local_path, "wb");
+                        $context->file_path = $local_path;
+                    }
+
+                    if ($context->file_handle && isset($chunk["body"])) {
+                        fwrite($context->file_handle, $chunk["body"]);
+                    }
+
+                    if ($is_last && $context->file_handle) {
                         fclose($context->file_handle);
                         $context->file_handle = null;
+
+                        $ctime = $chunk["headers"]["x-file-ctime"] ?? null;
+                        if ($ctime !== null) {
+                            @touch($local_path, (int) $ctime);
+                        }
+
+                        $downloaded++;
+                        $this->audit_log("RUNTIME FILES | saved {$path} → {$local_path}");
                     }
-                    $dir = dirname($local_path);
-                    if (!is_dir($dir)) {
-                        @mkdir($dir, 0755, true);
-                    }
-                    $context->file_handle = @fopen($local_path, "wb");
-                    $context->file_path = $local_path;
+                } elseif ($chunk_type === "error") {
+                    $body = json_decode($chunk["body"] ?? "{}", true);
+                    $error_path = isset($body["path"]) ? base64_decode($body["path"]) : "unknown";
+                    $message = $body["message"] ?? "unknown error";
+                    $this->audit_log("RUNTIME FILES | error for {$error_path}: {$message}");
                 }
+            };
 
-                if ($context->file_handle && isset($chunk["body"])) {
-                    fwrite($context->file_handle, $chunk["body"]);
-                }
-
-                if ($is_last && $context->file_handle) {
-                    fclose($context->file_handle);
-                    $context->file_handle = null;
-
-                    $ctime = $chunk["headers"]["x-file-ctime"] ?? null;
-                    if ($ctime !== null) {
-                        @touch($local_path, (int) $ctime);
-                    }
-
-                    $downloaded++;
-                    $this->audit_log("RUNTIME FILES | saved {$path} → {$local_path}");
-                }
-            } elseif ($chunk_type === "error") {
-                $body = json_decode($chunk["body"] ?? "{}", true);
-                $error_path = isset($body["path"]) ? base64_decode($body["path"]) : "unknown";
-                $message = $body["message"] ?? "unknown error";
-                $this->audit_log("RUNTIME FILES | error for {$error_path}: {$message}");
+            try {
+                $this->fetch_streaming($url, null, $context, $post_data, "file_fetch");
+            } catch (\RuntimeException $e) {
+                // Tolerate failures — these are system paths that may not be
+                // accessible to the web server process.
+                $this->audit_log(
+                    "RUNTIME FILES | fetch failed for {$directory} (non-fatal): " .
+                        substr($e->getMessage(), 0, 200),
+                );
             }
-        };
 
-        try {
-            $this->fetch_streaming($url, null, $context, $post_data, "file_fetch");
-        } catch (\RuntimeException $e) {
-            // Tolerate failures — these are system paths that may not be
-            // accessible to the web server process.
-            $this->audit_log(
-                "RUNTIME FILES | fetch failed (non-fatal): " . substr($e->getMessage(), 0, 200),
-            );
+            @unlink($tmp);
+
+            if ($context->file_handle) {
+                fclose($context->file_handle);
+            }
         }
 
-        @unlink($tmp);
-
-        if ($context->file_handle) {
-            fclose($context->file_handle);
-        }
-
-        $this->audit_log("RUNTIME FILES | downloaded {$downloaded}/" . count($files) . " file(s)");
+        $this->audit_log("RUNTIME FILES | downloaded {$downloaded}/{$total} file(s)");
     }
 
     /**

--- a/importer/import.php
+++ b/importer/import.php
@@ -1752,67 +1752,18 @@ class ImportClient
     }
 
     /**
-     * Collect the filesystem paths of PHP runtime config files reported
-     * in the preflight response: the main php.ini, any scanned .ini
-     * files, and auto_prepend_file / auto_append_file.
-     *
-     * @return array{files: string[], directories: string[]}
-     *   - files: absolute paths of individual files to fetch
-     *   - directories: their parent directories (for the export allow-list)
-     */
-    private function collect_runtime_file_paths(): array
-    {
-        $preflight = $this->state["preflight"]["data"] ?? [];
-        $runtime = $preflight["runtime"] ?? [];
-
-        $files = [];
-
-        foreach (["php_ini", "auto_prepend_file", "auto_append_file"] as $key) {
-            $path = $runtime[$key] ?? "";
-            if (is_string($path) && $path !== "") {
-                $files[] = $path;
-            }
-        }
-
-        $scanned = $runtime["php_ini_scanned_files"] ?? "";
-        if (is_string($scanned) && $scanned !== "") {
-            foreach (array_map("trim", explode(",", $scanned)) as $ini_path) {
-                if ($ini_path !== "") {
-                    $files[] = $ini_path;
-                }
-            }
-        }
-
-        // Deduplicate and compute parent directories for the export allow-list.
-        $files = array_values(array_unique($files));
-        $dirs = [];
-        foreach ($files as $f) {
-            $parent = dirname($f);
-            if ($parent !== "" && $parent !== ".") {
-                $dirs[rtrim($parent, "/")] = true;
-            }
-        }
-
-        return [
-            "files" => $files,
-            "directories" => array_keys($dirs),
-        ];
-    }
-
-    /**
-     * Download PHP runtime configuration files (php.ini, scanned .ini
+     * Write PHP runtime configuration files (php.ini, scanned .ini
      * files, auto_prepend_file, auto_append_file) into the state
      * directory under runtime_files/.
+     *
+     * The file contents are already included in the preflight response
+     * (base64-encoded), so no additional HTTP request is needed.
      *
      * Called on every preflight: the runtime_files/ directory is deleted
      * and re-created so it always reflects the current server state.
      */
     private function download_runtime_files(): void
     {
-        $info = $this->collect_runtime_file_paths();
-        $files = $info["files"];
-        $directories = $info["directories"];
-
         $runtime_dir = $this->state_dir . "/runtime_files";
 
         // Always wipe and recreate so the directory reflects current state.
@@ -1821,65 +1772,57 @@ class ImportClient
             $this->audit_log("RUNTIME FILES | deleted {$runtime_dir}");
         }
 
-        if (empty($files)) {
-            $this->audit_log("RUNTIME FILES | no runtime files to download");
+        $entries = $this->state["preflight"]["data"]["runtime_files"] ?? [];
+        if (!is_array($entries) || empty($entries)) {
+            $this->audit_log("RUNTIME FILES | no runtime files in preflight");
             return;
         }
 
-        if (!mkdir($runtime_dir, 0755, true)) {
-            $this->audit_log("RUNTIME FILES | failed to create {$runtime_dir}", true);
-            return;
+        $written = 0;
+        foreach ($entries as $entry) {
+            if (!is_array($entry)) {
+                continue;
+            }
+            $path = $entry["path"] ?? "";
+            $content_b64 = $entry["content"] ?? null;
+            $error = $entry["error"] ?? null;
+
+            if (!is_string($path) || $path === "") {
+                continue;
+            }
+            if ($error !== null) {
+                $this->audit_log("RUNTIME FILES | skip {$path}: {$error}");
+                continue;
+            }
+            if ($content_b64 === null) {
+                continue;
+            }
+
+            $content = base64_decode($content_b64, true);
+            if ($content === false) {
+                $this->audit_log("RUNTIME FILES | skip {$path}: base64 decode failed");
+                continue;
+            }
+
+            $local_path = $runtime_dir . $path;
+            $dir = dirname($local_path);
+            if (!is_dir($dir) && !mkdir($dir, 0755, true)) {
+                $this->audit_log("RUNTIME FILES | skip {$path}: mkdir failed for {$dir}");
+                continue;
+            }
+
+            if (file_put_contents($local_path, $content) === false) {
+                $this->audit_log("RUNTIME FILES | skip {$path}: write failed");
+                continue;
+            }
+
+            $written++;
+            $this->audit_log("RUNTIME FILES | saved {$path} → {$local_path}");
         }
 
         $this->audit_log(
-            "RUNTIME FILES | downloading " . count($files) . " file(s): " .
-                implode(", ", $files),
+            "RUNTIME FILES | wrote {$written}/" . count($entries) . " file(s)",
         );
-
-        // Build a JSON file list for the file_fetch endpoint.
-        $tmp = tempnam(sys_get_temp_dir(), "runtime-fetch-");
-        if ($tmp === false) {
-            $this->audit_log("RUNTIME FILES | failed to create temp file", true);
-            return;
-        }
-        file_put_contents($tmp, json_encode($files, JSON_UNESCAPED_SLASHES));
-
-        $post_data = [
-            "file_list" => new CURLFile($tmp, "application/json", "file_list"),
-        ];
-
-        $params = ["directory" => $directories];
-        $url = $this->build_url("file_fetch", null, $params);
-
-        // Reuse the standard file chunk handler by setting target_base_dir
-        // on the context — handle_file_chunk will write files there instead
-        // of the import docroot and skip index/state updates.
-        $context = new StreamingContext();
-        $context->target_base_dir = $runtime_dir;
-
-        $context->on_chunk = function ($chunk) use ($context) {
-            $chunk_type = $chunk["headers"]["x-chunk-type"] ?? "";
-            if ($chunk_type === "file") {
-                $this->handle_file_chunk($chunk, $context);
-            } elseif ($chunk_type === "error") {
-                $this->handle_error_chunk($chunk, "runtime_files", $context);
-            }
-        };
-
-        try {
-            $this->fetch_streaming($url, null, $context, $post_data, "file_fetch");
-        } catch (RuntimeException $e) {
-            $this->audit_log(
-                "RUNTIME FILES | fetch failed: " . substr($e->getMessage(), 0, 200),
-                true,
-            );
-        }
-
-        @unlink($tmp);
-
-        if ($context->file_handle) {
-            fclose($context->file_handle);
-        }
     }
 
     /**
@@ -5880,13 +5823,7 @@ class ImportClient
             return;
         }
 
-        // When target_base_dir is set on the context, write files there
-        // instead of the import docroot.  This is used by download_runtime_files()
-        // to store php.ini / auto_prepend / auto_append files in the state dir.
-        $custom_target = $context->target_base_dir !== null;
-        $local_path = $custom_target
-            ? $context->target_base_dir . $path
-            : $this->remote_path_to_local_path_within_import_root($path);
+        $local_path = $this->remote_path_to_local_path_within_import_root($path);
 
         // Open file on first chunk
         if ($is_first) {
@@ -5894,7 +5831,6 @@ class ImportClient
             $context->skip_current_file = false;
 
             if (
-                !$custom_target &&
                 (file_exists($local_path) || is_link($local_path)) &&
                 (!is_file($local_path) || is_link($local_path))
             ) {
@@ -5927,11 +5863,9 @@ class ImportClient
                 false,
             );
 
-            if (!$custom_target) {
-                $this->show_progress_line(
-                    sprintf("[%d files] %s", $this->files_imported, $this->display_path($path)),
-                );
-            }
+            $this->show_progress_line(
+                sprintf("[%d files] %s", $this->files_imported, $this->display_path($path)),
+            );
         }
 
         // Skip body/close for files being preserved
@@ -5952,18 +5886,14 @@ class ImportClient
             // Create parent directory if needed
             $dir = dirname($local_path);
             if (!is_dir($dir)) {
-                if ($custom_target) {
-                    @mkdir($dir, 0755, true);
-                } else {
-                    // Check if any component of the path exists as a file and remove it
-                    try {
-                        $this->ensure_directory_path($dir);
-                    } catch (PreserveLocalSkipException $e) {
-                        $context->skip_current_file = true;
-                        $this->audit_log($e->getMessage(), true);
-                        $this->show_progress_line("[skip] " . $this->display_path($path));
-                        return;
-                    }
+                // Check if any component of the path exists as a file and remove it
+                try {
+                    $this->ensure_directory_path($dir);
+                } catch (PreserveLocalSkipException $e) {
+                    $context->skip_current_file = true;
+                    $this->audit_log($e->getMessage(), true);
+                    $this->show_progress_line("[skip] " . $this->display_path($path));
+                    return;
                 }
             }
 
@@ -6011,44 +5941,41 @@ class ImportClient
                 touch($context->file_path, $context->file_ctime);
             }
 
-            if (!$custom_target) {
-                // Index update (JSON lines)
-                $file_size = (int) ($headers["x-file-size"] ?? 0);
-                $final_size = file_exists($context->file_path)
-                    ? filesize($context->file_path)
-                    : 0;
+            // Index update (JSON lines)
+            $file_size = (int) ($headers["x-file-size"] ?? 0);
+            $final_size = file_exists($context->file_path)
+                ? filesize($context->file_path)
+                : 0;
 
-                $file_changed = ($headers["x-file-changed"] ?? "0") === "1";
+            $file_changed = ($headers["x-file-changed"] ?? "0") === "1";
 
-                if ($context->file_ctime && !$file_changed) {
-                    $this->upsert_index_entry(
-                        $path,
-                        $context->file_ctime,
-                        $file_size,
-                        "file",
-                    );
-                    $this->files_imported++; // Count completed files only
-                    $this->clear_volatile_file($path);
-                    $this->audit_log(
-                        sprintf("  Indexed (wrote %d bytes)", $final_size),
-                        false,
-                    );
-                } elseif ($file_changed) {
-                    $this->audit_log(
-                        "  File changed during stream; index not updated",
-                        true,
-                    );
-                }
-
-                // Clear crash recovery tracking - file is complete
-                $this->state["current_file"] = null;
-                $this->state["current_file_bytes"] = null;
+            if ($context->file_ctime && !$file_changed) {
+                $this->upsert_index_entry(
+                    $path,
+                    $context->file_ctime,
+                    $file_size,
+                    "file",
+                );
+                $this->files_imported++; // Count completed files only
+                $this->clear_volatile_file($path);
+                $this->audit_log(
+                    sprintf("  Indexed (wrote %d bytes)", $final_size),
+                    false,
+                );
+            } elseif ($file_changed) {
+                $this->audit_log(
+                    "  File changed during stream; index not updated",
+                    true,
+                );
             }
 
             $context->file_handle = null;
             $context->file_path = null;
             $context->file_ctime = null;
             $context->file_bytes_written = 0;
+            // Clear crash recovery tracking - file is complete
+            $this->state["current_file"] = null;
+            $this->state["current_file_bytes"] = null;
         }
     }
 
@@ -7697,6 +7624,15 @@ class ImportClient
             }
         }
 
+        if (isset($data["runtime_files"]) && is_array($data["runtime_files"])) {
+            foreach ($data["runtime_files"] as $idx => $entry) {
+                if (!is_array($entry) || !array_key_exists("path", $entry)) {
+                    continue;
+                }
+                $data["runtime_files"][$idx]["path"] = $this->encode_state_path_value($entry["path"]);
+            }
+        }
+
         return $data;
     }
 
@@ -7771,6 +7707,15 @@ class ImportClient
                         $data["wp_content"]["roots"][$idx][$key] = $this->decode_state_path_value($root_entry[$key]);
                     }
                 }
+            }
+        }
+
+        if (isset($data["runtime_files"]) && is_array($data["runtime_files"])) {
+            foreach ($data["runtime_files"] as $idx => $entry) {
+                if (!is_array($entry) || !array_key_exists("path", $entry)) {
+                    continue;
+                }
+                $data["runtime_files"][$idx]["path"] = $this->decode_state_path_value($entry["path"]);
             }
         }
 
@@ -8073,9 +8018,6 @@ class StreamingContext
     public $saw_completion = false;
     // When true, skip writing the current file (preserve-local mode)
     public $skip_current_file = false;
-    // When set, file chunks are written under this directory instead of
-    // the import docroot, and index/state updates are skipped.
-    public $target_base_dir = null;
 }
 
 /**

--- a/importer/import.php
+++ b/importer/import.php
@@ -1753,8 +1753,10 @@ class ImportClient
 
     /**
      * Collect the filesystem paths of PHP runtime config files reported
-     * in the preflight response: the main php.ini, any scanned .ini
-     * files, and auto_prepend_file / auto_append_file.
+     * in the preflight response: the main php.ini and any scanned .ini
+     * files.  Values like auto_prepend_file and auto_append_file are
+     * already captured in ini_get_all so they don't need separate
+     * file downloads.
      *
      * @return array{files: string[], directories: string[]}
      *   - files: absolute paths of individual files to fetch
@@ -1767,11 +1769,9 @@ class ImportClient
 
         $files = [];
 
-        foreach (["php_ini", "auto_prepend_file", "auto_append_file"] as $key) {
-            $path = $runtime[$key] ?? "";
-            if (is_string($path) && $path !== "") {
-                $files[] = $path;
-            }
+        $php_ini = $runtime["php_ini"] ?? "";
+        if (is_string($php_ini) && $php_ini !== "") {
+            $files[] = $php_ini;
         }
 
         $scanned = $runtime["php_ini_scanned_files"] ?? "";
@@ -1800,8 +1800,8 @@ class ImportClient
     }
 
     /**
-     * Download PHP runtime configuration files (php.ini, scanned .ini
-     * files, auto_prepend_file, auto_append_file) into the state
+     * Download PHP runtime configuration files (php.ini and scanned .ini
+     * files) into the state
      * directory under runtime_files/.
      *
      * Uses the file_fetch endpoint with the parent directories of
@@ -7711,7 +7711,7 @@ class ImportClient
         }
 
         if (isset($data["runtime"]) && is_array($data["runtime"])) {
-            foreach (["php_ini", "auto_prepend_file", "auto_append_file", "temp_dir", "document_root", "script_filename", "cwd"] as $key) {
+            foreach (["php_ini", "temp_dir", "document_root", "script_filename", "cwd"] as $key) {
                 if (array_key_exists($key, $data["runtime"])) {
                     $data["runtime"][$key] = $this->encode_state_path_value($data["runtime"][$key]);
                 }
@@ -7788,7 +7788,7 @@ class ImportClient
         }
 
         if (isset($data["runtime"]) && is_array($data["runtime"])) {
-            foreach (["php_ini", "auto_prepend_file", "auto_append_file", "temp_dir", "document_root", "script_filename", "cwd"] as $key) {
+            foreach (["php_ini", "temp_dir", "document_root", "script_filename", "cwd"] as $key) {
                 if (array_key_exists($key, $data["runtime"])) {
                     $data["runtime"][$key] = $this->decode_state_path_value($data["runtime"][$key]);
                 }

--- a/tests/Import/RuntimeFilesTest.php
+++ b/tests/Import/RuntimeFilesTest.php
@@ -113,10 +113,10 @@ class RuntimeFilesTest extends TestCase
     }
 
     /**
-     * collect_runtime_file_paths() extracts php_ini and scanned ini files
-     * from the preflight runtime section.
+     * collect_runtime_file_paths() extracts auto_prepend_file and
+     * auto_append_file from ini_get_all.
      */
-    public function testCollectRuntimeFilePathsAllFields()
+    public function testCollectRuntimeFilePathsFromIniGetAll()
     {
         $this->writeState([
             "preflight" => [
@@ -124,8 +124,11 @@ class RuntimeFilesTest extends TestCase
                 "data" => [
                     "ok" => true,
                     "runtime" => [
-                        "php_ini" => "/etc/php/8.1/php.ini",
-                        "php_ini_scanned_files" => "/etc/php/8.1/conf.d/curl.ini, /etc/php/8.1/conf.d/gd.ini",
+                        "ini_get_all" => [
+                            "auto_prepend_file" => "/scripts/prepend.php",
+                            "auto_append_file" => "/scripts/append.php",
+                            "max_execution_time" => "30",
+                        ],
                     ],
                 ],
             ],
@@ -136,23 +139,16 @@ class RuntimeFilesTest extends TestCase
 
         $result = $this->callPrivate($client, 'collect_runtime_file_paths');
 
-        $this->assertEqualsCanonicalizing(
-            [
-                "/etc/php/8.1/php.ini",
-                "/etc/php/8.1/conf.d/curl.ini",
-                "/etc/php/8.1/conf.d/gd.ini",
-            ],
+        $this->assertEquals(
+            ["/scripts/prepend.php", "/scripts/append.php"],
             $result["files"],
         );
-
-        // Parent directories should be computed for each unique path.
-        $this->assertContains("/etc/php/8.1", $result["directories"]);
-        $this->assertContains("/etc/php/8.1/conf.d", $result["directories"]);
+        $this->assertContains("/scripts", $result["directories"]);
     }
 
     /**
-     * collect_runtime_file_paths() deduplicates paths — if php_ini and a
-     * scanned ini share the same path, it appears only once.
+     * collect_runtime_file_paths() deduplicates when prepend and append
+     * point to the same file.
      */
     public function testCollectRuntimeFilePathsDeduplicates()
     {
@@ -162,8 +158,10 @@ class RuntimeFilesTest extends TestCase
                 "data" => [
                     "ok" => true,
                     "runtime" => [
-                        "php_ini" => "/etc/php.ini",
-                        "php_ini_scanned_files" => "/etc/php.ini, /etc/conf.d/extra.ini",
+                        "ini_get_all" => [
+                            "auto_prepend_file" => "/scripts/shared.php",
+                            "auto_append_file" => "/scripts/shared.php",
+                        ],
                     ],
                 ],
             ],
@@ -174,11 +172,7 @@ class RuntimeFilesTest extends TestCase
 
         $result = $this->callPrivate($client, 'collect_runtime_file_paths');
 
-        // /etc/php.ini should appear only once despite being in both php_ini and scanned list.
-        $this->assertEquals(
-            ["/etc/php.ini", "/etc/conf.d/extra.ini"],
-            $result["files"],
-        );
+        $this->assertEquals(["/scripts/shared.php"], $result["files"]);
     }
 
     /**

--- a/tests/Import/RuntimeFilesTest.php
+++ b/tests/Import/RuntimeFilesTest.php
@@ -214,10 +214,10 @@ class RuntimeFilesTest extends TestCase
     }
 
     /**
-     * When preflight has no runtime paths, download_runtime_files() should
-     * not create the runtime_files/ directory.
+     * When preflight has no runtime section, the runtime_files/ directory
+     * is created but contains no files.
      */
-    public function testNoRuntimeFilesNoDirectory()
+    public function testNoRuntimeDataEmptyDirectory()
     {
         $this->writeState([
             "preflight" => [
@@ -232,7 +232,52 @@ class RuntimeFilesTest extends TestCase
         $this->loadClientState($client);
         $this->callPrivate($client, 'download_runtime_files');
 
-        $this->assertDirectoryDoesNotExist($this->stateDir . '/runtime_files');
+        $runtimeDir = $this->stateDir . '/runtime_files';
+        $this->assertDirectoryExists($runtimeDir);
+        // No ini_get_all.json since there's no runtime section at all.
+        $this->assertFileDoesNotExist($runtimeDir . '/ini_get_all.json');
+    }
+
+    /**
+     * ini_get_all data from the preflight response is written to
+     * runtime_files/ini_get_all.json.
+     */
+    public function testIniGetAllWrittenToFile()
+    {
+        $iniData = [
+            "max_execution_time" => [
+                "global_value" => "30",
+                "local_value" => "30",
+                "access" => 7,
+            ],
+            "memory_limit" => [
+                "global_value" => "128M",
+                "local_value" => "256M",
+                "access" => 7,
+            ],
+        ];
+
+        $this->writeState([
+            "preflight" => [
+                "http_code" => 200,
+                "data" => [
+                    "ok" => true,
+                    "runtime" => [
+                        "ini_get_all" => $iniData,
+                    ],
+                ],
+            ],
+        ]);
+
+        $client = $this->makeClient();
+        $this->loadClientState($client);
+        $this->callPrivate($client, 'download_runtime_files');
+
+        $path = $this->stateDir . '/runtime_files/ini_get_all.json';
+        $this->assertFileExists($path);
+
+        $written = json_decode(file_get_contents($path), true);
+        $this->assertEquals($iniData, $written);
     }
 
     /**

--- a/tests/Import/RuntimeFilesTest.php
+++ b/tests/Import/RuntimeFilesTest.php
@@ -7,18 +7,16 @@ use PHPUnit\Framework\TestCase;
 require_once __DIR__ . '/../../importer/import.php';
 
 /**
- * Tests for PHP runtime file path collection and directory management.
+ * Tests for auto_prepend/append script downloading during preflight.
  *
- * The import side reads runtime file paths (php.ini, scanned ini files,
- * auto_prepend/append scripts) from the preflight response and downloads
- * them via the file_fetch endpoint.  Since unit tests cannot hit a real
- * server, these tests cover:
+ * The import side reads auto_prepend_file and auto_append_file paths
+ * from ini_get_all in the preflight response and downloads them via
+ * the file_fetch endpoint into state_dir/runtime_files/.
  *
- * - collect_runtime_file_paths(): correct parsing of preflight runtime data
+ * Since unit tests cannot hit a real server, these tests cover:
  * - Directory wipe/create lifecycle of runtime_files/
- * - Graceful handling when no runtime paths are present
- * - Tolerance of fetch failures (the file_fetch call will fail against a
- *   fake URL, but download_runtime_files() must not throw)
+ * - Graceful handling when no scripts are configured
+ * - Tolerance of fetch failures
  */
 class RuntimeFilesTest extends TestCase
 {
@@ -103,9 +101,6 @@ class RuntimeFilesTest extends TestCase
         $p->setValue($client, $value);
     }
 
-    /**
-     * Load state from disk and assign to client's state property.
-     */
     private function loadClientState(\ImportClient $client): void
     {
         $state = $this->callPrivate($client, 'load_state');
@@ -113,11 +108,43 @@ class RuntimeFilesTest extends TestCase
     }
 
     /**
-     * collect_runtime_file_paths() extracts auto_prepend_file and
-     * auto_append_file from ini_get_all.
+     * When no auto_prepend/append scripts are configured, the
+     * runtime_files/ directory is not created.
      */
-    public function testCollectRuntimeFilePathsFromIniGetAll()
+    public function testNoScriptsNoDirectory()
     {
+        $this->writeState([
+            "preflight" => [
+                "http_code" => 200,
+                "data" => [
+                    "ok" => true,
+                    "runtime" => [
+                        "ini_get_all" => [
+                            "auto_prepend_file" => "",
+                            "auto_append_file" => "",
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $client = $this->makeClient();
+        $this->loadClientState($client);
+        $this->callPrivate($client, 'download_runtime_files');
+
+        $this->assertDirectoryDoesNotExist($this->stateDir . '/runtime_files');
+    }
+
+    /**
+     * download_runtime_files() wipes the existing runtime_files/ directory
+     * on re-run.
+     */
+    public function testRuntimeFilesDirWipedOnRerun()
+    {
+        $runtimeDir = $this->stateDir . '/runtime_files';
+        mkdir($runtimeDir . '/old', 0755, true);
+        file_put_contents($runtimeDir . '/old/stale.php', '<?php // old');
+
         $this->writeState([
             "preflight" => [
                 "http_code" => 200,
@@ -126,156 +153,8 @@ class RuntimeFilesTest extends TestCase
                     "runtime" => [
                         "ini_get_all" => [
                             "auto_prepend_file" => "/scripts/prepend.php",
-                            "auto_append_file" => "/scripts/append.php",
-                            "max_execution_time" => "30",
+                            "auto_append_file" => "",
                         ],
-                    ],
-                ],
-            ],
-        ]);
-
-        $client = $this->makeClient();
-        $this->loadClientState($client);
-
-        $result = $this->callPrivate($client, 'collect_runtime_file_paths');
-
-        $this->assertEquals(
-            ["/scripts/prepend.php", "/scripts/append.php"],
-            $result["files"],
-        );
-        $this->assertContains("/scripts", $result["directories"]);
-    }
-
-    /**
-     * collect_runtime_file_paths() deduplicates when prepend and append
-     * point to the same file.
-     */
-    public function testCollectRuntimeFilePathsDeduplicates()
-    {
-        $this->writeState([
-            "preflight" => [
-                "http_code" => 200,
-                "data" => [
-                    "ok" => true,
-                    "runtime" => [
-                        "ini_get_all" => [
-                            "auto_prepend_file" => "/scripts/shared.php",
-                            "auto_append_file" => "/scripts/shared.php",
-                        ],
-                    ],
-                ],
-            ],
-        ]);
-
-        $client = $this->makeClient();
-        $this->loadClientState($client);
-
-        $result = $this->callPrivate($client, 'collect_runtime_file_paths');
-
-        $this->assertEquals(["/scripts/shared.php"], $result["files"]);
-    }
-
-    /**
-     * collect_runtime_file_paths() returns empty arrays when no runtime
-     * section is present in preflight data.
-     */
-    public function testCollectRuntimeFilePathsEmpty()
-    {
-        $this->writeState([
-            "preflight" => [
-                "http_code" => 200,
-                "data" => [
-                    "ok" => true,
-                ],
-            ],
-        ]);
-
-        $client = $this->makeClient();
-        $this->loadClientState($client);
-
-        $result = $this->callPrivate($client, 'collect_runtime_file_paths');
-
-        $this->assertEmpty($result["files"]);
-        $this->assertEmpty($result["directories"]);
-    }
-
-    /**
-     * When preflight has no runtime section, the runtime_files/ directory
-     * is created but contains no files.
-     */
-    public function testNoRuntimeDataEmptyDirectory()
-    {
-        $this->writeState([
-            "preflight" => [
-                "http_code" => 200,
-                "data" => [
-                    "ok" => true,
-                ],
-            ],
-        ]);
-
-        $client = $this->makeClient();
-        $this->loadClientState($client);
-        $this->callPrivate($client, 'download_runtime_files');
-
-        $runtimeDir = $this->stateDir . '/runtime_files';
-        $this->assertDirectoryExists($runtimeDir);
-        // No ini_get_all.json since there's no runtime section at all.
-        $this->assertFileDoesNotExist($runtimeDir . '/ini_get_all.json');
-    }
-
-    /**
-     * ini_get_all data from the preflight response is written to
-     * runtime_files/ini_get_all.json.
-     */
-    public function testIniGetAllWrittenToFile()
-    {
-        // ini_get_all(null, false) returns scalar local values, not detailed arrays.
-        $iniData = [
-            "max_execution_time" => "30",
-            "memory_limit" => "256M",
-        ];
-
-        $this->writeState([
-            "preflight" => [
-                "http_code" => 200,
-                "data" => [
-                    "ok" => true,
-                    "runtime" => [
-                        "ini_get_all" => $iniData,
-                    ],
-                ],
-            ],
-        ]);
-
-        $client = $this->makeClient();
-        $this->loadClientState($client);
-        $this->callPrivate($client, 'download_runtime_files');
-
-        $path = $this->stateDir . '/runtime_files/ini_get_all.json';
-        $this->assertFileExists($path);
-
-        $written = json_decode(file_get_contents($path), true);
-        $this->assertEquals($iniData, $written);
-    }
-
-    /**
-     * download_runtime_files() wipes the existing runtime_files/ directory
-     * even when the fetch fails (which it will against a fake URL).
-     */
-    public function testRuntimeFilesDirWipedOnRerun()
-    {
-        $runtimeDir = $this->stateDir . '/runtime_files';
-        mkdir($runtimeDir . '/etc/old', 0755, true);
-        file_put_contents($runtimeDir . '/etc/old/stale.ini', 'stale content');
-
-        $this->writeState([
-            "preflight" => [
-                "http_code" => 200,
-                "data" => [
-                    "ok" => true,
-                    "runtime" => [
-                        "php_ini" => "/etc/php.ini",
                     ],
                 ],
             ],
@@ -286,17 +165,11 @@ class RuntimeFilesTest extends TestCase
         $this->callPrivate($client, 'download_runtime_files');
 
         // The old stale file should be gone because the directory was wiped.
-        $this->assertFileDoesNotExist($runtimeDir . '/etc/old/stale.ini');
-
-        // The runtime_files/ directory itself should exist (it was recreated
-        // because there are files to download, even though the fetch failed).
-        $this->assertDirectoryExists($runtimeDir);
+        $this->assertFileDoesNotExist($runtimeDir . '/old/stale.php');
     }
 
     /**
      * download_runtime_files() tolerates fetch failures without throwing.
-     * The file_fetch call against a fake URL will fail, but the method
-     * must catch the exception and continue.
      */
     public function testDownloadToleratesFetchFailure()
     {
@@ -306,8 +179,10 @@ class RuntimeFilesTest extends TestCase
                 "data" => [
                     "ok" => true,
                     "runtime" => [
-                        "php_ini" => "/etc/php/8.1/php.ini",
-                        "auto_prepend_file" => "/scripts/prepend.php",
+                        "ini_get_all" => [
+                            "auto_prepend_file" => "/scripts/prepend.php",
+                            "auto_append_file" => "/scripts/append.php",
+                        ],
                     ],
                 ],
             ],

--- a/tests/Import/RuntimeFilesTest.php
+++ b/tests/Import/RuntimeFilesTest.php
@@ -244,17 +244,10 @@ class RuntimeFilesTest extends TestCase
      */
     public function testIniGetAllWrittenToFile()
     {
+        // ini_get_all(null, false) returns scalar local values, not detailed arrays.
         $iniData = [
-            "max_execution_time" => [
-                "global_value" => "30",
-                "local_value" => "30",
-                "access" => 7,
-            ],
-            "memory_limit" => [
-                "global_value" => "128M",
-                "local_value" => "256M",
-                "access" => 7,
-            ],
+            "max_execution_time" => "30",
+            "memory_limit" => "256M",
         ];
 
         $this->writeState([

--- a/tests/Import/RuntimeFilesTest.php
+++ b/tests/Import/RuntimeFilesTest.php
@@ -113,9 +113,8 @@ class RuntimeFilesTest extends TestCase
     }
 
     /**
-     * collect_runtime_file_paths() extracts php_ini, auto_prepend_file,
-     * auto_append_file, and scanned ini files from the preflight runtime
-     * section.
+     * collect_runtime_file_paths() extracts php_ini and scanned ini files
+     * from the preflight runtime section.
      */
     public function testCollectRuntimeFilePathsAllFields()
     {
@@ -126,8 +125,6 @@ class RuntimeFilesTest extends TestCase
                     "ok" => true,
                     "runtime" => [
                         "php_ini" => "/etc/php/8.1/php.ini",
-                        "auto_prepend_file" => "/scripts/prepend.php",
-                        "auto_append_file" => "/scripts/append.php",
                         "php_ini_scanned_files" => "/etc/php/8.1/conf.d/curl.ini, /etc/php/8.1/conf.d/gd.ini",
                     ],
                 ],
@@ -142,8 +139,6 @@ class RuntimeFilesTest extends TestCase
         $this->assertEqualsCanonicalizing(
             [
                 "/etc/php/8.1/php.ini",
-                "/scripts/prepend.php",
-                "/scripts/append.php",
                 "/etc/php/8.1/conf.d/curl.ini",
                 "/etc/php/8.1/conf.d/gd.ini",
             ],
@@ -152,7 +147,6 @@ class RuntimeFilesTest extends TestCase
 
         // Parent directories should be computed for each unique path.
         $this->assertContains("/etc/php/8.1", $result["directories"]);
-        $this->assertContains("/scripts", $result["directories"]);
         $this->assertContains("/etc/php/8.1/conf.d", $result["directories"]);
     }
 
@@ -169,8 +163,6 @@ class RuntimeFilesTest extends TestCase
                     "ok" => true,
                     "runtime" => [
                         "php_ini" => "/etc/php.ini",
-                        "auto_prepend_file" => null,
-                        "auto_append_file" => "",
                         "php_ini_scanned_files" => "/etc/php.ini, /etc/conf.d/extra.ini",
                     ],
                 ],

--- a/tests/Import/RuntimeFilesTest.php
+++ b/tests/Import/RuntimeFilesTest.php
@@ -1,0 +1,302 @@
+<?php
+
+namespace ImportTests;
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../importer/import.php';
+
+/**
+ * Tests for PHP runtime file downloading during preflight.
+ *
+ * The export preflight includes a runtime_files array with
+ * base64-encoded contents of php.ini, scanned ini files,
+ * and auto_prepend/append scripts.  The import side writes
+ * these into state_dir/runtime_files/ preserving their
+ * original absolute paths.
+ */
+class RuntimeFilesTest extends TestCase
+{
+    private $tempDir;
+    private $stateDir;
+    private $docroot;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->tempDir = sys_get_temp_dir() . '/runtime-files-test-' . uniqid();
+        $this->stateDir = $this->tempDir . '/state';
+        $this->docroot = $this->tempDir . '/docroot';
+        mkdir($this->stateDir, 0755, true);
+        mkdir($this->docroot, 0755, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->recursiveDelete($this->tempDir);
+        parent::tearDown();
+    }
+
+    private function recursiveDelete(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        foreach (scandir($dir) as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $path = $dir . '/' . $item;
+            if (is_link($path)) {
+                unlink($path);
+            } elseif (is_dir($path)) {
+                $this->recursiveDelete($path);
+            } else {
+                unlink($path);
+            }
+        }
+        rmdir($dir);
+    }
+
+    private function makeClient(): \ImportClient
+    {
+        return new \ImportClient('http://fake.url', $this->stateDir, $this->docroot);
+    }
+
+    private function writeState(array $state): void
+    {
+        $defaults = [
+            "command" => null,
+            "status" => null,
+            "cursor" => null,
+            "stage" => null,
+            "preflight" => ["data" => ["ok" => true], "http_code" => 200],
+            "remote_protocol_version" => null,
+            "remote_protocol_min_version" => null,
+            "version" => null,
+            "follow_symlinks" => false,
+            "docroot_nonempty_behavior" => "error",
+            "max_allowed_packet" => null,
+        ];
+        file_put_contents(
+            $this->stateDir . '/.import-state.json',
+            json_encode(array_merge($defaults, $state), JSON_PRETTY_PRINT),
+        );
+    }
+
+    private function callPrivate(\ImportClient $client, string $method, array $args = [])
+    {
+        $reflection = new \ReflectionClass($client);
+        $m = $reflection->getMethod($method);
+        return $m->invoke($client, ...$args);
+    }
+
+    private function setPrivate(\ImportClient $client, string $property, $value): void
+    {
+        $reflection = new \ReflectionClass($client);
+        $p = $reflection->getProperty($property);
+        $p->setValue($client, $value);
+    }
+
+    /**
+     * Load state from disk and assign to client's state property.
+     */
+    private function loadClientState(\ImportClient $client): void
+    {
+        $state = $this->callPrivate($client, 'load_state');
+        $this->setPrivate($client, 'state', $state);
+    }
+
+    /**
+     * Runtime files from preflight are written to state_dir/runtime_files/
+     * preserving the original absolute path structure.
+     */
+    public function testRuntimeFilesWrittenFromPreflight()
+    {
+        $phpIniContent = "; PHP configuration\nmax_execution_time = 30\n";
+        $prependContent = "<?php // auto prepend\n";
+        $scannedContent = "extension=curl\n";
+
+        $this->writeState([
+            "preflight" => [
+                "http_code" => 200,
+                "data" => [
+                    "ok" => true,
+                    "runtime_files" => [
+                        [
+                            "path" => "/etc/php/8.1/php.ini",
+                            "content" => base64_encode($phpIniContent),
+                            "size" => strlen($phpIniContent),
+                            "error" => null,
+                        ],
+                        [
+                            "path" => "/scripts/env.php",
+                            "content" => base64_encode($prependContent),
+                            "size" => strlen($prependContent),
+                            "error" => null,
+                        ],
+                        [
+                            "path" => "/etc/php/8.1/conf.d/curl.ini",
+                            "content" => base64_encode($scannedContent),
+                            "size" => strlen($scannedContent),
+                            "error" => null,
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $client = $this->makeClient();
+        $this->loadClientState($client);
+        $this->callPrivate($client, 'download_runtime_files');
+
+        $runtimeDir = $this->stateDir . '/runtime_files';
+        $this->assertDirectoryExists($runtimeDir);
+
+        $phpIniPath = $runtimeDir . '/etc/php/8.1/php.ini';
+        $this->assertFileExists($phpIniPath);
+        $this->assertEquals($phpIniContent, file_get_contents($phpIniPath));
+
+        $prependPath = $runtimeDir . '/scripts/env.php';
+        $this->assertFileExists($prependPath);
+        $this->assertEquals($prependContent, file_get_contents($prependPath));
+
+        $curlIniPath = $runtimeDir . '/etc/php/8.1/conf.d/curl.ini';
+        $this->assertFileExists($curlIniPath);
+        $this->assertEquals($scannedContent, file_get_contents($curlIniPath));
+    }
+
+    /**
+     * Entries with errors in the preflight data are skipped gracefully.
+     */
+    public function testRuntimeFilesSkipsErrors()
+    {
+        $goodContent = "extension=gd\n";
+
+        $this->writeState([
+            "preflight" => [
+                "http_code" => 200,
+                "data" => [
+                    "ok" => true,
+                    "runtime_files" => [
+                        [
+                            "path" => "/etc/php/unreadable.ini",
+                            "content" => null,
+                            "size" => null,
+                            "error" => "not readable",
+                        ],
+                        [
+                            "path" => "/etc/php/8.1/conf.d/gd.ini",
+                            "content" => base64_encode($goodContent),
+                            "size" => strlen($goodContent),
+                            "error" => null,
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $client = $this->makeClient();
+        $this->loadClientState($client);
+        $this->callPrivate($client, 'download_runtime_files');
+
+        $runtimeDir = $this->stateDir . '/runtime_files';
+
+        // Errored file should not exist
+        $this->assertFileDoesNotExist($runtimeDir . '/etc/php/unreadable.ini');
+
+        // Good file should exist
+        $gdPath = $runtimeDir . '/etc/php/8.1/conf.d/gd.ini';
+        $this->assertFileExists($gdPath);
+        $this->assertEquals($goodContent, file_get_contents($gdPath));
+    }
+
+    /**
+     * Re-running preflight wipes and recreates runtime_files/.
+     */
+    public function testRuntimeFilesWipedOnRerun()
+    {
+        $content = "max_execution_time = 60\n";
+
+        $this->writeState([
+            "preflight" => [
+                "http_code" => 200,
+                "data" => [
+                    "ok" => true,
+                    "runtime_files" => [
+                        [
+                            "path" => "/etc/php.ini",
+                            "content" => base64_encode("old content"),
+                            "size" => 11,
+                            "error" => null,
+                        ],
+                        [
+                            "path" => "/etc/old-file.ini",
+                            "content" => base64_encode("stale"),
+                            "size" => 5,
+                            "error" => null,
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        // First run
+        $client = $this->makeClient();
+        $this->loadClientState($client);
+        $this->callPrivate($client, 'download_runtime_files');
+
+        $runtimeDir = $this->stateDir . '/runtime_files';
+        $this->assertFileExists($runtimeDir . '/etc/php.ini');
+        $this->assertFileExists($runtimeDir . '/etc/old-file.ini');
+
+        // Simulate a second preflight with different files
+        $this->writeState([
+            "preflight" => [
+                "http_code" => 200,
+                "data" => [
+                    "ok" => true,
+                    "runtime_files" => [
+                        [
+                            "path" => "/etc/php.ini",
+                            "content" => base64_encode($content),
+                            "size" => strlen($content),
+                            "error" => null,
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $client2 = $this->makeClient();
+        $this->loadClientState($client2);
+        $this->callPrivate($client2, 'download_runtime_files');
+
+        // New content should be there
+        $this->assertEquals($content, file_get_contents($runtimeDir . '/etc/php.ini'));
+
+        // Old stale file should be gone
+        $this->assertFileDoesNotExist($runtimeDir . '/etc/old-file.ini');
+    }
+
+    /**
+     * When preflight has no runtime_files, the directory should not be created.
+     */
+    public function testNoRuntimeFilesNoDirectory()
+    {
+        $this->writeState([
+            "preflight" => [
+                "http_code" => 200,
+                "data" => [
+                    "ok" => true,
+                ],
+            ],
+        ]);
+
+        $client = $this->makeClient();
+        $this->loadClientState($client);
+        $this->callPrivate($client, 'download_runtime_files');
+
+        $this->assertDirectoryDoesNotExist($this->stateDir . '/runtime_files');
+    }
+}

--- a/tests/Import/RuntimeFilesTest.php
+++ b/tests/Import/RuntimeFilesTest.php
@@ -7,13 +7,18 @@ use PHPUnit\Framework\TestCase;
 require_once __DIR__ . '/../../importer/import.php';
 
 /**
- * Tests for PHP runtime file downloading during preflight.
+ * Tests for PHP runtime file path collection and directory management.
  *
- * The export preflight includes a runtime_files array with
- * base64-encoded contents of php.ini, scanned ini files,
- * and auto_prepend/append scripts.  The import side writes
- * these into state_dir/runtime_files/ preserving their
- * original absolute paths.
+ * The import side reads runtime file paths (php.ini, scanned ini files,
+ * auto_prepend/append scripts) from the preflight response and downloads
+ * them via the file_fetch endpoint.  Since unit tests cannot hit a real
+ * server, these tests cover:
+ *
+ * - collect_runtime_file_paths(): correct parsing of preflight runtime data
+ * - Directory wipe/create lifecycle of runtime_files/
+ * - Graceful handling when no runtime paths are present
+ * - Tolerance of fetch failures (the file_fetch call will fail against a
+ *   fake URL, but download_runtime_files() must not throw)
  */
 class RuntimeFilesTest extends TestCase
 {
@@ -108,39 +113,22 @@ class RuntimeFilesTest extends TestCase
     }
 
     /**
-     * Runtime files from preflight are written to state_dir/runtime_files/
-     * preserving the original absolute path structure.
+     * collect_runtime_file_paths() extracts php_ini, auto_prepend_file,
+     * auto_append_file, and scanned ini files from the preflight runtime
+     * section.
      */
-    public function testRuntimeFilesWrittenFromPreflight()
+    public function testCollectRuntimeFilePathsAllFields()
     {
-        $phpIniContent = "; PHP configuration\nmax_execution_time = 30\n";
-        $prependContent = "<?php // auto prepend\n";
-        $scannedContent = "extension=curl\n";
-
         $this->writeState([
             "preflight" => [
                 "http_code" => 200,
                 "data" => [
                     "ok" => true,
-                    "runtime_files" => [
-                        [
-                            "path" => "/etc/php/8.1/php.ini",
-                            "content" => base64_encode($phpIniContent),
-                            "size" => strlen($phpIniContent),
-                            "error" => null,
-                        ],
-                        [
-                            "path" => "/scripts/env.php",
-                            "content" => base64_encode($prependContent),
-                            "size" => strlen($prependContent),
-                            "error" => null,
-                        ],
-                        [
-                            "path" => "/etc/php/8.1/conf.d/curl.ini",
-                            "content" => base64_encode($scannedContent),
-                            "size" => strlen($scannedContent),
-                            "error" => null,
-                        ],
+                    "runtime" => [
+                        "php_ini" => "/etc/php/8.1/php.ini",
+                        "auto_prepend_file" => "/scripts/prepend.php",
+                        "auto_append_file" => "/scripts/append.php",
+                        "php_ini_scanned_files" => "/etc/php/8.1/conf.d/curl.ini, /etc/php/8.1/conf.d/gd.ini",
                     ],
                 ],
             ],
@@ -148,49 +136,42 @@ class RuntimeFilesTest extends TestCase
 
         $client = $this->makeClient();
         $this->loadClientState($client);
-        $this->callPrivate($client, 'download_runtime_files');
 
-        $runtimeDir = $this->stateDir . '/runtime_files';
-        $this->assertDirectoryExists($runtimeDir);
+        $result = $this->callPrivate($client, 'collect_runtime_file_paths');
 
-        $phpIniPath = $runtimeDir . '/etc/php/8.1/php.ini';
-        $this->assertFileExists($phpIniPath);
-        $this->assertEquals($phpIniContent, file_get_contents($phpIniPath));
+        $this->assertEqualsCanonicalizing(
+            [
+                "/etc/php/8.1/php.ini",
+                "/scripts/prepend.php",
+                "/scripts/append.php",
+                "/etc/php/8.1/conf.d/curl.ini",
+                "/etc/php/8.1/conf.d/gd.ini",
+            ],
+            $result["files"],
+        );
 
-        $prependPath = $runtimeDir . '/scripts/env.php';
-        $this->assertFileExists($prependPath);
-        $this->assertEquals($prependContent, file_get_contents($prependPath));
-
-        $curlIniPath = $runtimeDir . '/etc/php/8.1/conf.d/curl.ini';
-        $this->assertFileExists($curlIniPath);
-        $this->assertEquals($scannedContent, file_get_contents($curlIniPath));
+        // Parent directories should be computed for each unique path.
+        $this->assertContains("/etc/php/8.1", $result["directories"]);
+        $this->assertContains("/scripts", $result["directories"]);
+        $this->assertContains("/etc/php/8.1/conf.d", $result["directories"]);
     }
 
     /**
-     * Entries with errors in the preflight data are skipped gracefully.
+     * collect_runtime_file_paths() deduplicates paths — if php_ini and a
+     * scanned ini share the same path, it appears only once.
      */
-    public function testRuntimeFilesSkipsErrors()
+    public function testCollectRuntimeFilePathsDeduplicates()
     {
-        $goodContent = "extension=gd\n";
-
         $this->writeState([
             "preflight" => [
                 "http_code" => 200,
                 "data" => [
                     "ok" => true,
-                    "runtime_files" => [
-                        [
-                            "path" => "/etc/php/unreadable.ini",
-                            "content" => null,
-                            "size" => null,
-                            "error" => "not readable",
-                        ],
-                        [
-                            "path" => "/etc/php/8.1/conf.d/gd.ini",
-                            "content" => base64_encode($goodContent),
-                            "size" => strlen($goodContent),
-                            "error" => null,
-                        ],
+                    "runtime" => [
+                        "php_ini" => "/etc/php.ini",
+                        "auto_prepend_file" => null,
+                        "auto_append_file" => "",
+                        "php_ini_scanned_files" => "/etc/php.ini, /etc/conf.d/extra.ini",
                     ],
                 ],
             ],
@@ -198,89 +179,43 @@ class RuntimeFilesTest extends TestCase
 
         $client = $this->makeClient();
         $this->loadClientState($client);
-        $this->callPrivate($client, 'download_runtime_files');
 
-        $runtimeDir = $this->stateDir . '/runtime_files';
+        $result = $this->callPrivate($client, 'collect_runtime_file_paths');
 
-        // Errored file should not exist
-        $this->assertFileDoesNotExist($runtimeDir . '/etc/php/unreadable.ini');
-
-        // Good file should exist
-        $gdPath = $runtimeDir . '/etc/php/8.1/conf.d/gd.ini';
-        $this->assertFileExists($gdPath);
-        $this->assertEquals($goodContent, file_get_contents($gdPath));
+        // /etc/php.ini should appear only once despite being in both php_ini and scanned list.
+        $this->assertEquals(
+            ["/etc/php.ini", "/etc/conf.d/extra.ini"],
+            $result["files"],
+        );
     }
 
     /**
-     * Re-running preflight wipes and recreates runtime_files/.
+     * collect_runtime_file_paths() returns empty arrays when no runtime
+     * section is present in preflight data.
      */
-    public function testRuntimeFilesWipedOnRerun()
+    public function testCollectRuntimeFilePathsEmpty()
     {
-        $content = "max_execution_time = 60\n";
-
         $this->writeState([
             "preflight" => [
                 "http_code" => 200,
                 "data" => [
                     "ok" => true,
-                    "runtime_files" => [
-                        [
-                            "path" => "/etc/php.ini",
-                            "content" => base64_encode("old content"),
-                            "size" => 11,
-                            "error" => null,
-                        ],
-                        [
-                            "path" => "/etc/old-file.ini",
-                            "content" => base64_encode("stale"),
-                            "size" => 5,
-                            "error" => null,
-                        ],
-                    ],
                 ],
             ],
         ]);
 
-        // First run
         $client = $this->makeClient();
         $this->loadClientState($client);
-        $this->callPrivate($client, 'download_runtime_files');
 
-        $runtimeDir = $this->stateDir . '/runtime_files';
-        $this->assertFileExists($runtimeDir . '/etc/php.ini');
-        $this->assertFileExists($runtimeDir . '/etc/old-file.ini');
+        $result = $this->callPrivate($client, 'collect_runtime_file_paths');
 
-        // Simulate a second preflight with different files
-        $this->writeState([
-            "preflight" => [
-                "http_code" => 200,
-                "data" => [
-                    "ok" => true,
-                    "runtime_files" => [
-                        [
-                            "path" => "/etc/php.ini",
-                            "content" => base64_encode($content),
-                            "size" => strlen($content),
-                            "error" => null,
-                        ],
-                    ],
-                ],
-            ],
-        ]);
-
-        $client2 = $this->makeClient();
-        $this->loadClientState($client2);
-        $this->callPrivate($client2, 'download_runtime_files');
-
-        // New content should be there
-        $this->assertEquals($content, file_get_contents($runtimeDir . '/etc/php.ini'));
-
-        // Old stale file should be gone
-        $this->assertFileDoesNotExist($runtimeDir . '/etc/old-file.ini');
+        $this->assertEmpty($result["files"]);
+        $this->assertEmpty($result["directories"]);
     }
 
     /**
-     * When preflight has no runtime_files, the directory should not be created.
+     * When preflight has no runtime paths, download_runtime_files() should
+     * not create the runtime_files/ directory.
      */
     public function testNoRuntimeFilesNoDirectory()
     {
@@ -298,5 +233,69 @@ class RuntimeFilesTest extends TestCase
         $this->callPrivate($client, 'download_runtime_files');
 
         $this->assertDirectoryDoesNotExist($this->stateDir . '/runtime_files');
+    }
+
+    /**
+     * download_runtime_files() wipes the existing runtime_files/ directory
+     * even when the fetch fails (which it will against a fake URL).
+     */
+    public function testRuntimeFilesDirWipedOnRerun()
+    {
+        $runtimeDir = $this->stateDir . '/runtime_files';
+        mkdir($runtimeDir . '/etc/old', 0755, true);
+        file_put_contents($runtimeDir . '/etc/old/stale.ini', 'stale content');
+
+        $this->writeState([
+            "preflight" => [
+                "http_code" => 200,
+                "data" => [
+                    "ok" => true,
+                    "runtime" => [
+                        "php_ini" => "/etc/php.ini",
+                    ],
+                ],
+            ],
+        ]);
+
+        $client = $this->makeClient();
+        $this->loadClientState($client);
+        $this->callPrivate($client, 'download_runtime_files');
+
+        // The old stale file should be gone because the directory was wiped.
+        $this->assertFileDoesNotExist($runtimeDir . '/etc/old/stale.ini');
+
+        // The runtime_files/ directory itself should exist (it was recreated
+        // because there are files to download, even though the fetch failed).
+        $this->assertDirectoryExists($runtimeDir);
+    }
+
+    /**
+     * download_runtime_files() tolerates fetch failures without throwing.
+     * The file_fetch call against a fake URL will fail, but the method
+     * must catch the exception and continue.
+     */
+    public function testDownloadToleratesFetchFailure()
+    {
+        $this->writeState([
+            "preflight" => [
+                "http_code" => 200,
+                "data" => [
+                    "ok" => true,
+                    "runtime" => [
+                        "php_ini" => "/etc/php/8.1/php.ini",
+                        "auto_prepend_file" => "/scripts/prepend.php",
+                    ],
+                ],
+            ],
+        ]);
+
+        $client = $this->makeClient();
+        $this->loadClientState($client);
+
+        // This must not throw — failures are caught internally.
+        $this->callPrivate($client, 'download_runtime_files');
+
+        // The directory should exist even though no files were downloaded.
+        $this->assertDirectoryExists($this->stateDir . '/runtime_files');
     }
 }

--- a/tests/e2e/tests/import-33-preflight-state-path-encoding.test.js
+++ b/tests/e2e/tests/import-33-preflight-state-path-encoding.test.js
@@ -67,18 +67,9 @@ describe('Import: Preflight state path encoding', () => {
         }
 
         const runtime = data.runtime || {};
-        for (const key of ['php_ini', 'temp_dir', 'document_root', 'script_filename', 'cwd']) {
+        for (const key of ['temp_dir', 'document_root', 'script_filename', 'cwd']) {
             if (typeof runtime[key] === 'string') {
                 assertEncoded(runtime[key], `runtime.${key}`);
-            }
-        }
-
-        // php_ini_scanned_files is a comma-separated list of base64-encoded paths.
-        if (typeof runtime.php_ini_scanned_files === 'string' && runtime.php_ini_scanned_files !== '') {
-            const parts = runtime.php_ini_scanned_files.split(',').map(s => s.trim()).filter(Boolean);
-            assert.ok(parts.length > 0, 'Expected at least one scanned ini file');
-            for (const [idx, part] of parts.entries()) {
-                assertEncoded(part, `runtime.php_ini_scanned_files[${idx}]`);
             }
         }
 

--- a/tests/e2e/tests/import-33-preflight-state-path-encoding.test.js
+++ b/tests/e2e/tests/import-33-preflight-state-path-encoding.test.js
@@ -67,7 +67,7 @@ describe('Import: Preflight state path encoding', () => {
         }
 
         const runtime = data.runtime || {};
-        for (const key of ['php_ini', 'temp_dir', 'document_root', 'script_filename', 'cwd']) {
+        for (const key of ['php_ini', 'auto_prepend_file', 'auto_append_file', 'temp_dir', 'document_root', 'script_filename', 'cwd']) {
             if (typeof runtime[key] === 'string') {
                 assertEncoded(runtime[key], `runtime.${key}`);
             }

--- a/tests/e2e/tests/import-33-preflight-state-path-encoding.test.js
+++ b/tests/e2e/tests/import-33-preflight-state-path-encoding.test.js
@@ -67,7 +67,7 @@ describe('Import: Preflight state path encoding', () => {
         }
 
         const runtime = data.runtime || {};
-        for (const key of ['php_ini', 'auto_prepend_file', 'auto_append_file', 'temp_dir', 'document_root', 'script_filename', 'cwd']) {
+        for (const key of ['php_ini', 'temp_dir', 'document_root', 'script_filename', 'cwd']) {
             if (typeof runtime[key] === 'string') {
                 assertEncoded(runtime[key], `runtime.${key}`);
             }

--- a/tests/e2e/tests/import-33-preflight-state-path-encoding.test.js
+++ b/tests/e2e/tests/import-33-preflight-state-path-encoding.test.js
@@ -73,6 +73,21 @@ describe('Import: Preflight state path encoding', () => {
             }
         }
 
+        // php_ini_scanned_files is a comma-separated list of base64-encoded paths.
+        if (typeof runtime.php_ini_scanned_files === 'string' && runtime.php_ini_scanned_files !== '') {
+            const parts = runtime.php_ini_scanned_files.split(',').map(s => s.trim()).filter(Boolean);
+            assert.ok(parts.length > 0, 'Expected at least one scanned ini file');
+            for (const [idx, part] of parts.entries()) {
+                assertEncoded(part, `runtime.php_ini_scanned_files[${idx}]`);
+            }
+        }
+
+        // ini_get_all is NOT a path field — it should be a plain object, not encoded.
+        assert.ok(
+            typeof runtime.ini_get_all === 'object' && runtime.ini_get_all !== null,
+            'runtime.ini_get_all should be a plain object (not base64-encoded)'
+        );
+
         const directories = data.filesystem?.directories || [];
         assert.ok(Array.isArray(directories) && directories.length > 0, 'Expected filesystem.directories entries');
         for (const [idx, dir] of directories.entries()) {

--- a/tests/e2e/tests/import-39-runtime-files.test.js
+++ b/tests/e2e/tests/import-39-runtime-files.test.js
@@ -81,27 +81,14 @@ describe('Import: Runtime files', () => {
         assert.deepEqual(fileKeys, stateKeys, 'ini_get_all.json keys should match state keys');
     });
 
-    it('reports auto_prepend_file and auto_append_file in preflight', () => {
-        const state = JSON.parse(readFileSync(join(tempDir, '.import-state.json'), 'utf-8'));
-        const runtime = state.preflight?.data?.runtime;
-        assert.ok(runtime, 'preflight state should contain runtime section');
+    it('ini_get_all includes auto_prepend_file and auto_append_file directives', () => {
+        const iniPath = join(tempDir, 'runtime_files', 'ini_get_all.json');
+        const iniData = JSON.parse(readFileSync(iniPath, 'utf-8'));
 
-        // These fields must be present in the runtime section (even if null).
-        assert.ok('auto_prepend_file' in runtime, 'runtime should have auto_prepend_file field');
-        assert.ok('auto_append_file' in runtime, 'runtime should have auto_append_file field');
-
-        // In the default e2e environment these are typically not set.
-        // If they are set, the value should be a base64-encoded path string.
-        for (const key of ['auto_prepend_file', 'auto_append_file']) {
-            const value = runtime[key];
-            if (value !== null) {
-                assert.equal(typeof value, 'string', `runtime.${key} should be a string or null`);
-                assert.ok(
-                    value.startsWith('base64:'),
-                    `runtime.${key} should be base64-encoded when set, got: ${value}`
-                );
-            }
-        }
+        // These directives should always be present in ini_get_all,
+        // even when empty — they're part of core PHP configuration.
+        assert.ok('auto_prepend_file' in iniData, 'ini_get_all should contain auto_prepend_file');
+        assert.ok('auto_append_file' in iniData, 'ini_get_all should contain auto_append_file');
     });
 
     it('audit log records runtime file activity', () => {

--- a/tests/e2e/tests/import-39-runtime-files.test.js
+++ b/tests/e2e/tests/import-39-runtime-files.test.js
@@ -1,0 +1,135 @@
+/**
+ * Test 39: Runtime files (ini_get_all and auto_prepend/append)
+ *
+ * Verifies that after preflight:
+ * - runtime_files/ directory is created in the state directory
+ * - ini_get_all.json is written with the full computed PHP configuration
+ * - auto_prepend_file and auto_append_file are reported in preflight data
+ *   (and downloaded when accessible, or absent when not set)
+ * - Re-running preflight wipes and recreates runtime_files/
+ */
+import { describe, it, beforeAll, afterAll } from 'vitest';
+import assert from 'node:assert/strict';
+import { readFileSync, existsSync, readdirSync, writeFileSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+    runImporter, createTempDir, cleanupTempDir,
+    getSiteUrl, getSiteSecret, getSiteDir, readAuditLog,
+} from '../lib/test-helpers.js';
+import { ensureSite } from '../lib/site-setup.js';
+
+describe('Import: Runtime files', () => {
+    const site = 'basic';
+    let tempDir;
+
+    function importUrlWithDirectory() {
+        return `${getSiteUrl(site)}&directory=${getSiteDir(site)}`;
+    }
+
+    beforeAll(async () => {
+        await ensureSite(site);
+        tempDir = createTempDir('e2e-runtime-files');
+
+        const result = runImporter(importUrlWithDirectory(), tempDir, 'preflight', {
+            secret: getSiteSecret(site),
+        });
+        assert.equal(result.exitCode, 0, `Expected exit 0\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);
+    });
+
+    afterAll(() => {
+        cleanupTempDir(tempDir);
+    });
+
+    it('creates runtime_files/ directory', () => {
+        const runtimeDir = join(tempDir, 'runtime_files');
+        assert.ok(existsSync(runtimeDir), 'runtime_files/ directory should exist after preflight');
+    });
+
+    it('writes ini_get_all.json with valid INI directives', () => {
+        const iniPath = join(tempDir, 'runtime_files', 'ini_get_all.json');
+        assert.ok(existsSync(iniPath), 'ini_get_all.json should exist');
+
+        const iniData = JSON.parse(readFileSync(iniPath, 'utf-8'));
+        assert.equal(typeof iniData, 'object', 'ini_get_all.json should be an object');
+
+        // Every PHP installation has these core directives.
+        assert.ok('max_execution_time' in iniData, 'Should contain max_execution_time');
+        assert.ok('memory_limit' in iniData, 'Should contain memory_limit');
+        assert.ok('error_reporting' in iniData, 'Should contain error_reporting');
+        assert.ok('upload_max_filesize' in iniData, 'Should contain upload_max_filesize');
+
+        // Each directive should have global_value, local_value, access.
+        const entry = iniData['max_execution_time'];
+        assert.ok('global_value' in entry, 'INI entry should have global_value');
+        assert.ok('local_value' in entry, 'INI entry should have local_value');
+        assert.ok('access' in entry, 'INI entry should have access');
+    });
+
+    it('ini_get_all.json matches preflight state data', () => {
+        const state = JSON.parse(readFileSync(join(tempDir, '.import-state.json'), 'utf-8'));
+        const stateIni = state.preflight?.data?.runtime?.ini_get_all;
+        assert.ok(stateIni, 'preflight state should contain runtime.ini_get_all');
+
+        const fileIni = JSON.parse(
+            readFileSync(join(tempDir, 'runtime_files', 'ini_get_all.json'), 'utf-8')
+        );
+
+        // The file should contain the same directives as the state.
+        // State values may be base64-encoded for path fields, but ini_get_all
+        // values are not paths so they should match directly.
+        const stateKeys = Object.keys(stateIni).sort();
+        const fileKeys = Object.keys(fileIni).sort();
+        assert.deepEqual(fileKeys, stateKeys, 'ini_get_all.json keys should match state keys');
+    });
+
+    it('reports auto_prepend_file and auto_append_file in preflight', () => {
+        const state = JSON.parse(readFileSync(join(tempDir, '.import-state.json'), 'utf-8'));
+        const runtime = state.preflight?.data?.runtime;
+        assert.ok(runtime, 'preflight state should contain runtime section');
+
+        // These fields must be present in the runtime section (even if null).
+        assert.ok('auto_prepend_file' in runtime, 'runtime should have auto_prepend_file field');
+        assert.ok('auto_append_file' in runtime, 'runtime should have auto_append_file field');
+
+        // In the default e2e environment these are typically not set.
+        // If they are set, the value should be a base64-encoded path string.
+        for (const key of ['auto_prepend_file', 'auto_append_file']) {
+            const value = runtime[key];
+            if (value !== null) {
+                assert.equal(typeof value, 'string', `runtime.${key} should be a string or null`);
+                assert.ok(
+                    value.startsWith('base64:'),
+                    `runtime.${key} should be base64-encoded when set, got: ${value}`
+                );
+            }
+        }
+    });
+
+    it('audit log records runtime file activity', () => {
+        const log = readAuditLog(tempDir);
+        assert.ok(log.includes('RUNTIME FILES'), 'Audit log should mention RUNTIME FILES');
+        assert.ok(log.includes('ini_get_all.json'), 'Audit log should mention ini_get_all.json');
+    });
+
+    it('wipes runtime_files/ on preflight re-run', () => {
+        const runtimeDir = join(tempDir, 'runtime_files');
+
+        // Plant a stale file that should be removed on re-run.
+        const staleDir = join(runtimeDir, 'stale');
+        mkdirSync(staleDir, { recursive: true });
+        writeFileSync(join(staleDir, 'old.ini'), 'should be deleted');
+        assert.ok(existsSync(join(staleDir, 'old.ini')), 'Stale file should exist before re-run');
+
+        // Re-run preflight.
+        const result = runImporter(importUrlWithDirectory(), tempDir, 'preflight', {
+            secret: getSiteSecret(site),
+        });
+        assert.equal(result.exitCode, 0, `Expected exit 0\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);
+
+        // Stale file should be gone.
+        assert.ok(!existsSync(join(staleDir, 'old.ini')), 'Stale file should be removed after preflight re-run');
+
+        // But ini_get_all.json should be freshly written.
+        assert.ok(existsSync(join(runtimeDir, 'ini_get_all.json')), 'ini_get_all.json should exist after re-run');
+    });
+});

--- a/tests/e2e/tests/import-39-runtime-files.test.js
+++ b/tests/e2e/tests/import-39-runtime-files.test.js
@@ -1,16 +1,14 @@
 /**
- * Test 39: Runtime files (ini_get_all and auto_prepend/append)
+ * Test 39: Runtime files (ini_get_all, auto_prepend/append scripts)
  *
  * Verifies that after preflight:
- * - runtime_files/ directory is created in the state directory
- * - ini_get_all.json is written with the full computed PHP configuration
- * - auto_prepend_file and auto_append_file are reported in preflight data
- *   (and downloaded when accessible, or absent when not set)
+ * - ini_get_all is stored in preflight state with all PHP directives
+ * - auto_prepend_file and auto_append_file values are captured
  * - Re-running preflight wipes and recreates runtime_files/
  */
 import { describe, it, beforeAll, afterAll } from 'vitest';
 import assert from 'node:assert/strict';
-import { readFileSync, existsSync, readdirSync, writeFileSync, mkdirSync } from 'node:fs';
+import { readFileSync, existsSync, writeFileSync, mkdirSync } from 'node:fs';
 import { join } from 'node:path';
 import {
     runImporter, createTempDir, cleanupTempDir,
@@ -40,71 +38,45 @@ describe('Import: Runtime files', () => {
         cleanupTempDir(tempDir);
     });
 
-    it('creates runtime_files/ directory', () => {
-        const runtimeDir = join(tempDir, 'runtime_files');
-        assert.ok(existsSync(runtimeDir), 'runtime_files/ directory should exist after preflight');
-    });
-
-    it('writes ini_get_all.json with valid INI directives', () => {
-        const iniPath = join(tempDir, 'runtime_files', 'ini_get_all.json');
-        assert.ok(existsSync(iniPath), 'ini_get_all.json should exist');
-
-        const iniData = JSON.parse(readFileSync(iniPath, 'utf-8'));
-        assert.equal(typeof iniData, 'object', 'ini_get_all.json should be an object');
+    it('preflight state contains ini_get_all with core PHP directives', () => {
+        const state = JSON.parse(readFileSync(join(tempDir, '.import-state.json'), 'utf-8'));
+        const iniAll = state.preflight?.data?.runtime?.ini_get_all;
+        assert.ok(iniAll && typeof iniAll === 'object', 'runtime.ini_get_all should be an object');
 
         // Every PHP installation has these core directives.
-        assert.ok('max_execution_time' in iniData, 'Should contain max_execution_time');
-        assert.ok('memory_limit' in iniData, 'Should contain memory_limit');
-        assert.ok('error_reporting' in iniData, 'Should contain error_reporting');
-        assert.ok('upload_max_filesize' in iniData, 'Should contain upload_max_filesize');
+        assert.ok('max_execution_time' in iniAll, 'Should contain max_execution_time');
+        assert.ok('memory_limit' in iniAll, 'Should contain memory_limit');
+        assert.ok('error_reporting' in iniAll, 'Should contain error_reporting');
+        assert.ok('upload_max_filesize' in iniAll, 'Should contain upload_max_filesize');
 
-        // ini_get_all(null, false) returns scalar values (local value only),
-        // not the detailed {global_value, local_value, access} objects.
-        const entry = iniData['max_execution_time'];
+        // ini_get_all(null, false) returns scalar values (local value only).
+        const entry = iniAll['max_execution_time'];
         assert.equal(typeof entry, 'string', 'INI values should be strings (local value)');
     });
 
-    it('ini_get_all.json matches preflight state data', () => {
-        const state = JSON.parse(readFileSync(join(tempDir, '.import-state.json'), 'utf-8'));
-        const stateIni = state.preflight?.data?.runtime?.ini_get_all;
-        assert.ok(stateIni, 'preflight state should contain runtime.ini_get_all');
-
-        const fileIni = JSON.parse(
-            readFileSync(join(tempDir, 'runtime_files', 'ini_get_all.json'), 'utf-8')
-        );
-
-        // The file should contain the same directives as the state.
-        // State values may be base64-encoded for path fields, but ini_get_all
-        // values are not paths so they should match directly.
-        const stateKeys = Object.keys(stateIni).sort();
-        const fileKeys = Object.keys(fileIni).sort();
-        assert.deepEqual(fileKeys, stateKeys, 'ini_get_all.json keys should match state keys');
-    });
-
     it('ini_get_all includes auto_prepend_file and auto_append_file directives', () => {
-        const iniPath = join(tempDir, 'runtime_files', 'ini_get_all.json');
-        const iniData = JSON.parse(readFileSync(iniPath, 'utf-8'));
+        const state = JSON.parse(readFileSync(join(tempDir, '.import-state.json'), 'utf-8'));
+        const iniAll = state.preflight?.data?.runtime?.ini_get_all;
 
         // These directives should always be present in ini_get_all,
         // even when empty — they're part of core PHP configuration.
-        assert.ok('auto_prepend_file' in iniData, 'ini_get_all should contain auto_prepend_file');
-        assert.ok('auto_append_file' in iniData, 'ini_get_all should contain auto_append_file');
+        assert.ok('auto_prepend_file' in iniAll, 'ini_get_all should contain auto_prepend_file');
+        assert.ok('auto_append_file' in iniAll, 'ini_get_all should contain auto_append_file');
     });
 
     it('audit log records runtime file activity', () => {
         const log = readAuditLog(tempDir);
         assert.ok(log.includes('RUNTIME FILES'), 'Audit log should mention RUNTIME FILES');
-        assert.ok(log.includes('ini_get_all.json'), 'Audit log should mention ini_get_all.json');
     });
 
     it('wipes runtime_files/ on preflight re-run', () => {
+        // Create runtime_files/ with a stale file.
         const runtimeDir = join(tempDir, 'runtime_files');
-
-        // Plant a stale file that should be removed on re-run.
+        mkdirSync(runtimeDir, { recursive: true });
         const staleDir = join(runtimeDir, 'stale');
         mkdirSync(staleDir, { recursive: true });
-        writeFileSync(join(staleDir, 'old.ini'), 'should be deleted');
-        assert.ok(existsSync(join(staleDir, 'old.ini')), 'Stale file should exist before re-run');
+        writeFileSync(join(staleDir, 'old.php'), 'should be deleted');
+        assert.ok(existsSync(join(staleDir, 'old.php')), 'Stale file should exist before re-run');
 
         // Re-run preflight.
         const result = runImporter(importUrlWithDirectory(), tempDir, 'preflight', {
@@ -113,9 +85,6 @@ describe('Import: Runtime files', () => {
         assert.equal(result.exitCode, 0, `Expected exit 0\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);
 
         // Stale file should be gone.
-        assert.ok(!existsSync(join(staleDir, 'old.ini')), 'Stale file should be removed after preflight re-run');
-
-        // But ini_get_all.json should be freshly written.
-        assert.ok(existsSync(join(runtimeDir, 'ini_get_all.json')), 'ini_get_all.json should exist after re-run');
+        assert.ok(!existsSync(join(staleDir, 'old.php')), 'Stale file should be removed after preflight re-run');
     });
 });

--- a/tests/e2e/tests/import-39-runtime-files.test.js
+++ b/tests/e2e/tests/import-39-runtime-files.test.js
@@ -58,11 +58,10 @@ describe('Import: Runtime files', () => {
         assert.ok('error_reporting' in iniData, 'Should contain error_reporting');
         assert.ok('upload_max_filesize' in iniData, 'Should contain upload_max_filesize');
 
-        // Each directive should have global_value, local_value, access.
+        // ini_get_all(null, false) returns scalar values (local value only),
+        // not the detailed {global_value, local_value, access} objects.
         const entry = iniData['max_execution_time'];
-        assert.ok('global_value' in entry, 'INI entry should have global_value');
-        assert.ok('local_value' in entry, 'INI entry should have local_value');
-        assert.ok('access' in entry, 'INI entry should have access');
+        assert.equal(typeof entry, 'string', 'INI values should be strings (local value)');
     });
 
     it('ini_get_all.json matches preflight state data', () => {

--- a/wordpress-plugin/generic/export.php
+++ b/wordpress-plugin/generic/export.php
@@ -1150,6 +1150,80 @@ function endpoint_db_index(
 }
 
 /**
+ * Read PHP runtime configuration files and return their contents.
+ *
+ * Collects the main php.ini, all scanned .ini files, and the
+ * auto_prepend_file / auto_append_file scripts.  Each entry
+ * includes the absolute path and base64-encoded file content
+ * so the importer can recreate them without a separate fetch.
+ *
+ * @return array List of {path, content, size, error} entries.
+ */
+function collect_runtime_files(): array
+{
+    $paths = [];
+
+    $php_ini = function_exists("php_ini_loaded_file")
+        ? (php_ini_loaded_file() ?: null)
+        : null;
+    if ($php_ini !== null) {
+        $paths[] = $php_ini;
+    }
+
+    $prepend = ini_get("auto_prepend_file") ?: null;
+    if ($prepend !== null) {
+        $paths[] = $prepend;
+    }
+
+    $append = ini_get("auto_append_file") ?: null;
+    if ($append !== null) {
+        $paths[] = $append;
+    }
+
+    $scanned = function_exists("php_ini_scanned_files")
+        ? (php_ini_scanned_files() ?: null)
+        : null;
+    if ($scanned !== null) {
+        foreach (array_map("trim", explode(",", $scanned)) as $ini) {
+            if ($ini !== "") {
+                $paths[] = $ini;
+            }
+        }
+    }
+
+    $paths = array_values(array_unique($paths));
+    $result = [];
+
+    foreach ($paths as $file_path) {
+        $entry = [
+            "path" => $file_path,
+            "content" => null,
+            "size" => null,
+            "error" => null,
+        ];
+
+        if (!is_file($file_path) || !is_readable($file_path)) {
+            $entry["error"] = "not readable";
+            $result[] = $entry;
+            continue;
+        }
+
+        $data = @file_get_contents($file_path);
+        if ($data === false) {
+            $entry["error"] = "read failed";
+            $result[] = $entry;
+            continue;
+        }
+
+        $entry["content"] = base64_encode($data);
+        $entry["size"] = strlen($data);
+        $result[] = $entry;
+    }
+
+    return $result;
+}
+
+/**
  * Resolves directory paths from config.
  */
 function resolve_directories(array $config): array
@@ -2059,6 +2133,7 @@ function endpoint_preflight(array $config): array
             "script_filename" => $_SERVER["SCRIPT_FILENAME"] ?? null,
             "cwd" => getcwd() ?: null,
         ],
+        "runtime_files" => collect_runtime_files(),
         "filesystem" => [
             "directories" => $dir_checks,
             "error" => $dir_error,

--- a/wordpress-plugin/generic/export.php
+++ b/wordpress-plugin/generic/export.php
@@ -1150,80 +1150,6 @@ function endpoint_db_index(
 }
 
 /**
- * Read PHP runtime configuration files and return their contents.
- *
- * Collects the main php.ini, all scanned .ini files, and the
- * auto_prepend_file / auto_append_file scripts.  Each entry
- * includes the absolute path and base64-encoded file content
- * so the importer can recreate them without a separate fetch.
- *
- * @return array List of {path, content, size, error} entries.
- */
-function collect_runtime_files(): array
-{
-    $paths = [];
-
-    $php_ini = function_exists("php_ini_loaded_file")
-        ? (php_ini_loaded_file() ?: null)
-        : null;
-    if ($php_ini !== null) {
-        $paths[] = $php_ini;
-    }
-
-    $prepend = ini_get("auto_prepend_file") ?: null;
-    if ($prepend !== null) {
-        $paths[] = $prepend;
-    }
-
-    $append = ini_get("auto_append_file") ?: null;
-    if ($append !== null) {
-        $paths[] = $append;
-    }
-
-    $scanned = function_exists("php_ini_scanned_files")
-        ? (php_ini_scanned_files() ?: null)
-        : null;
-    if ($scanned !== null) {
-        foreach (array_map("trim", explode(",", $scanned)) as $ini) {
-            if ($ini !== "") {
-                $paths[] = $ini;
-            }
-        }
-    }
-
-    $paths = array_values(array_unique($paths));
-    $result = [];
-
-    foreach ($paths as $file_path) {
-        $entry = [
-            "path" => $file_path,
-            "content" => null,
-            "size" => null,
-            "error" => null,
-        ];
-
-        if (!is_file($file_path) || !is_readable($file_path)) {
-            $entry["error"] = "not readable";
-            $result[] = $entry;
-            continue;
-        }
-
-        $data = @file_get_contents($file_path);
-        if ($data === false) {
-            $entry["error"] = "read failed";
-            $result[] = $entry;
-            continue;
-        }
-
-        $entry["content"] = base64_encode($data);
-        $entry["size"] = strlen($data);
-        $result[] = $entry;
-    }
-
-    return $result;
-}
-
-/**
  * Resolves directory paths from config.
  */
 function resolve_directories(array $config): array
@@ -2133,7 +2059,6 @@ function endpoint_preflight(array $config): array
             "script_filename" => $_SERVER["SCRIPT_FILENAME"] ?? null,
             "cwd" => getcwd() ?: null,
         ],
-        "runtime_files" => collect_runtime_files(),
         "filesystem" => [
             "directories" => $dir_checks,
             "error" => $dir_error,

--- a/wordpress-plugin/generic/export.php
+++ b/wordpress-plugin/generic/export.php
@@ -2052,8 +2052,6 @@ function endpoint_preflight(array $config): array
             "php_ini_scanned_files" => function_exists("php_ini_scanned_files")
                 ? (php_ini_scanned_files() ?: null)
                 : null,
-            "auto_prepend_file" => ini_get("auto_prepend_file") ?: null,
-            "auto_append_file" => ini_get("auto_append_file") ?: null,
             // Every effective INI directive as computed by the PHP runtime
             // after merging php.ini, scanned .ini files, and htaccess
             // overrides.  This lets us reconstruct the full configuration

--- a/wordpress-plugin/generic/export.php
+++ b/wordpress-plugin/generic/export.php
@@ -2054,6 +2054,11 @@ function endpoint_preflight(array $config): array
                 : null,
             "auto_prepend_file" => ini_get("auto_prepend_file") ?: null,
             "auto_append_file" => ini_get("auto_append_file") ?: null,
+            // Every effective INI directive as computed by the PHP runtime
+            // after merging php.ini, scanned .ini files, and htaccess
+            // overrides.  This lets us reconstruct the full configuration
+            // even when the .ini files themselves are not readable.
+            "ini_get_all" => ini_get_all(null, false),
             "temp_dir" => sys_get_temp_dir(),
             "document_root" => $_SERVER["DOCUMENT_ROOT"] ?? null,
             "script_filename" => $_SERVER["SCRIPT_FILENAME"] ?? null,

--- a/wordpress-plugin/generic/export.php
+++ b/wordpress-plugin/generic/export.php
@@ -2046,16 +2046,10 @@ function endpoint_preflight(array $config): array
         ],
         "runtime" => [
             "server_software" => $_SERVER["SERVER_SOFTWARE"] ?? null,
-            "php_ini" => function_exists("php_ini_loaded_file")
-                ? (php_ini_loaded_file() ?: null)
-                : null,
-            "php_ini_scanned_files" => function_exists("php_ini_scanned_files")
-                ? (php_ini_scanned_files() ?: null)
-                : null,
             // Every effective INI directive as computed by the PHP runtime
             // after merging php.ini, scanned .ini files, and htaccess
-            // overrides.  This lets us reconstruct the full configuration
-            // even when the .ini files themselves are not readable.
+            // overrides.  This captures the full configuration without
+            // needing to read the .ini files themselves.
             "ini_get_all" => ini_get_all(null, false),
             "temp_dir" => sys_get_temp_dir(),
             "document_root" => $_SERVER["DOCUMENT_ROOT"] ?? null,

--- a/wordpress-plugin/generic/export.php
+++ b/wordpress-plugin/generic/export.php
@@ -2049,6 +2049,11 @@ function endpoint_preflight(array $config): array
             "php_ini" => function_exists("php_ini_loaded_file")
                 ? (php_ini_loaded_file() ?: null)
                 : null,
+            "php_ini_scanned_files" => function_exists("php_ini_scanned_files")
+                ? (php_ini_scanned_files() ?: null)
+                : null,
+            "auto_prepend_file" => ini_get("auto_prepend_file") ?: null,
+            "auto_append_file" => ini_get("auto_append_file") ?: null,
             "temp_dir" => sys_get_temp_dir(),
             "document_root" => $_SERVER["DOCUMENT_ROOT"] ?? null,
             "script_filename" => $_SERVER["SCRIPT_FILENAME"] ?? null,


### PR DESCRIPTION
## Summary

After preflight, the importer now captures the remote server's full PHP runtime configuration and auto-loaded scripts:

- **ini_get_all()**: The complete set of computed INI directives (via `ini_get_all(null, false)`) is shipped in the preflight response and saved to `runtime_files/ini_get_all.json`. This gives us every effective PHP setting without needing to read the .ini files themselves.

- **Prepend/append scripts**: The importer reads `auto_prepend_file` and `auto_append_file` paths from the ini_get_all data and downloads them via the `file_fetch` endpoint. These are the scripts that run before/after every PHP request on the source server. Download failures are tolerated since these paths may not be accessible to the web server process.

- **Lifecycle**: The `runtime_files/` directory is wiped and recreated on every preflight run to always reflect the current server state.

## Test plan

- [x] Unit tests for path collection from ini_get_all, deduplication, ini_get_all file writing, directory wipe, and fetch failure tolerance
- [x] E2E test (import-39) for the full lifecycle: directory creation, ini_get_all.json validity and structure, prepend/append directives present, preflight state consistency, audit logging, and wipe-on-rerun
- [x] E2E test (import-33) extended to verify ini_get_all is stored as a plain object (not base64-encoded)
- [x] Manual test against adamadam.blog — downloads `/scripts/env.php` (auto_prepend_file), tolerates inaccessible system paths