### PR TITLE
Make Site Export API configurable

### DIFF
--- a/tests/e2e/site-registry.json
+++ b/tests/e2e/site-registry.json
@@ -34,6 +34,7 @@
     "preserve-local":    { "port": 8107 },
     "url-rewriting":     { "port": 8108 },
     "wpcloud-flatten":   { "port": 8109 },
-    "defer-uploads":     { "port": 8110 }
+    "defer-uploads":     { "port": 8110 },
+    "custom-api-auth":   { "port": 8111 }
   }
 }

--- a/tests/e2e/tests/import-42-custom-api-auth.test.js
+++ b/tests/e2e/tests/import-42-custom-api-auth.test.js
@@ -24,11 +24,6 @@ describe('Import: Custom Site Export route and auth', () => {
                 writeFileSync(
                     join(muPluginsDir, 'site-export-custom-auth.php'),
                     `<?php
-add_filter('site_export_is_api_request', function ($is_api_request) {
-    $path = parse_url($_SERVER['REQUEST_URI'] ?? '', PHP_URL_PATH);
-    return $path === '/wp/v2/streaming-export';
-}, 10, 1);
-
 add_filter('site_export_api_url', function () {
     return home_url('/wp/v2/streaming-export');
 });

--- a/tests/e2e/tests/import-42-custom-api-auth.test.js
+++ b/tests/e2e/tests/import-42-custom-api-auth.test.js
@@ -1,0 +1,118 @@
+/**
+ * Test 42: Custom Site Export route and authorization.
+ *
+ * Verifies that the Site Export plugin can:
+ * - move the API off the default `?site-export-api` query arg
+ * - authorize requests via a custom callback instead of HMAC
+ */
+import { describe, it, beforeAll } from 'vitest';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { ensureSite } from '../lib/site-setup.js';
+import { getSiteDir, getSiteUrl } from '../lib/test-helpers.js';
+
+describe('Import: Custom Site Export route and auth', () => {
+    const site = 'custom-api-auth';
+
+    beforeAll(async () => {
+        await ensureSite(site, {
+            afterCreate: async (siteDir) => {
+                const muPluginsDir = join(siteDir, 'wp-content', 'mu-plugins');
+                mkdirSync(muPluginsDir, { recursive: true });
+                writeFileSync(
+                    join(muPluginsDir, 'site-export-custom-auth.php'),
+                    `<?php
+add_filter('site_export_is_api_request', function ($is_api_request) {
+    $path = parse_url($_SERVER['REQUEST_URI'] ?? '', PHP_URL_PATH);
+    return $path === '/wp/v2/streaming-export';
+}, 10, 1);
+
+add_filter('site_export_api_url', function () {
+    return home_url('/wp/v2/streaming-export');
+});
+
+add_filter('site_export_authorization_callback', function () {
+    return 'site_export_test_authorize_super_admin';
+});
+
+function site_export_test_authorize_super_admin() {
+    require_once ABSPATH . WPINC . '/pluggable.php';
+
+    if (is_super_admin()) {
+        return null;
+    }
+
+    return 'Current user is not a super admin.';
+}
+`
+                );
+            },
+        });
+    });
+
+    function customApiUrl() {
+        return new URL('/wp/v2/streaming-export', new URL(getSiteUrl(site)).origin);
+    }
+
+    function createAdminCookie() {
+        const allowRoot = process.getuid?.() === 0 ? ['--allow-root'] : [];
+        const output = execFileSync(
+            'php',
+            [
+                '/tmp/wp-cli.phar',
+                'eval',
+                'echo LOGGED_IN_COOKIE . "=" . wp_generate_auth_cookie(get_user_by("login", "admin")->ID, time() + 3600, "logged_in");',
+                `--path=${getSiteDir(site)}`,
+                ...allowRoot,
+            ],
+            { encoding: 'utf8' }
+        );
+
+        return output.trim();
+    }
+
+    async function preflightRequest(headers = {}) {
+        const url = customApiUrl();
+        url.searchParams.set('endpoint', 'preflight');
+        url.searchParams.set('directory', getSiteDir(site));
+
+        const response = await fetch(url, { headers });
+        const contentType = response.headers.get('content-type') || '';
+
+        return {
+            status: response.status,
+            contentType,
+            body: contentType.includes('application/json')
+                ? await response.json()
+                : await response.text(),
+        };
+    }
+
+    it('does not treat the default query-arg route as the export API anymore', async () => {
+        const response = await fetch(`${getSiteUrl(site)}&endpoint=preflight&directory=${encodeURIComponent(getSiteDir(site))}`);
+        const contentType = response.headers.get('content-type') || '';
+        const body = await response.text();
+
+        assert.equal(response.status, 200, `Expected 200 homepage response, got ${response.status}`);
+        assert.ok(contentType.includes('text/html'), `Expected HTML response, got ${contentType}`);
+        assert.match(body, /custom-api-auth/i, 'Expected the normal site homepage, not the export API');
+    });
+
+    it('rejects unauthenticated requests on the custom route', async () => {
+        const response = await preflightRequest();
+
+        assert.equal(response.status, 403, `Expected 403, got ${response.status}`);
+        assert.equal(response.body.error, 'Current user is not a super admin.');
+    });
+
+    it('allows requests from a super admin on the custom route', async () => {
+        const response = await preflightRequest({
+            Cookie: createAdminCookie(),
+        });
+
+        assert.equal(response.status, 200, `Expected 200, got ${response.status}`);
+        assert.equal(response.body.ok, true, `Expected ok=true, got ${JSON.stringify(response.body)}`);
+    });
+});

--- a/wordpress-plugin/README.md
+++ b/wordpress-plugin/README.md
@@ -8,7 +8,7 @@ Many shared hosts (SiteGround, GoDaddy, etc.) block direct PHP execution inside 
 
 The plugin file (`index.php`) is `include`'d by WordPress during its plugin loading loop — this happens *before* the `plugins_loaded` hook fires, making it the earliest interception point available to a regular plugin.
 
-When a request arrives at `https://example.com/?site-export-api`, the plugin:
+By default, when a request arrives at `https://example.com/?site-export-api`, the plugin:
 
 1. Detects `$_GET['site-export-api']` during plugin file load
 2. Reverts WordPress error display settings (`display_errors`, `html_errors`) that `wp_debug_mode()` may have turned on
@@ -17,3 +17,48 @@ When a request arrives at `https://example.com/?site-export-api`, the plugin:
 5. Calls `exit` — WordPress never finishes booting
 
 This gives us a clean execution environment while using WordPress's front controller as the entry point.
+
+## Configuration Filters
+
+The plugin keeps the current behavior by default, but key integration points are filterable:
+
+- `site_export_api_query_arg`
+  Changes the default front-controller query arg. Default: `site-export-api`.
+- `site_export_is_api_request`
+  Overrides request matching entirely. Use this when the API should live on a custom path instead of a query arg.
+- `site_export_api_url`
+  Controls the endpoint URL shown in the admin UI.
+- `site_export_authorization_callback`
+  Replaces the built-in secret-file + HMAC authorization callback.
+- `site_export_secret_file`
+  Changes the file path used by the built-in secret-based authorization flow.
+- `site_export_enable_ui`
+  Enables or disables all Site Export admin UI additions. By default, the UI is only enabled when using the built-in secret/HMAC flow.
+
+Route matching and request authorization happen during plugin load, before `plugins_loaded`. If you need to override those pieces for live API requests, register the relevant filters from an MU-plugin or another plugin that loads before Site Export.
+
+Example:
+
+```php
+add_filter('site_export_api_query_arg', function () {
+    return 'my-export-api';
+});
+
+add_filter('site_export_api_url', function () {
+    return home_url('/api/site-export');
+});
+
+add_filter('site_export_authorization_callback', function () {
+    return 'my_site_export_authorize_request';
+});
+
+add_filter('site_export_enable_ui', '__return_false');
+
+function my_site_export_authorize_request(array $context) {
+    if (!empty($_SERVER['HTTP_X_INTERNAL_TOKEN'])) {
+        return null;
+    }
+
+    return 'Missing internal authorization token.';
+}
+```

--- a/wordpress-plugin/README.md
+++ b/wordpress-plugin/README.md
@@ -22,16 +22,12 @@ This gives us a clean execution environment while using WordPress's front contro
 
 The plugin keeps the current behavior by default, but key integration points are filterable:
 
-- `site_export_api_query_arg`
-  Changes the default front-controller query arg. Default: `site-export-api`.
-- `site_export_is_api_request`
-  Overrides request matching entirely. Use this when the API should live on a custom path instead of a query arg.
 - `site_export_api_url`
-  Controls the endpoint URL shown in the admin UI.
+  Controls both the endpoint URL shown in the admin UI and the default request matching logic. Default: `https://example.com/?site-export-api`.
+- `site_export_is_api_request`
+  Overrides request matching entirely when URL-based matching is not enough.
 - `site_export_authorization_callback`
   Replaces the built-in secret-file + HMAC authorization callback.
-- `site_export_secret_file`
-  Changes the file path used by the built-in secret-based authorization flow.
 - `site_export_enable_ui`
   Enables or disables all Site Export admin UI additions. By default, the UI is only enabled when using the built-in secret/HMAC flow.
 
@@ -40,10 +36,6 @@ Route matching and request authorization happen during plugin load, before `plug
 Example:
 
 ```php
-add_filter('site_export_api_query_arg', function () {
-    return 'my-export-api';
-});
-
 add_filter('site_export_api_url', function () {
     return home_url('/api/site-export');
 });

--- a/wordpress-plugin/index.php
+++ b/wordpress-plugin/index.php
@@ -23,10 +23,97 @@ define('SITE_EXPORT_SECRET_FILE', SITE_EXPORT_PLUGIN_DIR . 'secret.php');
  */
 define('SITE_EXPORT_TIMESTAMP_TOLERANCE', 300);
 
+/**
+ * Get the query arg name used by the default front-controller route.
+ */
+function _site_export_get_api_query_arg(): string {
+    $query_arg = apply_filters('site_export_api_query_arg', 'site-export-api');
+
+    if (!is_string($query_arg) || $query_arg === '') {
+        return 'site-export-api';
+    }
+
+    return $query_arg;
+}
+
+/**
+ * Determine whether the current request should be handled by the export API.
+ */
+function _site_export_is_api_request(): bool {
+    $query_arg = _site_export_get_api_query_arg();
+    $is_api_request = isset($_GET[$query_arg]);
+
+    return (bool) apply_filters('site_export_is_api_request', $is_api_request, $query_arg);
+}
+
+/**
+ * Get the API URL shown in the admin UI.
+ */
+function _site_export_get_api_url(): string {
+    $query_arg = _site_export_get_api_query_arg();
+    $api_url = home_url('/?' . rawurlencode($query_arg));
+    $filtered_url = apply_filters('site_export_api_url', $api_url, $query_arg);
+
+    if (!is_string($filtered_url) || $filtered_url === '') {
+        return $api_url;
+    }
+
+    return $filtered_url;
+}
+
+/**
+ * Get the path to the shared secret file.
+ */
+function _site_export_get_secret_file(): string {
+    $secret_file = apply_filters('site_export_secret_file', SITE_EXPORT_SECRET_FILE);
+
+    if (!is_string($secret_file) || $secret_file === '') {
+        return SITE_EXPORT_SECRET_FILE;
+    }
+
+    return $secret_file;
+}
+
+/**
+ * Get the request authorization callback.
+ *
+ * The callback must return:
+ * - null or true on success
+ * - a string or WP_Error on failure
+ */
+function _site_export_get_authorization_callback() {
+    $default_callback = '_site_export_authorize_request_with_secret';
+    $callback = apply_filters('site_export_authorization_callback', $default_callback);
+
+    if (!is_callable($callback)) {
+        return $default_callback;
+    }
+
+    return $callback;
+}
+
+/**
+ * Check whether the plugin is using its default secret-based authorization.
+ */
+function _site_export_uses_default_secret_authorization(): bool {
+    return _site_export_get_authorization_callback() === '_site_export_authorize_request_with_secret';
+}
+
+/**
+ * Determine whether the admin UI should be registered.
+ *
+ * By default, the UI is enabled only for the built-in secret/HMAC flow.
+ */
+function _site_export_is_ui_enabled(): bool {
+    $enabled = _site_export_uses_default_secret_authorization();
+
+    return (bool) apply_filters('site_export_enable_ui', $enabled);
+}
+
 // Intercept export API requests as early as possible.
 // WordPress loads plugin files before firing `plugins_loaded`,
 // so this runs before almost anything else in the WordPress stack.
-if (isset($_GET['site-export-api'])) {
+if (_site_export_is_api_request()) {
     _site_export_handle_api_request();
     exit;
 }
@@ -102,17 +189,7 @@ function _site_export_handle_api_request(): void {
     });
 
     // -- Authenticate --
-    $secret_file = SITE_EXPORT_SECRET_FILE;
-    if (!file_exists($secret_file)) {
-        _site_export_error(503, 'Export not configured. Please configure the shared secret in WordPress admin under Tools > Site Export.');
-    }
-
-    $secret = require $secret_file;
-    if (empty($secret) || !is_string($secret)) {
-        _site_export_error(503, 'Invalid secret configuration. Please reconfigure in WordPress admin.');
-    }
-
-    $auth_error = _site_export_verify_hmac($secret);
+    $auth_error = _site_export_authorize_request();
     if ($auth_error !== null) {
         _site_export_error(403, $auth_error);
     }
@@ -239,6 +316,59 @@ function _site_export_error(int $code, string $message): void {
     header('Content-Type: application/json');
     echo json_encode(['error' => $message, 'code' => $code]);
     exit;
+}
+
+/**
+ * Authorize the current request using the configured callback.
+ */
+function _site_export_authorize_request(): ?string {
+    $callback = _site_export_get_authorization_callback();
+    $result = call_user_func($callback, [
+        'secret_file' => _site_export_get_secret_file(),
+        'request_method' => $_SERVER['REQUEST_METHOD'] ?? 'GET',
+    ]);
+
+    if ($result === null || $result === true) {
+        return null;
+    }
+
+    if ($result instanceof WP_Error) {
+        return $result->get_error_message();
+    }
+
+    if (is_string($result) && $result !== '') {
+        return $result;
+    }
+
+    if ($result === false) {
+        return 'Authorization failed.';
+    }
+
+    return 'Invalid Site Export authorization result.';
+}
+
+/**
+ * Default authorization callback using the shared secret file and HMAC.
+ *
+ * @param array<string, mixed> $context Request context.
+ */
+function _site_export_authorize_request_with_secret(array $context): ?string {
+    $secret_file = $context['secret_file'] ?? _site_export_get_secret_file();
+
+    if (!is_string($secret_file) || $secret_file === '') {
+        $secret_file = _site_export_get_secret_file();
+    }
+
+    if (!file_exists($secret_file)) {
+        return 'Export not configured. Please configure the shared secret in WordPress admin under Tools > Site Export.';
+    }
+
+    $secret = require $secret_file;
+    if (empty($secret) || !is_string($secret)) {
+        return 'Invalid secret configuration. Please reconfigure in WordPress admin.';
+    }
+
+    return _site_export_verify_hmac($secret);
 }
 
 /**

--- a/wordpress-plugin/index.php
+++ b/wordpress-plugin/index.php
@@ -24,54 +24,17 @@ define('SITE_EXPORT_SECRET_FILE', SITE_EXPORT_PLUGIN_DIR . 'secret.php');
 define('SITE_EXPORT_TIMESTAMP_TOLERANCE', 300);
 
 /**
- * Get the query arg name used by the default front-controller route.
- */
-function _site_export_get_api_query_arg(): string {
-    $query_arg = apply_filters('site_export_api_query_arg', 'site-export-api');
-
-    if (!is_string($query_arg) || $query_arg === '') {
-        return 'site-export-api';
-    }
-
-    return $query_arg;
-}
-
-/**
- * Determine whether the current request should be handled by the export API.
- */
-function _site_export_is_api_request(): bool {
-    $query_arg = _site_export_get_api_query_arg();
-    $is_api_request = isset($_GET[$query_arg]);
-
-    return (bool) apply_filters('site_export_is_api_request', $is_api_request, $query_arg);
-}
-
-/**
  * Get the API URL shown in the admin UI.
  */
 function _site_export_get_api_url(): string {
-    $query_arg = _site_export_get_api_query_arg();
-    $api_url = home_url('/?' . rawurlencode($query_arg));
-    $filtered_url = apply_filters('site_export_api_url', $api_url, $query_arg);
+    $api_url = home_url('/?site-export-api');
+    $filtered_url = apply_filters('site_export_api_url', $api_url);
 
     if (!is_string($filtered_url) || $filtered_url === '') {
         return $api_url;
     }
 
     return $filtered_url;
-}
-
-/**
- * Get the path to the shared secret file.
- */
-function _site_export_get_secret_file(): string {
-    $secret_file = apply_filters('site_export_secret_file', SITE_EXPORT_SECRET_FILE);
-
-    if (!is_string($secret_file) || $secret_file === '') {
-        return SITE_EXPORT_SECRET_FILE;
-    }
-
-    return $secret_file;
 }
 
 /**
@@ -108,6 +71,54 @@ function _site_export_is_ui_enabled(): bool {
     $enabled = _site_export_uses_default_secret_authorization();
 
     return (bool) apply_filters('site_export_enable_ui', $enabled);
+}
+
+/**
+ * Determine whether the current request matches the configured API URL.
+ */
+function _site_export_request_matches_api_url(string $api_url): bool {
+    $api_parts = wp_parse_url($api_url);
+    if (!is_array($api_parts)) {
+        return false;
+    }
+
+    $request_uri = $_SERVER['REQUEST_URI'] ?? '';
+    $request_parts = wp_parse_url($request_uri);
+    if (!is_array($request_parts)) {
+        return false;
+    }
+
+    $api_path = $api_parts['path'] ?? '/';
+    $request_path = $request_parts['path'] ?? '/';
+    if (untrailingslashit($request_path) !== untrailingslashit($api_path)) {
+        return false;
+    }
+
+    $api_query = [];
+    parse_str($api_parts['query'] ?? '', $api_query);
+
+    foreach ($api_query as $key => $value) {
+        if (!array_key_exists($key, $_GET)) {
+            return false;
+        }
+
+        $request_value = $_GET[$key];
+        if ($value !== '' && (string) $request_value !== (string) $value) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+/**
+ * Determine whether the current request should be handled by the export API.
+ */
+function _site_export_is_api_request(): bool {
+    $api_url = _site_export_get_api_url();
+    $is_api_request = _site_export_request_matches_api_url($api_url);
+
+    return (bool) apply_filters('site_export_is_api_request', $is_api_request, $api_url);
 }
 
 // Intercept export API requests as early as possible.
@@ -324,7 +335,6 @@ function _site_export_error(int $code, string $message): void {
 function _site_export_authorize_request(): ?string {
     $callback = _site_export_get_authorization_callback();
     $result = call_user_func($callback, [
-        'secret_file' => _site_export_get_secret_file(),
         'request_method' => $_SERVER['REQUEST_METHOD'] ?? 'GET',
     ]);
 
@@ -353,17 +363,11 @@ function _site_export_authorize_request(): ?string {
  * @param array<string, mixed> $context Request context.
  */
 function _site_export_authorize_request_with_secret(array $context): ?string {
-    $secret_file = $context['secret_file'] ?? _site_export_get_secret_file();
-
-    if (!is_string($secret_file) || $secret_file === '') {
-        $secret_file = _site_export_get_secret_file();
-    }
-
-    if (!file_exists($secret_file)) {
+    if (!file_exists(SITE_EXPORT_SECRET_FILE)) {
         return 'Export not configured. Please configure the shared secret in WordPress admin under Tools > Site Export.';
     }
 
-    $secret = require $secret_file;
+    $secret = require SITE_EXPORT_SECRET_FILE;
     if (empty($secret) || !is_string($secret)) {
         return 'Invalid secret configuration. Please reconfigure in WordPress admin.';
     }

--- a/wordpress-plugin/wordpress/site-export.php
+++ b/wordpress-plugin/wordpress/site-export.php
@@ -3,8 +3,9 @@
  * Admin interface for Site Export plugin.
  *
  * This plugin provides a WordPress admin UI for configuring the export API.
- * The export API is triggered via `?site-export-api` during plugin load,
- * before WordPress finishes booting. It reads the secret from secret.php.
+ * By default, the export API is triggered via `?site-export-api` during
+ * plugin load, before WordPress finishes booting. It reads the secret from
+ * secret.php.
  *
  * Authentication uses HMAC signatures: the importing side generates a secret,
  * the user enters it here, and all requests must include a valid signature
@@ -119,12 +120,13 @@ class Site_Export_Plugin {
         $content .= " */\n";
         $content .= "return " . var_export($secret, true) . ";\n";
 
-        $result = file_put_contents(SITE_EXPORT_SECRET_FILE, $content);
+        $secret_file = _site_export_get_secret_file();
+        $result = file_put_contents($secret_file, $content);
 
         if ($result === false) {
             return new WP_Error(
                 'write_failed',
-                'Could not write to ' . SITE_EXPORT_SECRET_FILE . '. Check file permissions.'
+                'Could not write to ' . $secret_file . '. Check file permissions.'
             );
         }
 
@@ -137,11 +139,13 @@ class Site_Export_Plugin {
      * @return string
      */
     private function load_secret(): string {
-        if (!file_exists(SITE_EXPORT_SECRET_FILE)) {
+        $secret_file = _site_export_get_secret_file();
+
+        if (!file_exists($secret_file)) {
             return '';
         }
 
-        $secret = require SITE_EXPORT_SECRET_FILE;
+        $secret = require $secret_file;
         return is_string($secret) ? $secret : '';
     }
 
@@ -154,7 +158,7 @@ class Site_Export_Plugin {
         }
 
         $secret = $this->load_secret();
-        $api_url = home_url('?site-export-api');
+        $api_url = _site_export_get_api_url();
         $is_configured = !empty($secret);
 
         ?>
@@ -359,13 +363,17 @@ class Site_Export_Plugin {
 
 // Initialize
 add_action('plugins_loaded', function() {
+    if (!_site_export_is_ui_enabled()) {
+        return;
+    }
+
     Site_Export_Plugin::get_instance();
 });
 
 // On activation: set a transient so we can redirect on the next admin page load.
 register_activation_hook(SITE_EXPORT_PLUGIN_DIR . 'index.php', function() {
     // Only redirect when activated through the admin UI (not via WP-CLI or bulk).
-    if (!wp_doing_ajax() && is_admin()) {
+    if (_site_export_is_ui_enabled() && !wp_doing_ajax() && is_admin()) {
         set_transient('site_export_activated', 1, 30);
     }
 
@@ -377,6 +385,11 @@ register_activation_hook(SITE_EXPORT_PLUGIN_DIR . 'index.php', function() {
 
 // Redirect to settings page after activation.
 add_action('admin_init', function() {
+    if (!_site_export_is_ui_enabled()) {
+        delete_transient('site_export_activated');
+        return;
+    }
+
     if (get_transient('site_export_activated')) {
         delete_transient('site_export_activated');
         if (!isset($_GET['activate-multi'])) {

--- a/wordpress-plugin/wordpress/site-export.php
+++ b/wordpress-plugin/wordpress/site-export.php
@@ -120,13 +120,12 @@ class Site_Export_Plugin {
         $content .= " */\n";
         $content .= "return " . var_export($secret, true) . ";\n";
 
-        $secret_file = _site_export_get_secret_file();
-        $result = file_put_contents($secret_file, $content);
+        $result = file_put_contents(SITE_EXPORT_SECRET_FILE, $content);
 
         if ($result === false) {
             return new WP_Error(
                 'write_failed',
-                'Could not write to ' . $secret_file . '. Check file permissions.'
+                'Could not write to ' . SITE_EXPORT_SECRET_FILE . '. Check file permissions.'
             );
         }
 
@@ -139,13 +138,11 @@ class Site_Export_Plugin {
      * @return string
      */
     private function load_secret(): string {
-        $secret_file = _site_export_get_secret_file();
-
-        if (!file_exists($secret_file)) {
+        if (!file_exists(SITE_EXPORT_SECRET_FILE)) {
             return '';
         }
 
-        $secret = require $secret_file;
+        $secret = require SITE_EXPORT_SECRET_FILE;
         return is_string($secret) ? $secret : '';
     }
 


### PR DESCRIPTION
## Summary
- make the Site Export API route configurable through filters while keeping `?site-export-api` as the default
- make request authorization pluggable through a filterable callback, while keeping the secret-file HMAC flow as the default
- make all Site Export admin UI additions easy to disable, and default them off when using a non-default auth flow

## Testing
- `php -l wordpress-plugin/index.php`
- `php -l wordpress-plugin/wordpress/site-export.php`
