### PR TITLE
Rename --docroot to --fs-root, flatten-docroot to flat-document-root

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,14 +94,14 @@ Override with environment variables if needed.
 
 ### Symlink Security
 
-Symlinks ARE automatically recreated during import. This is safe because all paths are relative to the `--docroot` directory, preventing directory traversal outside it. Errors are logged to the audit log.
+Symlinks ARE automatically recreated during import. This is safe because all paths are relative to the `--fs-root` directory, preventing directory traversal outside it. Errors are logged to the audit log.
 
-### Non-Empty Docroot Handling (`--on-docroot-nonempty`)
+### Non-Empty fs-root Handling (`--on-fs-root-nonempty`)
 
-By default, `files-sync` refuses to start if `--docroot` is non-empty (to prevent accidental overwrites). The `--on-docroot-nonempty` flag controls this behavior:
+By default, `files-sync` refuses to start if `--fs-root` is non-empty (to prevent accidental overwrites). The `--on-fs-root-nonempty` flag controls this behavior:
 
-- `--on-docroot-nonempty=error` (default): throw an error and abort.
-- `--on-docroot-nonempty=preserve-local`: import into the non-empty directory while preserving all existing local content.
+- `--on-fs-root-nonempty=error` (default): throw an error and abort.
+- `--on-fs-root-nonempty=preserve-local`: import into the non-empty directory while preserving all existing local content.
 
 In `preserve-local` mode:
 - Existing files are never overwritten — if anything (regular file, symlink, directory) already exists at a remote file's path, the remote file is skipped.
@@ -186,7 +186,7 @@ Progress is computed client-side by reading state files (all in `--state-dir`):
 - `.import-download-list.jsonl`: Files pending download
 - `db.sql`: SQL dump file size
 
-And from `--docroot`:
+And from `--fs-root`:
 - Actual downloaded files (recursive size/count)
 
 This keeps the protocol minimal while enabling rich progress visualization.

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ All commands below use the same base invocation. We'll use `$URL` and `$DIR` as 
 ```bash
 URL="https://example.com/?site-export-api"
 STATE_DIR="./local-directory-where-the-migration-state-will-be-tracked"
-DOCROOT="./local-directory-where-the-remote-site-files-will-be-recreated"
+FS_ROOT="./local-directory-where-the-remote-site-files-will-be-recreated"
 SECRET="your-shared-secret"
 ```
 
@@ -60,7 +60,7 @@ SECRET="your-shared-secret"
 First, we'll make sure the server is reachable and the environment is in a good shape:
 
 ```bash
-php importer.phar preflight "$URL" --state-dir="$STATE_DIR" --docroot="$DOCROOT" --secret="$SECRET"
+php importer.phar preflight "$URL" --state-dir="$STATE_DIR" --fs-root="$FS_ROOT" --secret="$SECRET"
 ```
 
 The preflight contacts the export server and collects environment details: PHP/MySQL versions, memory limits, filesystem access, database connectivity, WordPress version, plugins, themes, and directory layout. The result is stored in `.import-state.json` under the `preflight` key.
@@ -71,7 +71,7 @@ To run very basic diagnostics that confirms the remote server replied and it has
 sound-looking filesystem and a database connection, run:
 
 ```bash
-php importer.phar preflight-assert "$URL" --state-dir="$STATE_DIR" --docroot="$DOCROOT" --secret="$SECRET"
+php importer.phar preflight-assert "$URL" --state-dir="$STATE_DIR" --fs-root="$FS_ROOT" --secret="$SECRET"
 ```
 
 For hosting platform-specific checks, such as database version compatibility or
@@ -84,7 +84,7 @@ This first builds a full index of the remote directory tree, then streams every 
 It can be interrupted and resumed at any time — just re-run the same command:
 
 ```bash
-php importer.phar files-sync "$URL" --state-dir="$STATE_DIR" --docroot="$DOCROOT" --secret="$SECRET"
+php importer.phar files-sync "$URL" --state-dir="$STATE_DIR" --fs-root="$FS_ROOT" --secret="$SECRET"
 ```
 
 The command returns one of three exit codes:
@@ -95,13 +95,13 @@ The command returns one of three exit codes:
 
 Which is to say, you'll need to wrap it in a loop that runs until failure or full completion.
 
-**Non-empty local docroot**
+**Non-empty local fs-root**
 
-By default, `files-sync` refuses to start if `--docroot` is non-empty. If you need to use a non-empty local docroot,
-the `--on-docroot-nonempty` flag controls this behavior. It takes the following values:
+By default, `files-sync` refuses to start if `--fs-root` is non-empty. If you need to use a non-empty local fs-root,
+the `--on-fs-root-nonempty` flag controls this behavior. It takes the following values:
 
-- `--on-docroot-nonempty=error` (default): throw an error and abort.
-- `--on-docroot-nonempty=preserve-local`: import into the non-empty directory while preserving all existing local content.
+- `--on-fs-root-nonempty=error` (default): throw an error and abort.
+- `--on-fs-root-nonempty=preserve-local`: import into the non-empty directory while preserving all existing local content.
 
 **Filtering files**
 
@@ -110,7 +110,7 @@ and you want to bring the site online before downloading all the uploads:
 
 ```bash
 # Step 1: download only essential files (code, config, themes, plugins)
-php importer.phar files-sync "$URL" --state-dir="$STATE_DIR" --docroot="$DOCROOT" --secret="$SECRET" \
+php importer.phar files-sync "$URL" --state-dir="$STATE_DIR" --fs-root="$FS_ROOT" --secret="$SECRET" \
     --filter=essential-files
 ```
 
@@ -120,7 +120,7 @@ files are done, the sync marks itself **complete**. The skipped file list stays 
 
 ```bash
 # Step 2: download the uploads
-php importer.phar files-sync "$URL" --state-dir="$STATE_DIR" --docroot="$DOCROOT" --secret="$SECRET" \
+php importer.phar files-sync "$URL" --state-dir="$STATE_DIR" --fs-root="$FS_ROOT" --secret="$SECRET" \
     --filter=skipped-earlier
 ```
 
@@ -138,7 +138,7 @@ The uploads directory is detected from preflight data (`uploads.basedir`), falli
 By default, this streams a SQL dump into `$STATE_DIR/db.sql`:
 
 ```bash
-php importer.phar db-sync "$URL" --state-dir="$STATE_DIR" --docroot="$DOCROOT" --secret="$SECRET"
+php importer.phar db-sync "$URL" --state-dir="$STATE_DIR" --fs-root="$FS_ROOT" --secret="$SECRET"
 ```
 
 You can also pipe the SQL directly to stdout or stream it into a MySQL server
@@ -146,11 +146,11 @@ without writing a file to disk. Use `--sql-output` to choose the mode:
 
 ```bash
 # Pipe to stdout — useful for feeding into mysql CLI or another tool
-php importer.phar db-sync "$URL" --state-dir="$STATE_DIR" --docroot="$DOCROOT" --secret="$SECRET" \
+php importer.phar db-sync "$URL" --state-dir="$STATE_DIR" --fs-root="$FS_ROOT" --secret="$SECRET" \
     --sql-output=stdout | mysql -u root my_database
 
 # Stream directly into MySQL — no intermediate file, no pipe
-php importer.phar db-sync "$URL" --state-dir="$STATE_DIR" --docroot="$DOCROOT" --secret="$SECRET" \
+php importer.phar db-sync "$URL" --state-dir="$STATE_DIR" --fs-root="$FS_ROOT" --secret="$SECRET" \
     --sql-output=mysql --mysql-database=my_database --mysql-host=127.0.0.1 --mysql-user=root --mysql-password=secret
 ```
 
@@ -182,7 +182,7 @@ First, we must abort the previous files-sync. Otherwise, it would just
 tell us it's completed and refuse to proceed:
 
 ```bash
-php importer.phar files-sync "$URL" --state-dir="$STATE_DIR" --docroot="$DOCROOT" --secret="$SECRET" --abort
+php importer.phar files-sync "$URL" --state-dir="$STATE_DIR" --fs-root="$FS_ROOT" --secret="$SECRET" --abort
 ```
 
 From here, we can run the `files-sync` command again. It will index
@@ -190,7 +190,7 @@ the remote filesystem once again, compute which files have changed
 since the initial sync, and apply that delta in the local directory:
 
 ```bash
-php importer.phar files-sync "$URL" --state-dir="$STATE_DIR" --docroot="$DOCROOT" --secret="$SECRET"
+php importer.phar files-sync "$URL" --state-dir="$STATE_DIR" --fs-root="$FS_ROOT" --secret="$SECRET"
 ```
 
 The command returns one of three exit codes:
@@ -208,7 +208,7 @@ the SQL dump into a target database while rewriting all URLs in one pass.
 MySQL target:
 
 ```bash
-php importer.phar db-apply "$URL" --state-dir="$STATE_DIR" --docroot="$DOCROOT" --secret="$SECRET" \
+php importer.phar db-apply "$URL" --state-dir="$STATE_DIR" --fs-root="$FS_ROOT" --secret="$SECRET" \
     --target-user=root --target-db=wp_new \
     --rewrite-url https://old-site.com https://new-site.com
 ```
@@ -216,7 +216,7 @@ php importer.phar db-apply "$URL" --state-dir="$STATE_DIR" --docroot="$DOCROOT" 
 SQLite target:
 
 ```bash
-php importer.phar db-apply "$URL" --state-dir="$STATE_DIR" --docroot="$DOCROOT" --secret="$SECRET" \
+php importer.phar db-apply "$URL" --state-dir="$STATE_DIR" --fs-root="$FS_ROOT" --secret="$SECRET" \
     --target-engine=sqlite --target-sqlite-path="$STATE_DIR/wordpress.sqlite" \
     --target-db=wp_new \
     --rewrite-url https://old-site.com https://new-site.com
@@ -232,7 +232,7 @@ are recalculated, JSON is re-encoded, and block comment attributes are updated.
 You can map multiple domains by repeating the flag:
 
 ```bash
-php importer.phar db-apply "$URL" --state-dir="$STATE_DIR" --docroot="$DOCROOT" --secret="$SECRET" \
+php importer.phar db-apply "$URL" --state-dir="$STATE_DIR" --fs-root="$FS_ROOT" --secret="$SECRET" \
     --target-user=root --target-db=wp_new \
     --rewrite-url https://old-site.com https://new-site.com \
     --rewrite-url https://cdn.old-site.com https://cdn.new-site.com
@@ -253,7 +253,7 @@ For PHP's built-in development server:
 
 ```bash
 php importer.phar apply-runtime --state-dir="$STATE_DIR" \
-    --flattened-docroot="$FLAT_DIR" --output-dir="$RUNTIME_DIR" --runtime=php-builtin
+    --flat-document-root="$FLAT_DIR" --output-dir="$RUNTIME_DIR" --runtime=php-builtin
 bash "$RUNTIME_DIR/start.sh"
 ```
 
@@ -261,13 +261,13 @@ For nginx + PHP-FPM:
 
 ```bash
 php importer.phar apply-runtime --state-dir="$STATE_DIR" \
-    --flattened-docroot="$FLAT_DIR" --output-dir="$RUNTIME_DIR" --runtime=nginx-fpm
+    --flat-document-root="$FLAT_DIR" --output-dir="$RUNTIME_DIR" --runtime=nginx-fpm
 # Include $RUNTIME_DIR/nginx.conf in your nginx configuration, then reload
 ```
 
-The command accepts either `--docroot` (the raw download directory — the remote
-`document_root` path is appended automatically) or `--flattened-docroot` (a
-directory created by `flatten-docroot`, used as-is). These are mutually exclusive.
+The command accepts either `--fs-root` (the raw download directory — the remote
+`document_root` path is appended automatically) or `--flat-document-root` (a
+directory created by `flat-document-root`, used as-is). These are mutually exclusive.
 
 Host and port default to the URL rewrite target from `db-apply` (so the server
 listens on the same address the database was rewritten to). Override with
@@ -297,7 +297,7 @@ development server.
 
 #### Shoehorning the site onto your platform
 
-You've got a copy of the remote files in the `--docroot` directory and
+You've got a copy of the remote files in the `--fs-root` directory and
 the database either already applied (via `db-apply`) or in `--state-dir/db.sql`.
 From here, you need to figure out how to run that on your platform.
 
@@ -471,7 +471,7 @@ This is useful for debugging but noisy for production use.
 The importer accepts the following commands:
 
 ```
-php importer.phar <command> <URL> --state-dir=DIR --docroot=DIR [options]
+php importer.phar <command> <URL> --state-dir=DIR --fs-root=DIR [options]
 ```
 
 * `preflight` — Runs the preflight check and prints the full result as JSON. Exits with code 0 if OK, code 1 if not.
@@ -483,7 +483,7 @@ php importer.phar <command> <URL> --state-dir=DIR --docroot=DIR [options]
 * `db-apply` — Applies `db.sql` to a target MySQL or SQLite database. Accepts `--rewrite-url FROM TO` (repeatable) to rewrite domains during import.
 * `db-domains` — Lists domains discovered in the SQL dump. Reads `.import-domains.json` if available (written by `db-sync`), otherwise scans `db.sql`.
 * `db-index` — Indexes database tables and their statistics (name, row count, size) to `db-tables.jsonl`.
-* `flatten-docroot` — Creates a standard WordPress directory layout using symlinks. Useful when the source site has a non-standard layout (e.g. WP Cloud with ABSPATH separate from wp-content).
+* `flat-document-root` — Creates a standard WordPress directory layout using symlinks. Useful when the source site has a non-standard layout (e.g. WP Cloud with ABSPATH separate from wp-content).
 * `apply-runtime` — Generates server configuration files (`runtime.php`, `start.sh` or `nginx.conf`) from preflight data. See [Step 6](#step-6--generate-runtime-configuration).
 
 All commands except `preflight-assert` support `--abort` to abort the current sync and exit. For `files-sync`, this clears sync progress but keeps the local index and downloaded files — the next run performs a delta sync. For `db-sync` and `db-index`, it clears the output file so the next run starts from scratch. Interrupted commands automatically resume from the last saved cursor.
@@ -592,13 +592,13 @@ the **migration target** chooses how to handle it. A few choices are:
 
 Symlinks are automatically recreated during import. The importer receives symlink chunks from the
 export stream and calls `symlink()` to recreate them locally. This is safe because all paths are
-constrained to the `--docroot` directory.
+constrained to the `--fs-root` directory.
 
 Some symlinks may point to places on the remote filesystem that are
 outside of the requested directory root. By default, the importer
 follows these symlinks — it asks the server to expand them into real
 files and recreates the symlink structure locally, constrained within
-the `--docroot`.
+the `--fs-root`.
 
 To disable this behavior, pass `--no-follow-symlinks`. Symlinks pointing
 outside the directory root will then be skipped instead of followed.

--- a/importer/import.php
+++ b/importer/import.php
@@ -821,7 +821,7 @@ class ImportClient
     private $state_dir;
 
     /** @var string Directory where downloaded site files are written (no filesystem-root/ wrapper). */
-    private $docroot;
+    private $fs_root;
 
     /** @var string Path to .import-state.json — persists command, cursor, stage across invocations. */
     private $state_file;
@@ -922,14 +922,14 @@ class ImportClient
     private $follow_symlinks = true;
 
     /**
-     * @var string Controls behavior when the docroot is non-empty at import start.
+     * @var string Controls behavior when the fs root is non-empty at import start.
      *
-     * 'error' (default): throw an error if the docroot is non-empty.
+     * 'error' (default): throw an error if the fs root is non-empty.
      * 'preserve-local': preserve existing files, symlinks, and directories in the
-     * docroot instead of overwriting them; non-writable directories are skipped
+     * fs root instead of overwriting them; non-writable directories are skipped
      * gracefully and logged to the audit log.
      *
-     * On the first sync, existing docroot content is left untouched — any file,
+     * On the first sync, existing fs root content is left untouched — any file,
      * symlink, or directory that already exists at a path the remote tries to write
      * is skipped and never added to the local index.
      *
@@ -938,9 +938,9 @@ class ImportClient
      * (e.g. __wp__ symlinks, drop-in symlinks, shared plugin directories) is simply
      * invisible to the diff and never touched.
      *
-     * Set via --on-docroot-nonempty, persisted in state so it survives across invocations.
+     * Set via --on-fs-root-nonempty, persisted in state so it survives across invocations.
      */
-    private $docroot_nonempty_behavior = 'error';
+    private $fs_root_nonempty_behavior = 'error';
 
     /**
      * Controls which files are downloaded during files-sync.
@@ -1008,11 +1008,11 @@ class ImportClient
      */
     public $exit_code = 0;
 
-    public function __construct(string $remote_url, string $state_dir, string $docroot)
+    public function __construct(string $remote_url, string $state_dir, string $fs_root)
     {
         $this->remote_url = rtrim($remote_url, "?&");
         $this->state_dir = rtrim($state_dir, "/");
-        $this->docroot = rtrim($docroot, "/");
+        $this->fs_root = rtrim($fs_root, "/");
         $this->state_file = $this->state_dir . "/.import-state.json";
         $this->index_file = $this->state_dir . "/.import-index.jsonl";
         $this->index_updates_file =
@@ -1048,9 +1048,9 @@ class ImportClient
                 throw new RuntimeException("Failed to create directory: {$this->state_dir}");
             }
         }
