### PR TITLE
Proxy uploads from the remote server until they're downloaded

### DIFF
--- a/importer/import.php
+++ b/importer/import.php
@@ -3517,6 +3517,7 @@ class ImportClient
         // Step 1: Host analyzer produces a manifest from preflight data.
         $analyzer = host_analyzer_for($webhost);
         $manifest = $analyzer->analyze($preflight_data);
+        $this->maybe_enable_remote_upload_proxy($manifest, $preflight_data);
 
         // Step 1b: Merge target database configuration from db-apply state.
         // db-apply persists the target engine and connection details so that
@@ -3655,6 +3656,96 @@ class ImportClient
         foreach ($summary as $line) {
             fwrite(STDERR, "{$line}\n");
         }
+    }
+
+    /**
+     * Enable the temporary remote upload proxy when uploads may still be
+     * missing locally.
+     *
+     * The proxy is active in two cases:
+     * - files-sync is still incomplete
+     * - a prior --filter=essential-files run left skipped uploads on disk
+     */
+    private function maybe_enable_remote_upload_proxy(RuntimeManifest $manifest, array $preflight_data): void
+    {
+        if (!$this->should_enable_remote_upload_proxy()) {
+            return;
+        }
+
+        $base_url = $this->get_remote_upload_proxy_base_url($preflight_data);
+        if ($base_url === null) {
+            $this->audit_log(
+                "APPLY-RUNTIME | remote upload proxy skipped (no source uploads URL available)",
+                true,
+            );
+            return;
+        }
+
+        $manifest->constants["STREAMING_SITE_MIGRATION_REMOTE_UPLOAD_PROXY_BASEURL"] = $base_url;
+        $state_dir = realpath($this->state_dir) ?: $this->state_dir;
+        $manifest->constants["STREAMING_SITE_MIGRATION_REMOTE_UPLOAD_PROXY_STATE_FILE"] =
+            rtrim($state_dir, "/") . "/.import-state.json";
+        $manifest->constants["STREAMING_SITE_MIGRATION_REMOTE_UPLOAD_PROXY_SKIPPED_FILE"] =
+            rtrim($state_dir, "/") . "/.import-download-list-skipped.jsonl";
+        $manifest->routes[] = [
+            "handler" => "remote-upload-proxy",
+            "path_pattern" => "/wp-content/uploads/.*",
+            "condition" => "file_not_found",
+            "description" => "Proxy missing uploads from the source site until files-sync completes",
+        ];
+        $this->audit_log(
+            "APPLY-RUNTIME | enabled remote upload proxy ({$base_url})",
+            true,
+        );
+    }
+
+    /**
+     * Decide whether runtime should proxy missing uploads from the source.
+     *
+     * Once files-sync is fully complete and no skipped uploads remain, the
+     * proxy is disabled so requests are served only from local files.
+     */
+    private function should_enable_remote_upload_proxy(): bool
+    {
+        if (
+            file_exists($this->skipped_download_list_file) &&
+            filesize($this->skipped_download_list_file) > 0
+        ) {
+            return true;
+        }
+
+        if (($this->state["command"] ?? null) !== "files-sync") {
+            return false;
+        }
+
+        $status = $this->state["status"] ?? null;
+        return $status !== null && $status !== "complete";
+    }
+
+    /**
+     * Resolve the source uploads base URL used by the temporary runtime proxy.
+     */
+    private function get_remote_upload_proxy_base_url(array $preflight_data): ?string
+    {
+        $paths_urls = $preflight_data["database"]["wp"]["paths_urls"] ?? [];
+        $uploads_baseurl = $paths_urls["uploads"]["baseurl"] ?? null;
+        if (is_string($uploads_baseurl) && $uploads_baseurl !== "") {
+            return rtrim($uploads_baseurl, "/");
+        }
+
+        $site_urls = [
+            $paths_urls["home_url"] ?? null,
+            $paths_urls["site_url"] ?? null,
+            $preflight_data["database"]["wp"]["home"] ?? null,
+            $preflight_data["database"]["wp"]["siteurl"] ?? null,
+        ];
+        foreach ($site_urls as $site_url) {
+            if (is_string($site_url) && $site_url !== "") {
+                return rtrim($site_url, "/") . "/wp-content/uploads";
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/importer/lib/target-runtime/class-playground-cli-applier.php
+++ b/importer/lib/target-runtime/class-playground-cli-applier.php
@@ -49,6 +49,11 @@ class PlaygroundCliApplier implements RuntimeApplier
         $saved_sqlite = $manifest->sqlite;
         $manifest->sqlite = null;
 
+        // Route handlers that need importer state must use VFS paths inside
+        // Playground. Rewrite those constants and mount the underlying host
+        // files into the VM before we generate runtime.php/start.sh.
+        $extra_mounts = $this->prepare_extra_mounts($manifest);
+
         // 1. Write runtime.php using the VFS path (/wordpress) as fs-root.
         //    Inside Playground, the host's fs-root is mounted at /wordpress,
         //    so all resolved {fs-root} paths must reference /wordpress.
@@ -80,7 +85,15 @@ class PlaygroundCliApplier implements RuntimeApplier
 
         // 3. Write start.sh
         $start_path = $output_dir . '/start.sh';
-        $start_script = $this->generate_start_script($manifest, $fs_root, $output_dir, $runtime_path, $port, $options);
+        $start_script = $this->generate_start_script(
+            $manifest,
+            $fs_root,
+            $output_dir,
+            $runtime_path,
+            $port,
+            $options,
+            $extra_mounts,
+        );
         write_runtime_file($start_path, $start_script);
         chmod($start_path, 0755);
         $summary[] = "Wrote {$start_path}";
@@ -107,6 +120,42 @@ class PlaygroundCliApplier implements RuntimeApplier
             '$schema' => 'https://playground.wordpress.net/blueprint-schema.json',
             'landingPage' => '/',
         ];
+    }
+
+    /**
+     * Rewrite host-side runtime helper files to VFS paths and return the
+     * corresponding Playground mounts.
+     *
+     * Some route handlers need importer metadata produced outside the mounted
+     * WordPress tree, for example the files-sync state used by the temporary
+     * remote uploads proxy. Playground can only see files that are mounted
+     * explicitly, so we map those constants to /tmp paths in the VM.
+     *
+     * @return string[]
+     */
+    private function prepare_extra_mounts(RuntimeManifest $manifest): array
+    {
+        $mounts = [];
+        $runtime_file_mounts = [
+            'STREAMING_SITE_MIGRATION_REMOTE_UPLOAD_PROXY_STATE_FILE'
+                => '/tmp/streaming-site-migration/.import-state.json',
+            'STREAMING_SITE_MIGRATION_REMOTE_UPLOAD_PROXY_SKIPPED_FILE'
+                => '/tmp/streaming-site-migration/.import-download-list-skipped.jsonl',
+        ];
+
+        foreach ($runtime_file_mounts as $constant_name => $vfs_path) {
+            $host_path = $manifest->constants[$constant_name] ?? null;
+            if (!is_string($host_path) || $host_path === '') {
+                continue;
+            }
+
+            $manifest->constants[$constant_name] = $vfs_path;
+            if (file_exists($host_path)) {
+                $mounts[] = $host_path . ':' . $vfs_path;
+            }
+        }
+
+        return $mounts;
     }
 
     /**
@@ -179,7 +228,8 @@ class PlaygroundCliApplier implements RuntimeApplier
         string $output_dir,
         string $runtime_path,
         int $port,
-        array $options
+        array $options,
+        array $extra_mounts = []
     ): string {
         $lines = [];
         $lines[] = '#!/usr/bin/env bash';
@@ -205,6 +255,11 @@ class PlaygroundCliApplier implements RuntimeApplier
         // before other mu-plugins. mu-plugins don't need a Plugin Name
         // header and load on every request.
         $args[] = '--mount=' . escapeshellarg($runtime_path . ':/wordpress/wp-content/mu-plugins/0-playground-runtime.php');
+
+        // Mount additional runtime helper files needed by specific handlers.
+        foreach ($extra_mounts as $mount) {
+            $args[] = '--mount=' . escapeshellarg($mount);
+        }
 
         // The site is already installed — don't run Playground's WordPress
         // installer or download a fresh copy.

--- a/importer/lib/target-runtime/functions.php
+++ b/importer/lib/target-runtime/functions.php
@@ -254,6 +254,9 @@ function generate_route_handler_code(RuntimeManifest $manifest): string
     foreach ($manifest->routes as $route) {
         $handler = $route['handler'] ?? '';
         switch ($handler) {
+            case 'remote-upload-proxy':
+                $code .= remote_upload_proxy_code() . "\n";
+                break;
             case 'wpcloud-thumbnail-generator':
                 $code .= wpcloud_thumbnail_generator_code() . "\n";
                 break;

--- a/importer/lib/target-runtime/load.php
+++ b/importer/lib/target-runtime/load.php
@@ -4,6 +4,7 @@
  */
 
 require_once __DIR__ . '/route-handlers/wpcloud-thumbnail-generator.php';
+require_once __DIR__ . '/route-handlers/remote-upload-proxy.php';
 require_once __DIR__ . '/interface-runtime-applier.php';
 require_once __DIR__ . '/class-nginx-fpm-applier.php';
 require_once __DIR__ . '/class-php-builtin-applier.php';

--- a/importer/lib/target-runtime/route-handlers/remote-upload-proxy.php
+++ b/importer/lib/target-runtime/route-handlers/remote-upload-proxy.php
@@ -1,0 +1,173 @@
+<?php
+/**
+ * Remote upload proxy route handler.
+ *
+ * Returns PHP code that proxies requests for missing uploads to the source
+ * site while file synchronization is still incomplete.
+ */
+function remote_upload_proxy_code(): string
+{
+    return <<<'PHP'
+/**
+ * Proxy missing uploads from the source site until files-sync completes.
+ *
+ * This runs before WordPress boots. If a request under /wp-content/uploads/
+ * is missing locally, it fetches the corresponding source URL with cURL and
+ * relays the response status, headers, and body to the visitor.
+ */
+(function() {
+	if (!defined('STREAMING_SITE_MIGRATION_REMOTE_UPLOAD_PROXY_BASEURL')) return;
+	if (!defined('STREAMING_SITE_MIGRATION_REMOTE_UPLOAD_PROXY_STATE_FILE')) return;
+	if (!defined('STREAMING_SITE_MIGRATION_REMOTE_UPLOAD_PROXY_SKIPPED_FILE')) return;
+	if (!function_exists('curl_init')) return;
+
+	$proxy_enabled = false;
+	$skipped_file = STREAMING_SITE_MIGRATION_REMOTE_UPLOAD_PROXY_SKIPPED_FILE;
+	if (
+		is_string($skipped_file) &&
+		$skipped_file !== '' &&
+		file_exists($skipped_file) &&
+		filesize($skipped_file) > 0
+	) {
+		$proxy_enabled = true;
+	} else {
+		$state_file = STREAMING_SITE_MIGRATION_REMOTE_UPLOAD_PROXY_STATE_FILE;
+		if (
+			is_string($state_file) &&
+			$state_file !== '' &&
+			is_readable($state_file)
+		) {
+			$state = json_decode((string) file_get_contents($state_file), true);
+			if (is_array($state)) {
+				$command = $state['command'] ?? null;
+				$status = $state['status'] ?? null;
+				$proxy_enabled =
+					$command === 'files-sync' &&
+					$status !== null &&
+					$status !== 'complete';
+			}
+		}
+	}
+
+	if (!$proxy_enabled) return;
+
+	$method = strtoupper($_SERVER['REQUEST_METHOD'] ?? 'GET');
+	if ($method !== 'GET' && $method !== 'HEAD') return;
+
+	$uri = $_SERVER['REQUEST_URI'] ?? '';
+	$path = parse_url($uri, PHP_URL_PATH);
+	if (!is_string($path) || $path === '') return;
+
+	if (!preg_match('#/wp-content/uploads/(.+)$#', $path, $matches)) return;
+
+	$content_dir = defined('WP_CONTENT_DIR')
+		? rtrim(WP_CONTENT_DIR, '/')
+		: rtrim($_SERVER['DOCUMENT_ROOT'] ?? '', '/') . '/wp-content';
+	$local_path = $content_dir . '/uploads/' . ltrim($matches[1], '/');
+	if (file_exists($local_path)) return;
+
+	$remote_url = rtrim(STREAMING_SITE_MIGRATION_REMOTE_UPLOAD_PROXY_BASEURL, '/') . '/' . ltrim($matches[1], '/');
+	$query = parse_url($uri, PHP_URL_QUERY);
+	if (is_string($query) && $query !== '') {
+		$remote_url .= '?' . $query;
+	}
+
+	$request_headers = ['Accept-Encoding: identity'];
+	$forwarded_headers = [
+		'HTTP_ACCEPT' => 'Accept',
+		'HTTP_IF_MODIFIED_SINCE' => 'If-Modified-Since',
+		'HTTP_IF_NONE_MATCH' => 'If-None-Match',
+		'HTTP_IF_RANGE' => 'If-Range',
+		'HTTP_RANGE' => 'Range',
+		'HTTP_USER_AGENT' => 'User-Agent',
+	];
+	foreach ($forwarded_headers as $server_key => $header_name) {
+		$value = $_SERVER[$server_key] ?? null;
+		if (is_string($value) && $value !== '') {
+			$request_headers[] = $header_name . ': ' . $value;
+		}
+	}
+
+	$status_code = 502;
+	$response_headers = [];
+	$current_headers = [];
+	$headers_sent_to_client = false;
+	$send_headers = static function() use (&$headers_sent_to_client, &$status_code, &$response_headers) {
+		if ($headers_sent_to_client) {
+			return;
+		}
+		$headers_sent_to_client = true;
+
+		http_response_code($status_code > 0 ? $status_code : 502);
+		foreach ($response_headers as $header_line) {
+			if (preg_match('/^(Connection|Keep-Alive|Proxy-Authenticate|Proxy-Authorization|TE|Trailer|Transfer-Encoding|Upgrade):/i', $header_line)) {
+				continue;
+			}
+			header($header_line, false);
+		}
+	};
+
+	$curl = curl_init($remote_url);
+	if ($curl === false) {
+		return;
+	}
+
+	curl_setopt($curl, CURLOPT_CUSTOMREQUEST, $method);
+	curl_setopt($curl, CURLOPT_FAILONERROR, false);
+	curl_setopt($curl, CURLOPT_FOLLOWLOCATION, false);
+	curl_setopt($curl, CURLOPT_CONNECTTIMEOUT, 10);
+	curl_setopt($curl, CURLOPT_TIMEOUT, 0);
+	curl_setopt($curl, CURLOPT_HTTPHEADER, $request_headers);
+	curl_setopt($curl, CURLOPT_RETURNTRANSFER, false);
+	curl_setopt($curl, CURLOPT_HEADER, false);
+
+	if (defined('CURLPROTO_HTTP') && defined('CURLPROTO_HTTPS')) {
+		curl_setopt($curl, CURLOPT_PROTOCOLS, CURLPROTO_HTTP | CURLPROTO_HTTPS);
+	}
+	if ($method === 'HEAD') {
+		curl_setopt($curl, CURLOPT_NOBODY, true);
+	}
+
+	curl_setopt($curl, CURLOPT_HEADERFUNCTION, static function($ch, $line) use (&$status_code, &$response_headers, &$current_headers) {
+		$length = strlen($line);
+		$trimmed = trim($line);
+
+		if ($trimmed === '') {
+			$response_headers = $current_headers;
+			return $length;
+		}
+
+		if (preg_match('#^HTTP/\S+\s+(\d{3})#', $trimmed, $matches)) {
+			$status_code = (int) $matches[1];
+			$current_headers = [];
+			return $length;
+		}
+
+		$current_headers[] = $trimmed;
+		return $length;
+	});
+
+	curl_setopt($curl, CURLOPT_WRITEFUNCTION, static function($ch, $chunk) use ($send_headers) {
+		$send_headers();
+		echo $chunk;
+		flush();
+		return strlen($chunk);
+	});
+
+	$ok = curl_exec($curl);
+	if ($ok === false) {
+		if (!headers_sent()) {
+			http_response_code(502);
+			header('Content-Type: text/plain; charset=UTF-8');
+		}
+		echo "Remote upload proxy failed.";
+		curl_close($curl);
+		exit;
+	}
+
+	curl_close($curl);
+	$send_headers();
+	exit;
+})();
+PHP;
+}

--- a/tests/Import/PlaygroundRemoteUploadProxyRuntimeTest.php
+++ b/tests/Import/PlaygroundRemoteUploadProxyRuntimeTest.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace ImportTests;
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../importer/lib/host/class-runtime-manifest.php';
+require_once __DIR__ . '/../../importer/lib/target-runtime/load.php';
+
+class PlaygroundRemoteUploadProxyRuntimeTest extends TestCase
+{
+    private $tempDir;
+    private $fsRoot;
+    private $outputDir;
+    private $stateFile;
+    private $skippedFile;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->tempDir = sys_get_temp_dir() . '/playground-remote-upload-proxy-' . uniqid();
+        $this->fsRoot = $this->tempDir . '/fs-root';
+        $this->outputDir = $this->tempDir . '/runtime';
+        $stateDir = $this->tempDir . '/state';
+
+        mkdir($this->fsRoot, 0755, true);
+        mkdir($this->outputDir, 0755, true);
+        mkdir($stateDir, 0755, true);
+
+        file_put_contents($this->fsRoot . '/index.php', "<?php echo 'ok';\n");
+        $this->stateFile = $stateDir . '/.import-state.json';
+        $this->skippedFile = $stateDir . '/.import-download-list-skipped.jsonl';
+        file_put_contents($this->stateFile, "{\"command\":\"files-sync\",\"status\":\"partial\"}\n");
+        file_put_contents($this->skippedFile, "{\"path\":\"/wp-content/uploads/test.jpg\"}\n");
+    }
+
+    protected function tearDown(): void
+    {
+        $this->recursiveDelete($this->tempDir);
+        parent::tearDown();
+    }
+
+    private function recursiveDelete(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+
+        foreach (scandir($dir) as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+
+            $path = $dir . '/' . $item;
+            if (is_link($path) || is_file($path)) {
+                unlink($path);
+                continue;
+            }
+
+            if (is_dir($path)) {
+                $this->recursiveDelete($path);
+            }
+        }
+
+        rmdir($dir);
+    }
+
+    public function testPlaygroundMountsProxyStateFilesIntoVfs(): void
+    {
+        $manifest = new \RuntimeManifest('other');
+        $manifest->constants['STREAMING_SITE_MIGRATION_REMOTE_UPLOAD_PROXY_BASEURL'] =
+            'https://source.example/wp-content/uploads';
+        $manifest->constants['STREAMING_SITE_MIGRATION_REMOTE_UPLOAD_PROXY_STATE_FILE'] =
+            $this->stateFile;
+        $manifest->constants['STREAMING_SITE_MIGRATION_REMOTE_UPLOAD_PROXY_SKIPPED_FILE'] =
+            $this->skippedFile;
+        $manifest->routes[] = [
+            'handler' => 'remote-upload-proxy',
+            'path_pattern' => '/wp-content/uploads/.*',
+            'condition' => 'file_not_found',
+            'description' => 'Proxy missing uploads',
+        ];
+
+        $applier = new \PlaygroundCliApplier();
+        $applier->apply($manifest, $this->fsRoot, $this->outputDir, [
+            'port' => 9400,
+            'wordpress_index' => $this->fsRoot . '/index.php',
+        ]);
+
+        $runtime = file_get_contents($this->outputDir . '/runtime.php');
+        $startSh = file_get_contents($this->outputDir . '/start.sh');
+
+        $this->assertStringContainsString(
+            "/tmp/streaming-site-migration/.import-state.json",
+            $runtime,
+        );
+        $this->assertStringContainsString(
+            "/tmp/streaming-site-migration/.import-download-list-skipped.jsonl",
+            $runtime,
+        );
+        $this->assertStringNotContainsString($this->stateFile, $runtime);
+        $this->assertStringContainsString(
+            "--mount='" . $this->stateFile . ":/tmp/streaming-site-migration/.import-state.json'",
+            $startSh,
+        );
+        $this->assertStringContainsString(
+            "--mount='" . $this->skippedFile . ":/tmp/streaming-site-migration/.import-download-list-skipped.jsonl'",
+            $startSh,
+        );
+    }
+}

