### PR TITLE
Set up target DB config in apply-runtime

### DIFF
--- a/box.json
+++ b/box.json
@@ -40,6 +40,7 @@
 
     "files": [
         "importer/VERSION",
+        "lib/sqlite-database-integration/constants.php",
         "lib/sqlite-database-integration/php-polyfills.php",
         "lib/sqlite-database-integration/wp-pdo-mysql-on-sqlite.php",
         "lib/sqlite-database-integration/version.php",

--- a/importer/import.php
+++ b/importer/import.php
@@ -3318,6 +3318,7 @@ class ImportClient
             }
             $manifest->sqlite = [
                 'plugin_source' => dirname(__DIR__) . '/lib/sqlite-database-integration',
+                'plugin_dir' => '',  // resolved after copy_sqlite_plugin()
                 'db_dir' => $db_dir,
                 'db_file' => $db_file,
             ];

--- a/importer/import.php
+++ b/importer/import.php
@@ -3307,6 +3307,20 @@ class ImportClient
             // causes "Constant already defined" warnings. Flag this so the
             // generated runtime.php installs a handler to suppress them.
             $manifest->has_db_constants = true;
+        } elseif ($target_engine === "sqlite") {
+            $sqlite_path = $apply_state["target_sqlite_path"] ?? null;
+            if ($sqlite_path !== null && $sqlite_path !== '') {
+                $db_dir = rtrim(dirname($sqlite_path), '/') . '/';
+                $db_file = basename($sqlite_path);
+            } else {
+                $db_dir = '{docroot}/wp-content/database/';
+                $db_file = '.ht.sqlite';
+            }
+            $manifest->sqlite = [
+                'plugin_source' => dirname(__DIR__) . '/lib/sqlite-database-integration',
+                'db_dir' => $db_dir,
+                'db_file' => $db_file,
+            ];
         }
 
         $this->audit_log("APPLY-RUNTIME | analyzed preflight (source={$manifest->source}, webhost={$webhost})");
@@ -3360,21 +3374,28 @@ class ImportClient
         if ($port !== null) {
             $applier_options['port'] = (int) $port;
         }
+        // Step 2b: For SQLite targets, copy the integration plugin into the
+        // output directory BEFORE the applier runs, so generate_runtime_php()
+        // can embed the resolved plugin path in the lazy-loader code.
+        if ($manifest->sqlite !== null) {
+            $copied_plugin = copy_sqlite_plugin(
+                $manifest->sqlite['plugin_source'],
+                $abs_output_dir,
+            );
+            // Replace the source path with the copied-to path so the
+            // generated runtime.php points to the output directory.
+            $manifest->sqlite['plugin_dir'] = $copied_plugin;
+            // Resolve {docroot} in db_dir now that we have the real path.
+            $manifest->sqlite['db_dir'] = resolve_runtime_placeholders(
+                $manifest->sqlite['db_dir'],
+                $abs_docroot,
+            );
+        }
+
         $summary = $applier->apply($manifest, $abs_docroot, $abs_output_dir, $applier_options);
 
