### PR TITLE
Fix flaky wp-content symlink e2e tests

### DIFF
--- a/tests/e2e/tests/import-38-flatten-wpcloud.test.js
+++ b/tests/e2e/tests/import-38-flatten-wpcloud.test.js
@@ -36,14 +36,18 @@ describe('Import: Flat Document Root (WP Cloud-like layout)', () => {
     let tempDir;
 
     beforeAll(async () => {
-        // Clean up previous external dirs (may be nginx-owned from prior run)
-        execSync(`sudo rm -rf ${CORE_DIR} ${CONTENT_DIR}`);
-
         await ensureSite(site, {
             afterCreate: async (siteDir) => {
                 // Simulate WP Cloud layout:
                 //   wp-admin and wp-includes live behind __wp__ in a separate dir
                 //   wp-content lives in a completely separate dir
+                //
+                // Clean up previous external dirs first (may be nginx-owned
+                // from prior run).  This must happen inside afterCreate so
+                // that the dirs are only deleted when they will be recreated.
+                // Deleting them before ensureSite breaks re-runs: the marker
+                // file still exists → afterCreate is skipped → broken symlinks.
+                execSync(`sudo rm -rf ${CORE_DIR} ${CONTENT_DIR}`);
                 mkdirSync(CORE_DIR, { recursive: true });
                 mkdirSync(CONTENT_DIR, { recursive: true });
 

--- a/wordpress-plugin/generic/export.php
+++ b/wordpress-plugin/generic/export.php
@@ -1664,13 +1664,13 @@ function endpoint_preflight(array $config): array
                                 ? content_url()
                                 : (defined("WP_CONTENT_URL") ? WP_CONTENT_URL : null),
                             "plugins_dir" => defined("WP_PLUGIN_DIR")
-                                ? rtrim(WP_PLUGIN_DIR, "/")
+                                ? realpath(rtrim(WP_PLUGIN_DIR, "/"))
                                 : null,
                             "plugins_url" => function_exists("plugins_url")
                                 ? plugins_url()
                                 : (defined("WP_PLUGIN_URL") ? WP_PLUGIN_URL : null),
                             "mu_plugins_dir" => defined("WPMU_PLUGIN_DIR")
-                                ? rtrim(WPMU_PLUGIN_DIR, "/")
+                                ? realpath(rtrim(WPMU_PLUGIN_DIR, "/"))
                                 : null,
                             "mu_plugins_url" => function_exists("content_url")
                                 ? content_url("/mu-plugins")
@@ -1697,8 +1697,9 @@ function endpoint_preflight(array $config): array
                         if (function_exists("wp_upload_dir")) {
                             $uploads = wp_upload_dir(null, false);
                             if (is_array($uploads)) {
+                                $raw_basedir = $uploads["basedir"] ?? null;
                                 $paths_urls["uploads"]["basedir"] =
-                                    $uploads["basedir"] ?? null;
+                                    is_string($raw_basedir) ? realpath($raw_basedir) : null;
                                 $paths_urls["uploads"]["baseurl"] =
                                     $uploads["baseurl"] ?? null;
                                 $paths_urls["uploads"]["subdir"] =


### PR DESCRIPTION
## Summary

The two wp-content assertions in the flat-document-root e2e test (test 38) were
intermittently failing. Two independent bugs contributed:

**Re-run breakage in test setup** — The test deleted external directories
(CORE_DIR, CONTENT_DIR) *before* calling ensureSite. When the site marker
already exists from a previous run, ensureSite returns immediately without
running afterCreate, so those directories were never recreated. The site ended
up with dangling symlinks and WordPress couldn't resolve WP_CONTENT_DIR.
Moved the cleanup inside afterCreate where it only fires when the dirs will
be immediately rebuilt.

**Inconsistent realpath in export** — content_dir was resolved through
realpath() but plugins_dir, mu_plugins_dir, and uploads basedir were not. On
any system where a path component is a symlink, the flat-document-root prefix
comparison would see a mismatch and incorrectly flag sub-components as
"detached" from content_dir, turning wp-content into a real directory instead
of the expected symlink. All directory paths now go through realpath()
consistently.

## Test plan

- [ ] Run `import-38-flatten-wpcloud` e2e test — both "wp-content should be a symlink" and "wp-content is traversable and contains plugins" should pass reliably
- [ ] Re-run the same test (marker exists) — should still pass
- [ ] Full e2e suite passes with no regressions