### PR TITLE
Recover from cURL timeouts instead of crashing

### DIFF
--- a/importer/import.php
+++ b/importer/import.php
@@ -5033,7 +5033,7 @@ class ImportClient
         } catch (CurlTimeoutException $e) {
             // Throws RuntimeException after MAX_CONSECUTIVE_TIMEOUTS
             // with no progress, so we don't retry forever.
-            $this->track_consecutive_timeout("file_fetch", $cursor_before, $cursor);
+            $this->assert_can_retry_consecutive_timeout("file_fetch", $cursor_before, $cursor);
             // Save state so the next invocation resumes from the
             // last cursor instead of crashing with exit code 1.
             $this->state[$state_key]["cursor"] = $cursor;
@@ -5246,7 +5246,7 @@ class ImportClient
         } catch (CurlTimeoutException $e) {
             // Throws RuntimeException after MAX_CONSECUTIVE_TIMEOUTS
             // with no progress, so we don't retry forever.
-            $this->track_consecutive_timeout("file_index", $cursor_before, $cursor);
+            $this->assert_can_retry_consecutive_timeout("file_index", $cursor_before, $cursor);
             fclose($handle);
             $this->state["index"] = ["cursor" => $cursor];
             $this->state["status"] = "partial";
@@ -6507,7 +6507,7 @@ class ImportClient
                 } catch (CurlTimeoutException $e) {
                     // Throws RuntimeException after MAX_CONSECUTIVE_TIMEOUTS
                     // with no progress, so we don't retry forever.
-                    $this->track_consecutive_timeout("sql_chunk", $cursor_before, $cursor);
+                    $this->assert_can_retry_consecutive_timeout("sql_chunk", $cursor_before, $cursor);
                     // Save state so the next invocation resumes from the
                     // last cursor instead of crashing with exit code 1.
                     if ($sql_handle) {
@@ -6986,7 +6986,7 @@ class ImportClient
                 } catch (CurlTimeoutException $e) {
                     // Throws RuntimeException after MAX_CONSECUTIVE_TIMEOUTS
                     // with no progress, so we don't retry forever.
-                    $this->track_consecutive_timeout("db_index", $cursor_before, $cursor);
+                    $this->assert_can_retry_consecutive_timeout("db_index", $cursor_before, $cursor);
                     fflush($handle);
                     $this->state["cursor"] = $cursor;
                     $this->state["db_index"] = [
@@ -8253,7 +8253,7 @@ class ImportClient
      * @param ?string $cursor_before Cursor value at the start of the request
      * @param ?string $cursor_after  Cursor value when the timeout fired
      */
-    protected function track_consecutive_timeout(
+    protected function assert_can_retry_consecutive_timeout(
         string $phase,
         ?string $cursor_before,
         ?string $cursor_after

--- a/importer/import.php
+++ b/importer/import.php
@@ -814,6 +814,13 @@ class ImportClient
     private const SAVE_STATE_EVERY_N_CHUNKS = 50;
     private const STATE_PATH_ENCODING_PREFIX = "base64:";
 
+    /**
+     * Maximum number of consecutive cURL timeouts with no cursor progress
+     * before the importer gives up. This prevents infinite retry loops
+     * when the remote server is genuinely unresponsive.
+     */
+    private const MAX_CONSECUTIVE_TIMEOUTS = 3;
+
     /** @var string Export server URL. */
     private $remote_url;
 
@@ -5013,6 +5020,7 @@ class ImportClient
             }
         };
 
+        $cursor_before = $cursor;
         $request_start = microtime(true);
         try {
             $this->fetch_streaming(
@@ -5023,6 +5031,9 @@ class ImportClient
                 "file_fetch",
             );
         } catch (CurlTimeoutException $e) {
+            // Throws RuntimeException after MAX_CONSECUTIVE_TIMEOUTS
+            // with no progress, so we don't retry forever.
+            $this->track_consecutive_timeout("file_fetch", $cursor_before, $cursor);
             // Save state so the next invocation resumes from the
             // last cursor instead of crashing with exit code 1.
             $this->state[$state_key]["cursor"] = $cursor;
@@ -5034,13 +5045,9 @@ class ImportClient
             }
             $this->state["status"] = "partial";
             $this->save_state($this->state);
-            $this->audit_log(
-                "CURL TIMEOUT | file_fetch | saved state for resumption | cursor=" .
-                    ($cursor ? substr($cursor, 0, 20) . "..." : "none"),
-                true,
-            );
             return false;
         }
+        $this->state["consecutive_timeouts"] = 0;
         $wall_time = microtime(true) - $request_start;
 
         $this->finalize_tuned_request(
@@ -5232,21 +5239,21 @@ class ImportClient
             }
         };
 
+        $cursor_before = $cursor;
         $request_start = microtime(true);
         try {
             $this->fetch_streaming($url, $cursor, $context, null, "file_index");
         } catch (CurlTimeoutException $e) {
+            // Throws RuntimeException after MAX_CONSECUTIVE_TIMEOUTS
+            // with no progress, so we don't retry forever.
+            $this->track_consecutive_timeout("file_index", $cursor_before, $cursor);
             fclose($handle);
             $this->state["index"] = ["cursor" => $cursor];
             $this->state["status"] = "partial";
             $this->save_state($this->state);
-            $this->audit_log(
-                "CURL TIMEOUT | file_index | saved state for resumption | cursor=" .
-                    ($cursor ? substr($cursor, 0, 20) . "..." : "none"),
-                true,
-            );
             return false;
         }
+        $this->state["consecutive_timeouts"] = 0;
         $wall_time = microtime(true) - $request_start;
         $this->finalize_tuned_request(
             "file_index",
@@ -6493,10 +6500,14 @@ class ImportClient
                     }
                 };
 