-        if (!is_dir($this->docroot)) {
-            if (!mkdir($this->docroot, 0755, true)) {
-                throw new RuntimeException("Failed to create directory: {$this->docroot}");
+        if (!is_dir($this->fs_root)) {
+            if (!mkdir($this->fs_root, 0755, true)) {
+                throw new RuntimeException("Failed to create directory: {$this->fs_root}");
             }
         }
     }
@@ -1293,11 +1293,11 @@ class ImportClient
     {
         $this->verbose_mode = $options["verbose"] ?? false;
         $this->follow_symlinks = $options["follow_symlinks"] ?? true;
-        if (isset($options["docroot_nonempty_behavior"])) {
-            $this->docroot_nonempty_behavior = $options["docroot_nonempty_behavior"];
-            if (!in_array($this->docroot_nonempty_behavior, ['error', 'preserve-local'])) {
+        if (isset($options["fs_root_nonempty_behavior"])) {
+            $this->fs_root_nonempty_behavior = $options["fs_root_nonempty_behavior"];
+            if (!in_array($this->fs_root_nonempty_behavior, ['error', 'preserve-local'])) {
                 throw new InvalidArgumentException(
-                    "Invalid --on-docroot-nonempty value: {$this->docroot_nonempty_behavior}. " .
+                    "Invalid --on-fs-root-nonempty value: {$this->fs_root_nonempty_behavior}. " .
                         "Valid values: error, preserve-local",
                 );
             }
@@ -1309,7 +1309,7 @@ class ImportClient
 
         if (!$command) {
             throw new InvalidArgumentException(
-                "Command is required. Valid commands: files-sync, files-index, files-stats, db-sync, db-index, db-domains, db-apply, preflight, preflight-assert, flatten-docroot",
+                "Command is required. Valid commands: files-sync, files-index, files-stats, db-sync, db-index, db-domains, db-apply, preflight, preflight-assert, flat-document-root",
             );
         }
 
@@ -1324,12 +1324,12 @@ class ImportClient
                 "files-stats",
                 "preflight",
                 "preflight-assert",
-                "flatten-docroot",
+                "flat-document-root",
                 "apply-runtime",
             ])
         ) {
             throw new InvalidArgumentException(
-                "Invalid command: {$command}. Valid commands: files-sync, files-index, files-stats, db-sync, db-index, db-domains, db-apply, preflight, preflight-assert, flatten-docroot, apply-runtime",
+                "Invalid command: {$command}. Valid commands: files-sync, files-index, files-stats, db-sync, db-index, db-domains, db-apply, preflight, preflight-assert, flat-document-root, apply-runtime",
             );
         }
 
@@ -1344,14 +1344,14 @@ class ImportClient
             $this->follow_symlinks = $this->state["follow_symlinks"];
         }
 
-        // Persist docroot_nonempty_behavior in state so it survives across invocations.
+        // Persist fs_root_nonempty_behavior in state so it survives across invocations.
         // 'preserve-local' preserves existing local files instead of overwriting
         // them, and gracefully skips non-writable directories.
-        if (isset($options["docroot_nonempty_behavior"])) {
-            $this->state["docroot_nonempty_behavior"] = $this->docroot_nonempty_behavior;
+        if (isset($options["fs_root_nonempty_behavior"])) {
+            $this->state["fs_root_nonempty_behavior"] = $this->fs_root_nonempty_behavior;
             $this->save_state($this->state);
         } else {
-            $this->docroot_nonempty_behavior = $this->state["docroot_nonempty_behavior"] ?? 'error';
+            $this->fs_root_nonempty_behavior = $this->state["fs_root_nonempty_behavior"] ?? 'error';
         }
 
         // Persist filter in state so it survives across resume cycles.
@@ -1490,8 +1490,8 @@ class ImportClient
             $this->run_files_stats();
             return;
         }
-        if ($command === "flatten-docroot") {
-            $this->run_flatten_docroot($options);
+        if ($command === "flat-document-root") {
+            $this->run_flat_document_root($options);
             return;
         }
         if ($command === "apply-runtime") {
@@ -1777,10 +1777,10 @@ class ImportClient
 
         // Detect webhost environment from preflight data.
         // The host analyzers score based on preflight signals. We also
-        // check the local docroot for a __wp__ symlink as a fallback
+        // check the local fs root for a __wp__ symlink as a fallback
         // when the remote preflight didn't report enough filesystem data.
         $detected_webhost = is_array($payload) ? detect_host($payload) : 'other';
-        if ($detected_webhost === 'other' && is_link($this->docroot . '/__wp__')) {
+        if ($detected_webhost === 'other' && is_link($this->fs_root . '/__wp__')) {
             $detected_webhost = 'wpcloud';
         }
         $this->state["webhost"] = $detected_webhost;
@@ -2359,7 +2359,7 @@ class ImportClient
         }
 
         $is_empty =
-            !is_dir($this->docroot) || count(scandir($this->docroot)) <= 2; // only . and ..
+            !is_dir($this->fs_root) || count(scandir($this->fs_root)) <= 2; // only . and ..
 
         // A local index from a prior completed sync means the next run is a
         // delta: re-index the remote, diff against local, fetch only changes.
@@ -2389,12 +2389,12 @@ class ImportClient
             }
         } else {
             // Starting fresh — validate that target directory is empty.
-            // A delta sync ($is_delta) naturally has a non-empty docroot
+            // A delta sync ($is_delta) naturally has a non-empty fs root
             // because we put those files there during the initial sync.
-            if (!$is_empty && !$is_delta && $this->docroot_nonempty_behavior === 'error') {
+            if (!$is_empty && !$is_delta && $this->fs_root_nonempty_behavior === 'error') {
                 throw new RuntimeException(
                     "Target directory is not empty and no cursor found. " .
-                        "Either clear the target directory, use --abort flag, or use --on-docroot-nonempty=preserve-local to sync while preserving the existing content.",
+                        "Either clear the target directory, use --abort flag, or use --on-fs-root-nonempty=preserve-local to sync while preserving the existing content.",
                 );
             }
 
@@ -2422,7 +2422,7 @@ class ImportClient
                 }
             } else {
                 $this->audit_log(
-                    "START files-sync ({$this->docroot_nonempty_behavior} mode, ".($is_empty ? 'empty directory' : 'non-empty directory').")",
+                    "START files-sync ({$this->fs_root_nonempty_behavior} mode, ".($is_empty ? 'empty directory' : 'non-empty directory').")",
                     true,
                 );
 
@@ -2942,8 +2942,8 @@ class ImportClient
      *
      * Since the server indexes everything under realpath()-resolved paths,
      * the files are already downloaded to the target location (e.g.
-     * docroot/wordpress/...).  We just need to create the symlink
-     * (e.g. docroot/srv/wordpress -> /wordpress) so the directory
+     * fs-root/wordpress/...).  We just need to create the symlink
+     * (e.g. fs-root/srv/wordpress -> /wordpress) so the directory
      * layout matches the server.
      */
     private function recreate_intermediate_symlinks(): void
@@ -3412,11 +3412,11 @@ class ImportClient
      * the applier writes the files the target server needs to fulfill those
      * requirements.
      *
-     * The effective docroot is --docroot + the remote site's document_root
+     * The effective fs root is --fs-root + the remote site's document_root
      * prefix (from preflight). For example, if the remote document_root is
-     * /srv/htdocs and --docroot is ./files, the effective docroot is
-     * ./files/srv/htdocs. If the site was flattened with flatten-docroot,
-     * pass the flattened directory as --docroot directly and the prefix
+     * /srv/htdocs and --fs-root is ./files, the effective fs root is
+     * ./files/srv/htdocs. If the site was flattened with flat-document-root,
+     * pass the flattened directory as --fs-root directly and the prefix
      * is not applied.
      */
     private function run_apply_runtime(array $options): void
@@ -3447,19 +3447,19 @@ class ImportClient
         $preflight_data = $entry["data"];
         $webhost = $this->state["webhost"] ?? "other";
 
-        // Resolve the effective docroot from either --flattened-docroot
-        // (used as-is) or --docroot (prefixed with the remote document_root).
+        // Resolve the effective fs root from either --flat-document-root
+        // (used as-is) or --fs-root (prefixed with the remote document_root).
         // Mutual exclusion is already enforced at the CLI level.
-        $flattened_docroot = $options["flattened_docroot"] ?? null;
+        $flat_document_root = $options["flat_document_root"] ?? null;
 
-        if (!empty($flattened_docroot)) {
-            // --flattened-docroot: used directly as the web root.
-            $effective_docroot = rtrim($flattened_docroot, "/");
+        if (!empty($flat_document_root)) {
+            // --flat-document-root: used directly as the web root.
+            $effective_fs_root = rtrim($flat_document_root, "/");
         } else {
-            // --docroot: the raw download directory. The remote site's
+            // --fs-root: the raw download directory. The remote site's
             // document_root tells us where the web root lived on the
             // source server. Files are downloaded preserving the full
-            // remote path, so the effective docroot is --docroot +
+            // remote path, so the effective fs root is --fs-root +
             // document_root.
             $remote_doc_root = $preflight_data["runtime"]["document_root"] ?? "";
             if (is_string($remote_doc_root)) {
@@ -3469,24 +3469,24 @@ class ImportClient
             }
 
             if ($remote_doc_root !== "") {
-                $effective_docroot = $this->docroot . $remote_doc_root;
+                $effective_fs_root = $this->fs_root . $remote_doc_root;
             } else {
-                $effective_docroot = $this->docroot;
+                $effective_fs_root = $this->fs_root;
             }
 
-            if (!is_dir($effective_docroot)) {
+            if (!is_dir($effective_fs_root)) {
                 throw new RuntimeException(
-                    "Effective docroot does not exist: {$effective_docroot}\n" .
+                    "Effective fs root does not exist: {$effective_fs_root}\n" .
                     "The remote document_root was: {$remote_doc_root}\n" .
-                    "If you used flatten-docroot, pass the flattened directory " .
-                    "with --flattened-docroot instead of --docroot."
+                    "If you used flat-document-root, pass the flattened directory " .
+                    "with --flat-document-root instead of --fs-root."
                 );
             }
         }
 
         // Resolve to absolute paths so generated files work from any cwd.
         $abs_output_dir = realpath($output_dir) ?: $output_dir;
-        $abs_docroot = realpath($effective_docroot) ?: $effective_docroot;
+        $abs_fs_root = realpath($effective_fs_root) ?: $effective_fs_root;
 
         if (!is_dir($abs_output_dir)) {
             if (!mkdir($abs_output_dir, 0755, true)) {
@@ -3527,7 +3527,7 @@ class ImportClient
                 $db_dir = rtrim(dirname($sqlite_path), '/') . '/';
                 $db_file = basename($sqlite_path);
             } else {
-                $db_dir = '{docroot}/wp-content/database/';
+                $db_dir = '{fs-root}/wp-content/database/';
                 $db_file = '.ht.sqlite';
             }
             $manifest->sqlite = [
@@ -3561,20 +3561,20 @@ class ImportClient
         }
 
         // Resolve the path to WordPress's index.php. On standard hosts it
-        // lives in the docroot. On WPCloud the ABSPATH is a different
+        // lives in the fs root. On WPCloud the ABSPATH is a different
         // directory (e.g. /wordpress/core/X.Y.Z) which maps to
-        // download_root + abspath when using --docroot.
+        // download_root + abspath when using --fs-root.
         $paths_urls = $preflight_data["database"]["wp"]["paths_urls"] ?? [];
         $abspath = rtrim($paths_urls["abspath"] ?? "", "/");
-        if (!empty($flattened_docroot)) {
+        if (!empty($flat_document_root)) {
             // Flattened layout: index.php is at the top level.
-            $wordpress_index = $abs_docroot . '/index.php';
+            $wordpress_index = $abs_fs_root . '/index.php';
         } elseif ($abspath !== "") {
             // Raw download: ABSPATH is relative to the download root,
-            // not the effective docroot (which is download_root + document_root).
-            $wordpress_index = realpath($this->docroot . $abspath . '/index.php') ?: '';
+            // not the effective fs root (which is download_root + document_root).
+            $wordpress_index = realpath($this->fs_root . $abspath . '/index.php') ?: '';
         } else {
-            $wordpress_index = $abs_docroot . '/index.php';
+            $wordpress_index = $abs_fs_root . '/index.php';
         }
 
         // Step 2: Runtime applier writes server-specific config files.
@@ -3600,14 +3600,14 @@ class ImportClient
             // Replace the source path with the copied-to path so the
             // generated runtime.php points to the output directory.
             $manifest->sqlite['plugin_dir'] = $copied_plugin;
-            // Resolve {docroot} in db_dir now that we have the real path.
+            // Resolve {fs-root} in db_dir now that we have the real path.
             $manifest->sqlite['db_dir'] = resolve_runtime_placeholders(
                 $manifest->sqlite['db_dir'],
-                $abs_docroot,
+                $abs_fs_root,
             );
         }
 
-        $summary = $applier->apply($manifest, $abs_docroot, $abs_output_dir, $applier_options);
+        $summary = $applier->apply($manifest, $abs_fs_root, $abs_output_dir, $applier_options);
 
         if ($manifest->sqlite !== null) {
             $summary[] = "Copied sqlite-database-integration to {$abs_output_dir}/sqlite-database-integration";
@@ -3641,13 +3641,13 @@ class ImportClient
     }
 
     /**
-     * Command: flatten-docroot
+     * Command: flat-document-root
      *
      * Creates a directory at the specified --flatten-to path that mirrors
      * a vanilla WordPress installation layout by symlinking entries from
-     * the import docroot. Uses preflight data (paths_urls) to determine
+     * the import fs root. Uses preflight data (paths_urls) to determine
      * where each WordPress component actually lives, rather than blindly
-     * scanning docroot top-level entries.
+     * scanning fs root top-level entries.
      *
      * This is essential when the source site uses a non-standard layout
      * (e.g. WP Cloud with ABSPATH=/srv/htdocs and WP_CONTENT_DIR=/tmp/__wp__/wp-content)
@@ -3658,22 +3658,22 @@ class ImportClient
      * If a path that should be a symlink is a regular file/directory,
      * the command stops with an error unless --force is specified.
      */
-    private function run_flatten_docroot(array $options): void
+    private function run_flat_document_root(array $options): void
     {
         $flatten_to = $options["flatten_to"] ?? null;
         if (empty($flatten_to)) {
             throw new InvalidArgumentException(
-                "flatten-docroot requires --flatten-to=PATH",
+                "flat-document-root requires --flatten-to=PATH",
             );
         }
 
         $flatten_to = rtrim($flatten_to, "/");
         $force = $options["force"] ?? false;
 
-        // Ensure the docroot exists
-        if (!is_dir($this->docroot)) {
+        // Ensure the fs root exists
+        if (!is_dir($this->fs_root)) {
             throw new RuntimeException(
-                "Docroot does not exist: {$this->docroot}",
+                "Fs root does not exist: {$this->fs_root}",
             );
         }
 
@@ -3718,32 +3718,32 @@ class ImportClient
             );
         }
 
-        // Map remote paths to local paths within docroot
-        $local_abspath = $this->docroot . $abspath;
+        // Map remote paths to local paths within fs root
+        $local_abspath = $this->fs_root . $abspath;
         if (!is_dir($local_abspath)) {
             throw new RuntimeException(
-                "WordPress ABSPATH directory not found in docroot: {$local_abspath} " .
+                "WordPress ABSPATH directory not found in fs root: {$local_abspath} " .
                     "(remote ABSPATH: {$abspath}). Has the file sync completed?",
             );
         }
 
         $local_wp_admin = $wp_admin_path !== null
-            ? $this->docroot . $wp_admin_path
+            ? $this->fs_root . $wp_admin_path
             : null;
         $local_wp_includes = $wp_includes_path !== null
-            ? $this->docroot . $wp_includes_path
+            ? $this->fs_root . $wp_includes_path
             : null;
         $local_content_dir = $content_dir !== null
-            ? $this->docroot . $content_dir
+            ? $this->fs_root . $content_dir
             : null;
         $local_plugins_dir = $plugins_dir !== null
-            ? $this->docroot . $plugins_dir
+            ? $this->fs_root . $plugins_dir
             : null;
         $local_mu_plugins_dir = $mu_plugins_dir !== null
-            ? $this->docroot . $mu_plugins_dir
+            ? $this->fs_root . $mu_plugins_dir
             : null;
         $local_uploads_basedir = $uploads_basedir !== null
-            ? $this->docroot . $uploads_basedir
+            ? $this->fs_root . $uploads_basedir
             : null;
 
         // Determine which components are "detached" — located outside
@@ -3781,13 +3781,13 @@ class ImportClient
                 );
             }
             $this->audit_log(
-                "FLATTEN-DOCROOT | Created directory: {$flatten_to}",
+                "FLAT-DOCUMENT-ROOT | Created directory: {$flatten_to}",
             );
         }
 
         $this->audit_log(
             sprintf(
-                "FLATTEN-DOCROOT | abspath=%s wp_admin=%s wp_includes=%s " .
+                "FLAT-DOCUMENT-ROOT | abspath=%s wp_admin=%s wp_includes=%s " .
                     "content_dir=%s content_detached=%s " .
                     "plugins_detached=%s mu_plugins_detached=%s uploads_detached=%s",
                 $abspath,
@@ -3834,7 +3834,7 @@ class ImportClient
             }
             if (isset($skip_from_abspath[$entry])) {
                 $this->audit_log(
-                    "FLATTEN-DOCROOT | Skipping '{$entry}' from ABSPATH " .
+                    "FLAT-DOCUMENT-ROOT | Skipping '{$entry}' from ABSPATH " .
                         "(will be sourced from resolved location)",
                 );
                 continue;
@@ -3970,7 +3970,7 @@ class ImportClient
                 );
             } else {
                 $this->audit_log(
-                    "FLATTEN-DOCROOT | Warning: content_dir not found in docroot: " .
+                    "FLAT-DOCUMENT-ROOT | Warning: content_dir not found in fs root: " .
                         "{$local_content_dir} (remote: {$content_dir})",
                     true,
                 );
@@ -3979,7 +3979,7 @@ class ImportClient
 
         $this->audit_log(
             sprintf(
-                "FLATTEN-DOCROOT | Complete: %d created, %d refreshed, %d force-replaced",
+                "FLAT-DOCUMENT-ROOT | Complete: %d created, %d refreshed, %d force-replaced",
                 $created,
                 $refreshed,
                 $forced,
@@ -3990,7 +3990,7 @@ class ImportClient
         $result = [
             "status" => "complete",
             "flatten_to" => $flatten_to,
-            "docroot" => $this->docroot,
+            "fs_root" => $this->fs_root,
             "abspath" => $abspath,
             "wp_admin_path" => $wp_admin_path,
             "wp_includes_path" => $wp_includes_path,
@@ -4098,7 +4098,7 @@ class ImportClient
             // Points elsewhere — remove and recreate
             unlink($target);
             $this->audit_log(
-                "FLATTEN-DOCROOT | Refreshed symlink: {$target} (was -> {$current_link_target})",
+                "FLAT-DOCUMENT-ROOT | Refreshed symlink: {$target} (was -> {$current_link_target})",
             );
             if (!symlink($link_value, $target)) {
                 throw new RuntimeException(
@@ -4122,7 +4122,7 @@ class ImportClient
 
             $type = is_dir($target) ? "directory" : "file";
             $this->audit_log(
-                "FLATTEN-DOCROOT FORCE | Removing conflicting {$type}: {$target}",
+                "FLAT-DOCUMENT-ROOT FORCE | Removing conflicting {$type}: {$target}",
                 true,
             );
 
@@ -4144,7 +4144,7 @@ class ImportClient
             );
         }
         $this->audit_log(
-            "FLATTEN-DOCROOT | Created symlink: {$target} -> {$link_value}",
+            "FLAT-DOCUMENT-ROOT | Created symlink: {$target} -> {$link_value}",
         );
         $created++;
     }
@@ -4167,7 +4167,7 @@ class ImportClient
                 );
             }
             $this->audit_log(
-                "FLATTEN-DOCROOT FORCE | Replacing symlink with real directory: {$path}",
+                "FLAT-DOCUMENT-ROOT FORCE | Replacing symlink with real directory: {$path}",
                 true,
             );
             unlink($path);
@@ -4181,7 +4181,7 @@ class ImportClient
                 );
             }
             $this->audit_log(
-                "FLATTEN-DOCROOT | Created directory: {$path}",
+                "FLAT-DOCUMENT-ROOT | Created directory: {$path}",
             );
         }
     }