-        // Step 3: For SQLite targets, copy the sqlite-database-integration
-        // plugin into the output directory and set up the db.php drop-in.
-        // The plugin lives entirely in the output directory (not in the
-        // site's wp-content/plugins/). A small db.php drop-in is placed
-        // in wp-content/ to bridge WordPress to the external plugin — this
-        // is the standard WordPress mechanism for database driver overrides.
-        if ($target_engine === "sqlite") {
-            $sqlite_summary = $this->setup_sqlite_integration(
-                $abs_output_dir,
-                $abs_docroot,
-                $apply_state["target_sqlite_path"] ?? null,
-            );
-            $summary = array_merge($summary, $sqlite_summary);
+        if ($manifest->sqlite !== null) {
+            $summary[] = "Copied sqlite-database-integration to {$abs_output_dir}/sqlite-database-integration";
         }
 
         foreach ($summary as $line) {
@@ -3401,153 +3422,6 @@ class ImportClient
         fwrite(STDERR, "\n");
         foreach ($summary as $line) {
             fwrite(STDERR, "{$line}\n");
-        }
-    }
-
-    /**
-     * Set up the SQLite database integration for a target site.
-     *
-     * Copies the sqlite-database-integration plugin into the output
-     * directory (the runtime config directory) and generates a db.php
-     * drop-in that loads it. The drop-in is symlinked into wp-content/
-     * so WordPress discovers it through its standard mechanism — the
-     * plugin code itself lives entirely outside the docroot.
-     *
-     * This mirrors how WordPress Playground sets up SQLite: the
-     * integration plugin is external, and only a thin db.php loader
-     * is placed in wp-content/.
-     *
-     * @param string $output_dir  Runtime configuration directory.
-     * @param string $docroot     Effective docroot (web root).
-     * @param string|null $sqlite_path  Path to the .ht.sqlite file.
-     * @return string[] Human-readable summary lines.
-     */
-    private function setup_sqlite_integration(
-        string $output_dir,
-        string $docroot,
-        ?string $sqlite_path,
-    ): array {
-        $summary = [];
-
-        // 1. Copy the sqlite-database-integration plugin to the output
-        //    directory. We vendor it from lib/ (git submodule) so it is
-        //    available without network access.
-        $source_plugin = dirname(__DIR__) . '/lib/sqlite-database-integration';
-        $target_plugin = $output_dir . '/sqlite-database-integration';
-
-        if (!is_dir($source_plugin)) {
-            throw new RuntimeException(
-                "sqlite-database-integration not found at {$source_plugin}. " .
-                "Run 'git submodule update --init' to fetch it.",
-            );
-        }
-
-        if (!is_dir($target_plugin)) {
-            $this->copy_directory_recursive($source_plugin, $target_plugin);
-            $summary[] = "Copied sqlite-database-integration to {$target_plugin}";
-        } else {
-            $summary[] = "sqlite-database-integration already present at {$target_plugin}";
-        }
-
-        // 2. Generate the db.php drop-in. This small file defines the
-        //    constants the integration needs and loads it from the output
-        //    directory. It is modeled after the plugin's own db.copy
-        //    template but with a hard-coded path to the external plugin.
-        $db_php_path = $output_dir . '/db.php';
-        $escaped_plugin = addslashes($target_plugin);
-
-        // Resolve the SQLite database directory and file name from the
-        // target path used by db-apply. If no path was provided, fall
-        // back to the standard wp-content/database/.ht.sqlite.
-        if ($sqlite_path !== null && $sqlite_path !== '') {
-            $db_dir = rtrim(dirname($sqlite_path), '/') . '/';
-            $db_file = basename($sqlite_path);
-        } else {
-            $db_dir = $docroot . '/wp-content/database/';
-            $db_file = '.ht.sqlite';
-        }
-        $escaped_db_dir = addslashes($db_dir);
-        $escaped_db_file = addslashes($db_file);
-
-        $db_php = <<<PHP
-<?php
-/**
- * SQLite database drop-in — generated by apply-runtime.
- *
- * This file bridges WordPress to the sqlite-database-integration
- * plugin which lives in the runtime configuration directory,
- * outside the site's docroot.
- */
-
-define('SQLITE_DB_DROPIN_VERSION', '1.8.0');
-
-if (!defined('DB_DIR')) {
-    define('DB_DIR', '{$escaped_db_dir}');
-}
-if (!defined('DB_FILE')) {
-    define('DB_FILE', '{$escaped_db_file}');
-}
-if (!defined('DATABASE_TYPE')) {
-    define('DATABASE_TYPE', 'sqlite');
-}
-if (!defined('DB_ENGINE')) {
-    define('DB_ENGINE', 'sqlite');
-}
-
-\$sqlite_plugin = '{$escaped_plugin}';
-if (file_exists(\$sqlite_plugin . '/wp-includes/sqlite/db.php')) {
-    require_once \$sqlite_plugin . '/wp-includes/sqlite/db.php';
-}
-PHP;
-
-        file_put_contents($db_php_path, $db_php);
-        $summary[] = "Wrote {$db_php_path}";
-
-        // 3. Symlink the drop-in into wp-content/ so WordPress discovers
-        //    it through the standard require_wp_db() mechanism. This is
-        //    the only file placed inside the docroot — the actual plugin
-        //    code stays in the output directory.
-        $wp_content_db = $docroot . '/wp-content/db.php';
-        if (file_exists($wp_content_db) || is_link($wp_content_db)) {
-            // An existing db.php (from the source site or a prior run)
-            // is left in place — it may be intentional.
-            $summary[] = "wp-content/db.php already exists — skipped symlink";
-            $this->audit_log("APPLY-RUNTIME | wp-content/db.php exists, not overwriting");
-        } else {
-            if (@symlink($db_php_path, $wp_content_db)) {
-                $summary[] = "Symlinked {$wp_content_db} → {$db_php_path}";
-            } else {
-                // Symlink failed (e.g. Windows or restricted filesystem).
-                // Fall back to a direct copy.
-                copy($db_php_path, $wp_content_db);
-                $summary[] = "Copied db.php to {$wp_content_db} (symlink unavailable)";
-            }
-        }
-
-        return $summary;
-    }
-
-    /**
-     * Recursively copy a directory tree.
-     */
-    private function copy_directory_recursive(string $source, string $dest): void
-    {
-        if (!is_dir($dest)) {
-            mkdir($dest, 0755, true);
-        }
-        $iterator = new RecursiveIteratorIterator(
-            new RecursiveDirectoryIterator($source, RecursiveDirectoryIterator::SKIP_DOTS),
-            RecursiveIteratorIterator::SELF_FIRST,
-        );
-        foreach ($iterator as $item) {
-            $target = $dest . '/' . $iterator->getSubPathname();
-            if ($item->isDir()) {
-                if (!is_dir($target)) {
-                    mkdir($target, 0755, true);
-                }
-            } else {
-                copy($item->getPathname(), $target);
-            }
         }
     }
 
@@ -9303,8 +9177,9 @@ if (
                 "  engine and credentials are read from state and included in runtime.php\n" .
                 "  as DB_* constants. For MySQL targets this means DB_HOST, DB_NAME,\n" .
                 "  DB_USER, and DB_PASSWORD. For SQLite targets, the sqlite-database-\n" .
-                "  integration plugin is copied into the output directory and a db.php\n" .
-                "  drop-in is symlinked into wp-content/.\n" .
+                "  integration plugin is copied into the output directory and a lazy-\n" .
+                "  loading \$wpdb proxy is generated in runtime.php (Playground-style,\n" .
+                "  no files placed in the docroot).\n" .
                 "\n" .
                 "Output files (nginx-fpm):\n" .
                 "  (output-dir)/runtime.php             PHP runtime (constants, route handlers)\n" .
@@ -9316,8 +9191,6 @@ if (
                 "\n" .
                 "Output files (sqlite target, additional):\n" .
                 "  (output-dir)/sqlite-database-integration/   Plugin copy\n" .
-                "  (output-dir)/db.php                         Drop-in loader\n" .
-                "  (docroot)/wp-content/db.php                 Symlink to drop-in\n" .
                 "\n" .
                 "Examples:\n" .
                 "  # From raw download directory:\n" .

--- a/importer/import.php
+++ b/importer/import.php
@@ -3287,6 +3287,28 @@ class ImportClient
         $analyzer = host_analyzer_for($webhost);
         $manifest = $analyzer->analyze($preflight_data);
 
+        // Step 1b: Merge target database configuration from db-apply state.
+        // db-apply persists the target engine and connection details so that
+        // apply-runtime can generate the matching DB_* constants and, for
+        // SQLite targets, set up the database integration plugin.
+        $apply_state = $this->state["apply"] ?? [];
+        $target_engine = $apply_state["target_engine"] ?? null;
+        if ($target_engine === "mysql") {
+            $manifest->constants["DB_NAME"] = $apply_state["target_db"] ?? "";
+            $manifest->constants["DB_USER"] = $apply_state["target_user"] ?? "";
+            $manifest->constants["DB_PASSWORD"] = $apply_state["target_pass"] ?? "";
+            $host_value = $apply_state["target_host"] ?? "127.0.0.1";
+            $port_value = (int) ($apply_state["target_port"] ?? 3306);
+            if ($port_value !== 3306) {
+                $host_value .= ":" . $port_value;
+            }
+            $manifest->constants["DB_HOST"] = $host_value;
+            // runtime.php defines DB_* before wp-config.php loads, which
+            // causes "Constant already defined" warnings. Flag this so the
+            // generated runtime.php installs a handler to suppress them.
+            $manifest->has_db_constants = true;
+        }
+
         $this->audit_log("APPLY-RUNTIME | analyzed preflight (source={$manifest->source}, webhost={$webhost})");
 
         // Resolve host and port for the target server. If not provided on
@@ -3340,6 +3362,21 @@ class ImportClient
         }
         $summary = $applier->apply($manifest, $abs_docroot, $abs_output_dir, $applier_options);
 
+        // Step 3: For SQLite targets, copy the sqlite-database-integration
+        // plugin into the output directory and set up the db.php drop-in.
+        // The plugin lives entirely in the output directory (not in the
+        // site's wp-content/plugins/). A small db.php drop-in is placed
+        // in wp-content/ to bridge WordPress to the external plugin — this
+        // is the standard WordPress mechanism for database driver overrides.
+        if ($target_engine === "sqlite") {
+            $sqlite_summary = $this->setup_sqlite_integration(
+                $abs_output_dir,
+                $abs_docroot,
+                $apply_state["target_sqlite_path"] ?? null,
+            );
+            $summary = array_merge($summary, $sqlite_summary);
+        }
+
         foreach ($summary as $line) {
             $this->audit_log("APPLY-RUNTIME | {$line}");
         }
@@ -3352,14 +3389,165 @@ class ImportClient
             "runtime" => $runtime,
             "webhost" => $webhost,
             "webhost_source" => $manifest->source,
+            "target_engine" => $target_engine,
         ]);
 
         fwrite(STDERR, "\n");
         fwrite(STDERR, "Runtime: {$runtime}\n");
         fwrite(STDERR, "Source host: {$webhost}\n");
