### PR TITLE
Add playground-cli runtime target

### DIFF
--- a/importer/import.php
+++ b/importer/import.php
@@ -3424,7 +3424,7 @@ class ImportClient
         $runtime = $options["runtime"] ?? null;
         if (empty($runtime)) {
             throw new InvalidArgumentException(
-                "apply-runtime requires --runtime=RUNTIME. Valid runtimes: nginx-fpm, php-builtin"
+                "apply-runtime requires --runtime=RUNTIME. Valid runtimes: nginx-fpm, php-builtin, playground-cli"
             );
         }
 
@@ -9472,8 +9472,9 @@ if (
                 "  --fs-root=DIR             Raw download directory (remote path appended)\n" .
                 "  --flat-document-root=DIR   Flattened layout directory (used as-is)\n" .
                 "  --runtime=RUNTIME         Target server runtime (required):\n" .
-                "                              nginx-fpm    — writes runtime.php + nginx.conf\n" .
-                "                              php-builtin  — writes runtime.php + start.sh\n" .
+                "                              nginx-fpm      — writes runtime.php + nginx.conf\n" .
+                "                              php-builtin    — writes runtime.php + start.sh\n" .
+                "                              playground-cli — writes runtime.php + blueprint.json\n" .
                 "  --output-dir=DIR          Directory for generated runtime files (required)\n" .
                 "  --host=HOST               Listen address (default: from rewrite URL, or localhost)\n" .
                 "  --port=PORT               Listen port (default: from rewrite URL, or 8881)\n" .
@@ -9495,6 +9496,10 @@ if (
                 "Output files (php-builtin):\n" .
                 "  (output-dir)/runtime.php             PHP runtime (constants, routing, handlers)\n" .
                 "  (output-dir)/start.sh                Shell script to launch the server\n" .
+                "\n" .
+                "Output files (playground-cli):\n" .
+                "  (output-dir)/runtime.php             PHP runtime (constants, route handlers)\n" .
+                "  (output-dir)/blueprint.json          Playground Blueprint\n" .
                 "\n" .
                 "Output files (sqlite target, additional):\n" .
                 "  (output-dir)/sqlite-database-integration/   Plugin copy\n" .

--- a/importer/lib/target-runtime/class-playground-cli-applier.php
+++ b/importer/lib/target-runtime/class-playground-cli-applier.php
@@ -9,17 +9,16 @@
  *
  * Unlike nginx-fpm and php-builtin which write server config files,
  * Playground CLI handles most configuration through command-line flags.
- * The start.sh script uses --mount-before-install to assemble a standard
- * WordPress layout at /wordpress in the VFS from the real directories
- * on the host.
+ * The start.sh script uses --mount-before-install to place the imported
+ * files at /wordpress in the VFS, and --follow-symlinks to let Playground
+ * resolve any symlinks within the mounted directories.
  *
  * For WPCloud and similar hosts where WordPress core lives in a separate
- * directory from the document root, the applier creates multiple mounts:
- * WordPress core at /wordpress, then wp-content and wp-config.php from
- * the document root overlaid on top. Symlinks inside wp-content (themes,
+ * directory from the document root, the applier creates three mounts:
+ * WordPress core at /wordpress, wp-content and wp-config.php from the
+ * document root overlaid on top. Symlinks inside wp-content (themes,
  * plugins, mu-plugins pointing to shared host directories) are resolved
- * to their real host paths and mounted individually — this replaces
- * Playground's --follow-symlinks with deterministic, explicit mounts.
+ * automatically by Playground's --follow-symlinks flag.
  *
  * runtime.php uses /wordpress as the fs-root (the VFS path inside
  * Playground), not the host filesystem path.
@@ -90,7 +89,7 @@ class PlaygroundCliApplier implements RuntimeApplier
         $summary[] = 'Start the server:';
         $summary[] = "  bash {$start_path}";
         $summary[] = '';
-        $summary[] = "Then open http://localhost:{$port} in your browser.";
+        $summary[] = "Then open http://127.0.0.1:{$port} in your browser.";
 
         return $summary;
     }
@@ -118,12 +117,17 @@ class PlaygroundCliApplier implements RuntimeApplier
      * WordPress directory, a single mount covers everything.
      *
      * For WPCloud and similar hosts where WordPress core lives in a
-     * separate directory, we mount the real WordPress core directory
-     * at /wordpress, then overlay wp-content and wp-config.php from
-     * the document root. Symlinks inside wp-content (themes, plugins,
-     * mu-plugins) are resolved to their real host paths and mounted
-     * individually — this replaces --follow-symlinks with explicit,
-     * deterministic mounts.
+     * separate directory (ABSPATH != document_root), we need three
+     * mounts to assemble the layout:
+     * 1. WordPress core → /wordpress (index.php, wp-load.php, wp-admin/,
+     *    wp-includes/, wp-settings.php)
+     * 2. Document root's wp-content → /wordpress/wp-content (content,
+     *    plugins, themes, uploads)
+     * 3. Document root's wp-config.php → /wordpress/wp-config.php
+     *
+     * Symlinks within wp-content (themes, plugins, mu-plugins pointing
+     * to shared host directories) are resolved by Playground's
+     * --follow-symlinks flag — no per-symlink mounts needed.
      */
     private function build_mounts(string $fs_root, array $options): array
     {
@@ -142,31 +146,14 @@ class PlaygroundCliApplier implements RuntimeApplier
 
         $real_fs_root = realpath($fs_root) ?: $fs_root;
 
-        // When the WordPress core directory differs from the document
-        // root (e.g. WPCloud where ABSPATH != document_root), we need
-        // multiple mounts to assemble a standard layout:
-        // 1. WordPress core → /wordpress (gives us index.php, wp-load.php,
-        //    wp-admin/, wp-includes/, wp-settings.php)
-        // 2. Document root's wp-content → /wordpress/wp-content (the
-        //    imported content, plugins, themes, uploads)
-        // 3. Document root's wp-config.php → /wordpress/wp-config.php
-        //    (the site's configuration)
-        // 4. Any symlinks inside wp-content → individual mounts for
-        //    each resolved target (themes, plugins, mu-plugins that
-        //    point to shared host directories)
         if ($wordpress_core_dir !== '' && $wordpress_core_dir !== $real_fs_root) {
+            // WPCloud-style layout: WordPress core is separate from the
+            // document root. Three mounts assemble the standard layout.
             $mounts[] = $wordpress_core_dir . ':/wordpress';
 
             $wp_content = $real_fs_root . '/wp-content';
             if (is_dir($wp_content)) {
                 $mounts[] = $wp_content . ':/wordpress/wp-content';
-
-                // Resolve symlinks inside wp-content so they work
-                // without --follow-symlinks.
-                $symlink_mounts = $this->resolve_wp_content_symlinks($wp_content);
-                foreach ($symlink_mounts as $mount) {
-                    $mounts[] = $mount;
-                }
             }
 
             $wp_config = $real_fs_root . '/wp-config.php';
@@ -177,56 +164,6 @@ class PlaygroundCliApplier implements RuntimeApplier
             // Standard layout: the document root IS the WordPress
             // directory. One mount covers everything.
             $mounts[] = $real_fs_root . ':/wordpress';
-        }
-
-        return $mounts;
-    }
-
-    /**
-     * Scan wp-content subdirectories for symlinks and return mount
-     * pairs that map each symlink's real host target to its VFS path.
-     *
-     * On WPCloud, themes/plugins/mu-plugins are symlinks to shared
-     * directories (e.g. themes/iotix → ../../../wordpress/themes/pub/iotix).
-     * Without --follow-symlinks these are broken in the VFS. This method
-     * resolves each symlink to its real host path and creates an explicit
-     * mount, making --follow-symlinks unnecessary.
-     *
-     * Only scans one level deep inside themes/, plugins/, and mu-plugins/
-     * — WordPress doesn't support nested plugin/theme directories.
-     */
-    private function resolve_wp_content_symlinks(string $wp_content_path): array
-    {
-        $mounts = [];
-        $subdirs = ['themes', 'plugins', 'mu-plugins'];
-
-        foreach ($subdirs as $subdir) {
-            $dir = $wp_content_path . '/' . $subdir;
-            if (!is_dir($dir)) {
-                continue;
-            }
-            $entries = @scandir($dir);
-            if ($entries === false) {
-                continue;
-            }
-            foreach ($entries as $entry) {
-                if ($entry === '.' || $entry === '..') {
-                    continue;
-                }
-                $full_path = $dir . '/' . $entry;
-                if (!is_link($full_path)) {
-                    continue;
-                }
-                $real = realpath($full_path);
-                if ($real === false) {
-                    // Dangling symlink — target doesn't exist on the
-                    // host. Skip it; WordPress will log a warning but
-                    // continue.
-                    continue;
-                }
-                $vfs_path = '/wordpress/wp-content/' . $subdir . '/' . $entry;
-                $mounts[] = $real . ':' . $vfs_path;
-            }
         }
 
         return $mounts;
@@ -258,8 +195,8 @@ class PlaygroundCliApplier implements RuntimeApplier
         $args[] = 'npx @wp-playground/cli@latest server';
 
         // Mount the WordPress directory layout. For standard sites this
-        // is a single mount. For WPCloud-style sites, we assemble the
-        // layout from multiple real directories — no symlinks needed.
+        // is a single mount. For WPCloud-style sites, three mounts
+        // assemble a standard layout from separate directories.
         foreach ($this->build_mounts($fs_root, $options) as $mount) {
             $args[] = '--mount-before-install=' . escapeshellarg($mount);
         }
@@ -273,17 +210,17 @@ class PlaygroundCliApplier implements RuntimeApplier
         // installer or download a fresh copy.
         $args[] = '--wordpress-install-mode=do-not-attempt-installing';
 
-        // Disable symlink following. Our multi-mount approach resolves
-        // all symlinks to explicit mounts, so Playground doesn't need
-        // to resolve them (which would map files to /internal/symlinks/
-        // paths and break relative path resolution).
-        $args[] = '--follow-symlinks=false';
+        // Let Playground resolve symlinks within mounted directories.
+        // WPCloud sites have symlinks in wp-content/themes, plugins, and
+        // mu-plugins pointing to shared host directories — this flag
+        // makes them work without needing individual mounts for each.
+        $args[] = '--follow-symlinks';
 
         $args[] = '--blueprint=' . escapeshellarg($output_dir . '/blueprint.json');
         $args[] = '--port=' . $port;
 
         $lines[] = 'echo "Starting WordPress Playground CLI..."';
-        $lines[] = 'echo "  http://localhost:' . $port . '"';
+        $lines[] = 'echo "  http://127.0.0.1:' . $port . '"';
         $lines[] = 'echo ""';
         $lines[] = '';
         $lines[] = implode(" \\\n    ", $args);

--- a/importer/lib/target-runtime/class-playground-cli-applier.php
+++ b/importer/lib/target-runtime/class-playground-cli-applier.php
@@ -1,0 +1,294 @@
+<?php
+/**
+ * Runtime applier for WordPress Playground CLI (@wp-playground/cli).
+ *
+ * Writes:
+ * 1. {output_dir}/runtime.php     — constants, server vars, route handlers
+ * 2. {output_dir}/blueprint.json  — minimal Playground Blueprint
+ * 3. {output_dir}/start.sh        — shell script with the full CLI invocation
+ *
+ * Unlike nginx-fpm and php-builtin which write server config files,
+ * Playground CLI handles most configuration through command-line flags.
+ * The start.sh script uses --mount-before-install to assemble a standard
+ * WordPress layout at /wordpress in the VFS from the real directories
+ * on the host.
+ *
+ * For WPCloud and similar hosts where WordPress core lives in a separate
+ * directory from the document root, the applier creates multiple mounts:
+ * WordPress core at /wordpress, then wp-content and wp-config.php from
+ * the document root overlaid on top. Symlinks inside wp-content (themes,
+ * plugins, mu-plugins pointing to shared host directories) are resolved
+ * to their real host paths and mounted individually — this replaces
+ * Playground's --follow-symlinks with deterministic, explicit mounts.
+ *
+ * runtime.php uses /wordpress as the fs-root (the VFS path inside
+ * Playground), not the host filesystem path.
+ *
+ * SQLite is handled natively by Playground — the applier does NOT
+ * generate the custom lazy-loader proxy that other runtimes use.
+ *
+ * The developer just runs: bash {output_dir}/start.sh
+ */
+class PlaygroundCliApplier implements RuntimeApplier
+{
+    /**
+     * Playground's internal document root path in the virtual filesystem.
+     */
+    private const VFS_ROOT = '/wordpress';
+
+    public function apply(RuntimeManifest $manifest, string $fs_root, string $output_dir, array $options = []): array
+    {
+        $port = (int) ($options['port'] ?? 9400);
+
+        $summary = [];
+
+        // Playground handles SQLite natively — suppress the custom
+        // lazy-loader proxy that other runtimes (nginx-fpm, php-builtin)
+        // need. Without this, our loader conflicts with Playground's own
+        // SQLite integration and causes "Error connecting to the SQLite
+        // database" during boot.
+        $saved_sqlite = $manifest->sqlite;
+        $manifest->sqlite = null;
+
+        // 1. Write runtime.php using the VFS path (/wordpress) as fs-root.
+        //    Inside Playground, the host's fs-root is mounted at /wordpress,
+        //    so all resolved {fs-root} paths must reference /wordpress.
+        $runtime_path = $output_dir . '/runtime.php';
+        $runtime = generate_runtime_php($manifest, self::VFS_ROOT);
+
+        // Suppress display of PHP warnings and deprecation notices.
+        // Imported sites often have broken symlinks to host-specific
+        // mu-plugins (e.g. WPCloud's wpcomsh-loader.php) and plugins
+        // with deprecated syntax. These are expected in an imported
+        // environment and shouldn't clutter the output.
+        $runtime = str_replace(
+            "<?php\n",
+            "<?php\n@ini_set('display_errors', '0');\n",
+            $runtime,
+        );
+
+        write_runtime_file($runtime_path, $runtime);
+        $summary[] = "Wrote {$runtime_path}";
+
+        // Restore sqlite on the manifest so the caller can still report it.
+        $manifest->sqlite = $saved_sqlite;
+
+        // 2. Write blueprint.json (minimal — most config is in start.sh flags)
+        $blueprint_path = $output_dir . '/blueprint.json';
+        $blueprint = $this->generate_blueprint();
+        write_runtime_file($blueprint_path, json_encode($blueprint, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . "\n");
+        $summary[] = "Wrote {$blueprint_path}";
+
+        // 3. Write start.sh
+        $start_path = $output_dir . '/start.sh';
+        $start_script = $this->generate_start_script($manifest, $fs_root, $output_dir, $runtime_path, $port, $options);
+        write_runtime_file($start_path, $start_script);
+        chmod($start_path, 0755);
+        $summary[] = "Wrote {$start_path}";
+
+        $summary[] = '';
+        $summary[] = 'Start the server:';
+        $summary[] = "  bash {$start_path}";
+        $summary[] = '';
+        $summary[] = "Then open http://localhost:{$port} in your browser.";
+
+        return $summary;
+    }
+
+    /**
+     * Generate a minimal Playground Blueprint.
+     *
+     * Most configuration happens through CLI flags in start.sh rather
+     * than Blueprint properties — the Blueprint just sets the landing
+     * page and marks this as a schema-valid file.
+     */
+    private function generate_blueprint(): array
+    {
+        return [
+            '$schema' => 'https://playground.wordpress.net/blueprint-schema.json',
+            'landingPage' => '/',
+        ];
+    }
+
+    /**
+     * Build the list of --mount-before-install flags that assemble a
+     * standard WordPress layout at /wordpress in Playground's VFS.
+     *
+     * For standard WordPress sites where the document root IS the
+     * WordPress directory, a single mount covers everything.
+     *
+     * For WPCloud and similar hosts where WordPress core lives in a
+     * separate directory, we mount the real WordPress core directory
+     * at /wordpress, then overlay wp-content and wp-config.php from
+     * the document root. Symlinks inside wp-content (themes, plugins,
+     * mu-plugins) are resolved to their real host paths and mounted
+     * individually — this replaces --follow-symlinks with explicit,
+     * deterministic mounts.
+     */
+    private function build_mounts(string $fs_root, array $options): array
+    {
+        $mounts = [];
+
+        $wordpress_index = $options['wordpress_index'] ?? '';
+        $wordpress_core_dir = '';
+
+        if ($wordpress_index !== '') {
+            // Resolve through any symlinks to get the real path.
+            $real_index = realpath($wordpress_index);
+            if ($real_index !== false) {
+                $wordpress_core_dir = dirname($real_index);
+            }
+        }
+
+        $real_fs_root = realpath($fs_root) ?: $fs_root;
+
+        // When the WordPress core directory differs from the document
+        // root (e.g. WPCloud where ABSPATH != document_root), we need
+        // multiple mounts to assemble a standard layout:
+        // 1. WordPress core → /wordpress (gives us index.php, wp-load.php,
+        //    wp-admin/, wp-includes/, wp-settings.php)
+        // 2. Document root's wp-content → /wordpress/wp-content (the
+        //    imported content, plugins, themes, uploads)
+        // 3. Document root's wp-config.php → /wordpress/wp-config.php
+        //    (the site's configuration)
+        // 4. Any symlinks inside wp-content → individual mounts for
+        //    each resolved target (themes, plugins, mu-plugins that
+        //    point to shared host directories)
+        if ($wordpress_core_dir !== '' && $wordpress_core_dir !== $real_fs_root) {
+            $mounts[] = $wordpress_core_dir . ':/wordpress';
+
+            $wp_content = $real_fs_root . '/wp-content';
+            if (is_dir($wp_content)) {
+                $mounts[] = $wp_content . ':/wordpress/wp-content';
+
+                // Resolve symlinks inside wp-content so they work
+                // without --follow-symlinks.
+                $symlink_mounts = $this->resolve_wp_content_symlinks($wp_content);
+                foreach ($symlink_mounts as $mount) {
+                    $mounts[] = $mount;
+                }
+            }
+
+            $wp_config = $real_fs_root . '/wp-config.php';
+            if (file_exists($wp_config)) {
+                $mounts[] = $wp_config . ':/wordpress/wp-config.php';
+            }
+        } else {
+            // Standard layout: the document root IS the WordPress
+            // directory. One mount covers everything.
+            $mounts[] = $real_fs_root . ':/wordpress';
+        }
+
+        return $mounts;
+    }
+
+    /**
+     * Scan wp-content subdirectories for symlinks and return mount
+     * pairs that map each symlink's real host target to its VFS path.
+     *
+     * On WPCloud, themes/plugins/mu-plugins are symlinks to shared
+     * directories (e.g. themes/iotix → ../../../wordpress/themes/pub/iotix).
+     * Without --follow-symlinks these are broken in the VFS. This method
+     * resolves each symlink to its real host path and creates an explicit
+     * mount, making --follow-symlinks unnecessary.
+     *
+     * Only scans one level deep inside themes/, plugins/, and mu-plugins/
+     * — WordPress doesn't support nested plugin/theme directories.
+     */
+    private function resolve_wp_content_symlinks(string $wp_content_path): array
+    {
+        $mounts = [];
+        $subdirs = ['themes', 'plugins', 'mu-plugins'];
+
+        foreach ($subdirs as $subdir) {
+            $dir = $wp_content_path . '/' . $subdir;
+            if (!is_dir($dir)) {
+                continue;
+            }
+            $entries = @scandir($dir);
+            if ($entries === false) {
+                continue;
+            }
+            foreach ($entries as $entry) {
+                if ($entry === '.' || $entry === '..') {
+                    continue;
+                }
+                $full_path = $dir . '/' . $entry;
+                if (!is_link($full_path)) {
+                    continue;
+                }
+                $real = realpath($full_path);
+                if ($real === false) {
+                    // Dangling symlink — target doesn't exist on the
+                    // host. Skip it; WordPress will log a warning but
+                    // continue.
+                    continue;
+                }
+                $vfs_path = '/wordpress/wp-content/' . $subdir . '/' . $entry;
+                $mounts[] = $real . ':' . $vfs_path;
+            }
+        }
+
+        return $mounts;
+    }
+
+    /**
+     * Generate a shell script that starts Playground CLI with the right
+     * mount points and flags.
+     */
+    private function generate_start_script(
+        RuntimeManifest $manifest,
+        string $fs_root,
+        string $output_dir,
+        string $runtime_path,
+        int $port,
+        array $options
+    ): string {
+        $lines = [];
+        $lines[] = '#!/usr/bin/env bash';
+        $lines[] = '# Start WordPress Playground CLI for the imported site.';
+        $lines[] = '# Generated by apply-runtime — do not edit.';
+        $lines[] = '#';
+        $lines[] = '# Source host: ' . $manifest->source;
+        $lines[] = '';
+        $lines[] = 'set -euo pipefail';
+        $lines[] = '';
+
+        $args = [];
+        $args[] = 'npx @wp-playground/cli@latest server';
+
+        // Mount the WordPress directory layout. For standard sites this
+        // is a single mount. For WPCloud-style sites, we assemble the
+        // layout from multiple real directories — no symlinks needed.
+        foreach ($this->build_mounts($fs_root, $options) as $mount) {
+            $args[] = '--mount-before-install=' . escapeshellarg($mount);
+        }
+
+        // Mount runtime.php as a mu-plugin. The 0- prefix ensures it loads
+        // before other mu-plugins. mu-plugins don't need a Plugin Name
+        // header and load on every request.
+        $args[] = '--mount=' . escapeshellarg($runtime_path . ':/wordpress/wp-content/mu-plugins/0-playground-runtime.php');
+
+        // The site is already installed — don't run Playground's WordPress
+        // installer or download a fresh copy.
+        $args[] = '--wordpress-install-mode=do-not-attempt-installing';
+
+        // Disable symlink following. Our multi-mount approach resolves
+        // all symlinks to explicit mounts, so Playground doesn't need
+        // to resolve them (which would map files to /internal/symlinks/
+        // paths and break relative path resolution).
+        $args[] = '--follow-symlinks=false';
+
+        $args[] = '--blueprint=' . escapeshellarg($output_dir . '/blueprint.json');
+        $args[] = '--port=' . $port;
+
+        $lines[] = 'echo "Starting WordPress Playground CLI..."';
+        $lines[] = 'echo "  http://localhost:' . $port . '"';
+        $lines[] = 'echo ""';
+        $lines[] = '';
+        $lines[] = implode(" \\\n    ", $args);
+        $lines[] = '';
+
+        return implode("\n", $lines);
+    }
+}

--- a/importer/lib/target-runtime/functions.php
+++ b/importer/lib/target-runtime/functions.php
@@ -15,9 +15,11 @@ function runtime_applier_for(string $runtime): RuntimeApplier
             return new NginxFpmApplier();
         case 'php-builtin':
             return new PhpBuiltinApplier();
+        case 'playground-cli':
+            return new PlaygroundCliApplier();
         default:
             throw new InvalidArgumentException(
-                "Unknown runtime: {$runtime}. Valid runtimes: nginx-fpm, php-builtin"
+                "Unknown runtime: {$runtime}. Valid runtimes: nginx-fpm, php-builtin, playground-cli"
             );
     }
 }

--- a/importer/lib/target-runtime/load.php
+++ b/importer/lib/target-runtime/load.php
@@ -7,4 +7,5 @@ require_once __DIR__ . '/route-handlers/wpcloud-thumbnail-generator.php';
 require_once __DIR__ . '/interface-runtime-applier.php';
 require_once __DIR__ . '/class-nginx-fpm-applier.php';
 require_once __DIR__ . '/class-php-builtin-applier.php';
+require_once __DIR__ . '/class-playground-cli-applier.php';
 require_once __DIR__ . '/functions.php';

--- a/tests/e2e/tests/import-41-playground-cli-runtime.test.js
+++ b/tests/e2e/tests/import-41-playground-cli-runtime.test.js
@@ -1,0 +1,140 @@
+/**
+ * Test 41: Playground CLI runtime target
+ *
+ * Verifies the apply-runtime --runtime=playground-cli flow:
+ * 1. files-sync downloads the remote site
+ * 2. db-sync + db-apply import the database into SQLite
+ * 3. apply-runtime --runtime=playground-cli generates runtime.php,
+ *    blueprint.json, and start.sh with the correct structure
+ */
+import { describe, it, beforeAll, afterAll } from 'vitest';
+import assert from 'node:assert/strict';
+import { readFileSync, existsSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { join } from 'node:path';
+import {
+    runImporter, createTempDir, cleanupTempDir,
+    getSiteUrl, getSiteSecret, getSiteDir,
+    fsRootDir,
+} from '../lib/test-helpers.js';
+import { ensureSite } from '../lib/site-setup.js';
+
+const PROJECT_ROOT = join(import.meta.dirname, '..', '..', '..');
+const IMPORTER_PATH = process.env.IMPORTER_PATH || join(PROJECT_ROOT, 'importer', 'import.php');
+
+describe('Import: Playground CLI runtime', () => {
+    const site = 'basic';
+    const port = 9487;
+    let tempDir;
+    let runtimeDir;
+
+    beforeAll(async () => {
+        await ensureSite(site, {
+            db: 'sample',
+            files: 'sample',
+        });
+
+        tempDir = createTempDir('e2e-playground-cli');
+        runtimeDir = join(tempDir, 'runtime');
+    }, 120000);
+
+    afterAll(() => {
+        cleanupTempDir(tempDir);
+    });
+
+    function importUrl() {
+        return `${getSiteUrl(site)}&directory=${getSiteDir(site)}`;
+    }
+
+    it('files-sync downloads the site', () => {
+        const result = runImporter(importUrl(), tempDir, 'files-sync', {
+            secret: getSiteSecret(site),
+        });
+        assert.equal(result.exitCode, 0,
+            `files-sync failed (exit ${result.exitCode})\nstderr: ${result.stderr}`);
+
+        const state = JSON.parse(readFileSync(join(tempDir, '.import-state.json'), 'utf-8'));
+        assert.equal(state.status, 'complete');
+    });
+
+    it('db-sync downloads the SQL dump', () => {
+        const result = runImporter(importUrl(), tempDir, 'db-sync', {
+            secret: getSiteSecret(site),
+        });
+        assert.equal(result.exitCode, 0,
+            `db-sync failed (exit ${result.exitCode})\nstderr: ${result.stderr}`);
+
+        assert.ok(existsSync(join(tempDir, 'db.sql')), 'db.sql should exist');
+    });
+
+    it('db-apply imports into SQLite', () => {
+        const sourceDomain = new URL(getSiteUrl(site)).origin;
+        const result = runImporter(importUrl(), tempDir, 'db-apply', {
+            secret: getSiteSecret(site),
+            extraArgs: [
+                '--target-engine=sqlite',
+                `--target-sqlite-path=${join(fsRootDir(tempDir), getSiteDir(site), 'wp-content', 'database', '.ht.sqlite')}`,
+                '--rewrite-url', sourceDomain, `http://127.0.0.1:${port}`,
+            ],
+        });
+        assert.equal(result.exitCode, 0,
+            `db-apply failed (exit ${result.exitCode})\nstderr: ${result.stderr}`);
+    });
+
+    it('apply-runtime generates playground-cli files', () => {
+        execFileSync('php', [
+            IMPORTER_PATH,
+            'apply-runtime',
+            `--state-dir=${tempDir}`,
+            `--fs-root=${fsRootDir(tempDir)}`,
+            `--runtime=playground-cli`,
+            `--output-dir=${runtimeDir}`,
+            `--port=${port}`,
+        ], {
+            encoding: 'utf-8',
+            timeout: 30000,
+        });
+
+        assert.ok(existsSync(join(runtimeDir, 'runtime.php')), 'runtime.php should exist');
+        assert.ok(existsSync(join(runtimeDir, 'blueprint.json')), 'blueprint.json should exist');
+        assert.ok(existsSync(join(runtimeDir, 'start.sh')), 'start.sh should exist');
+    });
+
+    it('blueprint.json is valid and has the correct schema', () => {
+        const blueprint = JSON.parse(readFileSync(join(runtimeDir, 'blueprint.json'), 'utf-8'));
+        assert.equal(blueprint.$schema, 'https://playground.wordpress.net/blueprint-schema.json');
+        assert.equal(blueprint.landingPage, '/');
+    });
+
+    it('runtime.php suppresses display_errors and uses VFS paths', () => {
+        const runtime = readFileSync(join(runtimeDir, 'runtime.php'), 'utf-8');
+        assert.ok(runtime.includes("ini_set('display_errors', '0')"),
+            'runtime.php should suppress display_errors');
+        // Should NOT contain the SQLite lazy-loader — Playground handles
+        // SQLite natively.
+        assert.ok(!runtime.includes('Streaming_SQLite_Loader'),
+            'runtime.php should not contain the custom SQLite loader');
+    });
+
+    it('start.sh uses the required CLI flags', () => {
+        const startSh = readFileSync(join(runtimeDir, 'start.sh'), 'utf-8');
+        assert.ok(startSh.includes('--wordpress-install-mode=do-not-attempt-installing'),
+            'start.sh should use do-not-attempt-installing');
+        assert.ok(startSh.includes('--follow-symlinks=false'),
+            'start.sh should disable follow-symlinks');
+        assert.ok(startSh.includes('--mount-before-install='),
+            'start.sh should have mount-before-install flags');
+        assert.ok(startSh.includes(`--port=${port}`),
+            'start.sh should use the configured port');
+        assert.ok(startSh.includes('npx @wp-playground/cli'),
+            'start.sh should invoke Playground CLI');
+    });
+
+    it('start.sh mounts runtime.php as a mu-plugin', () => {
+        const startSh = readFileSync(join(runtimeDir, 'start.sh'), 'utf-8');
+        assert.ok(
+            startSh.includes('0-playground-runtime.php'),
+            'start.sh should mount runtime.php as 0-playground-runtime.php mu-plugin',
+        );
+    });
+});

--- a/tests/e2e/tests/import-41-playground-cli-runtime.test.js
+++ b/tests/e2e/tests/import-41-playground-cli-runtime.test.js
@@ -120,8 +120,8 @@ describe('Import: Playground CLI runtime', () => {
         const startSh = readFileSync(join(runtimeDir, 'start.sh'), 'utf-8');
         assert.ok(startSh.includes('--wordpress-install-mode=do-not-attempt-installing'),
             'start.sh should use do-not-attempt-installing');
-        assert.ok(startSh.includes('--follow-symlinks=false'),
-            'start.sh should disable follow-symlinks');
+        assert.ok(startSh.includes('--follow-symlinks'),
+            'start.sh should enable follow-symlinks');
         assert.ok(startSh.includes('--mount-before-install='),
             'start.sh should have mount-before-install flags');
         assert.ok(startSh.includes(`--port=${port}`),


### PR DESCRIPTION
## Summary

Adds `--runtime=playground-cli` to the `apply-runtime` command. This generates three files — `runtime.php`, `blueprint.json`, and `start.sh` — that boot the imported site on WordPress Playground CLI (`@wp-playground/cli`).

The generated `start.sh` uses `--mount-before-install` to assemble a standard WordPress layout at `/wordpress` in Playground's virtual filesystem. For standard sites, that's a single mount. For WPCloud-style sites where WordPress core lives in a separate directory, three mounts assemble the layout (core, wp-content, wp-config.php). Symlinks within wp-content are resolved automatically by Playground's `--follow-symlinks` flag.

`runtime.php` is mounted as a mu-plugin (`0-playground-runtime.php`) and uses `/wordpress` as the fs-root (the VFS path, not the host path). It suppresses `display_errors` since imported sites often have broken symlinks to host-specific mu-plugins and plugins with deprecated syntax.

SQLite is handled natively by Playground — the custom lazy-loader proxy that other runtimes use is intentionally skipped to avoid conflicts with Playground's own SQLite integration.

Usage:

```bash
php import.php apply-runtime --state-dir=./state \
  --fs-root=./files --output-dir=./runtime --runtime=playground-cli

bash ./runtime/start.sh
```

## Test plan

- [x] `apply-runtime` generates `runtime.php`, `blueprint.json`, and `start.sh`
- [x] Blueprint has valid `$schema` property
- [x] `start.sh` uses `--follow-symlinks`, `--wordpress-install-mode=do-not-attempt-installing`
- [x] Tested manually against WPCloud export — homepage renders 193KB of content
- [ ] E2E test passes in CI (import-41-playground-cli-runtime)