+                $cursor_before = $cursor;
                 $request_start = microtime(true);
                 try {
                     $this->fetch_streaming($url, $cursor, $context, null, "sql_chunk");
                 } catch (CurlTimeoutException $e) {
+                    // Throws RuntimeException after MAX_CONSECUTIVE_TIMEOUTS
+                    // with no progress, so we don't retry forever.
+                    $this->track_consecutive_timeout("sql_chunk", $cursor_before, $cursor);
                     // Save state so the next invocation resumes from the
                     // last cursor instead of crashing with exit code 1.
                     if ($sql_handle) {
@@ -6507,12 +6518,6 @@ class ImportClient
                     $this->state["sql_statements_counted"] = $sql_statements_counted;
                     $this->state["status"] = "partial";
                     $this->save_state($this->state);
-                    $this->audit_log(
-                        "CURL TIMEOUT | sql_chunk | saved state for resumption | cursor=" .
-                            ($cursor ? substr($cursor, 0, 20) . "..." : "none") .
-                            " | sql_bytes={$sql_bytes_written}",
-                        true,
-                    );
                     // Discard any pending SQL buffer — it's incomplete and
                     // will be re-fetched on the next invocation. Setting
                     // this to "" also prevents the finally block from
@@ -6521,6 +6526,7 @@ class ImportClient
                     $curl_timed_out = true;
                     break;
                 }
+                $this->state["consecutive_timeouts"] = 0;
                 $wall_time = microtime(true) - $request_start;
                 $this->finalize_tuned_request(
                     "sql_chunk",
@@ -6967,6 +6973,7 @@ class ImportClient
                     }
                 };
 
+                $cursor_before = $cursor;
                 $request_start = microtime(true);
                 try {
                     $this->fetch_streaming(
@@ -6977,6 +6984,9 @@ class ImportClient
                         "db_index",
                     );
                 } catch (CurlTimeoutException $e) {
+                    // Throws RuntimeException after MAX_CONSECUTIVE_TIMEOUTS
+                    // with no progress, so we don't retry forever.
+                    $this->track_consecutive_timeout("db_index", $cursor_before, $cursor);
                     fflush($handle);
                     $this->state["cursor"] = $cursor;
                     $this->state["db_index"] = [
@@ -6988,12 +6998,9 @@ class ImportClient
                     ];
                     $this->state["status"] = "partial";
                     $this->save_state($this->state);
-                    $this->audit_log(
-                        "CURL TIMEOUT | db_index | saved state for resumption",
-                        true,
-                    );
                     return;
                 }
+                $this->state["consecutive_timeouts"] = 0;
                 $wall_time = microtime(true) - $request_start;
                 $this->finalize_tuned_request(
                     "db_index",
@@ -8234,6 +8241,50 @@ class ImportClient
     }
 
     /**
+     * Track consecutive cURL timeouts and decide whether to retry or give up.
+     *
+     * Compares the cursor before and after the request. If the cursor advanced
+     * (we got some data before stalling), the counter resets — the stall was
+     * transient and resuming makes sense. If the cursor didn't move, the
+     * counter increments. After MAX_CONSECUTIVE_TIMEOUTS with no progress,
+     * throws a RuntimeException so the runner sees exit code 1 and stops.
+     *
+     * @param string $phase   Human-readable phase name for logs (e.g. "sql_chunk")
+     * @param ?string $cursor_before Cursor value at the start of the request
+     * @param ?string $cursor_after  Cursor value when the timeout fired
+     */
+    protected function track_consecutive_timeout(
+        string $phase,
+        ?string $cursor_before,
+        ?string $cursor_after,
+    ): void {
+        if ($cursor_after !== null && $cursor_after !== $cursor_before) {
+            // Progress was made — reset the counter.
+            $this->state["consecutive_timeouts"] = 0;
+        } else {
+            $this->state["consecutive_timeouts"] =
+                ($this->state["consecutive_timeouts"] ?? 0) + 1;
+        }
+
+        $count = $this->state["consecutive_timeouts"];
+
+        $this->audit_log(
+            "CURL TIMEOUT | {$phase} | consecutive_timeouts={$count}/" .
+                self::MAX_CONSECUTIVE_TIMEOUTS .
+                " | cursor_moved=" .
+                ($cursor_after !== $cursor_before ? "yes" : "no"),
+            true,
+        );
+
+        if ($count >= self::MAX_CONSECUTIVE_TIMEOUTS) {
+            throw new RuntimeException(
+                "Remote server appears unreachable: {$count} consecutive " .
+                "cURL timeouts with no progress during {$phase}. Giving up.",
+            );
+        }
+    }
+
+    /**
      * Fetch a JSON response for a lightweight request (non-streaming).
      */
     private function fetch_json(string $url): array
@@ -8753,6 +8804,11 @@ class ImportClient
             "mysql_port" => null,
             "mysql_user" => null,
             "mysql_database" => null,
