### PR TITLE
Store site export secret in option

### DIFF
--- a/tests/SiteExportSecretTest.php
+++ b/tests/SiteExportSecretTest.php
@@ -1,0 +1,167 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+if (!defined('ABSPATH')) {
+    define('ABSPATH', __DIR__ . '/');
+}
+
+$site_export_test_plugin_dir = sys_get_temp_dir() . '/site-export-secret-test-' . getmypid() . '/';
+if (!defined('SITE_EXPORT_PLUGIN_DIR')) {
+    define('SITE_EXPORT_PLUGIN_DIR', $site_export_test_plugin_dir);
+}
+if (!defined('SITE_EXPORT_SECRET_FILE')) {
+    define('SITE_EXPORT_SECRET_FILE', SITE_EXPORT_PLUGIN_DIR . 'secret.php');
+}
+
+$GLOBALS['site_export_test_options'] = [];
+$GLOBALS['site_export_registered_settings'] = [];
+
+if (!function_exists('plugin_dir_path')) {
+    function plugin_dir_path(string $file): string {
+        return SITE_EXPORT_PLUGIN_DIR;
+    }
+}
+
+if (!function_exists('get_option')) {
+    function get_option(string $name, $default = false) {
+        return array_key_exists($name, $GLOBALS['site_export_test_options'])
+            ? $GLOBALS['site_export_test_options'][$name]
+            : $default;
+    }
+}
+
+if (!function_exists('update_option')) {
+    function update_option(string $name, $value, $autoload = null): bool {
+        $GLOBALS['site_export_test_options'][$name] = $value;
+        return true;
+    }
+}
+
+if (!function_exists('register_setting')) {
+    function register_setting(string $group, string $name, array $args = []): void {
+        $GLOBALS['site_export_registered_settings'][$name] = [
+            'group' => $group,
+            'args' => $args,
+        ];
+    }
+}
+
+if (!function_exists('add_action')) {
+    function add_action(...$args): void {}
+}
+
+if (!function_exists('add_filter')) {
+    function add_filter(...$args): void {}
+}
+
+if (!function_exists('plugin_basename')) {
+    function plugin_basename(string $file): string {
+        return basename($file);
+    }
+}
+
+if (!function_exists('register_activation_hook')) {
+    function register_activation_hook(...$args): void {}
+}
+
+if (!function_exists('wp_doing_ajax')) {
+    function wp_doing_ajax(): bool {
+        return false;
+    }
+}
+
+if (!function_exists('is_admin')) {
+    function is_admin(): bool {
+        return true;
+    }
+}
+
+if (!function_exists('set_transient')) {
+    function set_transient(...$args): void {}
+}
+
+if (!function_exists('get_transient')) {
+    function get_transient(...$args): bool {
+        return false;
+    }
+}
+
+if (!function_exists('delete_transient')) {
+    function delete_transient(...$args): void {}
+}
+
+if (!function_exists('wp_safe_redirect')) {
+    function wp_safe_redirect(...$args): void {}
+}
+
+require_once __DIR__ . '/../wordpress-plugin/lib.php';
+require_once __DIR__ . '/../wordpress-plugin/wordpress/site-export.php';
+
+final class SiteExportSecretTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (!is_dir(SITE_EXPORT_PLUGIN_DIR)) {
+            mkdir(SITE_EXPORT_PLUGIN_DIR, 0755, true);
+        }
+
+        $GLOBALS['site_export_test_options'] = [];
+        $GLOBALS['site_export_registered_settings'] = [];
+
+        if (file_exists(SITE_EXPORT_SECRET_FILE)) {
+            unlink(SITE_EXPORT_SECRET_FILE);
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        if (file_exists(SITE_EXPORT_SECRET_FILE)) {
+            unlink(SITE_EXPORT_SECRET_FILE);
+        }
+
+        if (is_dir(SITE_EXPORT_PLUGIN_DIR)) {
+            rmdir(SITE_EXPORT_PLUGIN_DIR);
+        }
+
+        parent::tearDown();
+    }
+
+    public function testSharedSecretFallsBackToOptionWhenSecretFileMissing(): void
+    {
+        $GLOBALS['site_export_test_options'][SITE_EXPORT_SECRET_OPTION] = 'option-secret';
+
+        $this->assertSame('option-secret', _site_export_get_shared_secret());
+    }
+
+    public function testSecretFileOverridesSiteOptionWhenPresent(): void
+    {
+        $GLOBALS['site_export_test_options'][SITE_EXPORT_SECRET_OPTION] = 'option-secret';
+        file_put_contents(SITE_EXPORT_SECRET_FILE, "<?php return 'file-secret';\n");
+
+        $this->assertSame('file-secret', _site_export_get_shared_secret());
+    }
+
+    public function testUpdatingSharedSecretOnlyTouchesTheSiteOption(): void
+    {
+        $this->assertTrue(_site_export_update_shared_secret('new-secret'));
+        $this->assertSame('new-secret', $GLOBALS['site_export_test_options'][SITE_EXPORT_SECRET_OPTION]);
+        $this->assertFileDoesNotExist(SITE_EXPORT_SECRET_FILE);
+    }
+
+    public function testPluginRegistersSecretOptionForCoreSettingsRestEndpoint(): void
+    {
+        Site_Export_Plugin::get_instance()->register_settings();
+
+        $setting = $GLOBALS['site_export_registered_settings'][SITE_EXPORT_SECRET_OPTION] ?? null;
+        $this->assertNotNull($setting);
+        $this->assertSame('general', $setting['group']);
+        $this->assertTrue($setting['args']['show_in_rest']);
+        $this->assertSame('string', $setting['args']['type']);
+        $this->assertSame('', $setting['args']['default']);
+    }
+}

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -21,6 +21,7 @@
         </testsuite>
         <testsuite name="Export Utility Tests">
             <file>BuildPdoDsnTest.php</file>
