### PR TITLE
Rename Composer packages to wp-php-toolkit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "wordpress/streaming-site-migration",
+    "name": "wp-php-toolkit/streaming-site-migration",
     "description": "Monorepo for the streaming importer, exporter, and release artifacts",
     "type": "project",
     "license": "GPL-2.0-or-later",
@@ -25,8 +25,8 @@
         "php": ">=7.4",
         "ext-pdo": "*",
         "ext-pdo_mysql": "*",
-        "wordpress/streaming-exporter": "*@dev",
-        "wordpress/streaming-importer": "*@dev"
+        "wp-php-toolkit/streaming-exporter": "*@dev",
+        "wp-php-toolkit/streaming-importer": "*@dev"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,76 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0ffe97af4b47a21cba962be9159a7790",
+    "content-hash": "e21abdea677e191878779abd9c299941",
     "packages": [
-        {
-            "name": "wordpress/streaming-exporter",
-            "version": "dev-trunk",
-            "dist": {
-                "type": "path",
-                "url": "packages/streaming-exporter",
-                "reference": "7624010763191bf7893ea6e734c4bd6e64510df0"
-            },
-            "require": {
-                "ext-pdo": "*",
-                "ext-pdo_mysql": "*",
-                "php": ">=7.4",
-                "wp-php-toolkit/data-liberation": "^0.4",
-                "wp-php-toolkit/html": "^0.4"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "WordPress\\DataLiberation\\": "src/"
-                },
-                "classmap": [
-                    "src/class-mysql-dump-producer.php",
-                    "src/class-file-tree-producer.php",
-                    "src/class-hmac-client.php",
-                    "src/class-sqlite-driver-pdo.php"
-                ],
-                "files": [
-                    "src/utils.php"
-                ]
-            },
-            "license": [
-                "GPL-2.0-or-later"
-            ],
-            "description": "Streaming export engine used by the Site Export WordPress plugin",
-            "transport-options": {
-                "symlink": false,
-                "relative": true
-            }
-        },
-        {
-            "name": "wordpress/streaming-importer",
-            "version": "dev-trunk",
-            "dist": {
-                "type": "path",
-                "url": "packages/streaming-importer",
-                "reference": "93c5633079eb19e694875d949d90d3de87f927a7"
-            },
-            "require": {
-                "ext-pdo": "*",
-                "ext-pdo_mysql": "*",
-                "php": ">=7.4",
-                "wordpress/streaming-exporter": "*@dev",
-                "wp-php-toolkit/data-liberation": "^0.4",
-                "wp-php-toolkit/html": "^0.4"
-            },
-            "bin": [
-                "bin/streaming-importer"
-            ],
-            "type": "library",
-            "license": [
-                "GPL-2.0-or-later"
-            ],
-            "description": "Streaming site importer with CLI and PHAR distribution support",
-            "transport-options": {
-                "symlink": false,
-                "relative": true
-            }
-        },
         {
             "name": "wp-php-toolkit/bytestream",
             "version": "v0.4.1",
@@ -384,6 +316,74 @@
                 "source": "https://github.com/wp-php-toolkit/http-client/tree/v0.4.0"
             },
             "time": "2025-11-20T12:04:55+00:00"
+        },
+        {
+            "name": "wp-php-toolkit/streaming-exporter",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "packages/streaming-exporter",
+                "reference": "4840cbc74c86641603e15ebc2edac59aa666daa5"
+            },
+            "require": {
+                "ext-pdo": "*",
+                "ext-pdo_mysql": "*",
+                "php": ">=7.4",
+                "wp-php-toolkit/data-liberation": "^0.4",
+                "wp-php-toolkit/html": "^0.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "WordPress\\DataLiberation\\": "src/"
+                },
+                "classmap": [
+                    "src/class-mysql-dump-producer.php",
+                    "src/class-file-tree-producer.php",
+                    "src/class-hmac-client.php",
+                    "src/class-sqlite-driver-pdo.php"
+                ],
+                "files": [
+                    "src/utils.php"
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Streaming export engine used by the Site Export WordPress plugin",
+            "transport-options": {
+                "symlink": false,
+                "relative": true
+            }
+        },
+        {
+            "name": "wp-php-toolkit/streaming-importer",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "packages/streaming-importer",
+                "reference": "0e2c91b745e3b45e2a9c1fd4ed77f65e02527153"
+            },
+            "require": {
+                "ext-pdo": "*",
+                "ext-pdo_mysql": "*",
+                "php": ">=7.4",
+                "wp-php-toolkit/data-liberation": "^0.4",
+                "wp-php-toolkit/html": "^0.4",
+                "wp-php-toolkit/streaming-exporter": "*@dev"
+            },
+            "bin": [
+                "bin/streaming-importer"
+            ],
+            "type": "library",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Streaming site importer with CLI and PHAR distribution support",
+            "transport-options": {
+                "symlink": false,
+                "relative": true
+            }
         },
         {
             "name": "wp-php-toolkit/xml",
@@ -2401,8 +2401,8 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
-        "wordpress/streaming-exporter": 20,
-        "wordpress/streaming-importer": 20
+        "wp-php-toolkit/streaming-exporter": 20,
+        "wp-php-toolkit/streaming-importer": 20
     },
     "prefer-stable": true,
     "prefer-lowest": false,

--- a/packages/streaming-exporter/composer.json
+++ b/packages/streaming-exporter/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "wordpress/streaming-exporter",
+    "name": "wp-php-toolkit/streaming-exporter",
     "description": "Streaming export engine used by the Site Export WordPress plugin",
     "type": "library",
     "version": "dev-trunk",