--- a/tests/Import/RemoteUploadProxyRuntimeTest.php
+++ b/tests/Import/RemoteUploadProxyRuntimeTest.php
@@ -1,0 +1,232 @@
+<?php
+
+namespace ImportTests;
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../importer/import.php';
+
+class RemoteUploadProxyRuntimeTest extends TestCase
+{
+    private $tempDir;
+    private $stateDir;
+    private $fsRoot;
+    private $outputDir;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->tempDir = sys_get_temp_dir() . '/remote-upload-proxy-test-' . uniqid();
+        $this->stateDir = $this->tempDir . '/state';
+        $this->fsRoot = $this->tempDir . '/fs-root';
+        $this->outputDir = $this->tempDir . '/runtime';
+
+        mkdir($this->stateDir, 0755, true);
+        mkdir($this->fsRoot, 0755, true);
+        file_put_contents($this->fsRoot . '/index.php', "<?php echo 'ok';\n");
+    }
+
+    protected function tearDown(): void
+    {
+        $this->recursiveDelete($this->tempDir);
+        parent::tearDown();
+    }
+
+    private function recursiveDelete(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+
+        foreach (scandir($dir) as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+
+            $path = $dir . '/' . $item;
+            if (is_link($path) || is_file($path)) {
+                unlink($path);
+                continue;
+            }
+
+            if (is_dir($path)) {
+                $this->recursiveDelete($path);
+            }
+        }
+
+        rmdir($dir);
+    }
+
+    private function writeState(array $state): void
+    {
+        $defaults = [
+            'command' => null,
+            'status' => null,
+            'cursor' => null,
+            'stage' => null,
+            'preflight' => [
+                'http_code' => 200,
+                'data' => [
+                    'runtime' => [
+                        'document_root' => '',
+                    ],
+                    'database' => [
+                        'wp' => [
+                            'siteurl' => 'https://source.example',
+                            'home' => 'https://source.example',
+                            'paths_urls' => [
+                                'abspath' => $this->fsRoot,
+                                'uploads' => [
+                                    'baseurl' => 'https://source.example/wp-content/uploads',
+                                ],
+                                'home_url' => 'https://source.example',
+                                'site_url' => 'https://source.example',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            'webhost' => 'other',
+            'follow_symlinks' => false,
+            'fs_root_nonempty_behavior' => 'error',
+            'filter' => 'none',
+            'max_allowed_packet' => null,
+        ];
+
+        file_put_contents(
+            $this->stateDir . '/.import-state.json',
+            json_encode(array_replace_recursive($defaults, $state), JSON_PRETTY_PRINT),
+        );
+    }
+
+    private function makeClient(): \ImportClient
+    {
+        return new \ImportClient('https://source.example/export.php', $this->stateDir, $this->fsRoot);
+    }
+
+    private function callPrivate(\ImportClient $client, string $method, array $args = [])
+    {
+        $reflection = new \ReflectionClass($client);
+        $method_reflection = $reflection->getMethod($method);
+        return $method_reflection->invoke($client, ...$args);
+    }
+
+    private function setPrivate(\ImportClient $client, string $property, $value): void
+    {
+        $reflection = new \ReflectionClass($client);
+        $property_reflection = $reflection->getProperty($property);
+        $property_reflection->setValue($client, $value);
+    }
+
+    private function loadClientState(\ImportClient $client): void
+    {
+        $state = $this->callPrivate($client, 'load_state');
+        $this->setPrivate($client, 'state', $state);
+    }
+
+    private function runApplyRuntime(\ImportClient $client): string
+    {
+        ob_start();
+        try {
+            $this->callPrivate($client, 'run_apply_runtime', [[
+                'runtime' => 'php-builtin',
+                'output_dir' => $this->outputDir,
+                'flat_document_root' => $this->fsRoot,
+            ]]);
+        } finally {
+            ob_end_clean();
+        }
+
+        return file_get_contents($this->outputDir . '/runtime.php');
+    }
+
+    public function testApplyRuntimeAddsProxyWhenSkippedUploadsRemain(): void
+    {
+        $this->writeState([
+            'command' => 'db-apply',
+            'status' => 'complete',
+            'filter' => 'essential-files',
+        ]);
+        file_put_contents(
+            $this->stateDir . '/.import-download-list-skipped.jsonl',
+            json_encode(['path' => '/wp-content/uploads/2024/01/photo.jpg']) . "\n",
+        );
+
+        $client = $this->makeClient();
+        $this->loadClientState($client);
+        $runtime = $this->runApplyRuntime($client);
+
+        $this->assertStringContainsString(
+            "STREAMING_SITE_MIGRATION_REMOTE_UPLOAD_PROXY_BASEURL",
+            $runtime,
+        );
+        $this->assertStringContainsString(
+            "STREAMING_SITE_MIGRATION_REMOTE_UPLOAD_PROXY_STATE_FILE",
+            $runtime,
+        );
+        $this->assertStringContainsString(
+            "STREAMING_SITE_MIGRATION_REMOTE_UPLOAD_PROXY_SKIPPED_FILE",
+            $runtime,
+        );
+        $this->assertStringContainsString(
+            "https://source.example/wp-content/uploads",
+            $runtime,
+        );
+        $this->assertStringContainsString(
+            "Remote upload proxy failed.",
+            $runtime,
+        );
+    }
+
+    public function testApplyRuntimeAddsProxyWhileFilesSyncIsIncomplete(): void
+    {
+        $this->writeState([
+            'command' => 'files-sync',
+            'status' => 'partial',
+            'stage' => 'fetch',
+        ]);
+
+        $client = $this->makeClient();
+        $this->loadClientState($client);
+        $runtime = $this->runApplyRuntime($client);
+
+        $this->assertStringContainsString(
+            "STREAMING_SITE_MIGRATION_REMOTE_UPLOAD_PROXY_BASEURL",
+            $runtime,
+        );
+        $this->assertStringContainsString(
+            "STREAMING_SITE_MIGRATION_REMOTE_UPLOAD_PROXY_STATE_FILE",
+            $runtime,
+        );
+        $this->assertStringContainsString(
+            "Proxy missing uploads from the source site until files-sync completes.",
+            $runtime,
+        );
+    }
+
+    public function testApplyRuntimeOmitsProxyAfterFilesSyncCompletes(): void
+    {
+        $this->writeState([
+            'command' => 'files-sync',
+            'status' => 'complete',
+            'filter' => 'none',
+        ]);
+
+        $client = $this->makeClient();
+        $this->loadClientState($client);
+        $runtime = $this->runApplyRuntime($client);
+
+        $this->assertStringNotContainsString(
+            "STREAMING_SITE_MIGRATION_REMOTE_UPLOAD_PROXY_BASEURL",
+            $runtime,
+        );
+        $this->assertStringNotContainsString(
+            "STREAMING_SITE_MIGRATION_REMOTE_UPLOAD_PROXY_STATE_FILE",
+            $runtime,
+        );
+        $this->assertStringNotContainsString(
+            "Remote upload proxy failed.",
+            $runtime,
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- add a runtime route handler that proxies missing `/wp-content/uploads/` files from the source site with cURL
- enable that handler from `apply-runtime` only while uploads may still be missing, using importer state and skipped-upload metadata
- add focused runtime tests covering enabled and disabled proxy generation

## Verification

Import a site from wp.com, configure a runtime, start a server, confirm that there are no local uploads but the images are still loading.