+            <file>SiteExportSecretTest.php</file>
         </testsuite>
         <testsuite name="Query Stream Tests">
             <file>NaiveQueryStreamTest.php</file>

--- a/wordpress-plugin/README.md
+++ b/wordpress-plugin/README.md
@@ -34,7 +34,8 @@ require_once '/path/to/wordpress-plugin/lib.php';
 
 // Route however you like — lib.php doesn't check URLs.
 if ($myRouter->matches('/export')) {
-    // Use default HMAC authentication (reads secret from SITE_EXPORT_SECRET_FILE):
+    // Use default HMAC authentication (reads secret.php when present,
+    // otherwise falls back to the site option):
     _site_export_handle_api_request();
 
     // Or supply your own authentication:
@@ -52,5 +53,6 @@ if ($myRouter->matches('/export')) {
 
 - `SITE_EXPORT_VERSION` — plugin version string
 - `SITE_EXPORT_PLUGIN_DIR` — absolute path to the plugin directory
-- `SITE_EXPORT_SECRET_FILE` — path to the PHP file that returns the HMAC shared secret
+- `SITE_EXPORT_SECRET_FILE` — optional path to a PHP file that overrides the stored HMAC shared secret
+- `SITE_EXPORT_SECRET_OPTION` — WordPress site option name used for the stored HMAC shared secret
 - `SITE_EXPORT_TIMESTAMP_TOLERANCE` — max request age in seconds (default 300)

--- a/wordpress-plugin/lib.php
+++ b/wordpress-plugin/lib.php
@@ -10,9 +10,18 @@ if (!defined('ABSPATH')) {
     exit;
 }
 
-define('SITE_EXPORT_VERSION', '1.0.0');
-define('SITE_EXPORT_PLUGIN_DIR', plugin_dir_path(__FILE__));
-define('SITE_EXPORT_SECRET_FILE', SITE_EXPORT_PLUGIN_DIR . 'secret.php');
+if (!defined('SITE_EXPORT_VERSION')) {
+    define('SITE_EXPORT_VERSION', '1.0.0');
+}
+if (!defined('SITE_EXPORT_PLUGIN_DIR')) {
+    define('SITE_EXPORT_PLUGIN_DIR', plugin_dir_path(__FILE__));
+}
+if (!defined('SITE_EXPORT_SECRET_FILE')) {
+    define('SITE_EXPORT_SECRET_FILE', SITE_EXPORT_PLUGIN_DIR . 'secret.php');
+}
+if (!defined('SITE_EXPORT_SECRET_OPTION')) {
+    define('SITE_EXPORT_SECRET_OPTION', 'site_export_secret');
+}
 
 /**
  * Maximum age of a request timestamp in seconds.
@@ -81,6 +90,61 @@ function _site_export_get_header(string $name): ?string {
     }
 
     return null;
+}
+
+/** Returns whether the legacy secret.php override exists. */
+function _site_export_has_secret_file(): bool {
+    return file_exists(SITE_EXPORT_SECRET_FILE);
+}
+
+/**
+ * Reads the legacy secret.php override when present.
+ *
+ * @return string|null String secret when the file is valid, otherwise null.
+ */
+function _site_export_get_file_secret(): ?string {
+    if (!_site_export_has_secret_file()) {
+        return null;
+    }
+
+    $secret = require SITE_EXPORT_SECRET_FILE;
+    return is_string($secret) ? $secret : null;
+}
+
+/** Reads the option-backed shared secret. */
+function _site_export_get_option_secret(): string {
+    if (!function_exists('get_option')) {
+        return '';
+    }
+
+    $secret = get_option(SITE_EXPORT_SECRET_OPTION, '');
+    return is_string($secret) ? $secret : '';
+}
+
+/**
+ * Returns the effective shared secret.
+ *
+ * The legacy secret.php file takes precedence when present; otherwise the
+ * site option is used.
+ */
+function _site_export_get_shared_secret(): ?string {
+    if (_site_export_has_secret_file()) {
+        return _site_export_get_file_secret();
+    }
+
+    $secret = _site_export_get_option_secret();
+    return $secret === '' ? null : $secret;
+}
+
+/**
+ * Updates only the option-backed shared secret used by the settings UI and REST API.
+ */
+function _site_export_update_shared_secret(string $secret): bool {
+    if (!function_exists('update_option')) {
+        return false;
+    }
+
+    return (bool) update_option(SITE_EXPORT_SECRET_OPTION, $secret, false);
 }
 
 /**
@@ -169,18 +233,22 @@ function _site_export_verify_hmac(string $secret): ?string {
 /**
  * Default HMAC authentication handler.
  *
- * Reads the shared secret from SITE_EXPORT_SECRET_FILE and verifies
- * the request's HMAC signature. Calls _site_export_error() on failure.
+ * Reads the shared secret from secret.php when present, otherwise from the
+ * site option, and verifies the request's HMAC signature.
+ * Calls _site_export_error() on failure.
  */
 function _site_export_default_authenticate(): void {
-    $secret_file = SITE_EXPORT_SECRET_FILE;
-    if (!file_exists($secret_file)) {
-        _site_export_error(503, 'Export not configured. Please configure the shared secret in WordPress admin under Tools > Site Export.');
+    if (_site_export_has_secret_file()) {
+        $secret = _site_export_get_file_secret();
+        if (empty($secret)) {
+            _site_export_error(503, 'Invalid secret.php configuration. Please remove it or replace it with a valid shared secret.');
+        }
+    } else {
+        $secret = _site_export_get_option_secret();
     }
 
-    $secret = require $secret_file;
     if (empty($secret) || !is_string($secret)) {
-        _site_export_error(503, 'Invalid secret configuration. Please reconfigure in WordPress admin.');
+        _site_export_error(503, 'Export not configured. Please configure the shared secret in WordPress admin under Tools > Site Export.');
     }
 
     $auth_error = _site_export_verify_hmac($secret);

--- a/wordpress-plugin/wordpress/site-export.php
+++ b/wordpress-plugin/wordpress/site-export.php
@@ -4,7 +4,8 @@
  *
  * This plugin provides a WordPress admin UI for configuring the export API.
  * The export API is triggered via `?site-export-api` during plugin load,
- * before WordPress finishes booting. It reads the secret from secret.php.
+ * before WordPress finishes booting. It reads the secret from a site option,
+ * with secret.php supported only as an override when present.
  *
  * Authentication uses HMAC signatures: the importing side generates a secret,
  * the user enters it here, and all requests must include a valid signature
@@ -22,10 +23,25 @@ class Site_Export_Plugin {
     }
 
     private function __construct() {
+        add_action('init', [$this, 'register_settings']);
         add_action('admin_menu', [$this, 'add_admin_menu']);
         add_action('admin_init', [$this, 'handle_settings_save']);
         add_filter('plugin_action_links_' . plugin_basename(SITE_EXPORT_PLUGIN_DIR . 'index.php'), [$this, 'add_settings_link']);
         add_action('admin_bar_menu', [$this, 'add_admin_bar_node'], 100);
+    }
+
+    /** Register the option so core's /wp/v2/settings endpoint can update it. */
+    public function register_settings() {
+        register_setting(
+            'general',
+            SITE_EXPORT_SECRET_OPTION,
+            [
+                'type' => 'string',
+                'sanitize_callback' => 'sanitize_text_field',
+                'default' => '',
+                'show_in_rest' => true,
+            ]
+        );
     }
 
     /**
@@ -83,16 +99,10 @@ class Site_Export_Plugin {
 
         $secret = isset($_POST['site_export_secret']) ? sanitize_text_field($_POST['site_export_secret']) : '';
 
-        // Write secret to PHP file
-        $result = $this->save_secret($secret);
+        $updated = _site_export_update_shared_secret($secret);
 
-        if (is_wp_error($result)) {
-            add_settings_error(
-                'site_export',
-                'save_failed',
-                'Failed to save secret: ' . $result->get_error_message(),
-                'error'
-            );
+        if (!$updated && _site_export_get_option_secret() !== $secret) {
+            add_settings_error('site_export', 'save_failed', 'Failed to save secret.', 'error');
         } else {
             add_settings_error(
                 'site_export',
@@ -104,48 +114,6 @@ class Site_Export_Plugin {
     }
 
     /**
-     * Save the secret to the PHP config file.
-     *
-     * @param string $secret The shared secret
-     * @return true|WP_Error
-     */
-    private function save_secret(string $secret) {
-        $content = "<?php\n";
-        $content .= "/**\n";
-        $content .= " * Site Export shared secret.\n";
-        $content .= " * Generated: " . gmdate('Y-m-d H:i:s') . " UTC\n";
-        $content .= " * \n";
-        $content .= " * DO NOT share this file or commit it to version control.\n";
-        $content .= " */\n";
-        $content .= "return " . var_export($secret, true) . ";\n";
-
-        $result = file_put_contents(SITE_EXPORT_SECRET_FILE, $content);
-
-        if ($result === false) {
-            return new WP_Error(
-                'write_failed',
-                'Could not write to ' . SITE_EXPORT_SECRET_FILE . '. Check file permissions.'
-            );
-        }
-
-        return true;
-    }
-
-    /**
-     * Load the current secret from config file.
-     *
-     * @return string
-     */
-    private function load_secret(): string {
-        if (!file_exists(SITE_EXPORT_SECRET_FILE)) {
-            return '';
-        }
-
-        $secret = require SITE_EXPORT_SECRET_FILE;
-        return is_string($secret) ? $secret : '';
-    }
-
-    /**
      * Render the admin page.
      */
     public function render_admin_page() {
@@ -153,9 +121,11 @@ class Site_Export_Plugin {
             return;
         }
 
-        $secret = $this->load_secret();
+        $stored_secret = _site_export_get_option_secret();
+        $effective_secret = _site_export_get_shared_secret() ?? '';
         $api_url = home_url('?site-export-api');
-        $is_configured = !empty($secret);
+        $is_configured = $effective_secret !== '';
+        $has_file_override = _site_export_has_secret_file();
 
         ?>
         <style>
@@ -285,6 +255,13 @@ class Site_Export_Plugin {
 
             <?php settings_errors('site_export'); ?>
 
+            <?php if ($has_file_override): ?>
+            <div class="site-export-status is-pending">
+                <span class="dashicons dashicons-lock"></span>
+                <span><strong><code>secret.php</code> override is active.</strong> This screen and the REST API update only the site option. Remove <code>secret.php</code> to use the stored option value.</span>
+            </div>
+            <?php endif; ?>
+
             <?php if ($is_configured): ?>
             <div class="site-export-status is-ready">
                 <span class="dashicons dashicons-yes-alt"></span>
@@ -310,7 +287,7 @@ class Site_Export_Plugin {
                         <input type="password"
                                id="site_export_secret"
                                name="site_export_secret"
-                               value="<?php echo esc_attr($secret); ?>"
+                               value="<?php echo esc_attr($stored_secret); ?>"
                                placeholder="Paste your token here"
                                autocomplete="off" />
                         <button type="button" class="site-export-toggle-btn" onclick="siteExportToggleSecret()" title="Show / hide token">


### PR DESCRIPTION
## Summary
- store the Site Export shared secret in a site option and expose it through the core `/wp/v2/settings` REST endpoint
- treat `secret.php` as an optional override only, with the option as the default secret source
- update the admin UI and add PHPUnit coverage for secret resolution and setting registration

## Testing
- php -l wordpress-plugin/lib.php
- php -l wordpress-plugin/wordpress/site-export.php
- php -l tests/SiteExportSecretTest.php
- vendor/bin/phpunit --configuration tests/phpunit.xml --filter SiteExportSecretTest