--- a/packages/streaming-importer/composer.json
+++ b/packages/streaming-importer/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "wordpress/streaming-importer",
+    "name": "wp-php-toolkit/streaming-importer",
     "description": "Streaming site importer with CLI and PHAR distribution support",
     "type": "library",
     "version": "dev-trunk",
@@ -10,7 +10,7 @@
         "ext-pdo_mysql": "*",
         "wp-php-toolkit/data-liberation": "^0.4",
         "wp-php-toolkit/html": "^0.4",
-        "wordpress/streaming-exporter": "*@dev"
+        "wp-php-toolkit/streaming-exporter": "*@dev"
     },
     "bin": [
         "bin/streaming-importer"

--- a/wordpress-plugin/composer.json
+++ b/wordpress-plugin/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "wordpress/site-export-plugin",
+    "name": "wp-php-toolkit/site-export-plugin",
     "description": "WordPress plugin wrapper for the streaming exporter package",
     "type": "project",
     "license": "GPL-2.0-or-later",
@@ -16,6 +16,6 @@
     ],
     "require": {
         "php": ">=7.4",
-        "wordpress/streaming-exporter": "*@dev"
+        "wp-php-toolkit/streaming-exporter": "*@dev"
     }
 }

--- a/wordpress-plugin/composer.lock
+++ b/wordpress-plugin/composer.lock
@@ -4,47 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "071110416102a6132c09c3ca7da82794",
+    "content-hash": "f4bbe19261f51b3c3402e5fddd73016e",
     "packages": [
-        {
-            "name": "wordpress/streaming-exporter",
-            "version": "dev-trunk",
-            "dist": {
-                "type": "path",
-                "url": "../packages/streaming-exporter",
-                "reference": "7624010763191bf7893ea6e734c4bd6e64510df0"
-            },
-            "require": {
-                "ext-pdo": "*",
-                "ext-pdo_mysql": "*",
-                "php": ">=7.4",
-                "wp-php-toolkit/data-liberation": "^0.4",
-                "wp-php-toolkit/html": "^0.4"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "WordPress\\DataLiberation\\": "src/"
-                },
-                "classmap": [
-                    "src/class-mysql-dump-producer.php",
-                    "src/class-file-tree-producer.php",
-                    "src/class-hmac-client.php",
-                    "src/class-sqlite-driver-pdo.php"
-                ],
-                "files": [
-                    "src/utils.php"
-                ]
-            },
-            "license": [
-                "GPL-2.0-or-later"
-            ],
-            "description": "Streaming export engine used by the Site Export WordPress plugin",
-            "transport-options": {
-                "symlink": false,
-                "relative": true
-            }
-        },
         {
             "name": "wp-php-toolkit/bytestream",
             "version": "v0.4.1",
@@ -357,6 +318,45 @@
             "time": "2025-11-20T12:04:55+00:00"
         },
         {
+            "name": "wp-php-toolkit/streaming-exporter",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../packages/streaming-exporter",
+                "reference": "4840cbc74c86641603e15ebc2edac59aa666daa5"
+            },
+            "require": {
+                "ext-pdo": "*",
+                "ext-pdo_mysql": "*",
+                "php": ">=7.4",
+                "wp-php-toolkit/data-liberation": "^0.4",
+                "wp-php-toolkit/html": "^0.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "WordPress\\DataLiberation\\": "src/"
+                },
+                "classmap": [
+                    "src/class-mysql-dump-producer.php",
+                    "src/class-file-tree-producer.php",
+                    "src/class-hmac-client.php",
+                    "src/class-sqlite-driver-pdo.php"
+                ],
+                "files": [
+                    "src/utils.php"
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Streaming export engine used by the Site Export WordPress plugin",
+            "transport-options": {
+                "symlink": false,
+                "relative": true
+            }
+        },
+        {
             "name": "wp-php-toolkit/xml",
             "version": "v0.4.0",
             "source": {
@@ -412,7 +412,7 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
-        "wordpress/streaming-exporter": 20
+        "wp-php-toolkit/streaming-exporter": 20
     },
     "prefer-stable": true,
     "prefer-lowest": false,

--- a/wordpress-plugin/lib.php
+++ b/wordpress-plugin/lib.php
@@ -32,7 +32,7 @@ function _site_export_error(int $code, string $message): void {
  * Resolve and load the exporter package runtime.
  *
  * Supports both plugin release bundles (with wordpress-plugin/vendor/) and
- * the monorepo checkout (root vendor/ + vendor/wordpress/streaming-exporter).
+ * the monorepo checkout (root vendor/ + vendor/wp-php-toolkit/streaming-exporter).
  *
  * @return string|null Absolute path to export.php, or null when the runtime is missing.
  */
@@ -41,11 +41,11 @@ function _site_export_load_exporter_runtime(): ?string {
     $candidates = [
         [
             'autoload' => SITE_EXPORT_PLUGIN_DIR . 'vendor/autoload.php',
-            'export' => SITE_EXPORT_PLUGIN_DIR . 'vendor/wordpress/streaming-exporter/src/export.php',
+            'export' => SITE_EXPORT_PLUGIN_DIR . 'vendor/wp-php-toolkit/streaming-exporter/src/export.php',
         ],
         [
             'autoload' => $repo_root . '/vendor/autoload.php',
-            'export' => $repo_root . '/vendor/wordpress/streaming-exporter/src/export.php',
+            'export' => $repo_root . '/vendor/wp-php-toolkit/streaming-exporter/src/export.php',
         ],
     ];
 


### PR DESCRIPTION
## Summary
- rename the importer and exporter Composer packages from  to 
- update the monorepo and plugin Composer metadata and lockfiles to require the new package names
- update the plugin runtime lookup to load the exporter from the renamed vendor path

## Testing
- composer validate --no-check-publish
- composer validate --no-check-publish --working-dir=wordpress-plugin
- composer build:phar
- php importer/import.php --version