+        if ($target_engine !== null) {
+            fwrite(STDERR, "Target database: {$target_engine}\n");
+        }
         fwrite(STDERR, "\n");
         foreach ($summary as $line) {
             fwrite(STDERR, "{$line}\n");
+        }
+    }
+
+    /**
+     * Set up the SQLite database integration for a target site.
+     *
+     * Copies the sqlite-database-integration plugin into the output
+     * directory (the runtime config directory) and generates a db.php
+     * drop-in that loads it. The drop-in is symlinked into wp-content/
+     * so WordPress discovers it through its standard mechanism — the
+     * plugin code itself lives entirely outside the docroot.
+     *
+     * This mirrors how WordPress Playground sets up SQLite: the
+     * integration plugin is external, and only a thin db.php loader
+     * is placed in wp-content/.
+     *
+     * @param string $output_dir  Runtime configuration directory.
+     * @param string $docroot     Effective docroot (web root).
+     * @param string|null $sqlite_path  Path to the .ht.sqlite file.
+     * @return string[] Human-readable summary lines.
+     */
+    private function setup_sqlite_integration(
+        string $output_dir,
+        string $docroot,
+        ?string $sqlite_path,
+    ): array {
+        $summary = [];
+
+        // 1. Copy the sqlite-database-integration plugin to the output
+        //    directory. We vendor it from lib/ (git submodule) so it is
+        //    available without network access.
+        $source_plugin = dirname(__DIR__) . '/lib/sqlite-database-integration';
+        $target_plugin = $output_dir . '/sqlite-database-integration';
+
+        if (!is_dir($source_plugin)) {
+            throw new RuntimeException(
+                "sqlite-database-integration not found at {$source_plugin}. " .
+                "Run 'git submodule update --init' to fetch it.",
+            );
+        }
+
+        if (!is_dir($target_plugin)) {
+            $this->copy_directory_recursive($source_plugin, $target_plugin);
+            $summary[] = "Copied sqlite-database-integration to {$target_plugin}";
+        } else {
+            $summary[] = "sqlite-database-integration already present at {$target_plugin}";
+        }
+
+        // 2. Generate the db.php drop-in. This small file defines the
+        //    constants the integration needs and loads it from the output
+        //    directory. It is modeled after the plugin's own db.copy
+        //    template but with a hard-coded path to the external plugin.
+        $db_php_path = $output_dir . '/db.php';
+        $escaped_plugin = addslashes($target_plugin);
+
+        // Resolve the SQLite database directory and file name from the
+        // target path used by db-apply. If no path was provided, fall
+        // back to the standard wp-content/database/.ht.sqlite.
+        if ($sqlite_path !== null && $sqlite_path !== '') {
+            $db_dir = rtrim(dirname($sqlite_path), '/') . '/';
+            $db_file = basename($sqlite_path);
+        } else {
+            $db_dir = $docroot . '/wp-content/database/';
+            $db_file = '.ht.sqlite';
+        }
+        $escaped_db_dir = addslashes($db_dir);
+        $escaped_db_file = addslashes($db_file);
+
+        $db_php = <<<PHP
+<?php
+/**
+ * SQLite database drop-in — generated by apply-runtime.
+ *
+ * This file bridges WordPress to the sqlite-database-integration
+ * plugin which lives in the runtime configuration directory,
+ * outside the site's docroot.
+ */
+
+define('SQLITE_DB_DROPIN_VERSION', '1.8.0');
+
+if (!defined('DB_DIR')) {
+    define('DB_DIR', '{$escaped_db_dir}');
+}
+if (!defined('DB_FILE')) {
+    define('DB_FILE', '{$escaped_db_file}');
+}
+if (!defined('DATABASE_TYPE')) {
+    define('DATABASE_TYPE', 'sqlite');
+}
+if (!defined('DB_ENGINE')) {
+    define('DB_ENGINE', 'sqlite');
+}
+
+\$sqlite_plugin = '{$escaped_plugin}';
+if (file_exists(\$sqlite_plugin . '/wp-includes/sqlite/db.php')) {
+    require_once \$sqlite_plugin . '/wp-includes/sqlite/db.php';
+}
+PHP;
+
+        file_put_contents($db_php_path, $db_php);
+        $summary[] = "Wrote {$db_php_path}";
+
+        // 3. Symlink the drop-in into wp-content/ so WordPress discovers
+        //    it through the standard require_wp_db() mechanism. This is
+        //    the only file placed inside the docroot — the actual plugin
+        //    code stays in the output directory.
+        $wp_content_db = $docroot . '/wp-content/db.php';
+        if (file_exists($wp_content_db) || is_link($wp_content_db)) {
+            // An existing db.php (from the source site or a prior run)
+            // is left in place — it may be intentional.
+            $summary[] = "wp-content/db.php already exists — skipped symlink";
+            $this->audit_log("APPLY-RUNTIME | wp-content/db.php exists, not overwriting");
+        } else {
+            if (@symlink($db_php_path, $wp_content_db)) {
+                $summary[] = "Symlinked {$wp_content_db} → {$db_php_path}";
+            } else {
+                // Symlink failed (e.g. Windows or restricted filesystem).
+                // Fall back to a direct copy.
+                copy($db_php_path, $wp_content_db);
+                $summary[] = "Copied db.php to {$wp_content_db} (symlink unavailable)";
+            }
+        }
+
+        return $summary;
+    }
+
+    /**
+     * Recursively copy a directory tree.
+     */
+    private function copy_directory_recursive(string $source, string $dest): void
+    {
+        if (!is_dir($dest)) {
+            mkdir($dest, 0755, true);
+        }
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($source, RecursiveDirectoryIterator::SKIP_DOTS),
+            RecursiveIteratorIterator::SELF_FIRST,
+        );
+        foreach ($iterator as $item) {
+            $target = $dest . '/' . $iterator->getSubPathname();
+            if ($item->isDir()) {
+                if (!is_dir($target)) {
+                    mkdir($target, 0755, true);
+                }
+            } else {
+                copy($item->getPathname(), $target);
+            }
         }
     }
 
