### PR TITLE
Publish streaming-exporter and streaming-importer as separate Composer packages

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,32 @@
+name: Publish Composer packages
+
+on:
+  push:
+    tags: ['v*']
+
+permissions:
+  contents: write
+
+jobs:
+  split-packages:
+    name: Push subtrees to package repos
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Push package subtrees
+        run: |
+          git subtree push --prefix=packages/streaming-exporter https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/wp-php-toolkit/streaming-exporter.git main
+          git subtree push --prefix=packages/streaming-importer https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/wp-php-toolkit/streaming-importer.git main
+
+      - name: Notify Packagist
+        run: |
+          for pkg in streaming-exporter streaming-importer; do
+            curl -fsS -X POST \
+              "https://packagist.org/api/update-package?username=${{ secrets.PACKAGIST_USERNAME }}&apiToken=${{ secrets.PACKAGIST_TOKEN }}" \
+              -H 'Content-Type: application/json' \
+              -d "{\"repository\":{\"url\":\"https://github.com/wp-php-toolkit/${pkg}\"}}"
+          done

--- a/packages/streaming-exporter/composer.json
+++ b/packages/streaming-exporter/composer.json
@@ -2,7 +2,7 @@
     "name": "wp-php-toolkit/streaming-exporter",
     "description": "Streaming export engine used by the Site Export WordPress plugin",
     "type": "library",
-    "version": "dev-trunk",
+    "version": "dev-main",
     "license": "GPL-2.0-or-later",
     "require": {
         "php": ">=7.4",

--- a/packages/streaming-importer/composer.json
+++ b/packages/streaming-importer/composer.json
@@ -2,7 +2,7 @@
     "name": "wp-php-toolkit/streaming-importer",
     "description": "Streaming site importer with CLI and PHAR distribution support",
     "type": "library",
-    "version": "dev-trunk",
+    "version": "dev-main",
     "license": "GPL-2.0-or-later",
     "require": {
         "php": ">=7.4",


### PR DESCRIPTION
## Summary

Packagist picked up the root composer.json and published the monorepo as a single `wp-php-toolkit/streaming-site-migration` package. Each sub-package needs its own repo so Packagist can track it independently.

- Created `wp-php-toolkit/streaming-exporter` and `wp-php-toolkit/streaming-importer` repos, seeded with `git subtree push`
- Added a `publish.yml` workflow that pushes subtrees and notifies Packagist on each version tag
- Fixed package `version` field from `dev-trunk` to `dev-main`

## Before merging

1. Add `PACKAGIST_USERNAME` and `PACKAGIST_TOKEN` secrets: https://github.com/adamziel/streaming-site-migration/settings/secrets/actions
2. Register the new repos on Packagist: https://packagist.org/packages/submit
3. Delete the monorepo package: https://packagist.org/packages/wp-php-toolkit/streaming-site-migration (Settings → Delete)