+            // Consecutive cURL timeout counter — tracks how many times in a
+            // row a timeout fired without the cursor advancing. After
+            // MAX_CONSECUTIVE_TIMEOUTS with no progress, the importer gives
+            // up instead of retrying forever.
+            "consecutive_timeouts" => 0,
             // Adaptive tuning state/config
             "tuning" => [
                 "config" => [],

--- a/importer/import.php
+++ b/importer/import.php
@@ -3163,6 +3163,11 @@ class ImportClient
 
             $this->download_db_index();
 
+            // Timeout during db-index — state already saved, exit partial.
+            if (($this->state["status"] ?? null) === "partial") {
+                return;
+            }
+
             $tables = (int) ($this->state["db_index"]["tables"] ?? 0);
             $this->audit_log(
                 sprintf("db-sync db-index stage complete: %d tables", $tables),
@@ -3181,6 +3186,11 @@ class ImportClient
         ]);
 
         $this->download_sql();
+
+        // Timeout during SQL download — state already saved, exit partial.
+        if (($this->state["status"] ?? null) === "partial") {
+            return;
+        }
 
         // Mark as complete
         $this->state["status"] = "complete";
@@ -5004,13 +5014,33 @@ class ImportClient
         };
 
         $request_start = microtime(true);
-        $this->fetch_streaming(
-            $url,
-            $cursor,
-            $context,
-            $post_data,
-            "file_fetch",
-        );
+        try {
+            $this->fetch_streaming(
+                $url,
+                $cursor,
+                $context,
+                $post_data,
+                "file_fetch",
+            );
+        } catch (CurlTimeoutException $e) {
+            // Save state so the next invocation resumes from the
+            // last cursor instead of crashing with exit code 1.
+            $this->state[$state_key]["cursor"] = $cursor;
+            $this->finalize_index_updates();
+            if ($context->file_handle && $context->file_path) {
+                fflush($context->file_handle);
+                $this->state["current_file"] = $context->file_path;
+                $this->state["current_file_bytes"] = $context->file_bytes_written;
+            }
+            $this->state["status"] = "partial";
+            $this->save_state($this->state);
+            $this->audit_log(
+                "CURL TIMEOUT | file_fetch | saved state for resumption | cursor=" .
+                    ($cursor ? substr($cursor, 0, 20) . "..." : "none"),
+                true,
+            );
+            return false;
+        }
         $wall_time = microtime(true) - $request_start;
 
         $this->finalize_tuned_request(
@@ -5203,7 +5233,20 @@ class ImportClient
         };
 
         $request_start = microtime(true);
-        $this->fetch_streaming($url, $cursor, $context, null, "file_index");
+        try {
+            $this->fetch_streaming($url, $cursor, $context, null, "file_index");
+        } catch (CurlTimeoutException $e) {
+            fclose($handle);
+            $this->state["index"] = ["cursor" => $cursor];
+            $this->state["status"] = "partial";
+            $this->save_state($this->state);
+            $this->audit_log(
+                "CURL TIMEOUT | file_index | saved state for resumption | cursor=" .
+                    ($cursor ? substr($cursor, 0, 20) . "..." : "none"),
+                true,
+            );
+            return false;
+        }
         $wall_time = microtime(true) - $request_start;
         $this->finalize_tuned_request(
             "file_index",
@@ -6450,7 +6493,27 @@ class ImportClient
                 };
 
                 $request_start = microtime(true);
-                $this->fetch_streaming($url, $cursor, $context, null, "sql_chunk");
+                try {
+                    $this->fetch_streaming($url, $cursor, $context, null, "sql_chunk");
+                } catch (CurlTimeoutException $e) {
+                    // Save state so the next invocation resumes from the
+                    // last cursor instead of crashing with exit code 1.
+                    if ($sql_handle) {
+                        fflush($sql_handle);
+                    }
+                    $this->state["cursor"] = $cursor;
+                    $this->state["sql_bytes"] = $sql_bytes_written;
+                    $this->state["sql_statements_counted"] = $sql_statements_counted;
+                    $this->state["status"] = "partial";
+                    $this->save_state($this->state);
+                    $this->audit_log(
+                        "CURL TIMEOUT | sql_chunk | saved state for resumption | cursor=" .
+                            ($cursor ? substr($cursor, 0, 20) . "..." : "none") .
+                            " | sql_bytes={$sql_bytes_written}",
+                        true,
+                    );
+                    return;
+                }
                 $wall_time = microtime(true) - $request_start;
                 $this->finalize_tuned_request(
                     "sql_chunk",
@@ -6894,13 +6957,32 @@ class ImportClient
                 };
 
                 $request_start = microtime(true);
