### PR TITLE
Simplify URL rewriting: don't analyze base64 values, use quick strpos heuristic to skip values without likely URL candidates

### DIFF
--- a/importer/lib/url-rewrite/class-structured-data-url-rewriter.php
+++ b/importer/lib/url-rewrite/class-structured-data-url-rewriter.php
@@ -35,12 +35,25 @@ class StructuredDataUrlRewriter
     /** @var array<string, string> URL mapping: source_url => target_url */
     private array $url_mapping;
 
+    /** @var string[] Source domains extracted from url_mapping keys, for quick-reject checks. */
+    private array $source_domains;
+
     /**
      * @param array<string, string> $url_mapping Source URL => target URL mapping.
      */
     public function __construct(array $url_mapping)
     {
         $this->url_mapping = $url_mapping;
+
+        // Extract unique source domains for the quick-reject check.
+        $domains = [];
+        foreach (array_keys($url_mapping) as $from_url) {
+            $host = parse_url($from_url, PHP_URL_HOST);
+            if ($host !== null && $host !== false) {
+                $domains[$host] = true;
+            }
+        }
+        $this->source_domains = array_keys($domains);
     }
 
     /**
@@ -63,6 +76,14 @@ class StructuredDataUrlRewriter
 
         if ($content_type === null) {
             $content_type = self::PLAIN_TEXT;
+        }
+
+        // Quick-reject: if the value doesn't contain href=", src=", or any
+        // source domain, there's nothing to rewrite. This avoids expensive
+        // parsing (serialized PHP, JSON, block markup) for the vast majority
+        // of values that don't contain any rewritable URLs.
+        if (!$this->maybe_contains_rewritable_urls($value)) {
+            return $value;
         }
 
         // Try serialized PHP: the parser validates the entire structure
@@ -93,23 +114,37 @@ class StructuredDataUrlRewriter
             return $iter->get_result();
         }
 
-        // Try base64 as a transport encoding. Decode, recurse on the
-        // decoded content, and re-encode if the recursive call changed
-        // anything. No format guessing on the decoded content — the
-        // recursive call tries the real parsers.
-        $decoded = base64_decode($value, true);
-        if ($decoded !== false && $decoded !== '') {
-            $rewritten = $this->rewrite($decoded, $content_type);
-            if ($rewritten !== $decoded) {
-                return base64_encode($rewritten);
-            }
-        }
+        // Base64 decoding is temporarily disabled for performance.
+        // The base64 transport layer in SQL is already handled by
+        // Base64ValueScanner in SqlStatementRewriter — this block
+        // was for base64-within-base64 nesting which is rare in practice.
 
         return self::rewrite_urls([
             'content' => $value,
             'content_type' => $content_type,
             'url-mapping' => $this->url_mapping,
         ]);
+    }
+
+    /**
+     * Quick-reject check: returns false when the value certainly doesn't
+     * contain any rewritable URLs, avoiding expensive parsing.
+     *
+     * A value is considered potentially rewritable if it contains:
+     * - href=" or src=" (HTML attributes that carry URLs), OR
+     * - any source domain from the url_mapping (bare URL occurrences)
+     */
+    private function maybe_contains_rewritable_urls(string $value): bool
+    {
+        if (strpos($value, 'href="') !== false || strpos($value, 'src="') !== false) {
+            return true;
+        }
+        foreach ($this->source_domains as $domain) {
+            if (strpos($value, $domain) !== false) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/tests/UrlRewriting/StructuredDataUrlRewriterTest.php
+++ b/tests/UrlRewriting/StructuredDataUrlRewriterTest.php
@@ -201,60 +201,34 @@ class StructuredDataUrlRewriterTest extends TestCase
 
     // --- Base64 ---
 
+    // Base64 processing is temporarily disabled for performance.
+    // These tests document the expected behavior when it's re-enabled.
+
     public function testRewritesBase64EncodedHtml(): void
     {
-        $rewriter = $this->createRewriter();
-        $html = '<a href="https://old-site.com/page">Link</a>';
-        $input = base64_encode($html);
-        $result = $rewriter->rewrite($input);
-        $decoded = base64_decode($result);
-        $this->assertStringContainsString('new-site.com/page', $decoded);
-        $this->assertStringNotContainsString('old-site.com', $decoded);
+        $this->markTestSkipped('Base64 processing is temporarily disabled for performance.');
     }
 
     public function testRewritesBase64EncodedJson(): void
     {
-        $rewriter = $this->createRewriter();
-        $json = json_encode(['url' => 'https://old-site.com/api'], JSON_UNESCAPED_SLASHES);
-        $input = base64_encode($json);
-        $result = $rewriter->rewrite($input);
-        $decoded = json_decode(base64_decode($result), true);
-        $this->assertSame('https://new-site.com/api', $decoded['url']);
+        $this->markTestSkipped('Base64 processing is temporarily disabled for performance.');
     }
 
     public function testRewritesBase64EncodedSerializedPhp(): void
     {
-        $rewriter = $this->createRewriter();
-        $serialized = serialize(['siteurl' => 'https://old-site.com/site']);
-        $input = base64_encode($serialized);
-        $result = $rewriter->rewrite($input);
-        $unserialized = unserialize(base64_decode($result));
-        $this->assertSame('https://new-site.com/site', $unserialized['siteurl']);
+        $this->markTestSkipped('Base64 processing is temporarily disabled for performance.');
     }
 
     public function testRewritesBase64EncodedBlockMarkup(): void
     {
-        $rewriter = $this->createRewriter();
-        $markup = '<!-- wp:image {"src":"https://old-site.com/img.jpg"} --><figure><img src="https://old-site.com/img.jpg"/></figure><!-- /wp:image -->';
-        $input = base64_encode($markup);
-        $result = $rewriter->rewrite($input);
-        $decoded = base64_decode($result);
-        $this->assertStringContainsString('new-site.com', $decoded);
-        $this->assertStringNotContainsString('old-site.com', $decoded);
+        $this->markTestSkipped('Base64 processing is temporarily disabled for performance.');
     }
 
     // --- Combinations: formats nested inside other formats ---
 
     public function testBase64InsideSerializedPhp(): void
     {
-        $rewriter = $this->createRewriter();
-        $html = '<a href="https://old-site.com/page">Link</a>';
-        $b64 = base64_encode($html);
-        $input = serialize(['encoded_html' => $b64]);
-        $result = $rewriter->rewrite($input);
-        $unserialized = unserialize($result);
-        $decoded = base64_decode($unserialized['encoded_html']);
-        $this->assertStringContainsString('new-site.com/page', $decoded);
+        $this->markTestSkipped('Base64 processing is temporarily disabled for performance.');
     }
 
     public function testSerializedPhpInsideJson(): void
@@ -270,21 +244,7 @@ class StructuredDataUrlRewriterTest extends TestCase
 
     public function testBase64InsideJsonInsideSerializedPhp(): void
     {
-        $rewriter = $this->createRewriter();
-        // Three layers: serialized PHP → JSON string → base64 → HTML
-        $html = '<img src="https://old-site.com/img.jpg"/>';
-        $b64 = base64_encode($html);
-        $json = json_encode(['encoded' => $b64], JSON_UNESCAPED_SLASHES);
-        $input = serialize(['config' => $json]);
-
-        $result = $rewriter->rewrite($input);
-
-        // Unwind all layers and verify the URL was rewritten
-        $unserialized = unserialize($result);
-        $json_decoded = json_decode($unserialized['config'], true);
-        $decoded_html = base64_decode($json_decoded['encoded']);
-        $this->assertStringContainsString('new-site.com/img.jpg', $decoded_html);
-        $this->assertStringNotContainsString('old-site.com', $decoded_html);
+        $this->markTestSkipped('Base64 processing is temporarily disabled for performance.');
     }
 
     public function testBase64WithNoUrlsIsUnchanged(): void
@@ -442,12 +402,6 @@ class StructuredDataUrlRewriterTest extends TestCase
 
     public function testBlockMarkupHintPropagatesThroughBase64(): void
     {
-        $rewriter = $this->createRewriter();
-        $markup = '<img src="https://old-site.com/img.jpg"/>';
-        $input = base64_encode($markup);
-        $result = $rewriter->rewrite($input, 'block_markup');
-        $decoded = base64_decode($result);
-        $this->assertStringContainsString('new-site.com/img.jpg', $decoded);
-        $this->assertStringNotContainsString('old-site.com', $decoded);
+        $this->markTestSkipped('Base64 processing is temporarily disabled for performance.');
     }
 }


### PR DESCRIPTION
## Summary

- Adds a quick-reject check in `StructuredDataUrlRewriter` that skips all parsing when a value doesn't contain `href="`, `src="`, or any source domain. Most database values don't contain URLs, so this avoids expensive serialized PHP, JSON, and block markup parsing for the vast majority of rows.
- Temporarily disables base64-within-base64 nesting in the rewriter. The SQL-level `FROM_BASE64()` handling in `Base64ValueScanner` still works — this only skips the rare case of base64 encoded inside already-decoded values.

This speeds up the rewrite process from ~80 seconds to ~20 seconds on my MBP

## Test plan

- [x] All 134 non-base64 URL rewriting tests pass
- [x] 7 base64 nesting tests are marked as skipped with clear reasoning