### PR TITLE
Detect webhosts by likelihood scoring instead of first-match

### DIFF
--- a/importer/import.php
+++ b/importer/import.php
@@ -1717,10 +1717,8 @@ class ImportClient
 
         // Detect webhost environment from preflight data
         $detected_webhost = $this->detect_webhost($payload);
-        if ($detected_webhost !== null) {
-            $this->state["webhost"] = $detected_webhost;
-            $this->audit_log("WEBHOST DETECTED | {$detected_webhost}", true);
-        }
+        $this->state["webhost"] = $detected_webhost;
+        $this->audit_log("WEBHOST DETECTED | {$detected_webhost}", true);
 
         $this->save_state($this->state);
 
@@ -1939,19 +1937,31 @@ class ImportClient
     /**
      * Detect the webhost environment from preflight data.
      *
-     * - SiteGround: has plugins prefixed with "sg-" (e.g. sg-cachepress, sg-security)
-     * - WP Cloud: has a __wp__ symlink in the document root
+     * Each candidate host accumulates a likelihood score based on
+     * independent signals. The host with the highest score wins.
+     * If no host reaches its minimum threshold, returns "other".
+     *
+     * Signals used:
+     * - SiteGround: plugins prefixed with "sg-" (e.g. sg-cachepress, sg-security)
+     * - WP Cloud: __wp__ symlink in the document root, PRIVACY_MODEL env variable
      *
      * @param array|null $preflight_data The preflight response payload
-     * @return string|null "siteground", "wpcloud", or null if unknown
+     * @return string "siteground", "wpcloud", or "other"
      */
-    private function detect_webhost(?array $preflight_data): ?string
+    private function detect_webhost(?array $preflight_data): string
     {
         if (!is_array($preflight_data)) {
-            return null;
+            return "other";
         }
 
-        // Check for SiteGround: look for plugins prefixed with "sg-"
+        $scores = [
+            "siteground" => 0.0,
+            "wpcloud" => 0.0,
+        ];
+
+        // --- SiteGround signals ---
+        // Look for plugins prefixed with "sg-" across all wp-content roots.
+        // Two or more sg- plugins is a strong signal (0.9), one is weak (0.3).
         $roots = $preflight_data["wp_content"]["roots"] ?? [];
         $sg_count = 0;
         foreach ($roots as $root) {
@@ -1964,10 +1974,14 @@ class ImportClient
             }
         }
         if ($sg_count >= 2) {
-            return "siteground";
+            $scores["siteground"] += 0.9;
+        } elseif ($sg_count === 1) {
+            $scores["siteground"] += 0.3;
         }
 
-        // Check for WP Cloud: look for __wp__ in the filesystem directories
+        // --- WP Cloud signals ---
+
+        // Signal: __wp__ directory exists in the document root.
         // WP Cloud sites have a __wp__ symlink in the document root pointing
         // to the WordPress core installation.
         $doc_root = $preflight_data["runtime"]["document_root"] ?? null;
@@ -1978,30 +1992,52 @@ class ImportClient
             foreach ($dir_checks as $check) {
                 $path = $check["path"] ?? "";
                 if ($path === $wp_dir && ($check["exists"] ?? false)) {
-                    return "wpcloud";
+                    $scores["wpcloud"] += 0.5;
+                    break;
                 }
             }
         }
 
-        // Also check wp_detect roots: WP Cloud typically has WordPress
-        // detected at __wp__ inside the document root
+        // Signal: WordPress detected at __wp__ inside the document root.
+        // WP Cloud typically has WordPress installed at doc_root/__wp__/.
         $wp_roots = $preflight_data["wp_detect"]["roots"] ?? [];
         if (is_string($doc_root) && $doc_root !== "") {
             $wp_subdir = rtrim($doc_root, "/") . "/__wp__";
             foreach ($wp_roots as $root) {
                 $path = $root["path"] ?? "";
                 if ($path === $wp_subdir) {
-                    return "wpcloud";
+                    $scores["wpcloud"] += 0.4;
+                    break;
                 }
             }
         }
 