-                $this->fetch_streaming(
-                    $url,
-                    $cursor,
-                    $context,
-                    null,
-                    "db_index",
-                );
+                try {
+                    $this->fetch_streaming(
+                        $url,
+                        $cursor,
+                        $context,
+                        null,
+                        "db_index",
+                    );
+                } catch (CurlTimeoutException $e) {
+                    fflush($handle);
+                    $this->state["cursor"] = $cursor;
+                    $this->state["db_index"] = [
+                        "file" => $tables_file,
+                        "tables" => $tables_written,
+                        "rows_estimated" => $rows_estimated,
+                        "bytes" => $bytes_written,
+                        "updated_at" => time(),
+                    ];
+                    $this->state["status"] = "partial";
+                    $this->save_state($this->state);
+                    $this->audit_log(
+                        "CURL TIMEOUT | db_index | saved state for resumption",
+                        true,
+                    );
+                    return;
+                }
                 $wall_time = microtime(true) - $request_start;
                 $this->finalize_tuned_request(
                     "db_index",
@@ -8134,6 +8216,9 @@ class ImportClient
             : 28;
         $this->last_curl_errno = $errno;
         $this->last_curl_timeout = $errno === $timeout_errno;
+        if ($this->last_curl_timeout) {
+            throw new CurlTimeoutException("cURL error: {$error}");
+        }
         throw new RuntimeException("cURL error: {$error}");
     }
 
@@ -8218,7 +8303,7 @@ class ImportClient
     /**
      * Fetch URL with streaming multipart parsing.
      */
-    private function fetch_streaming(
+    protected function fetch_streaming(
         string $url,
         ?string $cursor,
         StreamingContext $context,
@@ -9217,6 +9302,14 @@ class StreamingContext
  * Callers catch this to skip the current file/directory/symlink gracefully.
  */
 class PreserveLocalSkipException extends RuntimeException {}
+
+/**
+ * Thrown when a cURL request times out (CURLE_OPERATION_TIMEDOUT).
+ * Callers catch this to save state and exit with "partial" status instead
+ * of crashing with a fatal error — the next invocation resumes from the
+ * last saved cursor.
+ */
+class CurlTimeoutException extends RuntimeException {}
 
 // ============================================================================
 // CLI Entry Point

--- a/importer/import.php
+++ b/importer/import.php
@@ -6309,6 +6309,7 @@ class ImportClient
             false,
         );
 
+        $curl_timed_out = false;
         try {
             while (!$complete) {
                 $params = $this->get_tuned_params("sql_chunk");
@@ -6512,7 +6513,13 @@ class ImportClient
                             " | sql_bytes={$sql_bytes_written}",
                         true,
                     );
-                    return;
+                    // Discard any pending SQL buffer — it's incomplete and
+                    // will be re-fetched on the next invocation. Setting
+                    // this to "" also prevents the finally block from
+                    // throwing about un-executed buffered SQL.
+                    $sql_buffer = "";
+                    $curl_timed_out = true;
+                    break;
                 }
                 $wall_time = microtime(true) - $request_start;
                 $this->finalize_tuned_request(
@@ -6597,6 +6604,10 @@ class ImportClient
                     );
                 }
             }
+        }
+
+        if ($curl_timed_out) {
+            return;
         }
     }
 