@@ -5668,7 +5668,7 @@ class ImportClient
     }
 
     /**
-     * Delete a local file path safely under the docroot.
+     * Delete a local file path safely under the fs root.
      */
     private function delete_local_file_path(string $path): void
     {
@@ -6957,22 +6957,22 @@ class ImportClient
     }
 
     /**
-     * Return canonical docroot path, creating it if it doesn't exist.
+     * Return canonical fs root path, creating it if it doesn't exist.
      */
     private function get_filesystem_root_path(): string
     {
-        if (!is_dir($this->docroot)) {
-            if (!mkdir($this->docroot, 0755, true) && !is_dir($this->docroot)) {
+        if (!is_dir($this->fs_root)) {
+            if (!mkdir($this->fs_root, 0755, true) && !is_dir($this->fs_root)) {
                 throw new RuntimeException(
-                    "Failed to create docroot directory: {$this->docroot}",
+                    "Failed to create fs root directory: {$this->fs_root}",
                 );
             }
         }
 
-        $real = realpath($this->docroot);
+        $real = realpath($this->fs_root);
         if ($real === false) {
             throw new RuntimeException(
-                "Failed to resolve docroot path: {$this->docroot}",
+                "Failed to resolve fs root path: {$this->fs_root}",
             );
         }
 
@@ -6981,10 +6981,10 @@ class ImportClient
 
 
     /**
-     * Resolve a remote absolute path into a local path under the docroot.
+     * Resolve a remote absolute path into a local path under the fs root.
      *
      * Maps a remote absolute path (e.g. "/wp-content/uploads/photo.jpg") to a
-     * local path under the import docroot. Performs symlink traversal security
+     * local path under the import fs root. Performs symlink traversal security
      * checks to prevent directory traversal attacks that could write files
      * outside the import root.
      */
@@ -7214,7 +7214,7 @@ class ImportClient
      */
     private function should_skip_for_preserve_local(string $path): ?string
     {
-        if ($this->docroot_nonempty_behavior !== 'preserve-local') {
+        if ($this->fs_root_nonempty_behavior !== 'preserve-local') {
             return null;
         }
 
@@ -7274,7 +7274,7 @@ class ImportClient
      */
     private function ensure_directory_path(string $dir): void
     {
-        // Security: Ensure path is under the docroot
+        // Security: Ensure path is under the fs root
         $real_filesystem_root = $this->get_filesystem_root_path();
 
         // Resolve the target path (or what it would be)
@@ -7294,22 +7294,22 @@ class ImportClient
                 !path_is_within_root($real_check, $real_filesystem_root)
             ) {
                 // In preserve-local mode, a path that resolves outside the
-                // docroot is expected when a directory like wp-content/plugins
+                // fs root is expected when a directory like wp-content/plugins
                 // is symlinked to a shared hosting location.  Skip gracefully
                 // instead of treating it as a security violation.
-                if ($this->docroot_nonempty_behavior === 'preserve-local') {
+                if ($this->fs_root_nonempty_behavior === 'preserve-local') {
                     throw new PreserveLocalSkipException(
-                        "PRESERVE-LOCAL: path resolves outside docroot via symlink: {$dir}",
+                        "PRESERVE-LOCAL: path resolves outside fs root via symlink: {$dir}",
                     );
                 }
                 throw new RuntimeException(
-                    "Security: Refusing to create directory outside docroot: {$dir}",
+                    "Security: Refusing to create directory outside fs root: {$dir}",
                 );
             }
         }
 
         if (is_dir($dir) && !is_link($dir)) {
-            if ($this->docroot_nonempty_behavior === 'preserve-local' && !is_writable($dir)) {
+            if ($this->fs_root_nonempty_behavior === 'preserve-local' && !is_writable($dir)) {
                 throw new PreserveLocalSkipException(
                     "PRESERVE-LOCAL: directory not writable: {$dir}",
                 );
@@ -7322,7 +7322,7 @@ class ImportClient
             !str_starts_with($dir, $real_filesystem_root . "/")
         ) {
             throw new RuntimeException(
-                "Security: Refusing to create directory outside docroot: {$dir}",
+                "Security: Refusing to create directory outside fs root: {$dir}",
             );
         }
 
@@ -7339,7 +7339,7 @@ class ImportClient
             $current .= "/" . $part;
 
             if (is_link($current)) {
-                if ($this->docroot_nonempty_behavior === 'preserve-local') {
+                if ($this->fs_root_nonempty_behavior === 'preserve-local') {
                     // Never create directories through symlinks — the symlink
                     // and its target contents are shared hosting infrastructure
                     // that must not be modified.
@@ -7363,7 +7363,7 @@ class ImportClient
 
             // Remove file if blocking directory creation
             if (is_file($current)) {
-                if ($this->docroot_nonempty_behavior === 'preserve-local') {
+                if ($this->fs_root_nonempty_behavior === 'preserve-local') {
                     throw new PreserveLocalSkipException(
                         "PRESERVE-LOCAL: file blocks directory creation: {$current}",
                     );
@@ -7381,7 +7381,7 @@ class ImportClient
 
             // Create directory if it doesn't exist
             if (is_dir($current)) {
-                if ($this->docroot_nonempty_behavior === 'preserve-local' && !is_writable($current)) {
+                if ($this->fs_root_nonempty_behavior === 'preserve-local' && !is_writable($current)) {
                     throw new PreserveLocalSkipException(
                         "PRESERVE-LOCAL: directory not writable: {$current}",
                     );
@@ -7397,7 +7397,7 @@ class ImportClient
             $resolved = realpath($current);
             if ($resolved === false || !path_is_within_root($resolved, $real_filesystem_root)) {
                 throw new RuntimeException(
-                    "Security: Refusing to create directory outside docroot: {$current}",
+                    "Security: Refusing to create directory outside fs root: {$current}",
                 );
             }
         }
@@ -7430,7 +7430,7 @@ class ImportClient
         // directory or via a symlink to a directory), keep it as-is.
         // Also skip if any parent component is a symlink — we never create
         // new directories through symlinked paths.
-        if ($this->docroot_nonempty_behavior === 'preserve-local') {
+        if ($this->fs_root_nonempty_behavior === 'preserve-local') {
             if (is_dir($local_path)) {
                 $this->audit_log("PRESERVE-LOCAL skip directory (exists): {$path}", true);
                 $this->show_progress_line("[skip] " . $this->display_path($path));
@@ -7516,7 +7516,7 @@ class ImportClient
         // path, keep it — whether it's a file, directory, or another symlink.
         // Also skip if any parent component is a symlink — we never create
         // new content through symlinked directories.
-        if ($this->docroot_nonempty_behavior === 'preserve-local') {
+        if ($this->fs_root_nonempty_behavior === 'preserve-local') {
             if (file_exists($local_path) || is_link($local_path)) {
                 $this->audit_log("PRESERVE-LOCAL skip symlink (path exists): {$path} -> {$target}", true);
                 $this->show_progress_line("[skip] " . $this->display_path($path));
@@ -7661,7 +7661,7 @@ class ImportClient
             true,
         );
         if ($path !== "" && $is_file_error) {
-            $local_path = $this->docroot . $path;
+            $local_path = $this->fs_root . $path;
             if ($context->file_handle && $context->file_path === $local_path) {
                 fclose($context->file_handle);
                 $context->file_handle = null;
@@ -8571,14 +8571,14 @@ class ImportClient
         $version = $this->state["version"] ?? null;
         $webhost = $this->state["webhost"] ?? null;
         $follow = $this->state["follow_symlinks"] ?? false;
-        $nonempty = $this->state["docroot_nonempty_behavior"] ?? "error";
+        $nonempty = $this->state["fs_root_nonempty_behavior"] ?? "error";
         $max_packet = $this->state["max_allowed_packet"] ?? null;
         $this->state = $this->default_state();
         $this->state["preflight"] = $preflight;
         $this->state["version"] = $version;
         $this->state["webhost"] = $webhost;
         $this->state["follow_symlinks"] = $follow;
-        $this->state["docroot_nonempty_behavior"] = $nonempty;
+        $this->state["fs_root_nonempty_behavior"] = $nonempty;
         $this->state["max_allowed_packet"] = $max_packet;
     }
 
@@ -8595,7 +8595,7 @@ class ImportClient
             "version" => null,
             "webhost" => null,
             "follow_symlinks" => true,
-            "docroot_nonempty_behavior" => "error",
+            "fs_root_nonempty_behavior" => "error",
             "filter" => "none",
             "max_allowed_packet" => null,
             "db_index" => [
@@ -9261,7 +9261,7 @@ if (
         "files-sync" => [
             "short" => "Sync files (auto-detects initial vs delta)",
             "detail" =>
-                "Streams files from the remote server into the --docroot directory.\n" .
+                "Streams files from the remote server into the --fs-root directory.\n" .
                 "Auto-detects whether to run an initial or delta sync based on state:\n" .
                 "\n" .
                 "  - No prior sync: downloads the full directory tree (initial)\n" .
@@ -9272,8 +9272,8 @@ if (
                 "  --abort              Abort current sync and exit (keeps files and index)\n" .
                 "  --filter=MODE        Filter which files to download (none|essential-files|skipped-earlier)\n" .
                 "  --no-follow-symlinks Do not follow symlinks pointing outside root directories\n" .
-                "  --on-docroot-nonempty=MODE\n" .
-                "                       What to do when docroot is non-empty (error|preserve-local)\n" .
+                "  --on-fs-root-nonempty=MODE\n" .
+                "                       What to do when fs root is non-empty (error|preserve-local)\n" .
                 "  --secret=TOKEN       HMAC shared secret for export API authentication\n" .
                 "  --verbose, -v        Show detailed request/response logs\n" .
                 "\n" .
@@ -9284,7 +9284,7 @@ if (
                 "  skipped-earlier   Download only files skipped by a prior essential-files run.\n" .
                 "\n" .
                 "Output files:\n" .
-                "  (docroot)/                              Downloaded files\n" .
+                "  (fs-root)/                              Downloaded files\n" .
                 "  .import-index.jsonl                     Local file index\n" .
                 "  .import-remote-index.jsonl              Remote index snapshot\n" .
                 "  .import-download-list.jsonl             Files pending download\n" .
@@ -9427,7 +9427,7 @@ if (
                 "Options:\n" .
                 "  --secret=TOKEN   HMAC shared secret for export API authentication\n",
         ],
-        "flatten-docroot" => [
+        "flat-document-root" => [
             "short" => "Create a vanilla WordPress directory layout using symlinks",
             "detail" =>
                 "Creates a directory at --flatten-to that mirrors the standard\n" .
@@ -9436,7 +9436,7 @@ if (
                 "\n" .
                 "Uses preflight paths_urls (ABSPATH, WP_CONTENT_DIR, WP_PLUGIN_DIR,\n" .
                 "WPMU_PLUGIN_DIR, uploads basedir) to locate each WordPress component\n" .
-                "within the import docroot, even when they reside in different parent\n" .
+                "within the import fs root, even when they reside in different parent\n" .
                 "directories on the source server (e.g. WP Cloud with ABSPATH at\n" .
                 "/srv/htdocs and WP_CONTENT_DIR at /tmp/__wp__/wp-content).\n" .
                 "\n" .
@@ -9464,13 +9464,13 @@ if (
                 "Does not require a remote URL — reads only from local state.\n" .
                 "Requires a prior preflight run to detect the source host.\n" .
                 "\n" .
-                "Pass --docroot for the raw download directory (the remote document_root\n" .
-                "path is appended automatically), or --flattened-docroot for a directory\n" .
-                "created by flatten-docroot (used as-is). These are mutually exclusive.\n" .
+                "Pass --fs-root for the raw download directory (the remote document_root\n" .
+                "path is appended automatically), or --flat-document-root for a directory\n" .
+                "created by flat-document-root (used as-is). These are mutually exclusive.\n" .
                 "\n" .
                 "Options:\n" .
-                "  --docroot=DIR             Raw download directory (remote path appended)\n" .
-                "  --flattened-docroot=DIR   Flattened layout directory (used as-is)\n" .
+                "  --fs-root=DIR             Raw download directory (remote path appended)\n" .
+                "  --flat-document-root=DIR   Flattened layout directory (used as-is)\n" .
                 "  --runtime=RUNTIME         Target server runtime (required):\n" .
                 "                              nginx-fpm    — writes runtime.php + nginx.conf\n" .
                 "                              php-builtin  — writes runtime.php + start.sh\n" .
@@ -9486,7 +9486,7 @@ if (
                 "  DB_USER, and DB_PASSWORD. For SQLite targets, the sqlite-database-\n" .
                 "  integration plugin is copied into the output directory and a lazy-\n" .
                 "  loading \$wpdb proxy is generated in runtime.php (Playground-style,\n" .
-                "  no files placed in the docroot).\n" .
+                "  no files placed in the fs-root).\n" .
                 "\n" .
                 "Output files (nginx-fpm):\n" .
                 "  (output-dir)/runtime.php             PHP runtime (constants, route handlers)\n" .
@@ -9502,11 +9502,11 @@ if (
                 "Examples:\n" .
                 "  # From raw download directory:\n" .
                 "  php import.php apply-runtime --state-dir=./state \\\n" .
-                "    --docroot=./files --output-dir=./runtime --runtime=php-builtin\n" .
+                "    --fs-root=./files --output-dir=./runtime --runtime=php-builtin\n" .
                 "\n" .
                 "  # From flattened layout:\n" .
                 "  php import.php apply-runtime --state-dir=./state \\\n" .
-                "    --flattened-docroot=./flat --output-dir=./runtime --runtime=php-builtin\n" .
+                "    --flat-document-root=./flat --output-dir=./runtime --runtime=php-builtin\n" .
                 "\n" .
                 "  bash ./runtime/start.sh\n",
         ],
@@ -9516,7 +9516,7 @@ if (
     if ($argc < 2 || (isset($argv[1]) && in_array($argv[1], ["--help", "-h", "help"]))) {
         echo "Version " . get_importer_version() . "\n";
         echo "\n";
-        echo "Usage: php import.php <command> <remote-url> --state-dir=DIR --docroot=DIR [options]\n";
+        echo "Usage: php import.php <command> <remote-url> --state-dir=DIR --fs-root=DIR [options]\n";
         echo "\n";
         echo "Commands:\n";
         $max_len = max(array_map('strlen', array_keys($command_help)));
@@ -9528,14 +9528,14 @@ if (
         echo "\n";
         echo "Required options:\n";
         echo "  --state-dir=DIR      Directory for import state files and SQL dumps\n";
-        echo "  --docroot=DIR        Directory where downloaded site files are written\n";
+        echo "  --fs-root=DIR        Directory where downloaded site files are written\n";
         echo "\n";
         echo "Global options:\n";
         echo "  --secret=TOKEN       HMAC shared secret for export API authentication\n";
         echo "  --abort            Abort current sync and exit (preserves downloaded files)\n";
         echo "  --no-follow-symlinks Do not follow symlinks pointing outside root directories\n";
-        echo "  --on-docroot-nonempty=MODE\n";
-        echo "                       What to do when docroot is non-empty (error|preserve-local)\n";
+        echo "  --on-fs-root-nonempty=MODE\n";
+        echo "                       What to do when fs root is non-empty (error|preserve-local)\n";
         echo "  --version, -V        Print version and exit\n";
         echo "  --verbose, -v        Show detailed request/response logs\n";
         echo "  --no-adaptive        Disable adaptive request tuning\n";
@@ -9558,7 +9558,7 @@ if (
     // Per-command --help (can be requested before providing url/path)
     if (in_array("--help", array_slice($argv, 2)) || in_array("-h", array_slice($argv, 2))) {
         if (isset($command_help[$command])) {
-            echo "Usage: php import.php {$command} <remote-url> --state-dir=DIR --docroot=DIR [options]\n";
+            echo "Usage: php import.php {$command} <remote-url> --state-dir=DIR --fs-root=DIR [options]\n";
             echo "\n";
             echo $command_help[$command]["detail"] . "\n";
         } else {
@@ -9580,15 +9580,15 @@ if (
         $remote_url = $argv[2] ?? null;
         if (!$remote_url) {
             fwrite(STDERR, "Error: <remote-url> is required\n");
-            fwrite(STDERR, "Usage: php import.php {$command} <remote-url> --state-dir=DIR --docroot=DIR [options]\n");
+            fwrite(STDERR, "Usage: php import.php {$command} <remote-url> --state-dir=DIR --fs-root=DIR [options]\n");
             exit(1);
         }
         $option_start_index = 3;
     }
 
-    // Parse options (--state-dir and --docroot are required named options)
+    // Parse options (--state-dir and --fs-root are required named options)
     $state_dir = null;
-    $docroot = null;
+    $fs_root = null;
     $options = [
         "command" => $command,
         "abort" => false,
@@ -9600,8 +9600,8 @@ if (
     for ($i = $option_start_index; $i < $argc; $i++) {
         if (strpos($argv[$i], "--state-dir=") === 0) {
             $state_dir = substr($argv[$i], strlen("--state-dir="));
-        } elseif (strpos($argv[$i], "--docroot=") === 0) {
-            $docroot = substr($argv[$i], strlen("--docroot="));
+        } elseif (strpos($argv[$i], "--fs-root=") === 0) {
+            $fs_root = substr($argv[$i], strlen("--fs-root="));
         } elseif (strpos($argv[$i], "--secret=") === 0) {
             $options["secret"] = substr($argv[$i], strlen("--secret="));
         } elseif ($argv[$i] === "--abort") {
@@ -9620,10 +9620,10 @@ if (
                 exit(1);
             }
             $options["filter"] = $filter_value;
-        } elseif (strpos($argv[$i], "--on-docroot-nonempty=") === 0) {
-            $options["docroot_nonempty_behavior"] = substr(
+        } elseif (strpos($argv[$i], "--on-fs-root-nonempty=") === 0) {
+            $options["fs_root_nonempty_behavior"] = substr(
                 $argv[$i],
-                strlen("--on-docroot-nonempty="),
+                strlen("--on-fs-root-nonempty="),
             );
         } elseif (strpos($argv[$i], "--duty=") === 0) {
             $options["tuning_config"]["duty"] = (float) substr(
@@ -9849,8 +9849,8 @@ if (
             $options["runtime"] = substr($argv[$i], strlen("--runtime="));
         } elseif (strpos($argv[$i], "--output-dir=") === 0) {
             $options["output_dir"] = substr($argv[$i], strlen("--output-dir="));
-        } elseif (strpos($argv[$i], "--flattened-docroot=") === 0) {
-            $options["flattened_docroot"] = substr($argv[$i], strlen("--flattened-docroot="));
+        } elseif (strpos($argv[$i], "--flat-document-root=") === 0) {
+            $options["flat_document_root"] = substr($argv[$i], strlen("--flat-document-root="));
         } elseif (strpos($argv[$i], "--host=") === 0) {
             $options["host"] = substr($argv[$i], strlen("--host="));
         } elseif (strpos($argv[$i], "--port=") === 0) {
@@ -9863,30 +9863,30 @@ if (
 
     if (!$state_dir) {
         fwrite(STDERR, "Error: --state-dir=DIR is required\n");
-        fwrite(STDERR, "Usage: php import.php {$command} <remote-url> --state-dir=DIR --docroot=DIR [options]\n");
+        fwrite(STDERR, "Usage: php import.php {$command} <remote-url> --state-dir=DIR --fs-root=DIR [options]\n");
         exit(1);
     }
 
-    // apply-runtime accepts --flattened-docroot as an alternative to --docroot.
-    $flattened_docroot = $options["flattened_docroot"] ?? null;
-    if ($docroot && $flattened_docroot) {
-        fwrite(STDERR, "Error: --docroot and --flattened-docroot are mutually exclusive.\n");
-        fwrite(STDERR, "Use --docroot for the raw download directory, or --flattened-docroot for a flattened layout.\n");
+    // apply-runtime accepts --flat-document-root as an alternative to --fs-root.
+    $flat_document_root = $options["flat_document_root"] ?? null;
+    if ($fs_root && $flat_document_root) {
+        fwrite(STDERR, "Error: --fs-root and --flat-document-root are mutually exclusive.\n");
+        fwrite(STDERR, "Use --fs-root for the raw download directory, or --flat-document-root for a flattened layout.\n");
         exit(1);
     }
-    if (!$docroot && !$flattened_docroot) {
-        fwrite(STDERR, "Error: --docroot=DIR is required\n");
-        fwrite(STDERR, "Usage: php import.php {$command} <remote-url> --state-dir=DIR --docroot=DIR [options]\n");
+    if (!$fs_root && !$flat_document_root) {
+        fwrite(STDERR, "Error: --fs-root=DIR is required\n");
+        fwrite(STDERR, "Usage: php import.php {$command} <remote-url> --state-dir=DIR --fs-root=DIR [options]\n");
         exit(1);
     }
-    if (!$docroot) {
-        // For commands that need a docroot in the constructor, use the
-        // flattened docroot. run_apply_runtime will resolve it properly.
-        $docroot = $flattened_docroot;
+    if (!$fs_root) {
+        // For commands that need an fs root in the constructor, use the
+        // flattened fs root. run_apply_runtime will resolve it properly.
+        $fs_root = $flat_document_root;
     }
 
     try {
-        $client = new ImportClient($remote_url, $state_dir, $docroot);
+        $client = new ImportClient($remote_url, $state_dir, $fs_root);
         $client->run($options ?? []);
         exit($client->exit_code);
     } catch (\Throwable $e) {

--- a/importer/lib/host/analyzers/class-wpcloud-host-analyzer.php
+++ b/importer/lib/host/analyzers/class-wpcloud-host-analyzer.php
@@ -4,7 +4,7 @@
  *
  * WP Cloud sites have a non-standard directory layout: WordPress core lives
  * at a versioned path (/wordpress/core/X.Y.Z/) and wp-content is a separate
- * tree under /srv/htdocs/. After flatten-docroot, the local layout uses a
+ * tree under /srv/htdocs/. After flat-document-root, the local layout uses a
  * __wp__ directory for core.
  *
  * The export only ships original-size uploads, so the manifest declares a
@@ -73,8 +73,8 @@ class WpcloudHostAnalyzer implements HostAnalyzer
         $manifest->constants = $this->build_constants($preflight_data);
         $manifest->server_vars = [
             // WP Cloud uses a __wp__ directory for WordPress core. After
-            // flatten-docroot, it lives at {docroot}/__wp__/.
-            'WP_DIR' => '{docroot}/__wp__/',
+            // flat-document-root, it lives at {fs-root}/__wp__/.
+            'WP_DIR' => '{fs-root}/__wp__/',
         ];
 
         // WP Cloud exports only ship full-size uploads. WordPress post meta
@@ -97,7 +97,7 @@ class WpcloudHostAnalyzer implements HostAnalyzer
 
         // WP Cloud always needs THEMES_PATH_BASE since themes are under
         // wp-content, not under the __wp__ ABSPATH.
-        $result['THEMES_PATH_BASE'] = '{docroot}/wp-content/themes';
+        $result['THEMES_PATH_BASE'] = '{fs-root}/wp-content/themes';
 
         return $result;
     }

--- a/importer/lib/host/class-runtime-manifest.php
+++ b/importer/lib/host/class-runtime-manifest.php
@@ -13,9 +13,9 @@
  *
  * - php_ini:      INI directives the source site had (memory_limit, etc.)
  * - constants:    PHP constants to define before WordPress boots.
- *                 Values may contain {docroot} resolved at apply-time.
+ *                 Values may contain {fs-root} resolved at apply-time.
  * - server_vars:  $_SERVER entries to set before WordPress boots.
- *                 Values may contain {docroot}.
+ *                 Values may contain {fs-root}.
  * - routes:       Declarative request routes the target runtime must
  *                 implement. Each describes a URL path pattern, a handler
  *                 name, and an optional condition (e.g. "file_not_found").
@@ -31,10 +31,10 @@ class RuntimeManifest
     /** @var array<string, string> PHP INI directives */
     public array $php_ini = [];
 
-    /** @var array<string, string> PHP constants to define (values may use {docroot}) */
+    /** @var array<string, string> PHP constants to define (values may use {fs-root}) */
     public array $constants = [];
 
-    /** @var array<string, string> $_SERVER entries (values may use {docroot}) */
+    /** @var array<string, string> $_SERVER entries (values may use {fs-root}) */
     public array $server_vars = [];
 
     /**
@@ -69,7 +69,7 @@ class RuntimeManifest
      * SQLite database configuration.  When non-null, the target uses
      * SQLite instead of MySQL.  The runtime layer copies the plugin
      * into the output directory and generates a lazy-loading $wpdb
-     * proxy in runtime.php — no files are placed in the docroot.
+     * proxy in runtime.php — no files are placed in the fs-root.
      *
      * Keys:
      *   'plugin_source'  string  Absolute path to the sqlite-database-

--- a/importer/lib/host/functions.php
+++ b/importer/lib/host/functions.php
@@ -104,7 +104,7 @@ function extract_constants(array $preflight_data): array
     // (e.g. wpcloud has ABSPATH at /wordpress/core/X.Y.Z/ but wp-content
     // at /srv/htdocs/wp-content), we need to explicitly set it.
     if ($content_dir !== '' && $abspath !== '' && strpos($content_dir, $abspath) !== 0) {
-        $result['WP_CONTENT_DIR'] = '{docroot}/wp-content';
+        $result['WP_CONTENT_DIR'] = '{fs-root}/wp-content';
     }
 
     return $result;

--- a/importer/lib/target-runtime/class-nginx-fpm-applier.php
+++ b/importer/lib/target-runtime/class-nginx-fpm-applier.php
@@ -8,13 +8,13 @@
  *                                and INI directives passed via fastcgi_param
  *
  * Everything lives in the output directory — nothing is written to the
- * docroot. The nginx config passes PHP_VALUE directives to FPM via
+ * fs-root. The nginx config passes PHP_VALUE directives to FPM via
  * fastcgi_param, which is equivalent to .user.ini but configured in one
  * place alongside the rest of the server block.
  */
 class NginxFpmApplier implements RuntimeApplier
 {
-    public function apply(RuntimeManifest $manifest, string $docroot, string $output_dir, array $options = []): array
+    public function apply(RuntimeManifest $manifest, string $fs_root, string $output_dir, array $options = []): array
     {
         $host = $options['host'] ?? 'localhost';
         $port = (int) ($options['port'] ?? 80);
@@ -23,13 +23,13 @@ class NginxFpmApplier implements RuntimeApplier
 
         // 1. Write runtime.php
         $runtime_path = $output_dir . '/runtime.php';
-        $runtime = generate_runtime_php($manifest, $docroot);
+        $runtime = generate_runtime_php($manifest, $fs_root);
         write_runtime_file($runtime_path, $runtime);
         $summary[] = "Wrote {$runtime_path}";
 
         // 2. Write nginx.conf (includes auto_prepend_file + INI directives)
         $nginx_conf_path = $output_dir . '/nginx.conf';
-        $nginx_conf = $this->generate_nginx_conf($manifest, $docroot, $runtime_path, $host, $port);
+        $nginx_conf = $this->generate_nginx_conf($manifest, $fs_root, $runtime_path, $host, $port);
         write_runtime_file($nginx_conf_path, $nginx_conf);
         $summary[] = "Wrote {$nginx_conf_path}";
 
@@ -47,11 +47,11 @@ class NginxFpmApplier implements RuntimeApplier
      * Generate an nginx server block that serves static files directly
      * and routes PHP requests through PHP-FPM. INI directives and
      * auto_prepend_file are passed via fastcgi_param PHP_VALUE,
-     * so no .user.ini is needed in the docroot.
+     * so no .user.ini is needed in the fs-root.
      */
     private function generate_nginx_conf(
         RuntimeManifest $manifest,
-        string $docroot,
+        string $fs_root,
         string $runtime_path,
         string $host,
         int $port
@@ -63,7 +63,7 @@ class NginxFpmApplier implements RuntimeApplier
         $lines[] = 'server {';
         $lines[] = "    listen {$port};";
         $lines[] = "    server_name {$host};";
-        $lines[] = "    root {$docroot};";
+        $lines[] = "    root {$fs_root};";
         $lines[] = '    index index.php index.html;';
         $lines[] = '';
         $lines[] = '    # Static files served directly by nginx — no PHP involved.';
@@ -81,7 +81,7 @@ class NginxFpmApplier implements RuntimeApplier
 
         // Build the PHP_VALUE string — auto_prepend_file and INI directives.
         // fastcgi_param PHP_VALUE passes these to FPM as if they were in
-        // .user.ini, but without writing anything to the docroot.
+        // .user.ini, but without writing anything to the fs-root.
         $php_values = [];
         $php_values[] = "auto_prepend_file={$runtime_path}";
         foreach ($manifest->php_ini as $key => $value) {

--- a/importer/lib/target-runtime/class-php-builtin-applier.php
+++ b/importer/lib/target-runtime/class-php-builtin-applier.php
@@ -16,7 +16,7 @@
  */
 class PhpBuiltinApplier implements RuntimeApplier
 {
-    public function apply(RuntimeManifest $manifest, string $docroot, string $output_dir, array $options = []): array
+    public function apply(RuntimeManifest $manifest, string $fs_root, string $output_dir, array $options = []): array
     {
         $host = $options['host'] ?? 'localhost';
         $port = (int) ($options['port'] ?? 8881);
@@ -25,14 +25,14 @@ class PhpBuiltinApplier implements RuntimeApplier
 
         // 1. Write runtime.php (base layers + CLI-server routing)
         $runtime_path = $output_dir . '/runtime.php';
-        $runtime = generate_runtime_php($manifest, $docroot);
+        $runtime = generate_runtime_php($manifest, $fs_root);
         $runtime .= $this->generate_cli_server_routing($options);
         write_runtime_file($runtime_path, $runtime);
         $summary[] = "Wrote {$runtime_path}";
 
         // 2. Write start.sh
         $start_path = $output_dir . '/start.sh';
-        $start_script = $this->generate_start_script($manifest, $docroot, $runtime_path, $host, $port);
+        $start_script = $this->generate_start_script($manifest, $fs_root, $runtime_path, $host, $port);
         write_runtime_file($start_path, $start_script);
         chmod($start_path, 0755);
         $summary[] = "Wrote {$start_path}";
@@ -126,7 +126,7 @@ class PhpBuiltinApplier implements RuntimeApplier
      */
     private function generate_start_script(
         RuntimeManifest $manifest,
-        string $docroot,
+        string $fs_root,
         string $runtime_path,
         string $host,
         int $port
@@ -149,7 +149,7 @@ class PhpBuiltinApplier implements RuntimeApplier
         }
 
         $php_args[] = '-S ' . $host . ':' . $port;
-        $php_args[] = '-t ' . escapeshellarg($docroot);
+        $php_args[] = '-t ' . escapeshellarg($fs_root);
         $php_args[] = escapeshellarg($runtime_path);
 
         $lines[] = 'echo "Starting PHP built-in server..."';

--- a/importer/lib/target-runtime/functions.php
+++ b/importer/lib/target-runtime/functions.php
@@ -29,7 +29,7 @@ function runtime_applier_for(string $runtime): RuntimeApplier
  * Appliers may append platform-specific code to the result (e.g. the
  * php-builtin applier adds CLI-server routing).
  */
-function generate_runtime_php(RuntimeManifest $manifest, string $docroot): string
+function generate_runtime_php(RuntimeManifest $manifest, string $fs_root): string
 {
     $lines = [];
     $lines[] = '<?php';
@@ -59,7 +59,7 @@ function generate_runtime_php(RuntimeManifest $manifest, string $docroot): strin
     // Constants
     if (!empty($manifest->constants)) {
         foreach ($manifest->constants as $name => $value) {
-            $resolved = resolve_runtime_placeholders($value, $docroot);
+            $resolved = resolve_runtime_placeholders($value, $fs_root);
             $escaped = addslashes($resolved);
             $lines[] = "if (!defined('{$name}')) {";
             $lines[] = "    define('{$name}', '{$escaped}');";
@@ -71,7 +71,7 @@ function generate_runtime_php(RuntimeManifest $manifest, string $docroot): strin
     // Server variables
     if (!empty($manifest->server_vars)) {
         foreach ($manifest->server_vars as $name => $value) {
-            $resolved = resolve_runtime_placeholders($value, $docroot);
+            $resolved = resolve_runtime_placeholders($value, $fs_root);
             $escaped = addslashes($resolved);
             $lines[] = "\$_SERVER['{$name}'] = '{$escaped}';";
         }
@@ -261,11 +261,11 @@ function generate_route_handler_code(RuntimeManifest $manifest): string
 }
 
 /**
- * Replace {docroot} placeholders with the actual docroot path.
+ * Replace {fs-root} placeholders with the actual fs-root path.
  */
-function resolve_runtime_placeholders(string $value, string $docroot): string
+function resolve_runtime_placeholders(string $value, string $fs_root): string
 {
-    return str_replace('{docroot}', rtrim($docroot, '/'), $value);
+    return str_replace('{fs-root}', rtrim($fs_root, '/'), $value);
 }
 
 /**

--- a/importer/lib/target-runtime/interface-runtime-applier.php
+++ b/importer/lib/target-runtime/interface-runtime-applier.php
@@ -10,14 +10,14 @@
 interface RuntimeApplier
 {
     /**
-     * Apply a manifest to the target docroot.
+     * Apply a manifest to the target fs-root.
      *
      * @param RuntimeManifest $manifest   The manifest to apply.
-     * @param string          $docroot    Absolute path to the site docroot.
+     * @param string          $fs_root    Absolute path to the site fs-root.
      * @param string          $output_dir Absolute path to the output directory.
      * @param array           $options    Runtime-specific options (e.g. host, port,
      *                                    wordpress_index).
      * @return string[] Human-readable summary lines (printed to the user).
      */
-    public function apply(RuntimeManifest $manifest, string $docroot, string $output_dir, array $options = []): array;
+    public function apply(RuntimeManifest $manifest, string $fs_root, string $output_dir, array $options = []): array;
 }

--- a/preview.js
+++ b/preview.js
@@ -9,7 +9,7 @@
  * thinks it's on its original domain.
  *
  * Usage:
- *   node preview.js --state-dir=DIR --docroot=DIR [--url=<original-url>] [--port=<port>]
+ *   node preview.js --state-dir=DIR --fs-root=DIR [--url=<original-url>] [--port=<port>]
  *
  * Environment variables (all optional):
  *   DB_HOST          MySQL host          (default: 127.0.0.1)
@@ -28,15 +28,15 @@ import http from 'node:http';
 
 const args = process.argv.slice(2);
 let stateDir = null;
-let docroot = null;
+let fsRoot = null;
 let urlOverride = null;
 let port = null;
 
 for (const arg of args) {
 	if (arg.startsWith('--state-dir=')) {
 		stateDir = arg.slice('--state-dir='.length);
-	} else if (arg.startsWith('--docroot=')) {
-		docroot = arg.slice('--docroot='.length);
+	} else if (arg.startsWith('--fs-root=')) {
+		fsRoot = arg.slice('--fs-root='.length);
 	} else if (arg.startsWith('--url=')) {
 		urlOverride = arg.slice('--url='.length);
 	} else if (arg.startsWith('--port=')) {
@@ -44,13 +44,13 @@ for (const arg of args) {
 	}
 }
 
-if (!stateDir || !docroot) {
-	console.error('Usage: node preview.js --state-dir=DIR --docroot=DIR [--url=<original-url>] [--port=<port>]');
+if (!stateDir || !fsRoot) {
+	console.error('Usage: node preview.js --state-dir=DIR --fs-root=DIR [--url=<original-url>] [--port=<port>]');
 	process.exit(1);
 }
 
 stateDir = path.resolve(stateDir);
-docroot = path.resolve(docroot);
+fsRoot = path.resolve(fsRoot);
 
 const DB_HOST = process.env.DB_HOST || '127.0.0.1';
 const DB_USER = process.env.DB_USER || 'root';
@@ -110,8 +110,8 @@ function findDir(root, name, maxDepth = 6) {
 
 // ── Layout detection ────────────────────────────────────────────────
 
-if (!fs.existsSync(docroot)) {
-	console.error(`Error: docroot not found: ${docroot}`);
+if (!fs.existsSync(fsRoot)) {
+	console.error(`Error: fs-root not found: ${fsRoot}`);
 	process.exit(1);
 }
 
@@ -119,8 +119,8 @@ if (!fs.existsSync(docroot)) {
 // (__wp__ contains core, wp-config.php lives in the parent htdocs dir).
 // Check for standard layout first — a standard WP install might contain
 // a stray __wp__ directory inside a plugin or cache.
-const wpConfigFile = findFile(docroot, 'wp-config.php');
-const wpCoreDir = findDir(docroot, '__wp__');
+const wpConfigFile = findFile(fsRoot, 'wp-config.php');
+const wpCoreDir = findDir(fsRoot, '__wp__');
 const isWpcom = !!wpCoreDir && (!wpConfigFile || path.dirname(wpConfigFile) === path.dirname(wpCoreDir));
 
 let wpRoot;     // standard: dir containing wp-config.php; wpcom: __wp__ dir
@@ -140,7 +140,7 @@ if (isWpcom) {
 	console.log('Detected standard WordPress layout');
 	console.log(`  root: ${wpRoot}`);
 } else {
-	console.error(`Error: Could not detect WordPress layout under ${docroot}`);
+	console.error(`Error: Could not detect WordPress layout under ${fsRoot}`);
 	console.error('  No wp-config.php or __wp__ directory found.');
 	process.exit(1);
 }

--- a/tests/Import/AcceptEncodingTest.php
+++ b/tests/Import/AcceptEncodingTest.php
@@ -24,7 +24,7 @@ class AcceptEncodingTest extends TestCase
         parent::setUp();
         $this->tempDir = sys_get_temp_dir() . '/import-encoding-test-' . uniqid();
         mkdir($this->tempDir . '/state', 0755, true);
-        mkdir($this->tempDir . '/docroot', 0755, true);
+        mkdir($this->tempDir . '/fs-root', 0755, true);
     }
 
     protected function tearDown(): void
@@ -63,7 +63,7 @@ class AcceptEncodingTest extends TestCase
         $client = new \ImportClient(
             'http://fake.url',
             $this->tempDir . '/state',
-            $this->tempDir . '/docroot'
+            $this->tempDir . '/fs-root'
         );
 
         $method = new ReflectionMethod($client, 'get_base_headers');

--- a/tests/Import/FilesSyncStateTest.php
+++ b/tests/Import/FilesSyncStateTest.php
@@ -18,16 +18,16 @@ class FilesSyncStateTest extends TestCase
 {
     private $tempDir;
     private $stateDir;
-    private $docroot;
+    private $fs_root;
 
     protected function setUp(): void
     {
         parent::setUp();
         $this->tempDir = sys_get_temp_dir() . '/import-state-test-' . uniqid();
         $this->stateDir = $this->tempDir . '/state';
-        $this->docroot = $this->tempDir . '/docroot';
+        $this->fs_root = $this->tempDir . '/fs-root';
         mkdir($this->stateDir, 0755, true);
-        mkdir($this->docroot, 0755, true);
+        mkdir($this->fs_root, 0755, true);
     }
 
     protected function tearDown(): void
@@ -59,7 +59,7 @@ class FilesSyncStateTest extends TestCase
 
     private function makeClient(): \ImportClient
     {
-        return new \ImportClient('http://fake.url', $this->stateDir, $this->docroot);
+        return new \ImportClient('http://fake.url', $this->stateDir, $this->fs_root);
     }
 
     /**
@@ -77,7 +77,7 @@ class FilesSyncStateTest extends TestCase
             "remote_protocol_min_version" => null,
             "version" => null,
             "follow_symlinks" => false,
-            "docroot_nonempty_behavior" => "preserve-local",
+            "fs_root_nonempty_behavior" => "preserve-local",
             "max_allowed_packet" => null,
         ];
         file_put_contents(
@@ -142,7 +142,7 @@ class FilesSyncStateTest extends TestCase
         $ttyProperty = $reflection->getProperty('is_tty');
         $ttyProperty->setValue($client, false);
 
-        $behaviorProp = $reflection->getProperty('docroot_nonempty_behavior');
+        $behaviorProp = $reflection->getProperty('fs_root_nonempty_behavior');
         $behaviorProp->setValue($client, 'preserve-local');
 
         return [$client, $reflection];
@@ -256,7 +256,7 @@ class FilesSyncStateTest extends TestCase
         file_put_contents($remoteIndex, $this->indexLine('/wp-content/themes/flavor/style.css', 2000, 250));
 
         // The file exists locally (downloaded during the initial sync)
-        $localFile = $this->docroot . '/wp-content/themes/flavor/style.css';
+        $localFile = $this->fs_root . '/wp-content/themes/flavor/style.css';
         mkdir(dirname($localFile), 0755, true);
         file_put_contents($localFile, 'old content');
 
@@ -294,7 +294,7 @@ class FilesSyncStateTest extends TestCase
         file_put_contents($remoteIndex, $this->indexLine('/wp-content/object-cache.php', 1000, 500));
 
         // The file exists locally (pre-existing, e.g. hosting drop-in)
-        $localFile = $this->docroot . '/wp-content/object-cache.php';
+        $localFile = $this->fs_root . '/wp-content/object-cache.php';
         mkdir(dirname($localFile), 0755, true);
         file_put_contents($localFile, 'local drop-in');
 
@@ -330,7 +330,7 @@ class FilesSyncStateTest extends TestCase
     public function testFetchStageOverwritesPreviouslySyncedFile()
     {
         // Create the file locally (simulates a prior sync)
-        $localFile = $this->docroot . '/wp-content/themes/flavor/style.css';
+        $localFile = $this->fs_root . '/wp-content/themes/flavor/style.css';
         mkdir(dirname($localFile), 0755, true);
         file_put_contents($localFile, 'old content');
 

--- a/tests/Import/ImportSymlinkTest.php
+++ b/tests/Import/ImportSymlinkTest.php
@@ -18,7 +18,7 @@ class ImportSymlinkTest extends TestCase
         parent::setUp();
         $this->tempDir = sys_get_temp_dir() . '/import-symlink-test-' . uniqid();
         mkdir($this->tempDir, 0755, true);
-        mkdir($this->tempDir . '/docroot', 0755, true);
+        mkdir($this->tempDir . '/fs-root', 0755, true);
     }
 
     protected function tearDown(): void
@@ -56,7 +56,7 @@ class ImportSymlinkTest extends TestCase
 
     public function testSymlinkIsCreated()
     {
-        $client = new \ImportClient('http://fake.url', $this->tempDir, $this->tempDir . '/docroot');
+        $client = new \ImportClient('http://fake.url', $this->tempDir, $this->tempDir . '/fs-root');
 
         $reflection = new \ReflectionClass($client);
         $method = $reflection->getMethod('handle_symlink_chunk');
@@ -71,7 +71,7 @@ class ImportSymlinkTest extends TestCase
 
         $method->invoke($client, $chunk);
 
-        $symlinkPath = $this->tempDir . '/docroot/test/link';
+        $symlinkPath = $this->tempDir . '/fs-root/test/link';
         $this->assertTrue(is_link($symlinkPath), 'Symlink should be created');
         $this->assertEquals('target', readlink($symlinkPath), 'Symlink target should match');
     }
@@ -79,11 +79,11 @@ class ImportSymlinkTest extends TestCase
     /**
      * A relative symlink that escapes the filesystem root should be rejected.
      * Path /a/link with target ../../../escape resolves to
-     * docroot/a/../../escape = docroot/../escape — outside root.
+     * fs-root/a/../../escape = fs-root/../escape — outside root.
      */
     public function testRelativeSymlinkEscapingRootRejected()
     {
-        $client = new \ImportClient('http://fake.url', $this->tempDir, $this->tempDir . '/docroot');
+        $client = new \ImportClient('http://fake.url', $this->tempDir, $this->tempDir . '/fs-root');
 
         $reflection = new \ReflectionClass($client);
         $method = $reflection->getMethod('handle_symlink_chunk');
@@ -98,7 +98,7 @@ class ImportSymlinkTest extends TestCase
 
         $method->invoke($client, $chunk);
 
-        $symlinkPath = $this->tempDir . '/docroot/a/link';
+        $symlinkPath = $this->tempDir . '/fs-root/a/link';
         $this->assertFalse(is_link($symlinkPath), 'Symlink escaping root should not be created');
     }
 
@@ -109,7 +109,7 @@ class ImportSymlinkTest extends TestCase
      */
     public function testChainedSymlinksEscapingRootRejected()
     {
-        $client = new \ImportClient('http://fake.url', $this->tempDir, $this->tempDir . '/docroot');
+        $client = new \ImportClient('http://fake.url', $this->tempDir, $this->tempDir . '/fs-root');
 
         $reflection = new \ReflectionClass($client);
         $method = $reflection->getMethod('handle_symlink_chunk');
@@ -127,7 +127,7 @@ class ImportSymlinkTest extends TestCase
         ];
         $method->invoke($client, $chunk1);
 
-        $link1 = $this->tempDir . '/docroot/site/__wp__';
+        $link1 = $this->tempDir . '/fs-root/site/__wp__';
         $this->assertFalse(is_link($link1), 'Symlink escaping root should not be created');
 
         // Second symlink references a path within root — should succeed
@@ -140,7 +140,7 @@ class ImportSymlinkTest extends TestCase
         ];
         $method->invoke($client, $chunk2);
 
-        $link2 = $this->tempDir . '/docroot/site/wp-load.php';
+        $link2 = $this->tempDir . '/fs-root/site/wp-load.php';
         $this->assertTrue(is_link($link2), 'Symlink staying within root should be created');
         $this->assertEquals('__wp__/wp-load.php', readlink($link2));
     }
@@ -151,7 +151,7 @@ class ImportSymlinkTest extends TestCase
      */
     public function testAbsoluteSymlinkOutsideRootRejected()
     {
-        $client = new \ImportClient('http://fake.url', $this->tempDir, $this->tempDir . '/docroot');
+        $client = new \ImportClient('http://fake.url', $this->tempDir, $this->tempDir . '/fs-root');
 
         $reflection = new \ReflectionClass($client);
         $method = $reflection->getMethod('handle_symlink_chunk');
@@ -166,7 +166,7 @@ class ImportSymlinkTest extends TestCase
 
         $method->invoke($client, $chunk);
 
-        $symlinkPath = $this->tempDir . '/docroot/bin-link';
+        $symlinkPath = $this->tempDir . '/fs-root/bin-link';
         $this->assertFalse(is_link($symlinkPath), 'Absolute symlink outside root should not be created');
     }
 
@@ -176,7 +176,7 @@ class ImportSymlinkTest extends TestCase
      */
     public function testRelativeSymlinkWithinRootCreated()
     {
-        $client = new \ImportClient('http://fake.url', $this->tempDir, $this->tempDir . '/docroot');
+        $client = new \ImportClient('http://fake.url', $this->tempDir, $this->tempDir . '/fs-root');
 
         $reflection = new \ReflectionClass($client);
         $method = $reflection->getMethod('handle_symlink_chunk');
@@ -191,7 +191,7 @@ class ImportSymlinkTest extends TestCase
 
         $method->invoke($client, $chunk);
 
-        $symlinkPath = $this->tempDir . '/docroot/wp-content/link';
+        $symlinkPath = $this->tempDir . '/fs-root/wp-content/link';
         $this->assertTrue(is_link($symlinkPath), 'Symlink within root should be created');
         $this->assertEquals('../uploads/file.txt', readlink($symlinkPath));
     }
@@ -202,8 +202,8 @@ class ImportSymlinkTest extends TestCase
      */
     public function testAbsoluteSymlinkWithinRootCreated()
     {
-        $client = new \ImportClient('http://fake.url', $this->tempDir, $this->tempDir . '/docroot');
-        $root = realpath($this->tempDir . '/docroot');
+        $client = new \ImportClient('http://fake.url', $this->tempDir, $this->tempDir . '/fs-root');
+        $root = realpath($this->tempDir . '/fs-root');
 
         $reflection = new \ReflectionClass($client);
         $method = $reflection->getMethod('handle_symlink_chunk');
@@ -225,7 +225,7 @@ class ImportSymlinkTest extends TestCase
 
     public function testSymlinkWithMissingDataSkipped()
     {
-        $client = new \ImportClient('http://fake.url', $this->tempDir, $this->tempDir . '/docroot');
+        $client = new \ImportClient('http://fake.url', $this->tempDir, $this->tempDir . '/fs-root');
 
         $reflection = new \ReflectionClass($client);
         $method = $reflection->getMethod('handle_symlink_chunk');
@@ -263,10 +263,10 @@ class ImportSymlinkTest extends TestCase
 
     public function testSymlinkReplacesExistingFile()
     {
-        $client = new \ImportClient('http://fake.url', $this->tempDir, $this->tempDir . '/docroot');
+        $client = new \ImportClient('http://fake.url', $this->tempDir, $this->tempDir . '/fs-root');
 
         // Create a regular file
-        $filePath = $this->tempDir . '/docroot/test/link';
+        $filePath = $this->tempDir . '/fs-root/test/link';
         mkdir(dirname($filePath), 0755, true);
         file_put_contents($filePath, 'content');
         $this->assertTrue(is_file($filePath));

--- a/tests/Import/NewSiteUrlTest.php
+++ b/tests/Import/NewSiteUrlTest.php
@@ -19,7 +19,7 @@ class NewSiteUrlTest extends TestCase
         parent::setUp();
         $this->tempDir = sys_get_temp_dir() . '/import-new-site-url-test-' . uniqid();
         mkdir($this->tempDir, 0755, true);
-        mkdir($this->tempDir . '/docroot', 0755, true);
+        mkdir($this->tempDir . '/fs-root', 0755, true);
     }
 
     protected function tearDown(): void
@@ -63,7 +63,7 @@ class NewSiteUrlTest extends TestCase
         $client = new \ImportClient(
             'https://old-site.example.com/wp-json/export',
             $this->tempDir,
-            $this->tempDir . '/docroot'
+            $this->tempDir . '/fs-root'
         );
 
         $options = ['new_site_url' => 'https://new-site.example.com'];
@@ -86,7 +86,7 @@ class NewSiteUrlTest extends TestCase
         $client = new \ImportClient(
             'http://old-site.local/export?key=abc',
             $this->tempDir,
-            $this->tempDir . '/docroot'
+            $this->tempDir . '/fs-root'
         );
 
         $options = ['new_site_url' => 'https://new-site.example.com'];
@@ -108,7 +108,7 @@ class NewSiteUrlTest extends TestCase
         $client = new \ImportClient(
             'https://old-site.example.com:8443/export',
             $this->tempDir,
-            $this->tempDir . '/docroot'
+            $this->tempDir . '/fs-root'
         );
 
         $options = ['new_site_url' => 'https://new-site.example.com'];
@@ -130,7 +130,7 @@ class NewSiteUrlTest extends TestCase
         $client = new \ImportClient(
             'https://old-site.example.com/export',
             $this->tempDir,
-            $this->tempDir . '/docroot'
+            $this->tempDir . '/fs-root'
         );
 
         $options = [
@@ -161,7 +161,7 @@ class NewSiteUrlTest extends TestCase
         $client = new \ImportClient(
             'https://old-site.example.com/export',
             $this->tempDir,
-            $this->tempDir . '/docroot'
+            $this->tempDir . '/fs-root'
         );
 
         $options = [];
@@ -175,7 +175,7 @@ class NewSiteUrlTest extends TestCase
         $client = new \ImportClient(
             '://not-a-url',
             $this->tempDir,
-            $this->tempDir . '/docroot'
+            $this->tempDir . '/fs-root'
         );
 
         $this->expectException(\InvalidArgumentException::class);
@@ -190,7 +190,7 @@ class NewSiteUrlTest extends TestCase
         $client = new \ImportClient(
             'https://old-site.example.com/export',
             $this->tempDir,
-            $this->tempDir . '/docroot'
+            $this->tempDir . '/fs-root'
         );
 
         // The new URL should be used exactly as-is, even with a trailing path

--- a/tests/Import/RuntimeFilesTest.php
+++ b/tests/Import/RuntimeFilesTest.php
@@ -22,16 +22,16 @@ class RuntimeFilesTest extends TestCase
 {
     private $tempDir;
     private $stateDir;
-    private $docroot;
+    private $fs_root;
 
     protected function setUp(): void
     {
         parent::setUp();
         $this->tempDir = sys_get_temp_dir() . '/runtime-files-test-' . uniqid();
         $this->stateDir = $this->tempDir . '/state';
-        $this->docroot = $this->tempDir . '/docroot';
+        $this->fs_root = $this->tempDir . '/fs-root';
         mkdir($this->stateDir, 0755, true);
-        mkdir($this->docroot, 0755, true);
+        mkdir($this->fs_root, 0755, true);
     }
 
     protected function tearDown(): void
@@ -63,7 +63,7 @@ class RuntimeFilesTest extends TestCase
 
     private function makeClient(): \ImportClient
     {
-        return new \ImportClient('http://fake.url', $this->stateDir, $this->docroot);
+        return new \ImportClient('http://fake.url', $this->stateDir, $this->fs_root);
     }
 
     private function writeState(array $state): void
@@ -78,7 +78,7 @@ class RuntimeFilesTest extends TestCase
             "remote_protocol_min_version" => null,
             "version" => null,
             "follow_symlinks" => false,
-            "docroot_nonempty_behavior" => "error",
+            "fs_root_nonempty_behavior" => "error",
             "max_allowed_packet" => null,
         ];
         file_put_contents(

--- a/tests/Import/TypeSwapTest.php
+++ b/tests/Import/TypeSwapTest.php
@@ -21,7 +21,7 @@ class TypeSwapTest extends TestCase
         parent::setUp();
         $this->tempDir = sys_get_temp_dir() . '/import-typeswap-test-' . uniqid();
         mkdir($this->tempDir, 0755, true);
-        mkdir($this->tempDir . '/docroot', 0755, true);
+        mkdir($this->tempDir . '/fs-root', 0755, true);
     }
 
     protected function tearDown(): void
@@ -61,14 +61,14 @@ class TypeSwapTest extends TestCase
      */
     public function testEnsureDirectoryPathRemovesBlockingSymlink()
     {
-        $client = new \ImportClient('http://fake.url', $this->tempDir, $this->tempDir . '/docroot');
+        $client = new \ImportClient('http://fake.url', $this->tempDir, $this->tempDir . '/fs-root');
 
         $reflection = new \ReflectionClass($client);
         $method = $reflection->getMethod('ensure_directory_path');
 
-        // Resolve the docroot path so it matches the realpath() check
+        // Resolve the fs-root path so it matches the realpath() check
         // inside ensure_directory_path (on macOS, /var -> /private/var).
-        $fsRoot = realpath($this->tempDir . '/docroot');
+        $fsRoot = realpath($this->tempDir . '/fs-root');
 
         // Create a symlink at a path where we want a real directory
         $symlinkPath = $fsRoot . '/some-dir';
@@ -90,9 +90,9 @@ class TypeSwapTest extends TestCase
      */
     public function testFileChunkReplacesSymlinkToDirectory()
     {
-        $client = new \ImportClient('http://fake.url', $this->tempDir, $this->tempDir . '/docroot');
+        $client = new \ImportClient('http://fake.url', $this->tempDir, $this->tempDir . '/fs-root');
 
-        $fsRoot = $this->tempDir . '/docroot';
+        $fsRoot = $this->tempDir . '/fs-root';
 
         // Create a real directory and a symlink pointing to it
         $realDir = $fsRoot . '/real-target-dir';
@@ -134,9 +134,9 @@ class TypeSwapTest extends TestCase
      */
     public function testDirectoryChunkReplacesSymlinkToFile()
     {
-        $client = new \ImportClient('http://fake.url', $this->tempDir, $this->tempDir . '/docroot');
+        $client = new \ImportClient('http://fake.url', $this->tempDir, $this->tempDir . '/fs-root');
 
-        $fsRoot = $this->tempDir . '/docroot';
+        $fsRoot = $this->tempDir . '/fs-root';
 
         // Create a real file and a symlink pointing to it
         $realFile = $fsRoot . '/real-target-file';
@@ -170,9 +170,9 @@ class TypeSwapTest extends TestCase
      */
     public function testFileChunkUnderFormerSymlink()
     {
-        $client = new \ImportClient('http://fake.url', $this->tempDir, $this->tempDir . '/docroot');
+        $client = new \ImportClient('http://fake.url', $this->tempDir, $this->tempDir . '/fs-root');
 
-        $fsRoot = $this->tempDir . '/docroot';
+        $fsRoot = $this->tempDir . '/fs-root';
 
         // Create a symlink at the path
         $realFile = $fsRoot . '/target-file';
@@ -223,11 +223,11 @@ class TypeSwapTest extends TestCase
      */
     public function testNestedFileUnderExistingSymlinkViaEnsureDirectory()
     {
-        $client = new \ImportClient('http://fake.url', $this->tempDir, $this->tempDir . '/docroot');
+        $client = new \ImportClient('http://fake.url', $this->tempDir, $this->tempDir . '/fs-root');
 
-        // Resolve the docroot path so it matches the realpath() check
+        // Resolve the fs-root path so it matches the realpath() check
         // inside ensure_directory_path (on macOS, /var -> /private/var).
-        $fsRoot = realpath($this->tempDir . '/docroot');
+        $fsRoot = realpath($this->tempDir . '/fs-root');
 
         // Create a symlink at the top-level path component
         $targetDir = $fsRoot . '/real-target';

--- a/tests/e2e/lib/test-helpers.js
+++ b/tests/e2e/lib/test-helpers.js
@@ -211,17 +211,17 @@ function parseMultipart(body, boundary) {
 }
 
 /**
- * Return the docroot path for a given output directory.
- * By convention, E2E tests place downloaded files in outputDir/docroot.
+ * Return the fs-root path for a given output directory.
+ * By convention, E2E tests place downloaded files in outputDir/fs-root.
  */
-export function docrootDir(outputDir) {
-    return join(outputDir, 'docroot');
+export function fsRootDir(outputDir) {
+    return join(outputDir, 'fs-root');
 }
 
 /**
  * Run the importer CLI.
  * @param {string} url - Export URL
- * @param {string} outputDir - Local output directory (state files live here; docroot is outputDir/docroot)
+ * @param {string} outputDir - Local output directory (state files live here; fs-root is outputDir/fs-root)
  * @param {string} command - Import command (files-sync, db-sync, etc.)
  * @param {Object} options - Additional options
  * @returns {Object} { stdout, stderr, exitCode }
@@ -237,7 +237,7 @@ export function runImporter(url, outputDir, command, options = {}) {
             cmd,
             url,
             `--state-dir=${outputDir}`,
-            `--docroot=${docrootDir(outputDir)}`,
+            `--fs-root=${fsRootDir(outputDir)}`,
         ];
         if (secret) {
             args.push(`--secret=${secret}`);

--- a/tests/e2e/tests/import-01-basic-file-sync.test.js
+++ b/tests/e2e/tests/import-01-basic-file-sync.test.js
@@ -11,7 +11,7 @@ import {
     getSiteUrl, getSiteSecret, getSiteDir,
     assertTreesMatch,
     assertFileCount, assertSiteMirror,
-    docrootDir,
+    fsRootDir,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -47,10 +47,10 @@ describe('Import: Basic File Sync', () => {
         assert.equal(state.status, 'complete');
     });
 
-    it('docroot file hashes match source site directory', () => {
-        // The importer stores files at docroot/<absolute-path>,
-        // so the site dir content ends up at docroot/srv/e2e-sites/<site>/
-        const importedRoot = join(docrootDir(tempDir), getSiteDir(site));
+    it('fs-root file hashes match source site directory', () => {
+        // The importer stores files at fs-root/<absolute-path>,
+        // so the site dir content ends up at fs-root/srv/e2e-sites/<site>/
+        const importedRoot = join(fsRootDir(tempDir), getSiteDir(site));
         assert.ok(existsSync(importedRoot), `Expected ${importedRoot} to exist`);
 
         assertTreesMatch(getSiteDir(site), importedRoot);
@@ -68,7 +68,7 @@ describe('Import: Basic File Sync', () => {
     });
 
     it('imported files form a valid WordPress site mirror', () => {
-        assertSiteMirror(join(docrootDir(tempDir), getSiteDir(site)));
+        assertSiteMirror(join(fsRootDir(tempDir), getSiteDir(site)));
     });
 
     it('re-running after completion refuses without --abort', () => {

--- a/tests/e2e/tests/import-03-delta-sync.test.js
+++ b/tests/e2e/tests/import-03-delta-sync.test.js
@@ -12,7 +12,7 @@ import {
     getSiteUrl, getSiteSecret, getSiteDir,
     assertTreesMatch,
     assertFileCount, assertSiteMirror,
-    docrootDir,
+    fsRootDir,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -49,7 +49,7 @@ describe('Import: Delta Sync', () => {
     });
 
     it('imported files form a valid WordPress site mirror', () => {
-        assertSiteMirror(join(docrootDir(tempDir), getSiteDir(site)));
+        assertSiteMirror(join(fsRootDir(tempDir), getSiteDir(site)));
     });
 
     it('abort + re-sync with no changes completes (delta)', () => {
@@ -66,7 +66,7 @@ describe('Import: Delta Sync', () => {
         assert.equal(result.exitCode, 0, `Expected exit 0\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);
 
         // Hashes should still match
-        assertTreesMatch(getSiteDir(site), join(docrootDir(tempDir), getSiteDir(site)));
+        assertTreesMatch(getSiteDir(site), join(fsRootDir(tempDir), getSiteDir(site)));
     });
 
     it('files-sync picks up new file via delta', () => {
@@ -88,7 +88,7 @@ describe('Import: Delta Sync', () => {
         assert.equal(result.exitCode, 0, `Expected exit 0\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);
 
         // The new file should appear in the output
-        const importedPath = join(docrootDir(tempDir), getSiteDir(site), 'test-data', 'delta-test-added.txt');
+        const importedPath = join(fsRootDir(tempDir), getSiteDir(site), 'test-data', 'delta-test-added.txt');
         assert.ok(existsSync(importedPath), 'Expected delta-test-added.txt in output');
 
         // Clean up added file

--- a/tests/e2e/tests/import-05-unicode-paths.test.js
+++ b/tests/e2e/tests/import-05-unicode-paths.test.js
@@ -11,7 +11,7 @@ import {
     getSiteUrl, getSiteSecret, getSiteDir,
     hashDirectory, assertTreesMatch,
     assertFileCount, assertSiteMirror,
-    docrootDir,
+    fsRootDir,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -62,7 +62,7 @@ describe('Import: Unicode Paths', () => {
     });
 
     it('files with emoji, accented chars, spaces, and Chinese chars exist', () => {
-        const importedRoot = join(docrootDir(tempDir), getSiteDir(site));
+        const importedRoot = join(fsRootDir(tempDir), getSiteDir(site));
         assert.ok(existsSync(importedRoot), `Expected ${importedRoot} to exist`);
 
         // Check for files with special names
@@ -92,7 +92,7 @@ describe('Import: Unicode Paths', () => {
     });
 
     it('file hashes match source', () => {
-        const importedRoot = join(docrootDir(tempDir), getSiteDir(site));
+        const importedRoot = join(fsRootDir(tempDir), getSiteDir(site));
         assertTreesMatch(getSiteDir(site), importedRoot);
     });
 
@@ -101,7 +101,7 @@ describe('Import: Unicode Paths', () => {
     });
 
     it('imported files form a valid WordPress site mirror', () => {
-        assertSiteMirror(join(docrootDir(tempDir), getSiteDir(site)));
+        assertSiteMirror(join(fsRootDir(tempDir), getSiteDir(site)));
     });
 
     it('db-sync completes with valid dump', () => {

--- a/tests/e2e/tests/import-06-symlinks.test.js
+++ b/tests/e2e/tests/import-06-symlinks.test.js
@@ -12,7 +12,7 @@ import {
     getSiteUrl, getSiteSecret, getSiteDir,
     assertTreesMatch,
     assertFileCount, assertSiteMirror,
-    docrootDir,
+    fsRootDir,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -53,7 +53,7 @@ describe('Import: Symlinks', () => {
         });
 
         it('regular files are downloaded and match source', () => {
-            const importedRoot = join(docrootDir(tempDir), getSiteDir(site));
+            const importedRoot = join(fsRootDir(tempDir), getSiteDir(site));
             assertTreesMatch(getSiteDir(site), importedRoot);
         });
 
@@ -62,7 +62,7 @@ describe('Import: Symlinks', () => {
         });
 
         it('imported files form a valid WordPress site mirror', () => {
-            assertSiteMirror(join(docrootDir(tempDir), getSiteDir(site)));
+            assertSiteMirror(join(fsRootDir(tempDir), getSiteDir(site)));
         });
 
         it('sync completed without error despite symlinks', () => {
@@ -106,7 +106,7 @@ describe('Import: Symlinks', () => {
         });
 
         it('regular files are downloaded and match source', () => {
-            const importedRoot = join(docrootDir(tempDir), getSiteDir(site));
+            const importedRoot = join(fsRootDir(tempDir), getSiteDir(site));
             assertTreesMatch(getSiteDir(site), importedRoot);
         });
     });

--- a/tests/e2e/tests/import-07-permission-errors.test.js
+++ b/tests/e2e/tests/import-07-permission-errors.test.js
@@ -12,7 +12,7 @@ import {
     runImporter, createTempDir, cleanupTempDir,
     getSiteUrl, getSiteSecret, getSiteDir,
     assertTreesMatch, readAuditLog,
-    docrootDir,
+    fsRootDir,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -55,7 +55,7 @@ describe('Import: Permission Errors', () => {
         it('readable files are downloaded and match source', () => {
             // hashDirectory skips unreadable files on both sides,
             // so this verifies all readable files match exactly
-            const importedRoot = join(docrootDir(tempDir), getSiteDir(site));
+            const importedRoot = join(fsRootDir(tempDir), getSiteDir(site));
             assertTreesMatch(getSiteDir(site), importedRoot);
         });
 

--- a/tests/e2e/tests/import-08-large-directory.test.js
+++ b/tests/e2e/tests/import-08-large-directory.test.js
@@ -11,7 +11,7 @@ import {
     getSiteUrl, getSiteSecret, getSiteDir,
     hashDirectory, assertTreesMatch,
     assertFileCount, assertSiteMirror,
-    docrootDir,
+    fsRootDir,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -50,8 +50,8 @@ describe('Import: Large Directory', () => {
         assert.equal(result.exitCode, 0, `Expected exit 0\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);
     });
 
-    it('docroot has 2000+ files', () => {
-        const importedRoot = join(docrootDir(tempDir), getSiteDir(site));
+    it('fs-root has 2000+ files', () => {
+        const importedRoot = join(fsRootDir(tempDir), getSiteDir(site));
         assert.ok(existsSync(importedRoot), `Expected ${importedRoot} to exist`);
 
         const hashes = hashDirectory(importedRoot);
@@ -63,16 +63,16 @@ describe('Import: Large Directory', () => {
     });
 
     it('imported files form a valid WordPress site mirror', () => {
-        assertSiteMirror(join(docrootDir(tempDir), getSiteDir(site)));
+        assertSiteMirror(join(fsRootDir(tempDir), getSiteDir(site)));
     });
 
     it('all file hashes match source', () => {
-        const importedRoot = join(docrootDir(tempDir), getSiteDir(site));
+        const importedRoot = join(fsRootDir(tempDir), getSiteDir(site));
         assertTreesMatch(getSiteDir(site), importedRoot);
     });
 
     it('spot-check file content matches content-NNNN pattern', () => {
-        const importedRoot = join(docrootDir(tempDir), getSiteDir(site));
+        const importedRoot = join(fsRootDir(tempDir), getSiteDir(site));
         // Check a few specific files
         for (const num of ['0001', '0500', '1000', '1999']) {
             const filePath = join(importedRoot, 'test-data', 'many-files', `file-${num}.txt`);

--- a/tests/e2e/tests/import-10-resume-files.test.js
+++ b/tests/e2e/tests/import-10-resume-files.test.js
@@ -12,7 +12,7 @@ import {
     getSiteUrl, getSiteSecret, getSiteDir,
     assertTreesMatch,
     assertFileCount, assertSiteMirror,
-    docrootDir,
+    fsRootDir,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -68,11 +68,11 @@ describe('Import: Resume Files', { timeout: 180000 }, () => {
     });
 
     it('imported files form a valid WordPress site mirror', () => {
-        assertSiteMirror(join(docrootDir(tempDir), getSiteDir(site)));
+        assertSiteMirror(join(fsRootDir(tempDir), getSiteDir(site)));
     });
 
     it('all files present and correct after multi-request sync', () => {
-        const importedRoot = join(docrootDir(tempDir), getSiteDir(site));
+        const importedRoot = join(fsRootDir(tempDir), getSiteDir(site));
         assertTreesMatch(getSiteDir(site), importedRoot);
     });
 });

--- a/tests/e2e/tests/import-13-sha1-integrity.test.js
+++ b/tests/e2e/tests/import-13-sha1-integrity.test.js
@@ -12,7 +12,7 @@ import {
     getSiteUrl, getSiteSecret, getSiteDir,
     hashDirectory, assertTreesMatch, sha1File,
     assertFileCount, assertSiteMirror,
-    docrootDir,
+    fsRootDir,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -52,7 +52,7 @@ describe('Import: SHA1 Integrity', () => {
     });
 
     it('all file hashes match source', () => {
-        const importedRoot = join(docrootDir(tempDir), getSiteDir(site));
+        const importedRoot = join(fsRootDir(tempDir), getSiteDir(site));
         assertTreesMatch(getSiteDir(site), importedRoot);
     });
 
@@ -61,18 +61,18 @@ describe('Import: SHA1 Integrity', () => {
     });
 
     it('imported files form a valid WordPress site mirror', () => {
-        assertSiteMirror(join(docrootDir(tempDir), getSiteDir(site)));
+        assertSiteMirror(join(fsRootDir(tempDir), getSiteDir(site)));
     });
 
     it('at least 20 files with correct hashes', () => {
-        const importedRoot = join(docrootDir(tempDir), getSiteDir(site));
+        const importedRoot = join(fsRootDir(tempDir), getSiteDir(site));
         const importedHashes = hashDirectory(importedRoot);
         assert.ok(importedHashes.size >= 20, `Expected at least 20 files, got ${importedHashes.size}`);
     });
 
     it('large binary file (256KB) hash matches', () => {
         const sourcePath = join(getSiteDir(site), 'test-data', 'large-binary.bin');
-        const importedPath = join(docrootDir(tempDir), getSiteDir(site), 'test-data', 'large-binary.bin');
+        const importedPath = join(fsRootDir(tempDir), getSiteDir(site), 'test-data', 'large-binary.bin');
 
         assert.ok(existsSync(sourcePath), 'Expected source large-binary.bin to exist');
         assert.ok(existsSync(importedPath), 'Expected imported large-binary.bin to exist');

--- a/tests/e2e/tests/import-14-buffered-response.test.js
+++ b/tests/e2e/tests/import-14-buffered-response.test.js
@@ -11,7 +11,7 @@ import {
     getSiteUrl, getSiteSecret, getSiteDir,
     assertTreesMatch,
     assertFileCount, assertSiteMirror,
-    docrootDir,
+    fsRootDir,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -40,7 +40,7 @@ describe('Import: Buffered Response', () => {
     });
 
     it('files are correct', () => {
-        const importedRoot = join(docrootDir(tempDir), getSiteDir(site));
+        const importedRoot = join(fsRootDir(tempDir), getSiteDir(site));
         assertTreesMatch(getSiteDir(site), importedRoot);
     });
 
@@ -49,7 +49,7 @@ describe('Import: Buffered Response', () => {
     });
 
     it('imported files form a valid WordPress site mirror', () => {
-        assertSiteMirror(join(docrootDir(tempDir), getSiteDir(site)));
+        assertSiteMirror(join(fsRootDir(tempDir), getSiteDir(site)));
     });
 
     it('db-sync through buffered proxy completes', () => {

--- a/tests/e2e/tests/import-15-volatile-files.test.js
+++ b/tests/e2e/tests/import-15-volatile-files.test.js
@@ -14,7 +14,7 @@ import {
     hashDirectory, assertTreesMatch, readAuditLog,
     writeTestHooks, removeTestHooks,
     writeHookState, readHookState, clearHookState,
-    docrootDir,
+    fsRootDir,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -84,7 +84,7 @@ describe('Import: Volatile Files', () => {
 
         it('downloaded files have correct hashes (no corruption)', () => {
             const siteDir = getSiteDir(site);
-            const importedRoot = join(docrootDir(tempDir), siteDir);
+            const importedRoot = join(fsRootDir(tempDir), siteDir);
             // allowMissing: hook's sleep(1) slows export, so sync may be incomplete
             assertTreesMatch(siteDir, importedRoot, { exclude: ['large-volatile.bin'], allowMissing: true });
         });
@@ -160,7 +160,7 @@ describe('Import: Volatile Files', () => {
         });
 
         it('readable files are still downloaded', () => {
-            const importedRoot = join(docrootDir(tempDir), getSiteDir(site));
+            const importedRoot = join(fsRootDir(tempDir), getSiteDir(site));
             const hashes = hashDirectory(importedRoot);
             assert.ok(hashes.size > 0, 'Expected at least some files downloaded');
 
@@ -174,7 +174,7 @@ describe('Import: Volatile Files', () => {
             // The hook deleted test-data/subdir during the directory scan.
             // The scanner silently skips entries that no longer stat, so
             // files from subdir should not be indexed or downloaded.
-            const importedRoot = join(docrootDir(tempDir), getSiteDir(site));
+            const importedRoot = join(fsRootDir(tempDir), getSiteDir(site));
             const allFiles = [...hashDirectory(importedRoot).keys()];
             const subdirFiles = allFiles.filter(p => p.includes('subdir'));
             assert.equal(

--- a/tests/e2e/tests/import-16-custom-wp-content.test.js
+++ b/tests/e2e/tests/import-16-custom-wp-content.test.js
@@ -11,7 +11,7 @@ import {
     getSiteUrl, getSiteSecret, getSiteDir,
     assertTreesMatch,
     assertFileCount, assertSiteMirror,
-    docrootDir,
+    fsRootDir,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -51,7 +51,7 @@ describe('Import: Custom WP Content', () => {
     });
 
     it('files downloaded correctly', () => {
-        const importedRoot = join(docrootDir(tempDir), getSiteDir(site));
+        const importedRoot = join(fsRootDir(tempDir), getSiteDir(site));
         assert.ok(existsSync(importedRoot), `Expected ${importedRoot} to exist`);
 
         assertTreesMatch(getSiteDir(site), importedRoot);
@@ -62,7 +62,7 @@ describe('Import: Custom WP Content', () => {
     });
 
     it('imported files form a valid WordPress site mirror', () => {
-        assertSiteMirror(join(docrootDir(tempDir), getSiteDir(site)));
+        assertSiteMirror(join(fsRootDir(tempDir), getSiteDir(site)));
     });
 
     it('db-sync completes with valid dump', () => {

--- a/tests/e2e/tests/import-18-full-import-render.test.js
+++ b/tests/e2e/tests/import-18-full-import-render.test.js
@@ -15,7 +15,7 @@ import {
     assertTreesMatch,
     assertSiteMirror, createMysqlConnection,
     compareDatabases, getDbName,
-    docrootDir,
+    fsRootDir,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -73,12 +73,12 @@ describe('Import: Full Round-Trip', () => {
     });
 
     it('imported files form a valid WordPress site', () => {
-        const importedRoot = join(docrootDir(tempDir), getSiteDir(site));
+        const importedRoot = join(fsRootDir(tempDir), getSiteDir(site));
         assertSiteMirror(importedRoot);
     });
 
     it('imported files match source site', () => {
-        const importedRoot = join(docrootDir(tempDir), getSiteDir(site));
+        const importedRoot = join(fsRootDir(tempDir), getSiteDir(site));
         assertTreesMatch(getSiteDir(site), importedRoot);
     });
 

--- a/tests/e2e/tests/import-19-error-chunks.test.js
+++ b/tests/e2e/tests/import-19-error-chunks.test.js
@@ -20,7 +20,7 @@ import {
     readAuditLog,
     writeTestHooks, removeTestHooks,
     writeHookState, readHookState, clearHookState,
-    docrootDir,
+    fsRootDir,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -65,7 +65,7 @@ describe('Import: Error Chunks', () => {
 
         it('downloaded files have correct hashes (no corruption)', () => {
             const siteDir = getSiteDir(site);
-            const importedRoot = join(docrootDir(tempDir), siteDir);
+            const importedRoot = join(fsRootDir(tempDir), siteDir);
             assertTreesMatch(siteDir, importedRoot);
         });
     });
@@ -138,7 +138,7 @@ describe('Import: Error Chunks', () => {
 
         it('downloaded files have correct hashes (no corruption)', () => {
             const siteDir = getSiteDir(site);
-            const importedRoot = join(docrootDir(tempDir), siteDir);
+            const importedRoot = join(fsRootDir(tempDir), siteDir);
             // allowMissing: hook's sleep(1) slows export, so sync may be incomplete
             assertTreesMatch(siteDir, importedRoot, { exclude: ['large-volatile.bin'], allowMissing: true });
         });
@@ -208,7 +208,7 @@ describe('Import: Error Chunks', () => {
 
         it('downloaded files have correct hashes (no corruption)', () => {
             const siteDir = getSiteDir(site);
-            const importedRoot = join(docrootDir(tempDir), siteDir);
+            const importedRoot = join(fsRootDir(tempDir), siteDir);
             // allowMissing: hook deletes file mid-stream, which can cause incomplete sync
             assertTreesMatch(siteDir, importedRoot, { exclude: ['large-deletable.bin'], allowMissing: true });
         });

--- a/tests/e2e/tests/import-20-request-cutoff.test.js
+++ b/tests/e2e/tests/import-20-request-cutoff.test.js
@@ -15,7 +15,7 @@ import {
     readAuditLog,
     writeTestHooks, removeTestHooks,
     writeHookState, readHookState, clearHookState,
-    docrootDir,
+    fsRootDir,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -87,7 +87,7 @@ describe('Import: Request Cutoff', () => {
     });
 
     it('all file hashes match source after resume', () => {
-        const importedRoot = join(docrootDir(tempDir), getSiteDir(site));
+        const importedRoot = join(fsRootDir(tempDir), getSiteDir(site));
         assertTreesMatch(getSiteDir(site), importedRoot);
     });
 

--- a/tests/e2e/tests/import-22-delta-with-deletions.test.js
+++ b/tests/e2e/tests/import-22-delta-with-deletions.test.js
@@ -12,7 +12,7 @@ import {
     runImporter, createTempDir, cleanupTempDir,
     getSiteUrl, getSiteSecret, getSiteDir,
     hashDirectory, assertTreesMatch,
-    docrootDir,
+    fsRootDir,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -48,7 +48,7 @@ describe('Import: Delta Sync with Deletions', () => {
         });
         assert.equal(result.exitCode, 0, `Expected exit 0\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);
 
-        const importedRoot = join(docrootDir(tempDir), getSiteDir(site));
+        const importedRoot = join(fsRootDir(tempDir), getSiteDir(site));
         const hashes = hashDirectory(importedRoot);
         assert.ok(
             [...hashes.keys()].some(p => p.includes('will-be-deleted-1.txt')),
@@ -61,7 +61,7 @@ describe('Import: Delta Sync with Deletions', () => {
     });
 
     it('initial sync hashes match source', () => {
-        const importedRoot = join(docrootDir(tempDir), getSiteDir(site));
+        const importedRoot = join(fsRootDir(tempDir), getSiteDir(site));
         assertTreesMatch(getSiteDir(site), importedRoot);
     });
 

--- a/tests/e2e/tests/import-24-large-single-file.test.js
+++ b/tests/e2e/tests/import-24-large-single-file.test.js
@@ -13,7 +13,7 @@ import {
     runImporter, createTempDir, cleanupTempDir,
     getSiteUrl, getSiteSecret, getSiteDir,
     assertTreesMatch, sha1File,
-    docrootDir,
+    fsRootDir,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -51,7 +51,7 @@ describe('Import: Large Single File', { timeout: 180000 }, () => {
     });
 
     it('large file exists in import output', () => {
-        const importedPath = join(docrootDir(tempDir), getSiteDir(site), largeName);
+        const importedPath = join(fsRootDir(tempDir), getSiteDir(site), largeName);
         assert.ok(existsSync(importedPath), `Expected ${largeName} in output`);
 
         const stat = statSync(importedPath);
@@ -60,7 +60,7 @@ describe('Import: Large Single File', { timeout: 180000 }, () => {
 
     it('large file SHA1 matches source', () => {
         const sourcePath = join(getSiteDir(site), largeName);
-        const importedPath = join(docrootDir(tempDir), getSiteDir(site), largeName);
+        const importedPath = join(fsRootDir(tempDir), getSiteDir(site), largeName);
 
         const sourceHash = sha1File(sourcePath);
         const importedHash = sha1File(importedPath);
@@ -68,7 +68,7 @@ describe('Import: Large Single File', { timeout: 180000 }, () => {
     });
 
     it('all downloaded files have correct hashes', () => {
-        const importedRoot = join(docrootDir(tempDir), getSiteDir(site));
+        const importedRoot = join(fsRootDir(tempDir), getSiteDir(site));
         // allowMissing: large 12MB file transfer may leave sync incomplete
         assertTreesMatch(getSiteDir(site), importedRoot, { allowMissing: true });
     });

--- a/tests/e2e/tests/import-25-state-corruption.test.js
+++ b/tests/e2e/tests/import-25-state-corruption.test.js
@@ -11,7 +11,7 @@ import {
     runImporter, createTempDir, cleanupTempDir,
     getSiteUrl, getSiteSecret, getSiteDir,
     assertTreesMatch, readAuditLog,
-    docrootDir,
+    fsRootDir,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -66,7 +66,7 @@ describe('Import: State Corruption', () => {
         });
 
         it('files match source after recovery', () => {
-            const importedRoot = join(docrootDir(tempDir), getSiteDir(site));
+            const importedRoot = join(fsRootDir(tempDir), getSiteDir(site));
             assertTreesMatch(getSiteDir(site), importedRoot);
         });
     });
@@ -143,7 +143,7 @@ describe('Import: State Corruption', () => {
         });
 
         it('files match source after restart', () => {
-            const importedRoot = join(docrootDir(tempDir), getSiteDir(site));
+            const importedRoot = join(fsRootDir(tempDir), getSiteDir(site));
             assertTreesMatch(getSiteDir(site), importedRoot);
         });
     });

--- a/tests/e2e/tests/import-28-concurrent-errors.test.js
+++ b/tests/e2e/tests/import-28-concurrent-errors.test.js
@@ -17,7 +17,7 @@ import {
     assertTreesMatch, readAuditLog,
     writeTestHooks, removeTestHooks,
     writeHookState, readHookState, clearHookState,
-    docrootDir,
+    fsRootDir,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -119,7 +119,7 @@ describe('Import: Concurrent Errors', { timeout: 180000 }, () => {
     });
 
     it('non-error files are still downloaded correctly', () => {
-        const importedRoot = join(docrootDir(tempDir), getSiteDir(site));
+        const importedRoot = join(fsRootDir(tempDir), getSiteDir(site));
         // allowMissing: multiple hooks with sleep(1) slow export, so sync may be incomplete
         assertTreesMatch(getSiteDir(site), importedRoot, {
             exclude: ['concurrent-unreadable.txt', 'concurrent-volatile.bin', 'concurrent-deletable.bin'],

--- a/tests/e2e/tests/import-30-symlink-manifest.test.js
+++ b/tests/e2e/tests/import-30-symlink-manifest.test.js
@@ -16,7 +16,7 @@ import {
     getSiteUrl, getSiteSecret, getSiteDir,
     assertTreesMatch, readAuditLog,
     assertSiteMirror,
-    docrootDir,
+    fsRootDir,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -56,7 +56,7 @@ describe('Import: Symlink Handling', () => {
     });
 
     it('regular files are still downloaded correctly', () => {
-        const importedRoot = join(docrootDir(tempDir), getSiteDir(site));
+        const importedRoot = join(fsRootDir(tempDir), getSiteDir(site));
         assertTreesMatch(getSiteDir(site), importedRoot);
     });
 
@@ -71,7 +71,7 @@ describe('Import: Symlink Handling', () => {
     });
 
     it('external-link symlink is handled in the import', () => {
-        const importedRoot = join(docrootDir(tempDir), getSiteDir(site));
+        const importedRoot = join(fsRootDir(tempDir), getSiteDir(site));
         const externalLinkPath = join(importedRoot, 'test-data', 'external-link');
 
         if (existsSync(externalLinkPath)) {

--- a/tests/e2e/tests/import-31-follow-symlinks.test.js
+++ b/tests/e2e/tests/import-31-follow-symlinks.test.js
@@ -10,7 +10,7 @@
  * - Chained symlinks (target dir contains more symlinks) are followed recursively
  * - Circular symlinks don't cause infinite loops
  * - Multiple symlinks to the same target don't cause duplicate downloads
- * - The local docroot mirrors the server's directory layout
+ * - The local fs-root mirrors the server's directory layout
  */
 import { describe, it, beforeAll, afterAll } from 'vitest';
 import assert from 'node:assert/strict';
@@ -25,7 +25,7 @@ import {
     runImporter, createTempDir, cleanupTempDir,
     getSiteUrl, getSiteSecret, getSiteDir,
     readAuditLog,
-    docrootDir,
+    fsRootDir,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -84,8 +84,8 @@ describe('Import: Follow Symlinks', () => {
             // Start a PHP built-in server for this site as a fallback.
         }
 
-        const docRoot = join(getSiteDir(site), 'wp-content', 'plugins', 'site-export');
-        fallbackApiServer = spawn('php', ['-S', '127.0.0.1:8101', '-t', docRoot], {
+        const fsRoot = join(getSiteDir(site), 'wp-content', 'plugins', 'site-export');
+        fallbackApiServer = spawn('php', ['-S', '127.0.0.1:8101', '-t', fsRoot], {
             stdio: 'ignore',
         });
 
@@ -180,7 +180,7 @@ describe('Import: Follow Symlinks', () => {
     }
 
     function fsRoot() {
-        return docrootDir(tempDir);
+        return fsRootDir(tempDir);
     }
 
     function lstatIfExists(path) {
@@ -352,13 +352,13 @@ describe('Import: Follow Symlinks', () => {
 
     // ─── Layout correctness ────────────────────────────────────────
 
-    it('docroot mirrors the server directory layout', () => {
-        // The site root should be under docroot/<site-dir>
+    it('fs-root mirrors the server directory layout', () => {
+        // The site root should be under fs-root/<site-dir>
         const siteRoot = join(fsRoot(), getSiteDir(site));
         assert.ok(existsSync(siteRoot),
             `Expected site root at ${siteRoot}`);
 
-        // External content should be under docroot/<external-root>
+        // External content should be under fs-root/<external-root>
         const externalRoot = join(fsRoot(), EXTERNAL_ROOT);
         assert.ok(existsSync(externalRoot),
             `Expected external root at ${externalRoot}`);
@@ -366,7 +366,7 @@ describe('Import: Follow Symlinks', () => {
         // Both should share the same top-level prefix (/srv)
         const srvDir = join(fsRoot(), 'srv');
         assert.ok(existsSync(srvDir),
-            `Expected /srv directory in docroot`);
+            `Expected /srv directory in fs-root`);
     });
 
     it('WordPress core files are present alongside symlink targets', () => {

--- a/tests/e2e/tests/import-32-delta-deletions-and-type-swaps.test.js
+++ b/tests/e2e/tests/import-32-delta-deletions-and-type-swaps.test.js
@@ -15,7 +15,7 @@ import { join } from 'node:path';
 import {
     runImporter, createTempDir, cleanupTempDir,
     getSiteUrl, getSiteSecret, getSiteDir,
-    docrootDir,
+    fsRootDir,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -45,11 +45,11 @@ describe('Import: Delta deletions and type swaps', () => {
     }
 
     function localScenarioRoot() {
-        return join(docrootDir(tempDir), getSiteDir(site), 'test-data', scenarioName);
+        return join(fsRootDir(tempDir), getSiteDir(site), 'test-data', scenarioName);
     }
 
     function localPreserveFile() {
-        return join(docrootDir(tempDir), getSiteDir(site), 'test-data', preserveName, 'keep.txt');
+        return join(fsRootDir(tempDir), getSiteDir(site), 'test-data', preserveName, 'keep.txt');
     }
 
     function lstatIfExists(path) {

--- a/tests/e2e/tests/import-34-delta-type-swap-cache-invalidation.test.js
+++ b/tests/e2e/tests/import-34-delta-type-swap-cache-invalidation.test.js
@@ -15,7 +15,7 @@ import { setTimeout as sleep } from 'node:timers/promises';
 import {
     runImporter, createTempDir, cleanupTempDir,
     getSiteSecret, getSiteDir,
-    docrootDir,
+    fsRootDir,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -38,8 +38,8 @@ describe('Import: Delta type swaps cache invalidation', () => {
     };
 
     async function startApiServer() {
-        const docRoot = getSiteDir(site);
-        apiServer = spawn('php', ['-S', `127.0.0.1:${port}`, '-t', docRoot], {
+        const fsRoot = getSiteDir(site);
+        apiServer = spawn('php', ['-S', `127.0.0.1:${port}`, '-t', fsRoot], {
             stdio: 'ignore',
         });
 
@@ -136,7 +136,7 @@ chown -R nginx:nginx ${sh(remoteRoot)}
     it('delta keeps symlink->file transition', () => {
         const tempDir = runScenarioOnce('e2e-delta-cache-type-swaps-file');
         try {
-            const root = join(docrootDir(tempDir), remoteRoot);
+            const root = join(fsRootDir(tempDir), remoteRoot);
             const symlinkToDirToFile = join(root, 'symlink-to-dir-to-file');
             assert.ok(lstatSync(symlinkToDirToFile).isFile(), 'Expected symlink-to-dir-to-file to become a regular file');
             assert.equal(readFileSync(symlinkToDirToFile, 'utf-8'), 'became-file\n');
@@ -148,7 +148,7 @@ chown -R nginx:nginx ${sh(remoteRoot)}
     it('delta keeps symlink->directory transition with nested data', () => {
         const tempDir = runScenarioOnce('e2e-delta-cache-type-swaps-dir');
         try {
-            const root = join(docrootDir(tempDir), remoteRoot);
+            const root = join(fsRootDir(tempDir), remoteRoot);
             const nestedFile = join(root, 'symlink-to-file-to-dir', 'x', 'y', 'z', 'value.txt');
             assert.ok(existsSync(nestedFile), `Expected nested file at ${nestedFile}`);
             assert.equal(readFileSync(nestedFile, 'utf-8'), 'became-directory\n');

--- a/tests/e2e/tests/import-37-preserve-local.test.js
+++ b/tests/e2e/tests/import-37-preserve-local.test.js
@@ -4,7 +4,7 @@
  * Tests importing into a pre-existing WordPress hosting environment that uses
  * symlinks for shared infrastructure: WP core, plugins, themes, drop-ins, and
  * mu-plugins all live in a shared read-only directory and are symlinked into
- * the site docroot.
+ * the site fs-root.
  *
  * Pre-existing structure (mirrors real Atomic hosting):
  *
@@ -40,7 +40,7 @@ import {
     runImporter, createTempDir, cleanupTempDir,
     getSiteUrl, getSiteSecret, getSiteDir,
     readAuditLog,
-    docrootDir,
+    fsRootDir,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
@@ -76,17 +76,17 @@ describe('Import: --preserve-local', () => {
     }
 
     // ----------------------------------------------------------------
-    // Helper: build the realistic hosting structure inside a docroot.
+    // Helper: build the realistic hosting structure inside a fs-root.
     //
     // Places a shared "wordpress/" directory as a sibling of the site
-    // directory (both under docroot/srv/e2e-sites/), then creates all
+    // directory (both under fs-root/srv/e2e-sites/), then creates all
     // the hosting symlinks inside the site root.  The shared directory
     // is made read-only (chmod 555) so that files under symlinked dirs
     // cannot be written — matching real hosting constraints.
     // ----------------------------------------------------------------
-    function buildHostingStructureInLocalDocroot(docroot) {
-        const siteRoot = join(docroot, siteDir);
-        const wpShared = join(docroot, dirname(siteDir), 'wordpress');
+    function buildHostingStructureInLocalFsRoot(fsRoot) {
+        const siteRoot = join(fsRoot, siteDir);
+        const wpShared = join(fsRoot, dirname(siteDir), 'wordpress');
 
         // -- shared wordpress directory (read-only after setup) --------
         const dirs = [
@@ -196,11 +196,11 @@ describe('Import: --preserve-local', () => {
 
         beforeAll(() => {
             tempDir = createTempDir('e2e-preserve-local-no-flag');
-            buildHostingStructureInLocalDocroot(docrootDir(tempDir));
+            buildHostingStructureInLocalFsRoot(fsRootDir(tempDir));
         });
 
         afterAll(() => {
-            unlockSharedDir(join(docrootDir(tempDir), dirname(siteDir), 'wordpress'));
+            unlockSharedDir(join(fsRootDir(tempDir), dirname(siteDir), 'wordpress'));
             cleanupTempDir(tempDir);
         });
 
@@ -227,7 +227,7 @@ describe('Import: --preserve-local', () => {
 
         beforeAll(() => {
             tempDir = createTempDir('e2e-preserve-local-hosting');
-            const built = buildHostingStructureInLocalDocroot(docrootDir(tempDir));
+            const built = buildHostingStructureInLocalFsRoot(fsRootDir(tempDir));
             wpShared = built.wpShared;
             localSiteRoot = built.siteRoot;
         });
@@ -240,7 +240,7 @@ describe('Import: --preserve-local', () => {
         it('files-sync completes with --preserve-local', () => {
             const result = runImporter(importUrl(), tempDir, 'files-sync', {
                 secret: getSiteSecret(site),
-                extraArgs: ['--on-docroot-nonempty=preserve-local'],
+                extraArgs: ['--on-fs-root-nonempty=preserve-local'],
             });
             assert.equal(
                 result.exitCode, 0,
@@ -252,7 +252,7 @@ describe('Import: --preserve-local', () => {
             const stateFile = join(tempDir, '.import-state.json');
             const state = JSON.parse(readFileSync(stateFile, 'utf-8'));
             assert.equal(state.status, 'complete');
-            assert.equal(state.docroot_nonempty_behavior, 'preserve-local');
+            assert.equal(state.fs_root_nonempty_behavior, 'preserve-local');
         });
 
         // -- file symlinks preserved ----------------------------------
@@ -392,7 +392,7 @@ describe('Import: --preserve-local', () => {
 
         beforeAll(() => {
             tempDir = createTempDir('e2e-preserve-local-resume');
-            const built = buildHostingStructureInLocalDocroot(docrootDir(tempDir));
+            const built = buildHostingStructureInLocalFsRoot(fsRootDir(tempDir));
             wpShared = built.wpShared;
             localSiteRoot = built.siteRoot;
         });
@@ -405,7 +405,7 @@ describe('Import: --preserve-local', () => {
         it('completes after forced resume with --max-exec=3', () => {
             const result = runImporter(importUrl(), tempDir, 'files-sync', {
                 secret: getSiteSecret(site),
-                extraArgs: ['--on-docroot-nonempty=preserve-local', '--max-exec=3'],
+                extraArgs: ['--on-fs-root-nonempty=preserve-local', '--max-exec=3'],
                 timeout: 120000,
             });
             assert.equal(
@@ -423,7 +423,7 @@ describe('Import: --preserve-local', () => {
 
         it('state preserves preserve_local across resume cycles', () => {
             const state = JSON.parse(readFileSync(join(tempDir, '.import-state.json'), 'utf-8'));
-            assert.equal(state.docroot_nonempty_behavior, 'preserve-local');
+            assert.equal(state.fs_root_nonempty_behavior, 'preserve-local');
         });
     });
 
@@ -437,7 +437,7 @@ describe('Import: --preserve-local', () => {
 
         beforeAll(() => {
             tempDir = createTempDir('e2e-preserve-local-delta');
-            const built = buildHostingStructureInLocalDocroot(docrootDir(tempDir));
+            const built = buildHostingStructureInLocalFsRoot(fsRootDir(tempDir));
             wpShared = built.wpShared;
             localSiteRoot = built.siteRoot;
         });
@@ -450,7 +450,7 @@ describe('Import: --preserve-local', () => {
         it('initial import completes', () => {
             const result = runImporter(importUrl(), tempDir, 'files-sync', {
                 secret: getSiteSecret(site),
-                extraArgs: ['--on-docroot-nonempty=preserve-local'],
+                extraArgs: ['--on-fs-root-nonempty=preserve-local'],
             });
             assert.equal(result.exitCode, 0,
                 `Expected exit 0\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);
@@ -519,15 +519,15 @@ describe('Import: --preserve-local', () => {
     });
 
     // ------------------------------------------------------------------
-    // Test: directory-level symlink pointing outside docroot
+    // Test: directory-level symlink pointing outside fs-root
     //
     // This covers the case where an entire directory like wp-content/plugins
-    // is a symlink to a location outside the docroot (e.g., a shared hosting
+    // is a symlink to a location outside the fs-root (e.g., a shared hosting
     // plugins pool).  When the remote site has files under that directory,
     // they should all be skipped gracefully — we should never see "Security:
-    // Refusing to create directory outside docroot".
+    // Refusing to create directory outside fs-root".
     // ------------------------------------------------------------------
-    describe('directory-level symlink pointing outside docroot', () => {
+    describe('directory-level symlink pointing outside fs-root', () => {
         let tempDir;
         let localSiteRoot;
         let sharedPluginsDir;
@@ -535,20 +535,20 @@ describe('Import: --preserve-local', () => {
         beforeAll(() => {
             tempDir = createTempDir('e2e-preserve-local-dirlink');
 
-            const docroot = docrootDir(tempDir);
-            localSiteRoot = join(docroot, siteDir);
+            const fsRoot = fsRootDir(tempDir);
+            localSiteRoot = join(fsRoot, siteDir);
 
             // Create the site structure with wp-content/plugins as a
             // directory-level symlink rather than per-plugin symlinks.
             // The symlink target is a sibling of the site root, completely
-            // outside the docroot tree that the importer considers safe.
-            sharedPluginsDir = join(docroot, dirname(siteDir), 'shared-plugins-pool');
+            // outside the fs-root tree that the importer considers safe.
+            sharedPluginsDir = join(fsRoot, dirname(siteDir), 'shared-plugins-pool');
             mkdirSync(sharedPluginsDir, { recursive: true });
 
             // Build minimal site structure (no per-plugin symlinks this time)
             mkdirSync(join(localSiteRoot, 'wp-content'), { recursive: true });
 
-            // wp-content/plugins is itself a symlink outside the docroot.
+            // wp-content/plugins is itself a symlink outside the fs-root.
             // From wp-content/, ../../ goes to dirname(siteRoot) where the
             // shared pool lives.
             symlinkSync(
@@ -570,14 +570,14 @@ describe('Import: --preserve-local', () => {
         it('files-sync completes without security errors', () => {
             const result = runImporter(importUrl(), tempDir, 'files-sync', {
                 secret: getSiteSecret(site),
-                extraArgs: ['--on-docroot-nonempty=preserve-local'],
+                extraArgs: ['--on-fs-root-nonempty=preserve-local'],
             });
             assert.equal(
                 result.exitCode, 0,
                 `Expected exit 0\nstderr: ${result.stderr}\nstdout: ${result.stdout}`,
             );
             assert.ok(
-                !result.stderr.includes('Security: Refusing to create directory outside docroot'),
+                !result.stderr.includes('Security: Refusing to create directory outside fs-root'),
                 `Should not see security error, got: ${result.stderr}`,
             );
         });
@@ -591,7 +591,7 @@ describe('Import: --preserve-local', () => {
 
         it('no remote plugin files leaked into shared directory', () => {
             // The remote site has akismet/akismet.php and akismet/readme.txt.
-            // Since wp-content/plugins points outside the docroot, these
+            // Since wp-content/plugins points outside the fs-root, these
             // should be skipped — nothing should appear in the shared pool.
             const akismetDir = join(sharedPluginsDir, 'akismet');
             assert.ok(!existsSync(akismetDir),

--- a/tests/e2e/tests/import-38-flatten-wpcloud.test.js
+++ b/tests/e2e/tests/import-38-flatten-wpcloud.test.js
@@ -1,5 +1,5 @@
 /**
- * Test 38: flatten-docroot with WP Cloud-like directory layout
+ * Test 38: flat-document-root with WP Cloud-like directory layout
  *
  * Simulates a WP Cloud hosting environment where:
  * - ABSPATH is the document root (/srv/e2e-sites/wpcloud-flatten/)
@@ -10,7 +10,7 @@
  * Tests that:
  * 1. Preflight correctly resolves wp_admin_path / wp_includes_path via realpath()
  * 2. files-sync with --follow-symlinks downloads files at their resolved locations
- * 3. flatten-docroot creates a standard WP layout by sourcing each component
+ * 3. flat-document-root creates a standard WP layout by sourcing each component
  *    from where it physically lives
  */
 import { describe, it, beforeAll, afterAll } from 'vitest';
@@ -24,14 +24,14 @@ import { join } from 'node:path';
 import {
     runImporter, createTempDir, cleanupTempDir,
     getSiteUrl, getSiteSecret, getSiteDir,
-    docrootDir,
+    fsRootDir,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
 const CORE_DIR = '/tmp/e2e-wpcloud-core';
 const CONTENT_DIR = '/tmp/e2e-wpcloud-wpcontent';
 
-describe('Import: Flatten Docroot (WP Cloud-like layout)', () => {
+describe('Import: Flat Document Root (WP Cloud-like layout)', () => {
     const site = 'wpcloud-flatten';
     let tempDir;
 
@@ -146,12 +146,12 @@ require_once ABSPATH . 'wp-settings.php';
         assert.equal(result.exitCode, 0, `files-sync failed:\n${result.stderr}`);
     });
 
-    it('wp-admin files exist at the resolved core path in docroot', () => {
+    it('wp-admin files exist at the resolved core path in fs-root', () => {
         const state = JSON.parse(readFileSync(join(tempDir, '.import-state.json'), 'utf-8'));
         const wpAdminPath = state.preflight?.data?.database?.wp?.paths_urls?.wp_admin_path;
         assert.ok(wpAdminPath, 'wp_admin_path not found in state');
 
-        const localWpAdmin = join(docrootDir(tempDir), wpAdminPath);
+        const localWpAdmin = join(fsRootDir(tempDir), wpAdminPath);
         assert.ok(
             existsSync(localWpAdmin),
             `wp-admin should exist at resolved path: ${localWpAdmin}`,
@@ -162,12 +162,12 @@ require_once ABSPATH . 'wp-settings.php';
         );
     });
 
-    it('wp-content files exist at the separate content path in docroot', () => {
+    it('wp-content files exist at the separate content path in fs-root', () => {
         const state = JSON.parse(readFileSync(join(tempDir, '.import-state.json'), 'utf-8'));
         const contentDir = state.preflight?.data?.database?.wp?.paths_urls?.content_dir;
         assert.ok(contentDir, 'content_dir not found in state');
 
-        const localContent = join(docrootDir(tempDir), contentDir);
+        const localContent = join(fsRootDir(tempDir), contentDir);
         assert.ok(
             existsSync(localContent),
             `wp-content should exist at: ${localContent}`,
@@ -178,18 +178,18 @@ require_once ABSPATH . 'wp-settings.php';
         );
     });
 
-    describe('flatten-docroot', () => {
+    describe('flat-document-root', () => {
         let flattenTo;
 
         beforeAll(() => {
             flattenTo = join(tempDir, 'flattened');
-            const result = runImporter(importUrl(), tempDir, 'flatten-docroot', {
+            const result = runImporter(importUrl(), tempDir, 'flat-document-root', {
                 secret: getSiteSecret(site),
                 extraArgs: [`--flatten-to=${flattenTo}`],
             });
             assert.equal(
                 result.exitCode, 0,
-                `flatten-docroot failed:\n${result.stderr}\n${result.stdout}`,
+                `flat-document-root failed:\n${result.stderr}\n${result.stdout}`,
             );
         });
 

--- a/tests/e2e/tests/import-40-defer-uploads.test.js
+++ b/tests/e2e/tests/import-40-defer-uploads.test.js
@@ -17,7 +17,7 @@ import {
     runImporter, createTempDir, cleanupTempDir,
     getSiteUrl, getSiteSecret, getSiteDir,
     assertTreesMatch, readAuditLog,
-    docrootDir,
+    fsRootDir,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 import { mkdirSync, writeFileSync } from 'node:fs';
@@ -86,8 +86,8 @@ describe('Import: --filter', () => {
             assert.equal(state.filter, 'essential-files');
         });
 
-        it('upload files are NOT in the docroot', () => {
-            const importedRoot = join(docrootDir(tempDir), siteDir);
+        it('upload files are NOT in the fs-root', () => {
+            const importedRoot = join(fsRootDir(tempDir), siteDir);
             for (const f of UPLOAD_FILES) {
                 assert.ok(!existsSync(join(importedRoot, f)),
                     `Expected upload file to NOT exist: ${f}`);
@@ -95,7 +95,7 @@ describe('Import: --filter', () => {
         });
 
         it('essential files were downloaded', () => {
-            const importedRoot = join(docrootDir(tempDir), siteDir);
+            const importedRoot = join(fsRootDir(tempDir), siteDir);
             assert.ok(existsSync(join(importedRoot, 'wp-load.php')),
                 'Expected wp-load.php to exist');
             assert.ok(existsSync(join(importedRoot, 'wp-config.php')),
@@ -125,8 +125,8 @@ describe('Import: --filter', () => {
                 `Expected exit 0\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);
         });
 
-        it('upload files now exist in the docroot', () => {
-            const importedRoot = join(docrootDir(tempDir), siteDir);
+        it('upload files now exist in the fs-root', () => {
+            const importedRoot = join(fsRootDir(tempDir), siteDir);
             for (const f of UPLOAD_FILES) {
                 assert.ok(existsSync(join(importedRoot, f)),
                     `Expected upload file to exist after skipped-earlier: ${f}`);
@@ -139,7 +139,7 @@ describe('Import: --filter', () => {
         });
 
         it('all files match source', () => {
-            const importedRoot = join(docrootDir(tempDir), siteDir);
+            const importedRoot = join(fsRootDir(tempDir), siteDir);
             assertTreesMatch(siteDir, importedRoot);
         });
     });
@@ -175,7 +175,7 @@ describe('Import: --filter', () => {
         });
 
         it('uploads were NOT downloaded', () => {
-            const importedRoot = join(docrootDir(tempDir), siteDir);
+            const importedRoot = join(fsRootDir(tempDir), siteDir);
             for (const f of UPLOAD_FILES) {
                 assert.ok(!existsSync(join(importedRoot, f)),
                     `Expected upload file to NOT exist: ${f}`);
@@ -216,7 +216,7 @@ describe('Import: --filter', () => {
         });
 
         it('uploads were downloaded normally', () => {
-            const importedRoot = join(docrootDir(tempDir), siteDir);
+            const importedRoot = join(fsRootDir(tempDir), siteDir);
             for (const f of UPLOAD_FILES) {
                 assert.ok(existsSync(join(importedRoot, f)),
                     `Expected upload file to exist: ${f}`);


### PR DESCRIPTION
## Summary

The `--docroot` flag was misleading — it's not really a web server document root, it's the local filesystem root where remote files get recreated. This renames it to `--fs-root` to make the intent clearer.

Similarly, the `flatten-docroot` command becomes `flat-document-root` since it creates a standard WordPress document root layout from the raw fs-root download. The `--flattened-docroot` flag becomes `--flat-document-root` to match.

Mechanical rename across CLI flags, PHP variables/properties, JS helpers, all unit and e2e tests, and documentation. No behavioral changes.

## Test plan

- [ ] Verify PHP lint passes on all changed files
- [ ] Run unit tests (`composer test:fast`)
- [ ] Run e2e tests, especially test 37 (preserve-local) and test 38 (flatten wpcloud)
- [ ] Confirm no remaining occurrences of "docroot" in the codebase