### PR TITLE
Proxy missing uploads from the source site during migration

### DIFF
--- a/importer/import.php
+++ b/importer/import.php
@@ -3538,6 +3538,21 @@ class ImportClient
             ];
         }
 
+        // Remote upload proxy: while files-sync is still running, uploaded
+        // files may not exist locally yet.  Add a route handler that fetches
+        // missing uploads from the source site and streams the response to
+        // the client.  The source site URL comes from preflight wp_options.
+        $source_siteurl = $preflight_data["database"]["wp"]["siteurl"] ?? "";
+        if (is_string($source_siteurl) && $source_siteurl !== "") {
+            $manifest->constants["STREAMING_REMOTE_SITE_URL"] = $source_siteurl;
+            $manifest->routes[] = [
+                "handler" => "remote-upload-proxy",
+                "path_pattern" => "/wp-content/uploads/.*",
+                "condition" => "file_not_found",
+                "description" => "Proxy missing uploads from the source site during migration",
+            ];
+        }
+
         $this->audit_log("APPLY-RUNTIME | analyzed preflight (source={$manifest->source}, webhost={$webhost})");
 
         // Resolve host and port for the target server. If not provided on

--- a/importer/import.php
+++ b/importer/import.php
@@ -2446,18 +2446,6 @@ class ImportClient
         $this->state["status"] = "complete";
         $this->save_state($this->state);
 
-        // Signal the remote-upload-proxy that all uploads are available
-        // locally.  The proxy checks for this marker file and skips the
-        // cURL fetch when it exists — no more proxying once sync is done.
-        // Skip the marker when --filter=essential-files was used because
-        // uploads were not downloaded in that mode.
-        if ($this->filter !== 'essential-files') {
-            $marker = $this->state_dir . '/.streaming-uploads-synced';
-            if (!file_exists($marker)) {
-                file_put_contents($marker, '');
-            }
-        }
-
         $this->clear_progress_line();
         $index_size = $this->index_count();
         $label = $is_delta ? "files-sync (delta)" : "files-sync";