@@ -4070,6 +4258,11 @@ class ImportClient
                 fwrite(STDERR, "[db-apply] No --target-sqlite-path specified, defaulting to: $target_path\n");
             }
 
+            // Persist target database configuration for apply-runtime.
+            $this->state["apply"]["target_engine"] = "sqlite";
+            $this->state["apply"]["target_db"] = $target_db;
+            $this->state["apply"]["target_sqlite_path"] = $target_path;
+
             return [
                 $this->create_sqlite_target_pdo($target_path, $target_db),
                 sprintf(
@@ -4091,6 +4284,14 @@ class ImportClient
                 "db-apply with --target-engine=mysql requires --target-user and --target-db.",
             );
         }
+
+        // Persist target database configuration for apply-runtime.
+        $this->state["apply"]["target_engine"] = "mysql";
+        $this->state["apply"]["target_db"] = $target_db;
+        $this->state["apply"]["target_host"] = $target_host;
+        $this->state["apply"]["target_port"] = $target_port;
+        $this->state["apply"]["target_user"] = $target_user;
+        $this->state["apply"]["target_pass"] = $target_pass;
 
         $dsn = "mysql:host={$target_host};port={$target_port};dbname={$target_db};charset=utf8mb4";
         try {
@@ -8261,6 +8462,15 @@ class ImportClient
                 "statements_executed" => 0,
                 "bytes_read" => 0,
                 "rewrite_url" => null,
+                // Target database configuration — persisted by db-apply
+                // so that apply-runtime can generate DB_* constants.
+                "target_engine" => null,
+                "target_db" => null,
+                "target_host" => null,
+                "target_port" => null,
+                "target_user" => null,
+                "target_pass" => null,
+                "target_sqlite_path" => null,
             ],
             // SQL output mode (file, stdout, mysql) — persisted for resume
             "sql_output" => null,