--- a/importer/import.php
+++ b/importer/import.php
@@ -8256,7 +8256,7 @@ class ImportClient
     protected function track_consecutive_timeout(
         string $phase,
         ?string $cursor_before,
-        ?string $cursor_after,
+        ?string $cursor_after
     ): void {
         if ($cursor_after !== null && $cursor_after !== $cursor_before) {
             // Progress was made — reset the counter.

--- a/importer/import.php
+++ b/importer/import.php
@@ -8403,7 +8403,12 @@ class ImportClient
 
         curl_setopt_array($ch, [
             CURLOPT_FOLLOWLOCATION => false,
-            CURLOPT_TIMEOUT => 300,
+            // Don't cap total transfer time — streaming responses can
+            // legitimately run for 20+ minutes. Instead, detect stalled
+            // connections: timeout only when fewer than 1 byte/sec is
+            // received for 300 consecutive seconds.
+            CURLOPT_LOW_SPEED_LIMIT => 1,
+            CURLOPT_LOW_SPEED_TIME => 300,
             CURLOPT_ENCODING => "gzip, deflate",
             CURLOPT_HTTPHEADER => $headers,
             CURLOPT_HEADERFUNCTION => function ($ch, $header_line) use (

--- a/tests/Import/CurlTimeoutRecoveryTest.php
+++ b/tests/Import/CurlTimeoutRecoveryTest.php
@@ -500,7 +500,7 @@ class TimeoutTestClient extends \ImportClient
 {
     protected function fetch_streaming(
         string $url,
-        ?string &$cursor,
+        ?string $cursor,
         \StreamingContext $context,
         ?array $post_data = null,
         ?string $endpoint = null
@@ -519,7 +519,7 @@ class SuccessTestClient extends \ImportClient
 {
     protected function fetch_streaming(
         string $url,
-        ?string &$cursor,
+        ?string $cursor,
         \StreamingContext $context,
         ?array $post_data = null,
         ?string $endpoint = null

--- a/tests/Import/CurlTimeoutRecoveryTest.php
+++ b/tests/Import/CurlTimeoutRecoveryTest.php
@@ -13,6 +13,10 @@ require_once __DIR__ . '/../../importer/import.php';
  * Each download method (download_sql, download_file_fetch, download_remote_index,
  * download_db_index) is tested by injecting a CurlTimeoutException via a
  * subclass that overrides fetch_streaming.
+ *
+ * Also verifies the consecutive-timeout safety net: after
+ * MAX_CONSECUTIVE_TIMEOUTS with no cursor progress, the importer gives up
+ * with a RuntimeException instead of retrying forever.
  */
 class CurlTimeoutRecoveryTest extends TestCase
 {
@@ -85,11 +89,13 @@ class CurlTimeoutRecoveryTest extends TestCase
     }
 
     /**
-     * Prepare a TimeoutTestClient with state loaded and TTY disabled.
+     * Prepare a client test double with state loaded and TTY disabled.
+     *
+     * @param class-string $clientClass  Which test double to instantiate
      */
-    private function prepareClient(): array
+    private function prepareClient(string $clientClass = TimeoutTestClient::class): array
     {
-        $client = new TimeoutTestClient(
+        $client = new $clientClass(
             'http://fake.url',
             $this->stateDir,
             $this->fs_root,
@@ -316,17 +322,185 @@ class CurlTimeoutRecoveryTest extends TestCase
         $e = new \CurlTimeoutException("Operation timed out");
         $this->assertInstanceOf(\RuntimeException::class, $e);
     }
+
+    // ---------------------------------------------------------------
+    // Consecutive timeout counter
+    // ---------------------------------------------------------------
+
+    /**
+     * track_consecutive_timeout increments the counter when cursor didn't
+     * move. After MAX_CONSECUTIVE_TIMEOUTS it throws RuntimeException.
+     */
+    public function testTrackConsecutiveTimeoutIncrementsOnNoProgress()
+    {
+        $this->writeState([
+            "command" => "db-sync",
+            "status" => "in_progress",
+            "consecutive_timeouts" => 0,
+        ]);
+
+        [$client, $reflection] = $this->prepareClient();
+        $state = $reflection->getProperty('state');
+
+        $method = $reflection->getMethod('track_consecutive_timeout');
+
+        // First call — no progress (same cursor before and after)
+        $method->invoke($client, "sql_chunk", "abc", "abc");
+        $this->assertEquals(1, $state->getValue($client)["consecutive_timeouts"]);
+
+        // Second call — still no progress
+        $method->invoke($client, "sql_chunk", "abc", "abc");
+        $this->assertEquals(2, $state->getValue($client)["consecutive_timeouts"]);
+    }
+
+    public function testTrackConsecutiveTimeoutResetsOnProgress()
+    {
+        $this->writeState([
+            "command" => "db-sync",
+            "status" => "in_progress",
+            "consecutive_timeouts" => 2,
+        ]);
+
+        [$client, $reflection] = $this->prepareClient();
+        $state = $reflection->getProperty('state');
+
+        $method = $reflection->getMethod('track_consecutive_timeout');
+
+        // Cursor advanced — should reset to 0
+        $method->invoke($client, "sql_chunk", "abc", "def");
+        $this->assertEquals(0, $state->getValue($client)["consecutive_timeouts"]);
+    }
+
+    public function testTrackConsecutiveTimeoutThrowsAtMax()
+    {
+        $this->writeState([
+            "command" => "db-sync",
+            "status" => "in_progress",
+            "consecutive_timeouts" => 2,
+        ]);
+
+        [$client, $reflection] = $this->prepareClient();
+
+        $method = $reflection->getMethod('track_consecutive_timeout');
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('consecutive');
+
+        // 3rd no-progress timeout should throw
+        $method->invoke($client, "sql_chunk", "abc", "abc");
+    }
+
+    /**
+     * End-to-end: download_sql with counter already at MAX-1 and no
+     * cursor progress should throw RuntimeException.
+     */
+    public function testSqlDownloadGivesUpAfterMaxConsecutiveTimeouts()
+    {
+        $this->writeState([
+            "command" => "db-sync",
+            "status" => "in_progress",
+            "stage" => "sql",
+            "cursor" => base64_encode('{"table":"wp_posts","pk":42}'),
+            "sql_bytes" => 1024,
+            "consecutive_timeouts" => 2,
+        ]);
+
+        $sql_content = str_pad("", 1024, "INSERT INTO t VALUES (1);\n");
+        file_put_contents($this->stateDir . '/db.sql', $sql_content);
+
+        [$client, $reflection] = $this->prepareClient();
+
+        $modeProp = $reflection->getProperty('sql_output_mode');
+        $modeProp->setValue($client, 'file');
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('consecutive');
+
+        $downloadSql = $reflection->getMethod('download_sql');
+        $downloadSql->invoke($client);
+    }
+
+    public function testFirstTimeoutIncrementsCounterInState()
+    {
+        $this->writeState([
+            "command" => "db-sync",
+            "status" => "in_progress",
+            "stage" => "sql",
+            "cursor" => base64_encode('{"table":"wp_posts","pk":42}'),
+            "sql_bytes" => 1024,
+            "consecutive_timeouts" => 0,
+        ]);
+
+        $sql_content = str_pad("", 1024, "INSERT INTO t VALUES (1);\n");
+        file_put_contents($this->stateDir . '/db.sql', $sql_content);
+
+        [$client, $reflection] = $this->prepareClient();
+
+        $modeProp = $reflection->getProperty('sql_output_mode');
+        $modeProp->setValue($client, 'file');
+
+        $downloadSql = $reflection->getMethod('download_sql');
+        $downloadSql->invoke($client);
+
+        $state = $this->readState();
+        $this->assertEquals("partial", $state["status"]);
+        $this->assertEquals(
+            1,
+            $state["consecutive_timeouts"],
+            "First no-progress timeout should increment counter to 1"
+        );
+    }
+
+    public function testSuccessfulRequestResetsCounter()
+    {
+        $this->writeState([
+            "command" => "files-sync",
+            "status" => "in_progress",
+            "stage" => "index",
+            "index" => [
+                "cursor" => base64_encode('{"dir":"/wp-content","offset":500}'),
+            ],
+            "consecutive_timeouts" => 2,
+            "preflight" => [
+                "data" => [
+                    "ok" => true,
+                    "wp_detect" => [
+                        "roots" => [
+                            ["path" => "/srv/htdocs"],
+                        ],
+                    ],
+                ],
+                "http_code" => 200,
+            ],
+        ]);
+
+        [$client, $reflection] = $this->prepareClient(
+            SuccessTestClient::class,
+        );
+
+        $downloadIndex = $reflection->getMethod('download_remote_index');
+        $downloadIndex->invoke($client);
+
+        $state = $this->readState();
+        $this->assertEquals(
+            0,
+            $state["consecutive_timeouts"],
+            "Successful request should reset consecutive_timeouts to 0"
+        );
+    }
+
 }
 
 /**
  * Test double that throws CurlTimeoutException from fetch_streaming,
  * simulating a cURL timeout without making real HTTP requests.
+ * The cursor is NOT advanced — simulates a complete stall.
  */
 class TimeoutTestClient extends \ImportClient
 {
     protected function fetch_streaming(
         string $url,
-        ?string $cursor,
+        ?string &$cursor,
         \StreamingContext $context,
         ?array $post_data = null,
         ?string $endpoint = null
@@ -334,5 +508,23 @@ class TimeoutTestClient extends \ImportClient
         throw new \CurlTimeoutException(
             "cURL error: Operation timed out after 300001 milliseconds with 0 bytes received"
         );
+    }
+}
+
+/**
+ * Test double that completes successfully without throwing,
+ * simulating a normal request that finishes.
+ */
+class SuccessTestClient extends \ImportClient
+{
+    protected function fetch_streaming(
+        string $url,
+        ?string &$cursor,
+        \StreamingContext $context,
+        ?array $post_data = null,
+        ?string $endpoint = null
+    ): void {
+        // Signal completion
+        $context->saw_completion = true;
     }
 }

--- a/tests/Import/CurlTimeoutRecoveryTest.php
+++ b/tests/Import/CurlTimeoutRecoveryTest.php
@@ -328,7 +328,7 @@ class CurlTimeoutRecoveryTest extends TestCase
     // ---------------------------------------------------------------
 
     /**
-     * track_consecutive_timeout increments the counter when cursor didn't
+     * assert_can_retry_consecutive_timeout increments the counter when cursor didn't
      * move. After MAX_CONSECUTIVE_TIMEOUTS it throws RuntimeException.
      */
     public function testTrackConsecutiveTimeoutIncrementsOnNoProgress()
@@ -342,7 +342,7 @@ class CurlTimeoutRecoveryTest extends TestCase
         [$client, $reflection] = $this->prepareClient();
         $state = $reflection->getProperty('state');
 
-        $method = $reflection->getMethod('track_consecutive_timeout');
+        $method = $reflection->getMethod('assert_can_retry_consecutive_timeout');
 
         // First call — no progress (same cursor before and after)
         $method->invoke($client, "sql_chunk", "abc", "abc");
@@ -364,7 +364,7 @@ class CurlTimeoutRecoveryTest extends TestCase
         [$client, $reflection] = $this->prepareClient();
         $state = $reflection->getProperty('state');
 
-        $method = $reflection->getMethod('track_consecutive_timeout');
+        $method = $reflection->getMethod('assert_can_retry_consecutive_timeout');
 
         // Cursor advanced — should reset to 0
         $method->invoke($client, "sql_chunk", "abc", "def");
@@ -381,7 +381,7 @@ class CurlTimeoutRecoveryTest extends TestCase
 
         [$client, $reflection] = $this->prepareClient();
 
-        $method = $reflection->getMethod('track_consecutive_timeout');
+        $method = $reflection->getMethod('assert_can_retry_consecutive_timeout');
 
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('consecutive');

--- a/tests/Import/CurlTimeoutRecoveryTest.php
+++ b/tests/Import/CurlTimeoutRecoveryTest.php
@@ -1,0 +1,338 @@
+<?php
+
+namespace ImportTests;
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../importer/import.php';
+
+/**
+ * Verify that cURL timeouts during download save state and set status to
+ * "partial" instead of crashing with a fatal RuntimeException.
+ *
+ * Each download method (download_sql, download_file_fetch, download_remote_index,
+ * download_db_index) is tested by injecting a CurlTimeoutException via a
+ * subclass that overrides fetch_streaming.
+ */
+class CurlTimeoutRecoveryTest extends TestCase
+{
+    private $tempDir;
+    private $stateDir;
+    private $fs_root;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->tempDir = sys_get_temp_dir() . '/curl-timeout-test-' . uniqid();
+        $this->stateDir = $this->tempDir . '/state';
+        $this->fs_root = $this->tempDir . '/fs-root';
+        mkdir($this->stateDir, 0755, true);
+        mkdir($this->fs_root, 0755, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->recursiveDelete($this->tempDir);
+        parent::tearDown();
+    }
+
+    private function recursiveDelete(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        foreach (scandir($dir) as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $path = $dir . '/' . $item;
+            if (is_link($path)) {
+                unlink($path);
+            } elseif (is_dir($path)) {
+                $this->recursiveDelete($path);
+            } else {
+                unlink($path);
+            }
+        }
+        rmdir($dir);
+    }
+
+    private function writeState(array $state): void
+    {
+        $defaults = [
+            "command" => null,
+            "status" => null,
+            "cursor" => null,
+            "stage" => null,
+            "preflight" => ["data" => ["ok" => true], "http_code" => 200],
+            "remote_protocol_version" => null,
+            "remote_protocol_min_version" => null,
+            "version" => null,
+            "follow_symlinks" => false,
+            "fs_root_nonempty_behavior" => "preserve-local",
+            "max_allowed_packet" => null,
+        ];
+        file_put_contents(
+            $this->stateDir . '/.import-state.json',
+            json_encode(array_merge($defaults, $state), JSON_PRETTY_PRINT),
+        );
+    }
+
+    private function readState(): array
+    {
+        $contents = file_get_contents($this->stateDir . '/.import-state.json');
+        return json_decode($contents, true);
+    }
+
+    /**
+     * Prepare a TimeoutTestClient with state loaded and TTY disabled.
+     */
+    private function prepareClient(): array
+    {
+        $client = new TimeoutTestClient(
+            'http://fake.url',
+            $this->stateDir,
+            $this->fs_root,
+        );
+        $reflection = new \ReflectionClass(\ImportClient::class);
+
+        $stateProperty = $reflection->getProperty('state');
+        $loadState = $reflection->getMethod('load_state');
+        $stateProperty->setValue($client, $loadState->invoke($client));
+
+        $ttyProperty = $reflection->getProperty('is_tty');
+        $ttyProperty->setValue($client, false);
+
+        return [$client, $reflection];
+    }
+
+    // ---------------------------------------------------------------
+    // download_sql: timeout saves state as "partial"
+    // ---------------------------------------------------------------
+
+    public function testSqlDownloadTimeoutSavesPartialState()
+    {
+        $this->writeState([
+            "command" => "db-sync",
+            "status" => "in_progress",
+            "stage" => "sql",
+            "cursor" => base64_encode('{"table":"wp_posts","pk":42}'),
+            "sql_bytes" => 1024,
+        ]);
+
+        $sql_content = str_pad("", 1024, "INSERT INTO t VALUES (1);\n");
+        file_put_contents($this->stateDir . '/db.sql', $sql_content);
+
+        [$client, $reflection] = $this->prepareClient();
+
+        $modeProp = $reflection->getProperty('sql_output_mode');
+        $modeProp->setValue($client, 'file');
+
+        $downloadSql = $reflection->getMethod('download_sql');
+        $downloadSql->invoke($client);
+
+        $state = $this->readState();
+        $this->assertEquals(
+            "partial",
+            $state["status"],
+            "After cURL timeout, status should be 'partial' not an exception"
+        );
+        $this->assertNotNull(
+            $state["cursor"],
+            "Cursor should be preserved for resumption"
+        );
+        $this->assertNotNull(
+            $state["sql_bytes"],
+            "sql_bytes should be saved for crash recovery"
+        );
+    }
+
+    // ---------------------------------------------------------------
+    // download_file_fetch: timeout saves state and returns false
+    // ---------------------------------------------------------------
+
+    public function testFileFetchTimeoutSavesPartialState()
+    {
+        $this->writeState([
+            "command" => "files-sync",
+            "status" => "in_progress",
+            "stage" => "fetch",
+            "fetch" => [
+                "offset" => 0,
+                "next_offset" => 100,
+                "batch_file" => null,
+                "cursor" => base64_encode('{"path":"/wp-content/uploads/photo.jpg","offset":4096}'),
+            ],
+        ]);
+
+        [$client, $reflection] = $this->prepareClient();
+
+        $downloadFilesFetch = $reflection->getMethod('download_file_fetch');
+        $result = $downloadFilesFetch->invoke(
+            $client,
+            null,
+            base64_encode('{"path":"/photo.jpg","offset":4096}'),
+            "fetch",
+        );
+
+        $this->assertFalse(
+            $result,
+            "download_file_fetch should return false (not complete) on timeout"
+        );
+
+        $state = $this->readState();
+        $this->assertEquals(
+            "partial",
+            $state["status"],
+            "After cURL timeout during file fetch, status should be 'partial'"
+        );
+    }
+
+    // ---------------------------------------------------------------
+    // download_remote_index: timeout saves state and returns false
+    // ---------------------------------------------------------------
+
+    public function testRemoteIndexTimeoutSavesPartialState()
+    {
+        $this->writeState([
+            "command" => "files-sync",
+            "status" => "in_progress",
+            "stage" => "index",
+            "index" => [
+                "cursor" => base64_encode('{"dir":"/wp-content","offset":500}'),
+            ],
+            "preflight" => [
+                "data" => [
+                    "ok" => true,
+                    "wp_detect" => [
+                        "roots" => [
+                            ["path" => "/srv/htdocs"],
+                        ],
+                    ],
+                ],
+                "http_code" => 200,
+            ],
+        ]);
+
+        [$client, $reflection] = $this->prepareClient();
+
+        $downloadIndex = $reflection->getMethod('download_remote_index');
+        $result = $downloadIndex->invoke($client);
+
+        $this->assertFalse(
+            $result,
+            "download_remote_index should return false on timeout"
+        );
+
+        $state = $this->readState();
+        $this->assertEquals(
+            "partial",
+            $state["status"],
+            "After cURL timeout during index download, status should be 'partial'"
+        );
+        $this->assertNotNull(
+            $state["index"]["cursor"] ?? null,
+            "Index cursor should be preserved for resumption"
+        );
+    }
+
+    // ---------------------------------------------------------------
+    // download_db_index: timeout saves state as "partial"
+    // ---------------------------------------------------------------
+
+    public function testDbIndexTimeoutSavesPartialState()
+    {
+        $this->writeState([
+            "command" => "db-sync",
+            "status" => "in_progress",
+            "stage" => "db-index",
+            "cursor" => base64_encode('{"table_offset":5}'),
+            "db_index" => [
+                "file" => null,
+                "tables" => 3,
+                "rows_estimated" => 1000,
+                "bytes" => 256,
+                "updated_at" => time(),
+            ],
+        ]);
+
+        [$client, $reflection] = $this->prepareClient();
+
+        $downloadDbIndex = $reflection->getMethod('download_db_index');
+        $downloadDbIndex->invoke($client);
+
+        $state = $this->readState();
+        $this->assertEquals(
+            "partial",
+            $state["status"],
+            "After cURL timeout during db-index, status should be 'partial'"
+        );
+    }
+
+    // ---------------------------------------------------------------
+    // run_db_sync: timeout propagates as "partial", not exception
+    // ---------------------------------------------------------------
+
+    public function testRunDbSyncExitsPartialOnSqlTimeout()
+    {
+        $this->writeState([
+            "command" => "db-sync",
+            "status" => "in_progress",
+            "stage" => "sql",
+            "cursor" => base64_encode('{"table":"wp_posts","pk":42}'),
+            "sql_bytes" => 0,
+            "db_index" => [
+                "file" => $this->stateDir . "/db-tables.jsonl",
+                "tables" => 5,
+                "rows_estimated" => 10000,
+                "bytes" => 100,
+                "updated_at" => time(),
+            ],
+        ]);
+
+        [$client, $reflection] = $this->prepareClient();
+
+        $modeProp = $reflection->getProperty('sql_output_mode');
+        $modeProp->setValue($client, 'file');
+
+        // run_db_sync should NOT throw — it should return with partial status
+        $runDbSync = $reflection->getMethod('run_db_sync');
+        $runDbSync->invoke($client);
+
+        $state = $this->readState();
+        $this->assertEquals(
+            "partial",
+            $state["status"],
+            "run_db_sync should set status to 'partial' on timeout, not throw"
+        );
+    }
+
+    // ---------------------------------------------------------------
+    // Exception hierarchy
+    // ---------------------------------------------------------------
+
+    public function testCurlTimeoutExceptionExtendsRuntimeException()
+    {
+        $e = new \CurlTimeoutException("Operation timed out");
+        $this->assertInstanceOf(\RuntimeException::class, $e);
+    }
+}
+
+/**
+ * Test double that throws CurlTimeoutException from fetch_streaming,
+ * simulating a cURL timeout without making real HTTP requests.
+ */
+class TimeoutTestClient extends \ImportClient
+{
+    protected function fetch_streaming(
+        string $url,
+        ?string $cursor,
+        \StreamingContext $context,
+        ?array $post_data = null,
+        ?string $endpoint = null
+    ): void {
+        throw new \CurlTimeoutException(
+            "cURL error: Operation timed out after 300001 milliseconds with 0 bytes received"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

When a cURL request stalled mid-transfer, the importer crashed with exit code 1 instead of saving state and exiting gracefully. This defeated the cursor-based resumption design.

Three changes:

1. **Low-speed stall detection instead of absolute timeout** – replaced `CURLOPT_TIMEOUT` with `CURLOPT_LOW_SPEED_LIMIT` / `CURLOPT_LOW_SPEED_TIME`. Streaming responses can legitimately run for 20+ minutes, so an absolute timeout is wrong. Instead, we detect stalls: timeout only when fewer than 1 byte/sec is received for 300 consecutive seconds.

2. **Graceful recovery from stalls** – each download loop (SQL chunks, file fetch, file index, db index) catches `CurlTimeoutException`, saves the current cursor and byte counts to the state file, and returns with status "partial". The next invocation resumes from the saved cursor.

3. **Consecutive timeout safety net** – to prevent infinite retry loops when the remote server is genuinely down, we track consecutive no-progress timeouts in state. If the cursor didn't advance, the counter increments. After 3 consecutive no-progress timeouts, the importer gives up with a RuntimeException (exit code 1). Any timeout where the cursor moved resets the counter.

## Test plan

- [ ] Unit tests for `track_consecutive_timeout`: increments on no-progress, resets on progress, throws at max
- [ ] Integration tests: each download method saves "partial" state on timeout
- [ ] Integration test: `download_sql` throws after 3 consecutive no-progress timeouts
- [ ] Successful requests reset the consecutive timeout counter
- [ ] All existing tests pass (PHPStan, PHPUnit, E2E)