@@ -3557,7 +3545,7 @@ class ImportClient
         $source_siteurl = $preflight_data["database"]["wp"]["siteurl"] ?? "";
         if (is_string($source_siteurl) && $source_siteurl !== "") {
             $manifest->constants["STREAMING_REMOTE_SITE_URL"] = $source_siteurl;
-            $manifest->constants["STREAMING_SYNC_MARKER"] = $this->state_dir . '/.streaming-uploads-synced';
+            $manifest->constants["STREAMING_IMPORT_STATE"] = $this->state_file;
             $manifest->routes[] = [
                 "handler" => "remote-upload-proxy",
                 "path_pattern" => "/wp-content/uploads/.*",

--- a/importer/import.php
+++ b/importer/import.php
@@ -2446,6 +2446,18 @@ class ImportClient
         $this->state["status"] = "complete";
         $this->save_state($this->state);
 
+        // Signal the remote-upload-proxy that all uploads are available
+        // locally.  The proxy checks for this marker file and skips the
+        // cURL fetch when it exists — no more proxying once sync is done.
+        // Skip the marker when --filter=essential-files was used because
+        // uploads were not downloaded in that mode.
+        if ($this->filter !== 'essential-files') {
+            $marker = $this->fs_root . '/.streaming-uploads-synced';
+            if ($this->fs_root !== null && !file_exists($marker)) {
+                file_put_contents($marker, '');
+            }
+        }
+
         $this->clear_progress_line();
         $index_size = $this->index_count();
         $label = $is_delta ? "files-sync (delta)" : "files-sync";

--- a/importer/import.php
+++ b/importer/import.php
@@ -2446,6 +2446,13 @@ class ImportClient
         $this->state["status"] = "complete";
         $this->save_state($this->state);
 
+        // Disable the remote-upload-proxy in runtime.php now that all
+        // files are available locally.  Skip when --filter=essential-files
+        // was used because uploads were not downloaded in that mode.
+        if ($this->filter !== 'essential-files') {
+            $this->disable_upload_proxy();
+        }
+
         $this->clear_progress_line();
         $index_size = $this->index_count();
         $label = $is_delta ? "files-sync (delta)" : "files-sync";
@@ -3545,7 +3552,6 @@ class ImportClient
         $source_siteurl = $preflight_data["database"]["wp"]["siteurl"] ?? "";
         if (is_string($source_siteurl) && $source_siteurl !== "") {
             $manifest->constants["STREAMING_REMOTE_SITE_URL"] = $source_siteurl;
-            $manifest->constants["STREAMING_IMPORT_STATE"] = $this->state_file;
             $manifest->routes[] = [
                 "handler" => "remote-upload-proxy",
                 "path_pattern" => "/wp-content/uploads/.*",
@@ -3625,6 +3631,13 @@ class ImportClient
 
         $summary = $applier->apply($manifest, $abs_fs_root, $abs_output_dir, $applier_options);
 
+        // Persist the output dir so that files-sync can patch runtime.php
+        // to disable the upload proxy once sync completes.
+        $this->state["apply_runtime"] = [
+            "output_dir" => $abs_output_dir,
+        ];
+        $this->save_state($this->state);
+
         if ($manifest->sqlite !== null) {
             $summary[] = "Copied sqlite-database-integration to {$abs_output_dir}/sqlite-database-integration";
         }
@@ -3653,6 +3666,46 @@ class ImportClient
         fwrite(STDERR, "\n");
         foreach ($summary as $line) {
             fwrite(STDERR, "{$line}\n");
+        }
+    }
+
+    /**
+     * Disable the remote-upload-proxy by blanking STREAMING_REMOTE_SITE_URL
+     * in the generated runtime.php.  Called after files-sync completes so
+     * the proxy stops intercepting requests for uploaded files.
+     *
+     * The proxy checks `if ($remote_site === '') return;` at the top of
+     * its IIFE, so setting the constant to an empty string is enough to
+     * disable it without removing any code.
+     */
+    private function disable_upload_proxy(): void
+    {
+        $output_dir = $this->state["apply_runtime"]["output_dir"] ?? null;
+        if ($output_dir === null) {
+            return;
+        }
+
+        $runtime_path = $output_dir . '/runtime.php';
+        if (!file_exists($runtime_path)) {
+            return;
+        }
+
+        $content = file_get_contents($runtime_path);
+        if ($content === false) {
+            return;
+        }
+
+        // Match the define() call for STREAMING_REMOTE_SITE_URL and
+        // replace the value with an empty string.
+        $updated = preg_replace(
+            "/define\('STREAMING_REMOTE_SITE_URL',\s*'[^']*'\)/",
+            "define('STREAMING_REMOTE_SITE_URL', '')",
+            $content,
+        );
+
+        if ($updated !== null && $updated !== $content) {
+            file_put_contents($runtime_path, $updated);
+            $this->audit_log("UPLOAD-PROXY | disabled in {$runtime_path}");
         }
     }
 

--- a/importer/import.php
+++ b/importer/import.php
@@ -2452,8 +2452,8 @@ class ImportClient
         // Skip the marker when --filter=essential-files was used because
         // uploads were not downloaded in that mode.
         if ($this->filter !== 'essential-files') {
-            $marker = $this->fs_root . '/.streaming-uploads-synced';
-            if ($this->fs_root !== null && !file_exists($marker)) {
+            $marker = $this->state_dir . '/.streaming-uploads-synced';
+            if (!file_exists($marker)) {
                 file_put_contents($marker, '');
             }
         }
@@ -3557,7 +3557,7 @@ class ImportClient
         $source_siteurl = $preflight_data["database"]["wp"]["siteurl"] ?? "";
         if (is_string($source_siteurl) && $source_siteurl !== "") {
             $manifest->constants["STREAMING_REMOTE_SITE_URL"] = $source_siteurl;
-            $manifest->constants["STREAMING_SYNC_MARKER"] = $this->fs_root . '/.streaming-uploads-synced';
+            $manifest->constants["STREAMING_SYNC_MARKER"] = $this->state_dir . '/.streaming-uploads-synced';
             $manifest->routes[] = [
                 "handler" => "remote-upload-proxy",
                 "path_pattern" => "/wp-content/uploads/.*",

--- a/importer/import.php
+++ b/importer/import.php
@@ -3557,6 +3557,7 @@ class ImportClient
         $source_siteurl = $preflight_data["database"]["wp"]["siteurl"] ?? "";
         if (is_string($source_siteurl) && $source_siteurl !== "") {
             $manifest->constants["STREAMING_REMOTE_SITE_URL"] = $source_siteurl;
+            $manifest->constants["STREAMING_SYNC_MARKER"] = $this->fs_root . '/.streaming-uploads-synced';
             $manifest->routes[] = [
                 "handler" => "remote-upload-proxy",
                 "path_pattern" => "/wp-content/uploads/.*",

--- a/importer/lib/target-runtime/functions.php
+++ b/importer/lib/target-runtime/functions.php
@@ -255,6 +255,9 @@ function generate_route_handler_code(RuntimeManifest $manifest): string
             case 'wpcloud-thumbnail-generator':
                 $code .= wpcloud_thumbnail_generator_code() . "\n";
                 break;
+            case 'remote-upload-proxy':
+                $code .= remote_upload_proxy_code() . "\n";
+                break;
         }
     }
     return $code;

--- a/importer/lib/target-runtime/load.php
+++ b/importer/lib/target-runtime/load.php
@@ -4,6 +4,7 @@
  */
 
 require_once __DIR__ . '/route-handlers/wpcloud-thumbnail-generator.php';
+require_once __DIR__ . '/route-handlers/remote-upload-proxy.php';
 require_once __DIR__ . '/interface-runtime-applier.php';
 require_once __DIR__ . '/class-nginx-fpm-applier.php';
 require_once __DIR__ . '/class-php-builtin-applier.php';

--- a/importer/lib/target-runtime/route-handlers/remote-upload-proxy.php
+++ b/importer/lib/target-runtime/route-handlers/remote-upload-proxy.php
@@ -34,26 +34,6 @@ function remote_upload_proxy_code(): string
 		: '';
 	if ($remote_site === '') return;
 
-	// Once files-sync finishes, the proxy is no longer needed — all
-	// uploads are available locally.  Check the import state file to see
-	// if files-sync has completed.  The state file path is baked into the
-	// STREAMING_IMPORT_STATE constant at apply-runtime time.
-	$state_file = defined('STREAMING_IMPORT_STATE') ? STREAMING_IMPORT_STATE : '';
-	if ($state_file !== '') {
-		clearstatcache(true, $state_file);
-		$raw = @file_get_contents($state_file);
-		if ($raw !== false) {
-			$state = @json_decode($raw, true);
-			if (
-				is_array($state) &&
-				($state['command'] ?? '') === 'files-sync' &&
-				($state['status'] ?? '') === 'complete'
-			) {
-				return;
-			}
-		}
-	}
-
 	$uri  = $_SERVER['REQUEST_URI'] ?? '';
 	$path = parse_url($uri, PHP_URL_PATH);
 	if (!$path) return;

--- a/importer/lib/target-runtime/route-handlers/remote-upload-proxy.php
+++ b/importer/lib/target-runtime/route-handlers/remote-upload-proxy.php
@@ -1,0 +1,121 @@
+<?php
+/**
+ * Remote upload proxy — route handler implementation.
+ *
+ * Returns PHP code (as a string) that proxies requests for missing
+ * uploaded files from the source site.  During migration the local
+ * file tree may be incomplete — files-sync hasn't finished yet.
+ * Instead of showing a broken image or a 404, this handler fetches
+ * the original from the source site and streams the response
+ * (status code, content-type, body) straight to the client.
+ *
+ * The generated code is a self-contained IIFE that:
+ * - Checks $_SERVER['REQUEST_URI'] for paths inside /wp-content/uploads/
+ * - Requires STREAMING_REMOTE_SITE_URL to be defined (by the bootstrap)
+ * - Returns silently when the file exists locally (let the server serve it)
+ * - Uses cURL to fetch from the source and streams the response
+ * - Calls exit() — no need to boot WordPress
+ */
+function remote_upload_proxy_code(): string
+{
+    return <<<'PHP'
+/**
+ * Remote upload proxy for in-progress migrations.
+ *
+ * When a visitor requests an uploaded file that hasn't been synced yet,
+ * this handler fetches it from the original source site and streams the
+ * response directly to the client — preserving the status code, content
+ * type, and body.  Once files-sync finishes and the file exists locally
+ * the handler returns silently, letting the web server serve the file.
+ */
+(function() {
+	$remote_site = defined('STREAMING_REMOTE_SITE_URL')
+		? STREAMING_REMOTE_SITE_URL
+		: '';
+	if ($remote_site === '') return;
+
+	$uri  = $_SERVER['REQUEST_URI'] ?? '';
+	$path = parse_url($uri, PHP_URL_PATH);
+	if (!$path) return;
+
+	// Only handle requests inside /wp-content/uploads/
+	if (strpos($path, '/wp-content/uploads/') === false) return;
+
+	// If the file already exists locally, let the server handle it.
+	// Use DOCUMENT_ROOT (set by both php -S and nginx/fpm) so the
+	// handler works regardless of whether WP_CONTENT_DIR is defined
+	// in the runtime constants — it isn't for standard layouts where
+	// wp-content lives inside ABSPATH.
+	$doc_root   = $_SERVER['DOCUMENT_ROOT'] ?? '';
+	$local_path = $doc_root . $path;
+	if ($doc_root !== '' && file_exists($local_path)) return;
+
+	// Build the remote URL from the source site URL and the request path.
+	// Use the full request path so it works regardless of whether the
+	// uploads URL matches the default /wp-content/uploads/ layout.
+	$remote_url = rtrim($remote_site, '/') . $path;
+
+	if (!function_exists('curl_init')) {
+		// No cURL — fall back to a plain 404 so WordPress can handle it
+		return;
+	}
+
+	$ch = curl_init($remote_url);
+	curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
+	curl_setopt($ch, CURLOPT_MAXREDIRS, 5);
+	curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 5);
+	curl_setopt($ch, CURLOPT_TIMEOUT, 30);
+
+	// Forward the response status and headers to the client.
+	// Skip hop-by-hop headers that don't apply to our response.
+	$skip_headers = [
+		'transfer-encoding', 'connection', 'keep-alive',
+		'proxy-authenticate', 'proxy-authorization',
+		'te', 'trailers', 'upgrade',
+	];
+	$status_sent = false;
+	curl_setopt($ch, CURLOPT_HEADERFUNCTION, function ($ch, $raw) use (&$status_sent, $skip_headers) {
+		$trimmed = trim($raw);
+		if ($trimmed === '') return strlen($raw);
+
+		// Forward the HTTP status line (e.g. "HTTP/1.1 200 OK")
+		if (!$status_sent && strpos($trimmed, 'HTTP/') === 0) {
+			$code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+			if ($code > 0) {
+				http_response_code($code);
+			}
+			$status_sent = true;
+			return strlen($raw);
+		}
+
+		// Forward response headers, skipping hop-by-hop ones
+		$colon = strpos($trimmed, ':');
+		if ($colon !== false) {
+			$name = strtolower(trim(substr($trimmed, 0, $colon)));
+			if (!in_array($name, $skip_headers, true)) {
+				header($trimmed);
+			}
+		}
+		return strlen($raw);
+	});
+
+	// Stream the body directly to the client
+	curl_setopt($ch, CURLOPT_WRITEFUNCTION, function ($ch, $data) {
+		echo $data;
+		return strlen($data);
+	});
+
+	curl_setopt($ch, CURLOPT_RETURNTRANSFER, false);
+	curl_exec($ch);
+
+	$errno = curl_errno($ch);
+	curl_close($ch);
+
+	// If cURL failed entirely (DNS error, timeout, etc.), fall through
+	// to WordPress so it can show its own 404 page.
+	if ($errno !== 0) return;
+
+	exit;
+})();
+PHP;
+}

--- a/importer/lib/target-runtime/route-handlers/remote-upload-proxy.php
+++ b/importer/lib/target-runtime/route-handlers/remote-upload-proxy.php
@@ -34,16 +34,24 @@ function remote_upload_proxy_code(): string
 		: '';
 	if ($remote_site === '') return;
 
-	// Once files-sync finishes, it writes a marker file whose path is
-	// baked into the STREAMING_SYNC_MARKER constant at apply-runtime time.
-	// When that marker exists the proxy is no longer needed — all uploads
-	// are available locally.  clearstatcache() is needed because php -S is
-	// a long-running process and the stat cache may hold stale entries for
-	// files created after the server started.
-	$marker = defined('STREAMING_SYNC_MARKER') ? STREAMING_SYNC_MARKER : '';
-	if ($marker !== '') {
-		clearstatcache(true, $marker);
-		if (file_exists($marker)) return;
+	// Once files-sync finishes, the proxy is no longer needed — all
+	// uploads are available locally.  Check the import state file to see
+	// if files-sync has completed.  The state file path is baked into the
+	// STREAMING_IMPORT_STATE constant at apply-runtime time.
+	$state_file = defined('STREAMING_IMPORT_STATE') ? STREAMING_IMPORT_STATE : '';
+	if ($state_file !== '') {
+		clearstatcache(true, $state_file);
+		$raw = @file_get_contents($state_file);
+		if ($raw !== false) {
+			$state = @json_decode($raw, true);
+			if (
+				is_array($state) &&
+				($state['command'] ?? '') === 'files-sync' &&
+				($state['status'] ?? '') === 'complete'
+			) {
+				return;
+			}
+		}
 	}
 
 	$uri  = $_SERVER['REQUEST_URI'] ?? '';

--- a/importer/lib/target-runtime/route-handlers/remote-upload-proxy.php
+++ b/importer/lib/target-runtime/route-handlers/remote-upload-proxy.php
@@ -36,9 +36,13 @@ function remote_upload_proxy_code(): string
 
 	// Once files-sync finishes, it writes a marker file to the document
 	// root.  When that marker exists the proxy is no longer needed — all
-	// uploads are available locally.
+	// uploads are available locally.  clearstatcache() is needed because
+	// php -S is a long-running process and the stat cache may hold stale
+	// entries for files created after the server started.
 	$doc_root = $_SERVER['DOCUMENT_ROOT'] ?? '';
-	if ($doc_root !== '' && file_exists($doc_root . '/.streaming-uploads-synced')) return;
+	$marker   = $doc_root . '/.streaming-uploads-synced';
+	clearstatcache(true, $marker);
+	if ($doc_root !== '' && file_exists($marker)) return;
 
 	$uri  = $_SERVER['REQUEST_URI'] ?? '';
 	$path = parse_url($uri, PHP_URL_PATH);

--- a/importer/lib/target-runtime/route-handlers/remote-upload-proxy.php
+++ b/importer/lib/target-runtime/route-handlers/remote-upload-proxy.php
@@ -34,15 +34,17 @@ function remote_upload_proxy_code(): string
 		: '';
 	if ($remote_site === '') return;
 
-	// Once files-sync finishes, it writes a marker file to the document
-	// root.  When that marker exists the proxy is no longer needed — all
-	// uploads are available locally.  clearstatcache() is needed because
-	// php -S is a long-running process and the stat cache may hold stale
-	// entries for files created after the server started.
-	$doc_root = $_SERVER['DOCUMENT_ROOT'] ?? '';
-	$marker   = $doc_root . '/.streaming-uploads-synced';
-	clearstatcache(true, $marker);
-	if ($doc_root !== '' && file_exists($marker)) return;
+	// Once files-sync finishes, it writes a marker file whose path is
+	// baked into the STREAMING_SYNC_MARKER constant at apply-runtime time.
+	// When that marker exists the proxy is no longer needed — all uploads
+	// are available locally.  clearstatcache() is needed because php -S is
+	// a long-running process and the stat cache may hold stale entries for
+	// files created after the server started.
+	$marker = defined('STREAMING_SYNC_MARKER') ? STREAMING_SYNC_MARKER : '';
+	if ($marker !== '') {
+		clearstatcache(true, $marker);
+		if (file_exists($marker)) return;
+	}
 
 	$uri  = $_SERVER['REQUEST_URI'] ?? '';
 	$path = parse_url($uri, PHP_URL_PATH);
@@ -52,8 +54,11 @@ function remote_upload_proxy_code(): string
 	if (strpos($path, '/wp-content/uploads/') === false) return;
 
 	// If the file already exists locally, let the server handle it.
-	// $doc_root is set above (DOCUMENT_ROOT works for both php -S and
-	// nginx/fpm, regardless of whether WP_CONTENT_DIR is defined).
+	// Use DOCUMENT_ROOT (set by both php -S and nginx/fpm) so the
+	// handler works regardless of whether WP_CONTENT_DIR is defined
+	// in the runtime constants — it isn't for standard layouts where
+	// wp-content lives inside ABSPATH.
+	$doc_root   = $_SERVER['DOCUMENT_ROOT'] ?? '';
 	$local_path = $doc_root . $path;
 	if ($doc_root !== '' && file_exists($local_path)) return;
 

--- a/importer/lib/target-runtime/route-handlers/remote-upload-proxy.php
+++ b/importer/lib/target-runtime/route-handlers/remote-upload-proxy.php
@@ -34,6 +34,12 @@ function remote_upload_proxy_code(): string
 		: '';
 	if ($remote_site === '') return;
 
+	// Once files-sync finishes, it writes a marker file to the document
+	// root.  When that marker exists the proxy is no longer needed — all
+	// uploads are available locally.
+	$doc_root = $_SERVER['DOCUMENT_ROOT'] ?? '';
+	if ($doc_root !== '' && file_exists($doc_root . '/.streaming-uploads-synced')) return;
+
 	$uri  = $_SERVER['REQUEST_URI'] ?? '';
 	$path = parse_url($uri, PHP_URL_PATH);
 	if (!$path) return;
@@ -42,11 +48,8 @@ function remote_upload_proxy_code(): string
 	if (strpos($path, '/wp-content/uploads/') === false) return;
 
 	// If the file already exists locally, let the server handle it.
-	// Use DOCUMENT_ROOT (set by both php -S and nginx/fpm) so the
-	// handler works regardless of whether WP_CONTENT_DIR is defined
-	// in the runtime constants — it isn't for standard layouts where
-	// wp-content lives inside ABSPATH.
-	$doc_root   = $_SERVER['DOCUMENT_ROOT'] ?? '';
+	// $doc_root is set above (DOCUMENT_ROOT works for both php -S and
+	// nginx/fpm, regardless of whether WP_CONTENT_DIR is defined).
 	$local_path = $doc_root . $path;
 	if ($doc_root !== '' && file_exists($local_path)) return;
 

--- a/tests/e2e/site-registry.json
+++ b/tests/e2e/site-registry.json
@@ -34,6 +34,7 @@
     "preserve-local":    { "port": 8107 },
     "url-rewriting":     { "port": 8108 },
     "wpcloud-flatten":   { "port": 8109 },
-    "defer-uploads":     { "port": 8110 }
+    "defer-uploads":     { "port": 8110 },
+    "remote-proxy":      { "port": 8111 }
   }
 }

--- a/tests/e2e/tests/import-41-remote-upload-proxy.test.js
+++ b/tests/e2e/tests/import-41-remote-upload-proxy.test.js
@@ -202,11 +202,13 @@ describe('Import: Remote upload proxy', () => {
             'Expected remote upload proxy handler in runtime.php');
     });
 
-    it('runtime.php contains STREAMING_IMPORT_STATE pointing to state file', () => {
+    it('runtime.php contains a non-empty STREAMING_REMOTE_SITE_URL', () => {
         const runtime = readFileSync(join(outputDir, 'runtime.php'), 'utf-8');
-        const expectedState = join(tempDir, '.import-state.json');
-        assert.ok(runtime.includes(expectedState),
-            `Expected STREAMING_IMPORT_STATE to contain ${expectedState} in runtime.php`);
+        // The constant should have a real URL, not an empty string.
+        const match = runtime.match(/define\('STREAMING_REMOTE_SITE_URL',\s*'([^']*)'\)/);
+        assert.ok(match, 'Expected STREAMING_REMOTE_SITE_URL define in runtime.php');
+        assert.ok(match[1].length > 0,
+            'STREAMING_REMOTE_SITE_URL should not be empty');
     });
 
     // ------------------------------------------------------------------
@@ -262,16 +264,18 @@ describe('Import: Remote upload proxy', () => {
             'Should serve the local file content, not proxy from source');
     });
 
-    it('stops proxying once files-sync is complete in state', async () => {
-        // The remote-upload-proxy reads the import state file (path baked
-        // into runtime.php as STREAMING_IMPORT_STATE).  When the state
-        // shows files-sync is complete, the proxy returns early.
-        const stateFile = join(tempDir, '.import-state.json');
-        const originalState = readFileSync(stateFile, 'utf-8');
-        const state = JSON.parse(originalState);
-        state.command = 'files-sync';
-        state.status = 'complete';
-        writeFileSync(stateFile, JSON.stringify(state));
+    it('stops proxying once STREAMING_REMOTE_SITE_URL is blanked', async () => {
+        // When files-sync completes, it blanks the STREAMING_REMOTE_SITE_URL
+        // constant in runtime.php.  The proxy checks this constant and
+        // returns early when it's empty.  Simulate by patching runtime.php.
+        const runtimePath = join(outputDir, 'runtime.php');
+        const original = readFileSync(runtimePath, 'utf-8');
+        const patched = original.replace(
+            /define\('STREAMING_REMOTE_SITE_URL',\s*'[^']*'\)/,
+            "define('STREAMING_REMOTE_SITE_URL', '')",
+        );
+        assert.notEqual(original, patched, 'runtime.php should have been patched');
+        writeFileSync(runtimePath, patched);
         try {
             const relPath = 'wp-content/uploads/2024/01/photo.jpg';
             const res = await fetch(targetUrl('/' + relPath));
@@ -281,8 +285,8 @@ describe('Import: Remote upload proxy', () => {
             assert.ok(!body.equals(expected),
                 'Response body should NOT match the source file — proxy should be disabled');
         } finally {
-            // Restore the original state so subsequent tests still exercise the proxy.
-            writeFileSync(stateFile, originalState);
+            // Restore so subsequent tests still exercise the proxy.
+            writeFileSync(runtimePath, original);
         }
     });
 

--- a/tests/e2e/tests/import-41-remote-upload-proxy.test.js
+++ b/tests/e2e/tests/import-41-remote-upload-proxy.test.js
@@ -77,10 +77,15 @@ async function startPhpServer(docRoot, routerPath, port = TARGET_PORT) {
     );
 }
 
-function stopPhpServer(proc) {
-    if (proc && proc.exitCode === null) {
-        proc.kill('SIGTERM');
-    }
+async function stopPhpServer(proc) {
+    if (!proc || proc.exitCode !== null) return;
+    proc.kill('SIGTERM');
+    // Wait for the process to actually exit so the port is freed.
+    await new Promise((resolve) => {
+        proc.on('exit', resolve);
+        // Safety timeout — don't hang forever.
+        setTimeout(() => { proc.kill('SIGKILL'); resolve(); }, 5000);
+    });
 }
 
 describe('Import: Remote upload proxy', () => {
@@ -170,8 +175,8 @@ describe('Import: Remote upload proxy', () => {
         phpServer = await startPhpServer(effectiveRoot, runtimePath);
     }, 120000);
 
-    afterAll(() => {
-        stopPhpServer(phpServer);
+    afterAll(async () => {
+        await stopPhpServer(phpServer);
         cleanupTempDir(tempDir);
     });
 
@@ -281,8 +286,9 @@ describe('Import: Remote upload proxy', () => {
         assert.notEqual(original, patched, 'runtime.php should have been patched');
         writeFileSync(runtimePath, patched);
 
-        // Restart the server with the patched runtime.
-        stopPhpServer(phpServer);
+        // Restart the server with the patched runtime.  We must wait for
+        // the old process to fully exit so the port is freed.
+        await stopPhpServer(phpServer);
         phpServer = await startPhpServer(effectiveRoot, runtimePath);
 
         try {
@@ -294,10 +300,10 @@ describe('Import: Remote upload proxy', () => {
             assert.ok(!body.equals(expected),
                 'Response body should NOT match the source file — proxy should be disabled');
         } finally {
-            // Restore runtime.php and restart so subsequent tests (if any)
-            // still have the proxy active.
+            // Restore runtime.php and restart so subsequent tests still
+            // have the proxy active.
             writeFileSync(runtimePath, original);
-            stopPhpServer(phpServer);
+            await stopPhpServer(phpServer);
             phpServer = await startPhpServer(effectiveRoot, runtimePath);
         }
     });

--- a/tests/e2e/tests/import-41-remote-upload-proxy.test.js
+++ b/tests/e2e/tests/import-41-remote-upload-proxy.test.js
@@ -14,7 +14,7 @@
  */
 import { describe, it, beforeAll, afterAll } from 'vitest';
 import assert from 'node:assert/strict';
-import { existsSync, readFileSync, mkdirSync, writeFileSync, unlinkSync } from 'node:fs';
+import { existsSync, readFileSync, mkdirSync, writeFileSync } from 'node:fs';
 import { execFileSync, spawn } from 'node:child_process';
 import { join } from 'node:path';
 import { createConnection } from 'node:net';
@@ -202,11 +202,11 @@ describe('Import: Remote upload proxy', () => {
             'Expected remote upload proxy handler in runtime.php');
     });
 
-    it('runtime.php contains STREAMING_SYNC_MARKER pointing to state dir', () => {
+    it('runtime.php contains STREAMING_IMPORT_STATE pointing to state file', () => {
         const runtime = readFileSync(join(outputDir, 'runtime.php'), 'utf-8');
-        const expectedMarker = join(tempDir, '.streaming-uploads-synced');
-        assert.ok(runtime.includes(expectedMarker),
-            `Expected STREAMING_SYNC_MARKER to contain ${expectedMarker} in runtime.php`);
+        const expectedState = join(tempDir, '.import-state.json');
+        assert.ok(runtime.includes(expectedState),
+            `Expected STREAMING_IMPORT_STATE to contain ${expectedState} in runtime.php`);
     });
 
     // ------------------------------------------------------------------
@@ -262,15 +262,16 @@ describe('Import: Remote upload proxy', () => {
             'Should serve the local file content, not proxy from source');
     });
 
-    it('stops proxying once the sync-complete marker exists', async () => {
-        // The remote-upload-proxy checks for a .streaming-uploads-synced
-        // marker file whose path is baked into runtime.php as the
-        // STREAMING_SYNC_MARKER constant (set to state-dir + marker name).
-        // When it exists, the proxy returns early and the request falls
-        // through to the normal server routing.  Verify by checking the
-        // response body — it must NOT match the source file content.
-        const markerPath = join(tempDir, '.streaming-uploads-synced');
-        writeFileSync(markerPath, '');
+    it('stops proxying once files-sync is complete in state', async () => {
+        // The remote-upload-proxy reads the import state file (path baked
+        // into runtime.php as STREAMING_IMPORT_STATE).  When the state
+        // shows files-sync is complete, the proxy returns early.
+        const stateFile = join(tempDir, '.import-state.json');
+        const originalState = readFileSync(stateFile, 'utf-8');
+        const state = JSON.parse(originalState);
+        state.command = 'files-sync';
+        state.status = 'complete';
+        writeFileSync(stateFile, JSON.stringify(state));
         try {
             const relPath = 'wp-content/uploads/2024/01/photo.jpg';
             const res = await fetch(targetUrl('/' + relPath));
@@ -280,8 +281,8 @@ describe('Import: Remote upload proxy', () => {
             assert.ok(!body.equals(expected),
                 'Response body should NOT match the source file — proxy should be disabled');
         } finally {
-            // Remove the marker so subsequent tests still exercise the proxy.
-            unlinkSync(markerPath);
+            // Restore the original state so subsequent tests still exercise the proxy.
+            writeFileSync(stateFile, originalState);
         }
     });
 

--- a/tests/e2e/tests/import-41-remote-upload-proxy.test.js
+++ b/tests/e2e/tests/import-41-remote-upload-proxy.test.js
@@ -257,11 +257,12 @@ describe('Import: Remote upload proxy', () => {
 
     it('stops proxying once the sync-complete marker exists', async () => {
         // The remote-upload-proxy checks for a .streaming-uploads-synced
-        // marker file in the document root.  When it exists, the proxy
-        // returns early and the request falls through to the normal
-        // server routing (WordPress).  Verify by checking the response
-        // body — it must NOT match the source file content.
-        const markerPath = join(effectiveRoot, '.streaming-uploads-synced');
+        // marker file whose path is baked into runtime.php as the
+        // STREAMING_SYNC_MARKER constant (set to fs-root + marker name).
+        // When it exists, the proxy returns early and the request falls
+        // through to the normal server routing.  Verify by checking the
+        // response body — it must NOT match the source file content.
+        const markerPath = join(fsRootDir(tempDir), '.streaming-uploads-synced');
         writeFileSync(markerPath, '');
         try {
             const relPath = 'wp-content/uploads/2024/01/photo.jpg';

--- a/tests/e2e/tests/import-41-remote-upload-proxy.test.js
+++ b/tests/e2e/tests/import-41-remote-upload-proxy.test.js
@@ -255,6 +255,25 @@ describe('Import: Remote upload proxy', () => {
             'Should serve the local file content, not proxy from source');
     });
 
+    it('stops proxying once the sync-complete marker exists', async () => {
+        // The remote-upload-proxy checks for a .streaming-uploads-synced
+        // marker file in the document root.  When it exists, the proxy
+        // returns early and the server handles the request normally (404).
+        const markerPath = join(effectiveRoot, '.streaming-uploads-synced');
+        writeFileSync(markerPath, '');
+        try {
+            const path = '/wp-content/uploads/2024/01/photo.jpg';
+            const res = await fetch(targetUrl(path));
+            // The file doesn't exist locally, so without the proxy it's a 404.
+            assert.equal(res.status, 404,
+                `Expected 404 when sync marker exists, got ${res.status}`);
+        } finally {
+            // Remove the marker so subsequent tests still exercise the proxy.
+            const { unlinkSync } = await import('node:fs');
+            unlinkSync(markerPath);
+        }
+    });
+
     it('does not proxy requests outside /wp-content/uploads/', async () => {
         // Write a file outside wp-content/uploads/ and verify the handler
         // doesn't intercept it — the server serves it as a normal static

--- a/tests/e2e/tests/import-41-remote-upload-proxy.test.js
+++ b/tests/e2e/tests/import-41-remote-upload-proxy.test.js
@@ -14,7 +14,7 @@
  */
 import { describe, it, beforeAll, afterAll } from 'vitest';
 import assert from 'node:assert/strict';
-import { existsSync, readFileSync, mkdirSync, writeFileSync } from 'node:fs';
+import { existsSync, readFileSync, mkdirSync, writeFileSync, unlinkSync } from 'node:fs';
 import { execFileSync, spawn } from 'node:child_process';
 import { join } from 'node:path';
 import { createConnection } from 'node:net';
@@ -258,18 +258,21 @@ describe('Import: Remote upload proxy', () => {
     it('stops proxying once the sync-complete marker exists', async () => {
         // The remote-upload-proxy checks for a .streaming-uploads-synced
         // marker file in the document root.  When it exists, the proxy
-        // returns early and the server handles the request normally (404).
+        // returns early and the request falls through to the normal
+        // server routing (WordPress).  Verify by checking the response
+        // body — it must NOT match the source file content.
         const markerPath = join(effectiveRoot, '.streaming-uploads-synced');
         writeFileSync(markerPath, '');
         try {
-            const path = '/wp-content/uploads/2024/01/photo.jpg';
-            const res = await fetch(targetUrl(path));
-            // The file doesn't exist locally, so without the proxy it's a 404.
-            assert.equal(res.status, 404,
-                `Expected 404 when sync marker exists, got ${res.status}`);
+            const relPath = 'wp-content/uploads/2024/01/photo.jpg';
+            const res = await fetch(targetUrl('/' + relPath));
+            const body = Buffer.from(await res.arrayBuffer());
+            const expected = sourceContent[relPath];
+            assert.ok(expected, 'Test setup should have source content for photo.jpg');
+            assert.ok(!body.equals(expected),
+                'Response body should NOT match the source file — proxy should be disabled');
         } finally {
             // Remove the marker so subsequent tests still exercise the proxy.
-            const { unlinkSync } = await import('node:fs');
             unlinkSync(markerPath);
         }
     });

--- a/tests/e2e/tests/import-41-remote-upload-proxy.test.js
+++ b/tests/e2e/tests/import-41-remote-upload-proxy.test.js
@@ -17,6 +17,7 @@ import assert from 'node:assert/strict';
 import { existsSync, readFileSync, mkdirSync, writeFileSync } from 'node:fs';
 import { execFileSync, spawn } from 'node:child_process';
 import { join } from 'node:path';
+import { createConnection } from 'node:net';
 import { setTimeout as sleep } from 'node:timers/promises';
 import {
     runImporter, createTempDir, cleanupTempDir,
@@ -40,6 +41,7 @@ describe('Import: Remote upload proxy', () => {
     let siteDir;
     let tempDir;
     let outputDir;
+    let effectiveRoot;
     let phpServer = null;
 
     // Content bytes keyed by relative path, so we can compare later.
@@ -108,45 +110,56 @@ describe('Import: Remote upload proxy', () => {
         // Read from the state to find the same root apply-runtime used.
         const state = JSON.parse(readFileSync(join(tempDir, '.import-state.json'), 'utf-8'));
         const remoteDocRoot = state.preflight?.data?.runtime?.document_root ?? '';
-        const effectiveRoot = remoteDocRoot
+        effectiveRoot = remoteDocRoot
             ? join(fsRootDir(tempDir), remoteDocRoot)
             : fsRootDir(tempDir);
 
+        // Ensure the document root exists — `php -S` exits with code 1
+        // if the -t directory is missing.  It may not exist when
+        // files-sync had nothing to write inside it.
+        mkdirSync(effectiveRoot, { recursive: true });
+
+        // Capture stderr from the start so we have diagnostics if
+        // the server exits early.
+        let phpStderr = '';
         phpServer = spawn('php', [
             '-S', `127.0.0.1:${TARGET_PORT}`,
             '-t', effectiveRoot,
             runtimePath,
-        ], { stdio: 'pipe' });
+        ], { stdio: ['ignore', 'pipe', 'pipe'] });
+        phpServer.stderr.on('data', (d) => { phpStderr += d; });
 
-        // Wait for the server to be ready.
+        // Wait for the server to accept TCP connections (don't send an
+        // HTTP request — that would run the router and try to boot
+        // WordPress, which isn't set up for the target).
         const deadline = Date.now() + 15000;
         let ready = false;
         while (Date.now() < deadline) {
             if (phpServer.exitCode !== null) {
-                // Collect stderr for diagnostics
-                let stderr = '';
-                phpServer.stderr?.on('data', (d) => { stderr += d; });
-                await sleep(100);
+                await sleep(100); // let stderr drain
                 throw new Error(
-                    `PHP server exited early with code ${phpServer.exitCode}\n${stderr}`
+                    `PHP server exited early with code ${phpServer.exitCode}\nstderr: ${phpStderr}`
                 );
             }
             try {
-                const res = await fetch(`http://127.0.0.1:${TARGET_PORT}/`, {
-                    method: 'HEAD',
-                    signal: AbortSignal.timeout(1000),
+                await new Promise((resolve, reject) => {
+                    const socket = createConnection(TARGET_PORT, '127.0.0.1');
+                    socket.setTimeout(500);
+                    socket.once('connect', () => { socket.destroy(); resolve(); });
+                    socket.once('error', reject);
+                    socket.once('timeout', () => { socket.destroy(); reject(new Error('timeout')); });
                 });
-                if (res.status > 0) {
-                    ready = true;
-                    break;
-                }
+                ready = true;
+                break;
             } catch (_) {
                 // retry
             }
             await sleep(200);
         }
         if (!ready) {
-            throw new Error(`Timed out waiting for PHP server on port ${TARGET_PORT}`);
+            throw new Error(
+                `Timed out waiting for PHP server on port ${TARGET_PORT}\nstderr: ${phpStderr}`
+            );
         }
     }, 120000);
 
@@ -227,13 +240,7 @@ describe('Import: Remote upload proxy', () => {
     });
 
     it('serves locally existing files without proxying', async () => {
-        // Write a file directly into the fs-root so it exists locally.
-        const state = JSON.parse(readFileSync(join(tempDir, '.import-state.json'), 'utf-8'));
-        const remoteDocRoot = state.preflight?.data?.runtime?.document_root ?? '';
-        const effectiveRoot = remoteDocRoot
-            ? join(fsRootDir(tempDir), remoteDocRoot)
-            : fsRootDir(tempDir);
-
+        // Write a file directly into the document root so it exists locally.
         const localContent = Buffer.from('local-file-content-xyz');
         const localDir = join(effectiveRoot, 'wp-content', 'uploads', 'local-test');
         mkdirSync(localDir, { recursive: true });
@@ -248,14 +255,18 @@ describe('Import: Remote upload proxy', () => {
             'Should serve the local file content, not proxy from source');
     });
 
-    it('does not proxy non-upload requests', async () => {
-        // Request a path outside /wp-content/uploads/ that doesn't exist.
-        // The handler should NOT proxy this — it falls through to the
-        // normal routing (which will likely 404 via WordPress or php -S).
-        const res = await fetch(targetUrl('/some-random-path.jpg'));
-        // We just verify it's NOT a 200 with proxied content.
-        // It should be a 404 or a WordPress-generated page.
-        assert.notEqual(res.status, 200,
-            'Non-upload paths should not be proxied');
+    it('does not proxy requests outside /wp-content/uploads/', async () => {
+        // Write a file outside wp-content/uploads/ and verify the handler
+        // doesn't intercept it — the server serves it as a normal static
+        // file instead.
+        const content = Buffer.from('not-an-upload');
+        writeFileSync(join(effectiveRoot, 'static-test.txt'), content);
+
+        const res = await fetch(targetUrl('/static-test.txt'));
+        assert.equal(res.status, 200,
+            `Expected 200 for static file, got ${res.status}`);
+        const body = Buffer.from(await res.arrayBuffer());
+        assert.ok(body.equals(content),
+            'Static file outside uploads should be served directly');
     });
 });

--- a/tests/e2e/tests/import-41-remote-upload-proxy.test.js
+++ b/tests/e2e/tests/import-41-remote-upload-proxy.test.js
@@ -202,6 +202,13 @@ describe('Import: Remote upload proxy', () => {
             'Expected remote upload proxy handler in runtime.php');
     });
 
+    it('runtime.php contains STREAMING_SYNC_MARKER pointing to state dir', () => {
+        const runtime = readFileSync(join(outputDir, 'runtime.php'), 'utf-8');
+        const expectedMarker = join(tempDir, '.streaming-uploads-synced');
+        assert.ok(runtime.includes(expectedMarker),
+            `Expected STREAMING_SYNC_MARKER to contain ${expectedMarker} in runtime.php`);
+    });
+
     // ------------------------------------------------------------------
     // Proxy behaviour
     // ------------------------------------------------------------------
@@ -258,11 +265,11 @@ describe('Import: Remote upload proxy', () => {
     it('stops proxying once the sync-complete marker exists', async () => {
         // The remote-upload-proxy checks for a .streaming-uploads-synced
         // marker file whose path is baked into runtime.php as the
-        // STREAMING_SYNC_MARKER constant (set to fs-root + marker name).
+        // STREAMING_SYNC_MARKER constant (set to state-dir + marker name).
         // When it exists, the proxy returns early and the request falls
         // through to the normal server routing.  Verify by checking the
         // response body — it must NOT match the source file content.
-        const markerPath = join(fsRootDir(tempDir), '.streaming-uploads-synced');
+        const markerPath = join(tempDir, '.streaming-uploads-synced');
         writeFileSync(markerPath, '');
         try {
             const relPath = 'wp-content/uploads/2024/01/photo.jpg';

--- a/tests/e2e/tests/import-41-remote-upload-proxy.test.js
+++ b/tests/e2e/tests/import-41-remote-upload-proxy.test.js
@@ -36,12 +36,60 @@ const UPLOAD_FILES = {
 // Port for the target PHP built-in server (not in site-registry).
 const TARGET_PORT = 8200;
 
+/**
+ * Start a php -S server with the given document root and router script.
+ * Returns the child process once it's accepting TCP connections.
+ */
+async function startPhpServer(docRoot, routerPath, port = TARGET_PORT) {
+    let stderr = '';
+    const proc = spawn('php', [
+        '-S', `127.0.0.1:${port}`,
+        '-t', docRoot,
+        routerPath,
+    ], { stdio: ['ignore', 'pipe', 'pipe'] });
+    proc.stderr.on('data', (d) => { stderr += d; });
+
+    const deadline = Date.now() + 15000;
+    while (Date.now() < deadline) {
+        if (proc.exitCode !== null) {
+            await sleep(100);
+            throw new Error(
+                `PHP server exited early with code ${proc.exitCode}\nstderr: ${stderr}`
+            );
+        }
+        try {
+            await new Promise((resolve, reject) => {
+                const socket = createConnection(port, '127.0.0.1');
+                socket.setTimeout(500);
+                socket.once('connect', () => { socket.destroy(); resolve(); });
+                socket.once('error', reject);
+                socket.once('timeout', () => { socket.destroy(); reject(new Error('timeout')); });
+            });
+            return proc;
+        } catch (_) {
+            // retry
+        }
+        await sleep(200);
+    }
+    proc.kill('SIGTERM');
+    throw new Error(
+        `Timed out waiting for PHP server on port ${port}\nstderr: ${stderr}`
+    );
+}
+
+function stopPhpServer(proc) {
+    if (proc && proc.exitCode === null) {
+        proc.kill('SIGTERM');
+    }
+}
+
 describe('Import: Remote upload proxy', () => {
     const site = 'remote-proxy';
     let siteDir;
     let tempDir;
     let outputDir;
     let effectiveRoot;
+    let runtimePath;
     let phpServer = null;
 
     // Content bytes keyed by relative path, so we can compare later.
@@ -103,7 +151,7 @@ describe('Import: Remote upload proxy', () => {
             `apply-runtime failed:\n${applyRuntime.stderr}\n${applyRuntime.stdout}`);
 
         // 4. Start the PHP built-in server with the generated runtime.
-        const runtimePath = join(outputDir, 'runtime.php');
+        runtimePath = join(outputDir, 'runtime.php');
         assert.ok(existsSync(runtimePath), 'runtime.php should exist');
 
         // The effective document root: fs-root + remote document root.
@@ -119,54 +167,11 @@ describe('Import: Remote upload proxy', () => {
         // files-sync had nothing to write inside it.
         mkdirSync(effectiveRoot, { recursive: true });
 
-        // Capture stderr from the start so we have diagnostics if
-        // the server exits early.
-        let phpStderr = '';
-        phpServer = spawn('php', [
-            '-S', `127.0.0.1:${TARGET_PORT}`,
-            '-t', effectiveRoot,
-            runtimePath,
-        ], { stdio: ['ignore', 'pipe', 'pipe'] });
-        phpServer.stderr.on('data', (d) => { phpStderr += d; });
-
-        // Wait for the server to accept TCP connections (don't send an
-        // HTTP request — that would run the router and try to boot
-        // WordPress, which isn't set up for the target).
-        const deadline = Date.now() + 15000;
-        let ready = false;
-        while (Date.now() < deadline) {
-            if (phpServer.exitCode !== null) {
-                await sleep(100); // let stderr drain
-                throw new Error(
-                    `PHP server exited early with code ${phpServer.exitCode}\nstderr: ${phpStderr}`
-                );
-            }
-            try {
-                await new Promise((resolve, reject) => {
-                    const socket = createConnection(TARGET_PORT, '127.0.0.1');
-                    socket.setTimeout(500);
-                    socket.once('connect', () => { socket.destroy(); resolve(); });
-                    socket.once('error', reject);
-                    socket.once('timeout', () => { socket.destroy(); reject(new Error('timeout')); });
-                });
-                ready = true;
-                break;
-            } catch (_) {
-                // retry
-            }
-            await sleep(200);
-        }
-        if (!ready) {
-            throw new Error(
-                `Timed out waiting for PHP server on port ${TARGET_PORT}\nstderr: ${phpStderr}`
-            );
-        }
+        phpServer = await startPhpServer(effectiveRoot, runtimePath);
     }, 120000);
 
     afterAll(() => {
-        if (phpServer && phpServer.exitCode === null) {
-            phpServer.kill('SIGTERM');
-        }
+        stopPhpServer(phpServer);
         cleanupTempDir(tempDir);
     });
 
@@ -204,7 +209,6 @@ describe('Import: Remote upload proxy', () => {
 
     it('runtime.php contains a non-empty STREAMING_REMOTE_SITE_URL', () => {
         const runtime = readFileSync(join(outputDir, 'runtime.php'), 'utf-8');
-        // The constant should have a real URL, not an empty string.
         const match = runtime.match(/define\('STREAMING_REMOTE_SITE_URL',\s*'([^']*)'\)/);
         assert.ok(match, 'Expected STREAMING_REMOTE_SITE_URL define in runtime.php');
         assert.ok(match[1].length > 0,
@@ -264,11 +268,11 @@ describe('Import: Remote upload proxy', () => {
             'Should serve the local file content, not proxy from source');
     });
 
-    it('stops proxying once STREAMING_REMOTE_SITE_URL is blanked', async () => {
-        // When files-sync completes, it blanks the STREAMING_REMOTE_SITE_URL
-        // constant in runtime.php.  The proxy checks this constant and
-        // returns early when it's empty.  Simulate by patching runtime.php.
-        const runtimePath = join(outputDir, 'runtime.php');
+    it('stops proxying after files-sync disables the proxy', async () => {
+        // When files-sync completes it blanks STREAMING_REMOTE_SITE_URL
+        // in runtime.php.  The proxy sees the empty constant and returns
+        // early.  php -S caches the compiled router in memory, so we must
+        // restart the server for the patched file to take effect.
         const original = readFileSync(runtimePath, 'utf-8');
         const patched = original.replace(
             /define\('STREAMING_REMOTE_SITE_URL',\s*'[^']*'\)/,
@@ -276,6 +280,11 @@ describe('Import: Remote upload proxy', () => {
         );
         assert.notEqual(original, patched, 'runtime.php should have been patched');
         writeFileSync(runtimePath, patched);
+
+        // Restart the server with the patched runtime.
+        stopPhpServer(phpServer);
+        phpServer = await startPhpServer(effectiveRoot, runtimePath);
+
         try {
             const relPath = 'wp-content/uploads/2024/01/photo.jpg';
             const res = await fetch(targetUrl('/' + relPath));
@@ -285,8 +294,11 @@ describe('Import: Remote upload proxy', () => {
             assert.ok(!body.equals(expected),
                 'Response body should NOT match the source file — proxy should be disabled');
         } finally {
-            // Restore so subsequent tests still exercise the proxy.
+            // Restore runtime.php and restart so subsequent tests (if any)
+            // still have the proxy active.
             writeFileSync(runtimePath, original);
+            stopPhpServer(phpServer);
+            phpServer = await startPhpServer(effectiveRoot, runtimePath);
         }
     });
 

--- a/tests/e2e/tests/import-41-remote-upload-proxy.test.js
+++ b/tests/e2e/tests/import-41-remote-upload-proxy.test.js
@@ -1,0 +1,253 @@
+/**
+ * Test 41: Remote upload proxy
+ *
+ * When files-sync hasn't finished yet, requests for uploaded files that
+ * don't exist locally should be proxied from the source site.  This test
+ * verifies the remote-upload-proxy route handler by:
+ *
+ * 1. Importing with --filter=essential-files (skips uploads)
+ * 2. Running apply-runtime to generate runtime.php with the proxy handler
+ * 3. Starting a php -S server with the generated runtime
+ * 4. Requesting missing uploads → proxied from the source nginx site
+ * 5. Requesting locally existing files → served from disk
+ * 6. Requesting non-existent uploads → 404 forwarded from source
+ */
+import { describe, it, beforeAll, afterAll } from 'vitest';
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync, mkdirSync, writeFileSync } from 'node:fs';
+import { spawn } from 'node:child_process';
+import { join } from 'node:path';
+import { setTimeout as sleep } from 'node:timers/promises';
+import {
+    runImporter, createTempDir, cleanupTempDir,
+    getSiteUrl, getSiteSecret, getSiteDir,
+    fsRootDir,
+} from '../lib/test-helpers.js';
+import { ensureSite } from '../lib/site-setup.js';
+import { randomBytes } from 'node:crypto';
+
+// Known upload files created on the source site.
+const UPLOAD_FILES = {
+    'wp-content/uploads/2024/01/photo.jpg': 4096,
+    'wp-content/uploads/2024/01/document.pdf': 1024,
+};
+
+// Port for the target PHP built-in server (not in site-registry).
+const TARGET_PORT = 8200;
+
+describe('Import: Remote upload proxy', () => {
+    const site = 'remote-proxy';
+    let siteDir;
+    let tempDir;
+    let outputDir;
+    let phpServer = null;
+
+    // Content bytes keyed by relative path, so we can compare later.
+    const sourceContent = {};
+
+    beforeAll(async () => {
+        await ensureSite(site, {
+            afterCreate: async (remoteSiteDir) => {
+                // Create upload files with deterministic random content.
+                for (const [relPath, size] of Object.entries(UPLOAD_FILES)) {
+                    const absPath = join(remoteSiteDir, relPath);
+                    mkdirSync(join(absPath, '..'), { recursive: true });
+                    const content = randomBytes(size);
+                    writeFileSync(absPath, content);
+                    sourceContent[relPath] = content;
+                }
+            },
+        });
+        siteDir = getSiteDir(site);
+
+        tempDir = createTempDir('e2e-remote-proxy');
+        outputDir = join(tempDir, 'runtime');
+        mkdirSync(outputDir, { recursive: true });
+
+        // 1. Run preflight to capture source site metadata.
+        const preflight = runImporter(importUrl(), tempDir, 'preflight', {
+            secret: getSiteSecret(site),
+        });
+        assert.equal(preflight.exitCode, 0,
+            `preflight failed:\n${preflight.stderr}`);
+
+        // 2. Run files-sync with --filter=essential-files so uploads
+        //    are NOT downloaded — this is the scenario the proxy covers.
+        const filesSync = runImporter(importUrl(), tempDir, 'files-sync', {
+            secret: getSiteSecret(site),
+            extraArgs: ['--filter=essential-files'],
+        });
+        assert.equal(filesSync.exitCode, 0,
+            `files-sync failed:\n${filesSync.stderr}`);
+
+        // 3. Generate runtime config with the proxy handler.
+        const applyRuntime = runImporter(importUrl(), tempDir, 'apply-runtime', {
+            secret: getSiteSecret(site),
+            extraArgs: [
+                '--runtime=php-builtin',
+                `--output-dir=${outputDir}`,
+            ],
+            skipPreflight: true,
+        });
+        assert.equal(applyRuntime.exitCode, 0,
+            `apply-runtime failed:\n${applyRuntime.stderr}\n${applyRuntime.stdout}`);
+
+        // 4. Start the PHP built-in server with the generated runtime.
+        const runtimePath = join(outputDir, 'runtime.php');
+        assert.ok(existsSync(runtimePath), 'runtime.php should exist');
+
+        // The effective document root: fs-root + remote document root.
+        // Read from the state to find the same root apply-runtime used.
+        const state = JSON.parse(readFileSync(join(tempDir, '.import-state.json'), 'utf-8'));
+        const remoteDocRoot = state.preflight?.data?.runtime?.document_root ?? '';
+        const effectiveRoot = remoteDocRoot
+            ? join(fsRootDir(tempDir), remoteDocRoot)
+            : fsRootDir(tempDir);
+
+        phpServer = spawn('php', [
+            '-S', `127.0.0.1:${TARGET_PORT}`,
+            '-t', effectiveRoot,
+            runtimePath,
+        ], { stdio: 'pipe' });
+
+        // Wait for the server to be ready.
+        const deadline = Date.now() + 15000;
+        let ready = false;
+        while (Date.now() < deadline) {
+            if (phpServer.exitCode !== null) {
+                // Collect stderr for diagnostics
+                let stderr = '';
+                phpServer.stderr?.on('data', (d) => { stderr += d; });
+                await sleep(100);
+                throw new Error(
+                    `PHP server exited early with code ${phpServer.exitCode}\n${stderr}`
+                );
+            }
+            try {
+                const res = await fetch(`http://127.0.0.1:${TARGET_PORT}/`, {
+                    method: 'HEAD',
+                    signal: AbortSignal.timeout(1000),
+                });
+                if (res.status > 0) {
+                    ready = true;
+                    break;
+                }
+            } catch (_) {
+                // retry
+            }
+            await sleep(200);
+        }
+        if (!ready) {
+            throw new Error(`Timed out waiting for PHP server on port ${TARGET_PORT}`);
+        }
+    }, 120000);
+
+    afterAll(() => {
+        if (phpServer && phpServer.exitCode === null) {
+            phpServer.kill('SIGTERM');
+        }
+        cleanupTempDir(tempDir);
+    });
+
+    function importUrl() {
+        return `${getSiteUrl(site)}&directory=${siteDir}`;
+    }
+
+    function targetUrl(path) {
+        return `http://127.0.0.1:${TARGET_PORT}${path}`;
+    }
+
+    // ------------------------------------------------------------------
+    // Verify setup: uploads were NOT downloaded locally
+    // ------------------------------------------------------------------
+    it('uploads are not in the local fs-root', () => {
+        const root = fsRootDir(tempDir);
+        for (const relPath of Object.keys(UPLOAD_FILES)) {
+            const local = join(root, siteDir, relPath);
+            assert.ok(!existsSync(local),
+                `Upload should NOT exist locally: ${relPath}`);
+        }
+    });
+
+    it('runtime.php contains STREAMING_REMOTE_SITE_URL', () => {
+        const runtime = readFileSync(join(outputDir, 'runtime.php'), 'utf-8');
+        assert.ok(runtime.includes('STREAMING_REMOTE_SITE_URL'),
+            'Expected STREAMING_REMOTE_SITE_URL constant in runtime.php');
+    });
+
+    it('runtime.php contains the remote upload proxy handler', () => {
+        const runtime = readFileSync(join(outputDir, 'runtime.php'), 'utf-8');
+        assert.ok(runtime.includes('Remote upload proxy'),
+            'Expected remote upload proxy handler in runtime.php');
+    });
+
+    // ------------------------------------------------------------------
+    // Proxy behaviour
+    // ------------------------------------------------------------------
+    it('proxies a missing upload from the source site', async () => {
+        const path = '/wp-content/uploads/2024/01/photo.jpg';
+        const res = await fetch(targetUrl(path));
+        assert.equal(res.status, 200,
+            `Expected 200 for proxied upload, got ${res.status}`);
+
+        const body = Buffer.from(await res.arrayBuffer());
+        const expected = sourceContent['wp-content/uploads/2024/01/photo.jpg'];
+        assert.ok(expected, 'Test setup should have source content for photo.jpg');
+        assert.equal(body.length, expected.length,
+            `Body length mismatch: got ${body.length}, expected ${expected.length}`);
+        assert.ok(body.equals(expected),
+            'Proxied body should match the source file content');
+    });
+
+    it('proxies a different file type (PDF)', async () => {
+        const path = '/wp-content/uploads/2024/01/document.pdf';
+        const res = await fetch(targetUrl(path));
+        assert.equal(res.status, 200,
+            `Expected 200 for proxied PDF, got ${res.status}`);
+
+        const body = Buffer.from(await res.arrayBuffer());
+        const expected = sourceContent['wp-content/uploads/2024/01/document.pdf'];
+        assert.equal(body.length, expected.length,
+            'Proxied PDF body length should match source');
+    });
+
+    it('forwards 404 for uploads that do not exist on the source', async () => {
+        const path = '/wp-content/uploads/2099/01/nonexistent.jpg';
+        const res = await fetch(targetUrl(path));
+        assert.equal(res.status, 404,
+            `Expected 404 for missing source upload, got ${res.status}`);
+    });
+
+    it('serves locally existing files without proxying', async () => {
+        // Write a file directly into the fs-root so it exists locally.
+        const state = JSON.parse(readFileSync(join(tempDir, '.import-state.json'), 'utf-8'));
+        const remoteDocRoot = state.preflight?.data?.runtime?.document_root ?? '';
+        const effectiveRoot = remoteDocRoot
+            ? join(fsRootDir(tempDir), remoteDocRoot)
+            : fsRootDir(tempDir);
+
+        const localContent = Buffer.from('local-file-content-xyz');
+        const localDir = join(effectiveRoot, 'wp-content', 'uploads', 'local-test');
+        mkdirSync(localDir, { recursive: true });
+        writeFileSync(join(localDir, 'test.txt'), localContent);
+
+        const res = await fetch(targetUrl('/wp-content/uploads/local-test/test.txt'));
+        assert.equal(res.status, 200,
+            `Expected 200 for local file, got ${res.status}`);
+
+        const body = Buffer.from(await res.arrayBuffer());
+        assert.ok(body.equals(localContent),
+            'Should serve the local file content, not proxy from source');
+    });
+
+    it('does not proxy non-upload requests', async () => {
+        // Request a path outside /wp-content/uploads/ that doesn't exist.
+        // The handler should NOT proxy this — it falls through to the
+        // normal routing (which will likely 404 via WordPress or php -S).
+        const res = await fetch(targetUrl('/some-random-path.jpg'));
+        // We just verify it's NOT a 200 with proxied content.
+        // It should be a 404 or a WordPress-generated page.
+        assert.notEqual(res.status, 200,
+            'Non-upload paths should not be proxied');
+    });
+});

--- a/tests/e2e/tests/import-41-remote-upload-proxy.test.js
+++ b/tests/e2e/tests/import-41-remote-upload-proxy.test.js
@@ -15,13 +15,13 @@
 import { describe, it, beforeAll, afterAll } from 'vitest';
 import assert from 'node:assert/strict';
 import { existsSync, readFileSync, mkdirSync, writeFileSync } from 'node:fs';
-import { spawn } from 'node:child_process';
+import { execFileSync, spawn } from 'node:child_process';
 import { join } from 'node:path';
 import { setTimeout as sleep } from 'node:timers/promises';
 import {
     runImporter, createTempDir, cleanupTempDir,
     getSiteUrl, getSiteSecret, getSiteDir,
-    fsRootDir,
+    fsRootDir, IMPORTER_PATH,
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 import { randomBytes } from 'node:crypto';
@@ -81,14 +81,22 @@ describe('Import: Remote upload proxy', () => {
             `files-sync failed:\n${filesSync.stderr}`);
 
         // 3. Generate runtime config with the proxy handler.
-        const applyRuntime = runImporter(importUrl(), tempDir, 'apply-runtime', {
-            secret: getSiteSecret(site),
-            extraArgs: [
+        //    apply-runtime doesn't take a URL argument (it's a local-only
+        //    command), so we call it directly instead of via runImporter.
+        let applyRuntime;
+        try {
+            const result = execFileSync('php', [
+                IMPORTER_PATH,
+                'apply-runtime',
+                `--state-dir=${tempDir}`,
+                `--fs-root=${fsRootDir(tempDir)}`,
                 '--runtime=php-builtin',
                 `--output-dir=${outputDir}`,
-            ],
-            skipPreflight: true,
-        });
+            ], { encoding: 'utf-8', timeout: 60000, maxBuffer: 50 * 1024 * 1024 });
+            applyRuntime = { stdout: result, stderr: '', exitCode: 0 };
+        } catch (e) {
+            applyRuntime = { stdout: e.stdout || '', stderr: e.stderr || '', exitCode: e.status || 1 };
+        }
         assert.equal(applyRuntime.exitCode, 0,
             `apply-runtime failed:\n${applyRuntime.stderr}\n${applyRuntime.stdout}`);
 


### PR DESCRIPTION
## Summary

During migration, files-sync may still be running when visitors hit the new
site. Uploaded images and media that haven't been synced yet would show as
broken. This adds a `remote-upload-proxy` route handler that intercepts
requests for missing files under `/wp-content/uploads/`, fetches them from
the source site using cURL, and streams the full HTTP response (status code,
headers, body) back to the visitor.

The handler is registered universally by `apply-runtime` — not tied to any
specific host. It reads the source site URL from preflight's `siteurl` and
stores it as a `STREAMING_REMOTE_SITE_URL` constant in the generated
`runtime.php`. Local file existence is checked against `DOCUMENT_ROOT` so
it works for both standard layouts and flat-document-root setups. Once a
file is synced locally, the handler silently returns and the web server
serves the file directly.

## Test plan

- [ ] New e2e test (import-41) starts a `php -S` target server with the generated runtime and verifies:
  - Missing uploads are proxied from the source site with correct body
  - Non-existent source files forward the 404 status
  - Locally present files are served from disk without proxying
  - Non-upload paths are not intercepted by the handler