### PR TITLE
Increase E2E timeout from 15 to 20 minutes

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -32,7 +32,7 @@ jobs:
     name: E2E (PHP ${{ matrix.php }})
     needs: build-phar
     runs-on: ubuntu-22.04
-    timeout-minutes: 15
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary

The E2E job was being canceled despite all 311 tests passing. Infrastructure setup (PHP, nginx, MariaDB installation) takes ~11 minutes, tests run in ~3 minutes, totaling ~14.5 minutes — just over the 15-minute timeout on slower runners.

Bumps `timeout-minutes` from 15 to 20.