@@ -9088,6 +9298,14 @@ if (
                 "  --port=PORT               Listen port (default: from rewrite URL, or 8881)\n" .
                 "  --verbose, -v             Show detailed operation logs\n" .
                 "\n" .
+                "Database configuration:\n" .
+                "  When db-apply has been run before apply-runtime, the target database\n" .
+                "  engine and credentials are read from state and included in runtime.php\n" .
+                "  as DB_* constants. For MySQL targets this means DB_HOST, DB_NAME,\n" .
+                "  DB_USER, and DB_PASSWORD. For SQLite targets, the sqlite-database-\n" .
+                "  integration plugin is copied into the output directory and a db.php\n" .
+                "  drop-in is symlinked into wp-content/.\n" .
+                "\n" .
                 "Output files (nginx-fpm):\n" .
                 "  (output-dir)/runtime.php             PHP runtime (constants, route handlers)\n" .
                 "  (output-dir)/nginx.conf              Nginx server block\n" .
@@ -9095,6 +9313,11 @@ if (
                 "Output files (php-builtin):\n" .
                 "  (output-dir)/runtime.php             PHP runtime (constants, routing, handlers)\n" .
                 "  (output-dir)/start.sh                Shell script to launch the server\n" .
+                "\n" .
+                "Output files (sqlite target, additional):\n" .
+                "  (output-dir)/sqlite-database-integration/   Plugin copy\n" .
+                "  (output-dir)/db.php                         Drop-in loader\n" .
+                "  (docroot)/wp-content/db.php                 Symlink to drop-in\n" .
                 "\n" .
                 "Examples:\n" .
                 "  # From raw download directory:\n" .

--- a/importer/lib/host/class-runtime-manifest.php
+++ b/importer/lib/host/class-runtime-manifest.php
@@ -74,10 +74,12 @@ class RuntimeManifest
      * Keys:
      *   'plugin_source'  string  Absolute path to the sqlite-database-
      *                            integration source directory (e.g. lib/).
+     *   'plugin_dir'     string  Absolute path to the copied plugin in
+     *                            the output directory (set after copying).
      *   'db_dir'         string  Directory containing the .sqlite file.
      *   'db_file'        string  SQLite database file name.
      *
-     * @var array{plugin_source: string, db_dir: string, db_file: string}|null
+     * @var array{plugin_source: string, plugin_dir: string, db_dir: string, db_file: string}|null
      */
     public ?array $sqlite = null;
 

--- a/importer/lib/host/class-runtime-manifest.php
+++ b/importer/lib/host/class-runtime-manifest.php
@@ -54,6 +54,15 @@ class RuntimeManifest
      */
     public array $routes = [];
 
+    /**
+     * Whether the manifest includes DB_* constants that will collide
+     * with definitions in wp-config.php.  When true, the generated
+     * runtime.php installs a lightweight error handler that silences
+     * the "Constant already defined" warnings that occur when
+     * wp-config.php tries to redefine the same constants.
+     */
+    public bool $has_db_constants = false;
+
     public function __construct(string $source)
     {
         $this->source = $source;

--- a/importer/lib/host/class-runtime-manifest.php
+++ b/importer/lib/host/class-runtime-manifest.php
@@ -20,6 +20,8 @@
  *                 implement. Each describes a URL path pattern, a handler
  *                 name, and an optional condition (e.g. "file_not_found").
  *                 The target runtime decides how to implement the handler.
+ * - sqlite:       When non-null, the target uses SQLite instead of MySQL.
+ *                 Contains the plugin source path and database file location.
  */
 class RuntimeManifest
 {
@@ -62,6 +64,22 @@ class RuntimeManifest
      * wp-config.php tries to redefine the same constants.
      */
     public bool $has_db_constants = false;
+
+    /**
+     * SQLite database configuration.  When non-null, the target uses
+     * SQLite instead of MySQL.  The runtime layer copies the plugin
+     * into the output directory and generates a lazy-loading $wpdb
+     * proxy in runtime.php — no files are placed in the docroot.
+     *
+     * Keys:
+     *   'plugin_source'  string  Absolute path to the sqlite-database-
+     *                            integration source directory (e.g. lib/).
+     *   'db_dir'         string  Directory containing the .sqlite file.
+     *   'db_file'        string  SQLite database file name.
+     *
+     * @var array{plugin_source: string, db_dir: string, db_file: string}|null
+     */
+    public ?array $sqlite = null;
 
     public function __construct(string $source)
     {

--- a/importer/lib/target-runtime/functions.php
+++ b/importer/lib/target-runtime/functions.php
@@ -112,9 +112,9 @@ function generate_runtime_php(RuntimeManifest $manifest, string $docroot): strin
  * A mysqli_connect() stub is defined when the function doesn't exist,
  * because WordPress checks for it even when $wpdb is pre-set.
  *
- * @param array{plugin_source: string, db_dir: string, db_file: string} $sqlite
- *     'plugin_source' is resolved at generate-time to the copied plugin
- *     path inside the output directory (absolute).
+ * @param array{plugin_dir: string, db_dir: string, db_file: string} $sqlite
+ *     'plugin_dir' is the absolute path to the copied plugin inside the
+ *     output directory (set by the caller after copy_sqlite_plugin()).
  */
 function generate_sqlite_loader_code(array $sqlite): string
 {

--- a/importer/lib/target-runtime/functions.php
+++ b/importer/lib/target-runtime/functions.php
@@ -78,6 +78,17 @@ function generate_runtime_php(RuntimeManifest $manifest, string $docroot): strin
         $lines[] = '';
     }
 
+    // SQLite lazy-loading proxy — replaces $wpdb before WordPress boots.
+    // WordPress's require_wp_db() sees $wpdb is already set and skips
+    // the MySQL connection. The first real database call triggers the
+    // proxy to load the SQLite integration plugin from the output
+    // directory.  This is the same approach WordPress Playground uses:
+    // no db.php in wp-content/, no wp-config.php edits.
+    if ($manifest->sqlite !== null) {
+        $lines[] = generate_sqlite_loader_code($manifest->sqlite);
+        $lines[] = '';
+    }
+
     // Route handlers
     $route_code = generate_route_handler_code($manifest);
     if ($route_code !== '') {
@@ -85,6 +96,149 @@ function generate_runtime_php(RuntimeManifest $manifest, string $docroot): strin
     }
 
     return implode("\n", $lines);
+}
+
+/**
+ * Generate PHP code that installs a lazy-loading $wpdb proxy for
+ * SQLite, following the WordPress Playground pattern.
+ *
+ * The proxy is a tiny object that intercepts property access and
+ * method calls on $wpdb.  On the first interaction it loads the
+ * sqlite-database-integration plugin (which defines WP_SQLite_DB
+ * extending wpdb), then delegates.  Because $wpdb is already set
+ * when WordPress calls require_wp_db(), WordPress never attempts a
+ * MySQL connection.
+ *
+ * A mysqli_connect() stub is defined when the function doesn't exist,
+ * because WordPress checks for it even when $wpdb is pre-set.
+ *
+ * @param array{plugin_source: string, db_dir: string, db_file: string} $sqlite
+ *     'plugin_source' is resolved at generate-time to the copied plugin
+ *     path inside the output directory (absolute).
+ */
+function generate_sqlite_loader_code(array $sqlite): string
+{
+    $plugin_dir = addslashes($sqlite['plugin_dir']);
+    $db_dir = addslashes($sqlite['db_dir']);
+    $db_file = addslashes($sqlite['db_file']);
+
+    // The heredoc below is the code that ends up in runtime.php.
+    // It runs via auto_prepend_file (nginx-fpm) or the router
+    // script (php-builtin) — before any WordPress code executes.
+    return <<<'PROXY_HEADER'
+// --- SQLite integration (Playground-style lazy loader) ---
+//
+// Instead of placing a db.php drop-in in wp-content/, we pre-set
+// $wpdb to a proxy object.  WordPress's require_wp_db() checks
+// "isset($wpdb)" and returns early, so the MySQL path is never hit.
+// The first real database call loads the SQLite integration plugin.
+PROXY_HEADER
+    . "\n"
+    . "if (!defined('DB_DIR'))  define('DB_DIR',  '{$db_dir}');\n"
+    . "if (!defined('DB_FILE')) define('DB_FILE', '{$db_file}');\n"
+    . "\n"
+    . <<<'PROXY_BODY'
+if (!function_exists('mysqli_connect')) {
+    // WordPress checks for mysqli_connect() even when it won't use
+    // MySQL.  Provide a stub so the check doesn't fatal.
+    function mysqli_connect() { return false; }
+}
+
+/**
+ * Lazy-loading $wpdb proxy.  Defers loading the SQLite integration
+ * until the first actual database call, because the integration
+ * requires wpdb (loaded by require_wp_db) to be available.
+ */
+class Streaming_SQLite_Loader {
+    private static $loaded = false;
+
+    public function __call($name, $arguments) {
+        $this->ensure_loaded();
+        return call_user_func_array([$GLOBALS['wpdb'], $name], $arguments);
+    }
+
+    public function __get($name) {
+        $this->ensure_loaded();
+        return $GLOBALS['wpdb']->$name;
+    }
+
+    public function __set($name, $value) {
+        $this->ensure_loaded();
+        $GLOBALS['wpdb']->$name = $value;
+    }
+
+    public function __isset($name) {
+        $this->ensure_loaded();
+        return isset($GLOBALS['wpdb']->$name);
+    }
+
+    private function ensure_loaded() {
+        if (self::$loaded) return;
+        self::$loaded = true;
+PROXY_BODY
+    . "\n"
+    // Inject the resolved plugin path into the loader method.
+    . "        \$integration = '{$plugin_dir}/wp-includes/sqlite/db.php';\n"
+    . <<<'PROXY_TAIL'
+        if (file_exists($integration)) {
+            require_once $integration;
+        }
+    }
+}
+
+$wpdb = $GLOBALS['wpdb'] = new Streaming_SQLite_Loader();
+// --- end SQLite integration ---
+PROXY_TAIL;
+}
+
+/**
+ * Copy the sqlite-database-integration plugin into the output
+ * directory so it is available at runtime.
+ *
+ * @param string $source_dir  Path to the source plugin (e.g. lib/sqlite-database-integration).
+ * @param string $output_dir  Runtime configuration directory.
+ * @return string Absolute path to the copied plugin directory.
+ */
+function copy_sqlite_plugin(string $source_dir, string $output_dir): string
+{
+    if (!is_dir($source_dir)) {
+        throw new RuntimeException(
+            "sqlite-database-integration not found at {$source_dir}. " .
+            "Run 'git submodule update --init' to fetch it.",
+        );
+    }
+
+    $target_dir = $output_dir . '/sqlite-database-integration';
+
+    if (!is_dir($target_dir)) {
+        copy_directory_recursive($source_dir, $target_dir);
+    }
+
+    return $target_dir;
+}
+
+/**
+ * Recursively copy a directory tree.
+ */
+function copy_directory_recursive(string $source, string $dest): void
+{
+    if (!is_dir($dest)) {
+        mkdir($dest, 0755, true);
+    }
+    $iterator = new RecursiveIteratorIterator(
+        new RecursiveDirectoryIterator($source, RecursiveDirectoryIterator::SKIP_DOTS),
+        RecursiveIteratorIterator::SELF_FIRST,
+    );
+    foreach ($iterator as $item) {
+        $target = $dest . '/' . $iterator->getSubPathname();
+        if ($item->isDir()) {
+            if (!is_dir($target)) {
+                mkdir($target, 0755, true);
+            }
+        } else {
+            copy($item->getPathname(), $target);
+        }
+    }
 }
 
 /**

--- a/importer/lib/target-runtime/functions.php
+++ b/importer/lib/target-runtime/functions.php
@@ -39,6 +39,23 @@ function generate_runtime_php(RuntimeManifest $manifest, string $docroot): strin
     $lines[] = ' */';
     $lines[] = '';
 
+    // When runtime.php pre-defines DB_* constants (DB_HOST, DB_NAME,
+    // etc.), the source site's wp-config.php will try to redefine them
+    // with define() — which emits a warning in PHP 8+. Install a
+    // lightweight error handler that silences just those warnings.
+    if ($manifest->has_db_constants) {
+        $lines[] = '// Suppress "Constant already defined" warnings from wp-config.php.';
+        $lines[] = '// runtime.php pre-defines DB_* constants with target values; the';
+        $lines[] = '// source wp-config.php will attempt to redefine them.';
+        $lines[] = 'set_error_handler(function ($errno, $errstr) {';
+        $lines[] = '    if (strpos($errstr, \'already defined\') !== false) {';
+        $lines[] = '        return true;';
+        $lines[] = '    }';
+        $lines[] = '    return false;';
+        $lines[] = '}, E_WARNING | E_NOTICE);';
+        $lines[] = '';
+    }
+
     // Constants
     if (!empty($manifest->constants)) {
         foreach ($manifest->constants as $name => $value) {

--- a/importer/lib/target-runtime/functions.php
+++ b/importer/lib/target-runtime/functions.php
@@ -176,9 +176,9 @@ PROXY_BODY
     . "        \$integration = '{$plugin_dir}/wp-includes/sqlite/db.php';\n"
     . <<<'PROXY_TAIL'
         require_once $integration;
-		if($GLOBALS['wpdb'] === $this) {
-			throw new Exception('SQLite integration plugin could not be loaded');
-		}
+        if ($GLOBALS['wpdb'] === $this) {
+            throw new Exception('SQLite integration plugin could not be loaded');
+        }
     }
 }
 

--- a/importer/lib/target-runtime/functions.php
+++ b/importer/lib/target-runtime/functions.php
@@ -167,11 +167,6 @@ class Streaming_SQLite_Loader {
         $GLOBALS['wpdb']->$name = $value;
     }
 
-    public function __isset($name) {
-        $this->ensure_loaded();
-        return isset($GLOBALS['wpdb']->$name);
-    }
-
     private function ensure_loaded() {
         if (self::$loaded) return;
         self::$loaded = true;
@@ -180,12 +175,14 @@ PROXY_BODY
     // Inject the resolved plugin path into the loader method.
     . "        \$integration = '{$plugin_dir}/wp-includes/sqlite/db.php';\n"
     . <<<'PROXY_TAIL'
-        if (file_exists($integration)) {
-            require_once $integration;
-        }
+        require_once $integration;
+		if($GLOBALS['wpdb'] === $this) {
+			throw new Exception('SQLite integration plugin could not be loaded');
+		}
     }
 }
 
+define('DB_ENGINE', 'sqlite');
 $wpdb = $GLOBALS['wpdb'] = new Streaming_SQLite_Loader();
 // --- end SQLite integration ---
 PROXY_TAIL;


### PR DESCRIPTION
## Summary

When `db-apply` runs, it now persists the target database engine and credentials in state. `apply-runtime` reads this and generates the right configuration so the imported site connects to the target database without manual wp-config.php edits.

For **MySQL targets**, `runtime.php` pre-defines `DB_HOST`, `DB_NAME`, `DB_USER`, and `DB_PASSWORD`. A lightweight error handler suppresses the "Constant already defined" warnings from wp-config.php's own `define()` calls.

For **SQLite targets**, the `sqlite-database-integration` plugin is copied into the output directory (the runtime config dir) and a thin `db.php` drop-in is generated that loads it from there. The drop-in is symlinked into `wp-content/` — the standard WordPress mechanism for database driver overrides — while the plugin code itself stays entirely outside the docroot.

## Test plan

- [ ] Run `db-apply --target-engine=mysql` then `apply-runtime` — verify `runtime.php` contains `DB_HOST`, `DB_NAME`, `DB_USER`, `DB_PASSWORD` with the error handler block
- [ ] Run `db-apply --target-engine=sqlite` then `apply-runtime` — verify the output directory contains `sqlite-database-integration/` and `db.php`, and that `wp-content/db.php` is a symlink to the generated drop-in
- [ ] Start the PHP built-in server with `start.sh` — verify WordPress boots and connects to the target database
- [ ] Run `apply-runtime` without a prior `db-apply` — verify it works as before (no DB constants generated)
- [ ] Verify existing unit tests still pass