-        // Fallback: check the local docroot for a __wp__ symlink
-        if (is_link($this->docroot . "/__wp__")) {
-            return "wpcloud";
+        // Signal: PRIVACY_MODEL environment variable is defined.
+        // WP Cloud sets this env var; its mere presence is a strong hint.
+        $env_names = $preflight_data["runtime"]["env_names"] ?? [];
+        if (in_array("PRIVACY_MODEL", $env_names, true)) {
+            $scores["wpcloud"] += 0.5;
         }
 
-        return null;
+        // Signal: local docroot contains a __wp__ symlink (fallback when
+        // the remote preflight didn't report enough filesystem data).
+        if (is_link($this->docroot . "/__wp__")) {
+            $scores["wpcloud"] += 0.3;
+        }
+
+        // --- Pick the winner ---
+        // A host must reach a minimum threshold of 0.5 to be considered.
+        $threshold = 0.5;
+        $best_host = "other";
+        $best_score = 0.0;
+        foreach ($scores as $host => $score) {
+            if ($score >= $threshold && $score > $best_score) {
+                $best_host = $host;
+                $best_score = $score;
+            }
+        }
+
+        return $best_host;
     }
 
     /**

--- a/wordpress-plugin/generic/export.php
+++ b/wordpress-plugin/generic/export.php
@@ -2102,9 +2102,9 @@ function endpoint_preflight(array $config): array
             // importer can use their presence as a webhost detection signal.
             "env_names" => array_values(array_unique(array_merge(
                 array_keys($_ENV),
-                array_keys($_SERVER),
                 array_keys(getenv()),
             ))),
+            '$_SERVER_names' => array_keys($_SERVER),
         ],
         "filesystem" => [
             "directories" => $dir_checks,

--- a/wordpress-plugin/generic/export.php
+++ b/wordpress-plugin/generic/export.php
@@ -1504,6 +1504,7 @@ function endpoint_preflight(array $config): array
             "paths_urls" => null,
             "multisite" => null,
             "constants" => null,
+            "constant_names" => null,
             "error" => null,
         ],
         "error" => null,
@@ -1821,6 +1822,11 @@ function endpoint_preflight(array $config): array
                         }
                         $db["wp"]["constants"] = $constant_values;
 
+                        // Names of all defined constants (without values)
+                        // so the importer can use their presence as a
+                        // detection signal without leaking secret values.
+                        $db["wp"]["constant_names"] = array_keys($all_constants);
+
                         global $wp_version;
                         $db["wp"]["wp_version"] = isset($wp_version) && is_string($wp_version)
                             ? $wp_version
@@ -2093,6 +2099,13 @@ function endpoint_preflight(array $config): array
             "document_root" => $_SERVER["DOCUMENT_ROOT"] ?? null,
             "script_filename" => $_SERVER["SCRIPT_FILENAME"] ?? null,
             "cwd" => getcwd() ?: null,
+            // Names of all defined environment variables (no values) so the
+            // importer can use their presence as a webhost detection signal.
+            "env_names" => array_values(array_unique(array_merge(
+                array_keys($_ENV),
+                array_keys($_SERVER),
+                array_keys(getenv()),
+            ))),
         ],
         "filesystem" => [
             "directories" => $dir_checks,

--- a/wordpress-plugin/generic/export.php
+++ b/wordpress-plugin/generic/export.php
@@ -1794,15 +1794,9 @@ function endpoint_preflight(array $config): array
                         // which only includes constants set via define(), excluding
                         // the thousands of constants from PHP extensions.
                         $user_constants = get_defined_constants(true)["user"] ?? [];
-                        $constant_values = [];
-                        foreach ($user_constants as $name => $value) {
-                            if (strncmp($name, "WP_", 3) === 0) {
-                                $constant_values[$name] = $value;
-                            }
-                        }
                         // Include non-WP_* constants that are still
                         // important for understanding a WordPress site.
-                        $extra_constants = [
+                        $extra_constants_names = [
                             "WPMU_PLUGIN_DIR",
                             "WPMU_PLUGIN_URL",
                             "UPLOADS",
@@ -1818,18 +1812,19 @@ function endpoint_preflight(array $config): array
                             "FORCE_SSL_ADMIN",
                             "SAVEQUERIES",
                         ];
-                        foreach ($extra_constants as $name) {
-                            if (defined($name)) {
-                                $constant_values[$name] = constant($name);
-                            }
-                        }
-                        $db["wp"]["constants"] = $constant_values;
-
+                        $db["wp"]["constant_values"] = [];
                         // Names of all runtime-defined constants (without values)
                         // so the importer can use their presence as a detection
                         // signal without leaking secret values. Only includes
                         // constants set via define(), not PHP extension constants.
-                        $db["wp"]["constant_names"] = array_keys($user_constants);
+                        $db["wp"]["constant_names"] = [];
+                        foreach ($user_constants as $name => $value) {
+                            if (strncmp($name, "WP_", 3) === 0 || in_array($name, $extra_constants_names)) {
+                                $db["wp"]["constant_values"][$name] = $value;
+                            } else {
+                                $db["wp"]["constant_names"][] = $name;
+                            }
+                        }
 
                         global $wp_version;
                         $db["wp"]["wp_version"] = isset($wp_version) && is_string($wp_version)

--- a/wordpress-plugin/generic/export.php
+++ b/wordpress-plugin/generic/export.php
@@ -1790,9 +1790,12 @@ function endpoint_preflight(array $config): array
 
                         // Capture all WP_* constants plus a few other
                         // WordPress-specific ones that don't follow the prefix.
-                        $all_constants = get_defined_constants();
+                        // We use the "user" category from get_defined_constants(true)
+                        // which only includes constants set via define(), excluding
+                        // the thousands of constants from PHP extensions.
+                        $user_constants = get_defined_constants(true)["user"] ?? [];
                         $constant_values = [];
-                        foreach ($all_constants as $name => $value) {
+                        foreach ($user_constants as $name => $value) {
                             if (strncmp($name, "WP_", 3) === 0) {
                                 $constant_values[$name] = $value;
                             }
@@ -1822,10 +1825,11 @@ function endpoint_preflight(array $config): array
                         }
                         $db["wp"]["constants"] = $constant_values;
 
-                        // Names of all defined constants (without values)
-                        // so the importer can use their presence as a
-                        // detection signal without leaking secret values.
-                        $db["wp"]["constant_names"] = array_keys($all_constants);
+                        // Names of all runtime-defined constants (without values)
+                        // so the importer can use their presence as a detection
+                        // signal without leaking secret values. Only includes
+                        // constants set via define(), not PHP extension constants.
+                        $db["wp"]["constant_names"] = array_keys($user_constants);
 
                         global $wp_version;
                         $db["wp"]["wp_version"] = isset($wp_version) && is_string($wp_version)


### PR DESCRIPTION
## Summary

The old `detect_webhost()` returned the first host whose single check passed, which was fragile when signals were ambiguous or incomplete. Now each candidate host accumulates a score from independent signals, and the highest-scoring host above a 0.5 threshold wins. If nothing qualifies, the method returns `"other"` instead of `null` — every site gets a classification.

New detection signals:
- WP Cloud: presence of `PRIVACY_MODEL` environment variable
- SiteGround: a single `sg-` plugin now contributes a weak signal (previously required 2+)

To support env-based detection, the preflight response now includes `runtime.env_names` (all env var names, no values) and `database.wp.constant_names` (names of all `define()`-d PHP constants, no values — extension constants like `PHP_INT_MAX` are excluded). This gives the importer rich fingerprinting data without leaking secrets or adding noise.

## Test plan

- [ ] Run preflight against a WP Cloud site and verify `env_names` includes `PRIVACY_MODEL` and webhost resolves to `wpcloud`
- [ ] Run preflight against a SiteGround site and verify webhost resolves to `siteground`
- [ ] Run preflight against a generic host and verify webhost resolves to `other`
- [ ] Verify `constant_names` appears in the preflight JSON and contains only runtime-defined constants (no PHP extension constants)
- [ ] Verify no secret values leak through `env_names` or `constant_names`