### PR TITLE
Fix --new-site-url adding trailing slash to siteurl/home in SQLite

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -8,7 +8,7 @@
     "packages": [
         {
             "name": "wp-php-toolkit/bytestream",
-            "version": "v0.4.1",
+            "version": "v0.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-php-toolkit/bytestream.git",
@@ -52,30 +52,30 @@
             "description": "ByteStream component for WordPress.",
             "support": {
                 "issues": "https://github.com/wp-php-toolkit/bytestream/issues",
-                "source": "https://github.com/wp-php-toolkit/bytestream/tree/v0.4.1"
+                "source": "https://github.com/wp-php-toolkit/bytestream/tree/v0.5.1"
             },
             "time": "2025-09-11T23:53:08+00:00"
         },
         {
             "name": "wp-php-toolkit/data-liberation",
-            "version": "v0.4.0",
+            "version": "v0.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-php-toolkit/data-liberation.git",
-                "reference": "0725ddef6a5fddef634e964147485827f6f72de7"
+                "reference": "b42d4b045a3a0b124ec361de3b5873d85c9bb549"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-php-toolkit/data-liberation/zipball/0725ddef6a5fddef634e964147485827f6f72de7",
-                "reference": "0725ddef6a5fddef634e964147485827f6f72de7",
+                "url": "https://api.github.com/repos/wp-php-toolkit/data-liberation/zipball/b42d4b045a3a0b124ec361de3b5873d85c9bb549",
+                "reference": "b42d4b045a3a0b124ec361de3b5873d85c9bb549",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2",
-                "wp-php-toolkit/bytestream": "^0.4",
-                "wp-php-toolkit/filesystem": "^0.4",
-                "wp-php-toolkit/http-client": "^0.4",
-                "wp-php-toolkit/xml": "^0.4"
+                "wp-php-toolkit/bytestream": "^0.5.1",
+                "wp-php-toolkit/filesystem": "^0.5.1",
+                "wp-php-toolkit/http-client": "^0.5.1",
+                "wp-php-toolkit/xml": "^0.5.1"
             },
             "type": "library",
             "autoload": {
@@ -107,13 +107,13 @@
             "description": "Data Liberation component for WordPress.",
             "support": {
                 "issues": "https://github.com/wp-php-toolkit/data-liberation/issues",
-                "source": "https://github.com/wp-php-toolkit/data-liberation/tree/v0.4.0"
+                "source": "https://github.com/wp-php-toolkit/data-liberation/tree/v0.5.1"
             },
-            "time": "2025-11-20T12:04:55+00:00"
+            "time": "2026-04-02T14:37:51+00:00"
         },
         {
             "name": "wp-php-toolkit/encoding",
-            "version": "v0.4.1",
+            "version": "v0.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-php-toolkit/encoding.git",
@@ -156,27 +156,27 @@
             "description": "Encoding component for WordPress.",
             "support": {
                 "issues": "https://github.com/wp-php-toolkit/encoding/issues",
-                "source": "https://github.com/wp-php-toolkit/encoding/tree/v0.4.1"
+                "source": "https://github.com/wp-php-toolkit/encoding/tree/v0.5.1"
             },
             "time": "2025-11-20T12:04:55+00:00"
         },
         {
             "name": "wp-php-toolkit/filesystem",
-            "version": "v0.4.0",
+            "version": "v0.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-php-toolkit/filesystem.git",
-                "reference": "ba93f3cce4400a0373118963b1c93a413e46f504"
+                "reference": "900e4d8e1a8ef79e59e6efa52a1e0d46eb47e8e2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-php-toolkit/filesystem/zipball/ba93f3cce4400a0373118963b1c93a413e46f504",
-                "reference": "ba93f3cce4400a0373118963b1c93a413e46f504",
+                "url": "https://api.github.com/repos/wp-php-toolkit/filesystem/zipball/900e4d8e1a8ef79e59e6efa52a1e0d46eb47e8e2",
+                "reference": "900e4d8e1a8ef79e59e6efa52a1e0d46eb47e8e2",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2",
-                "wp-php-toolkit/bytestream": "^0.4"
+                "wp-php-toolkit/bytestream": "^0.5.1"
             },
             "require-dev": {
                 "phpunit/phpunit": "^9.5"
@@ -210,13 +210,13 @@
             "description": "Filesystem component for WordPress.",
             "support": {
                 "issues": "https://github.com/wp-php-toolkit/filesystem/issues",
-                "source": "https://github.com/wp-php-toolkit/filesystem/tree/v0.4.0"
+                "source": "https://github.com/wp-php-toolkit/filesystem/tree/v0.5.1"
             },
-            "time": "2025-11-20T12:04:55+00:00"
+            "time": "2026-04-02T14:37:51+00:00"
         },
         {
             "name": "wp-php-toolkit/html",
-            "version": "v0.4.1",
+            "version": "v0.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-php-toolkit/html.git",
@@ -260,29 +260,29 @@
             "description": "HTML component for WordPress.",
             "support": {
                 "issues": "https://github.com/wp-php-toolkit/html/issues",
-                "source": "https://github.com/wp-php-toolkit/html/tree/v0.4.1"
+                "source": "https://github.com/wp-php-toolkit/html/tree/v0.5.1"
             },
             "time": "2025-09-08T13:34:24+00:00"
         },
         {
             "name": "wp-php-toolkit/http-client",
-            "version": "v0.4.0",
+            "version": "v0.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-php-toolkit/http-client.git",
-                "reference": "9c04602811b91ef107d8303a66c8ebd246818665"
+                "reference": "c9f79808c164578c6080ac87a4ecc335c78dd947"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-php-toolkit/http-client/zipball/9c04602811b91ef107d8303a66c8ebd246818665",
-                "reference": "9c04602811b91ef107d8303a66c8ebd246818665",
+                "url": "https://api.github.com/repos/wp-php-toolkit/http-client/zipball/c9f79808c164578c6080ac87a4ecc335c78dd947",
+                "reference": "c9f79808c164578c6080ac87a4ecc335c78dd947",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2",
-                "wp-php-toolkit/bytestream": "^0.4",
-                "wp-php-toolkit/data-liberation": "^0.4",
-                "wp-php-toolkit/filesystem": "^0.4"
+                "wp-php-toolkit/bytestream": "^0.5.1",
+                "wp-php-toolkit/data-liberation": "^0.5.1",
+                "wp-php-toolkit/filesystem": "^0.5.1"
             },
             "require-dev": {
                 "phpunit/phpunit": "^9.5"
@@ -313,24 +313,24 @@
             "description": "HttpClient component for WordPress.",
             "support": {
                 "issues": "https://github.com/wp-php-toolkit/http-client/issues",
-                "source": "https://github.com/wp-php-toolkit/http-client/tree/v0.4.0"
+                "source": "https://github.com/wp-php-toolkit/http-client/tree/v0.5.1"
             },
-            "time": "2025-11-20T12:04:55+00:00"
+            "time": "2026-04-02T14:37:51+00:00"
         },
         {
             "name": "wp-php-toolkit/streaming-exporter",
-            "version": "dev-trunk",
+            "version": "dev-adamziel/new-site-url-sqlite",
             "dist": {
                 "type": "path",
                 "url": "packages/streaming-exporter",
-                "reference": "4840cbc74c86641603e15ebc2edac59aa666daa5"
+                "reference": "70accc62bc6fa13d2d8e0a6db39699918c1175d6"
             },
             "require": {
                 "ext-pdo": "*",
                 "ext-pdo_mysql": "*",
                 "php": ">=7.4",
-                "wp-php-toolkit/data-liberation": "^0.4",
-                "wp-php-toolkit/html": "^0.4"
+                "wp-php-toolkit/data-liberation": "^0.5.1",
+                "wp-php-toolkit/html": "^0.5.1"
             },
             "type": "library",
             "autoload": {
@@ -358,18 +358,18 @@
         },
         {
             "name": "wp-php-toolkit/streaming-importer",
-            "version": "dev-trunk",
+            "version": "dev-adamziel/new-site-url-sqlite",
             "dist": {
                 "type": "path",
                 "url": "packages/streaming-importer",
-                "reference": "0e2c91b745e3b45e2a9c1fd4ed77f65e02527153"
+                "reference": "b6ab722bb7744ab5cb8112171b72a6aab5669390"
             },
             "require": {
                 "ext-pdo": "*",
                 "ext-pdo_mysql": "*",
                 "php": ">=7.4",
-                "wp-php-toolkit/data-liberation": "^0.4",
-                "wp-php-toolkit/html": "^0.4",
+                "wp-php-toolkit/data-liberation": "^0.5.1",
+                "wp-php-toolkit/html": "^0.5.1",
                 "wp-php-toolkit/streaming-exporter": "*@dev"
             },
             "bin": [
@@ -387,21 +387,21 @@
         },
         {
             "name": "wp-php-toolkit/xml",
-            "version": "v0.4.0",
+            "version": "v0.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-php-toolkit/xml.git",
-                "reference": "000836ad0b8eae32a61454e7127c531b3496d15f"
+                "reference": "8ec4e2f16b18313d52c8a61a6528afacf1ceb34a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-php-toolkit/xml/zipball/000836ad0b8eae32a61454e7127c531b3496d15f",
-                "reference": "000836ad0b8eae32a61454e7127c531b3496d15f",
+                "url": "https://api.github.com/repos/wp-php-toolkit/xml/zipball/8ec4e2f16b18313d52c8a61a6528afacf1ceb34a",
+                "reference": "8ec4e2f16b18313d52c8a61a6528afacf1ceb34a",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2",
-                "wp-php-toolkit/encoding": "^0.4"
+                "wp-php-toolkit/encoding": "^0.5.1"
             },
             "require-dev": {
                 "phpunit/phpunit": "^9.5"
@@ -432,9 +432,9 @@
             "description": "XML component for WordPress.",
             "support": {
                 "issues": "https://github.com/wp-php-toolkit/xml/issues",
-                "source": "https://github.com/wp-php-toolkit/xml/tree/v0.4.0"
+                "source": "https://github.com/wp-php-toolkit/xml/tree/v0.5.1"
             },
-            "time": "2025-11-20T12:04:55+00:00"
+            "time": "2026-04-02T14:37:51+00:00"
         }
     ],
     "packages-dev": [

--- a/packages/streaming-exporter/composer.json
+++ b/packages/streaming-exporter/composer.json
@@ -7,8 +7,8 @@
         "php": ">=7.4",
         "ext-pdo": "*",
         "ext-pdo_mysql": "*",
-        "wp-php-toolkit/data-liberation": "^0.4",
-        "wp-php-toolkit/html": "^0.4"
+        "wp-php-toolkit/data-liberation": "^0.5.1",
+        "wp-php-toolkit/html": "^0.5.1"
     },
     "autoload": {
         "psr-4": {

--- a/packages/streaming-importer/composer.json
+++ b/packages/streaming-importer/composer.json
@@ -7,8 +7,8 @@
         "php": ">=7.4",
         "ext-pdo": "*",
         "ext-pdo_mysql": "*",
-        "wp-php-toolkit/data-liberation": "^0.4",
-        "wp-php-toolkit/html": "^0.4",
+        "wp-php-toolkit/data-liberation": "^0.5.1",
+        "wp-php-toolkit/html": "^0.5.1",
         "wp-php-toolkit/streaming-exporter": "*@dev"
     },
     "bin": [

--- a/packages/streaming-importer/src/lib/url-rewrite/class-structured-data-url-rewriter.php
+++ b/packages/streaming-importer/src/lib/url-rewrite/class-structured-data-url-rewriter.php
@@ -215,32 +215,17 @@ class StructuredDataUrlRewriter
                     $parsed_url = $p->get_parsed_url();
                     foreach ( $url_mapping as $mapping ) {
                         if ( is_child_url_of( $parsed_url, $mapping['from_url'] ) ) {
-                            $raw_url = $p->get_raw_url();
                             $new_raw_url = WPURL::replace_base_url(
                                 $parsed_url,
                                 array(
                                     'old_base_url' => $options['base_url'],
                                     'new_base_url' => $mapping['to_url'],
-                                    'raw_url'      => $raw_url,
+                                    'raw_url'      => $p->get_raw_url(),
                                     'is_relative'  => false,
                                 )
                             );
 
-                            // WPURL::replace_base_url() normalises an empty
-                            // path to "/" (per WHATWG), which adds a trailing
-                            // slash to origin-only URLs like
-                            // "https://example.com".  Preserve the original
-                            // URL's trailing-slash style so that siteurl/home
-                            // values don't get an unwanted "/" appended.
-                            $new_str = (string) $new_raw_url;
-                            if (
-                                strlen($new_str) > 1 &&
-                                $new_str[-1] === '/' &&
-                                $raw_url[-1] !== '/'
-                            ) {
-                                $new_str = substr($new_str, 0, -1);
-                            }
-                            $p->set_raw_url( $new_str );
+                            $p->set_raw_url( $new_raw_url );
                             break;
                         }
                     }

--- a/packages/streaming-importer/src/lib/url-rewrite/class-structured-data-url-rewriter.php
+++ b/packages/streaming-importer/src/lib/url-rewrite/class-structured-data-url-rewriter.php
@@ -215,17 +215,32 @@ class StructuredDataUrlRewriter
                     $parsed_url = $p->get_parsed_url();
                     foreach ( $url_mapping as $mapping ) {
                         if ( is_child_url_of( $parsed_url, $mapping['from_url'] ) ) {
+                            $raw_url = $p->get_raw_url();
                             $new_raw_url = WPURL::replace_base_url(
                                 $parsed_url,
                                 array(
                                     'old_base_url' => $options['base_url'],
                                     'new_base_url' => $mapping['to_url'],
-                                    'raw_url'      => $p->get_raw_url(),
+                                    'raw_url'      => $raw_url,
                                     'is_relative'  => false,
                                 )
                             );
 
-                            $p->set_raw_url( $new_raw_url );
+                            // WPURL::replace_base_url() normalises an empty
+                            // path to "/" (per WHATWG), which adds a trailing
+                            // slash to origin-only URLs like
+                            // "https://example.com".  Preserve the original
+                            // URL's trailing-slash style so that siteurl/home
+                            // values don't get an unwanted "/" appended.
+                            $new_str = (string) $new_raw_url;
+                            if (
+                                strlen($new_str) > 1 &&
+                                $new_str[-1] === '/' &&
+                                $raw_url[-1] !== '/'
+                            ) {
+                                $new_str = substr($new_str, 0, -1);
+                            }
+                            $p->set_raw_url( $new_str );
                             break;
                         }
                     }

--- a/tests/Import/NewSiteUrlSqliteTest.php
+++ b/tests/Import/NewSiteUrlSqliteTest.php
@@ -1,0 +1,317 @@
+<?php
+
+namespace ImportTests;
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../importer/import.php';
+
+/**
+ * Test that --new-site-url rewrites siteurl and home when db-apply
+ * targets a SQLite database. This is the integration test for the
+ * full flow: SQL dump → URL rewriting → SQLite execution → verify.
+ */
+class NewSiteUrlSqliteTest extends TestCase
+{
+    private string $tempDir;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (!extension_loaded('pdo_sqlite')) {
+            $this->markTestSkipped('pdo_sqlite extension required');
+        }
+
+        $this->tempDir = sys_get_temp_dir() . '/import-new-site-url-sqlite-' . uniqid();
+        mkdir($this->tempDir, 0755, true);
+        mkdir($this->tempDir . '/fs-root', 0755, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->recursiveDelete($this->tempDir);
+        parent::tearDown();
+    }
+
+    private function recursiveDelete(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        foreach (scandir($dir) as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $path = $dir . '/' . $item;
+            if (is_link($path)) {
+                unlink($path);
+            } elseif (is_dir($path)) {
+                $this->recursiveDelete($path);
+            } else {
+                unlink($path);
+            }
+        }
+        rmdir($dir);
+    }
+
+    /**
+     * Build a minimal SQL dump that creates wp_options and inserts
+     * siteurl and home rows. Uses FROM_BASE64() encoding exactly
+     * like the real MySQLDumpProducer.
+     */
+    private function buildSqlDump(string $siteUrl): string
+    {
+        $stmts = [];
+        $stmts[] = "DROP TABLE IF EXISTS `wp_options`;";
+        $stmts[] = "CREATE TABLE `wp_options` ("
+            . "`option_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT, "
+            . "`option_name` varchar(191) NOT NULL DEFAULT '', "
+            . "`option_value` longtext NOT NULL, "
+            . "`autoload` varchar(20) NOT NULL DEFAULT 'yes', "
+            . "PRIMARY KEY (`option_id`), "
+            . "UNIQUE KEY `option_name` (`option_name`)"
+            . ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;";
+
+        // INSERT with FROM_BASE64 — mirrors real dump output
+        $stmts[] = sprintf(
+            "INSERT INTO `wp_options` VALUES "
+            . "(1, FROM_BASE64('%s'), FROM_BASE64('%s'), FROM_BASE64('%s')), "
+            . "(2, FROM_BASE64('%s'), FROM_BASE64('%s'), FROM_BASE64('%s'));",
+            base64_encode('siteurl'),
+            base64_encode($siteUrl),
+            base64_encode('yes'),
+            base64_encode('home'),
+            base64_encode($siteUrl),
+            base64_encode('yes'),
+        );
+
+        // Add a non-URL option to make sure it's not clobbered
+        $stmts[] = sprintf(
+            "INSERT INTO `wp_options` VALUES "
+            . "(3, FROM_BASE64('%s'), FROM_BASE64('%s'), FROM_BASE64('%s'));",
+            base64_encode('blogname'),
+            base64_encode('My Test Blog'),
+            base64_encode('yes'),
+        );
+
+        return implode("\n", $stmts) . "\n";
+    }
+
+    /**
+     * Write the import state file that db-apply expects.
+     */
+    private function writeState(array $extra = []): void
+    {
+        $state = array_merge([
+            'command' => null,
+            'status' => null,
+            'apply' => [],
+        ], $extra);
+        file_put_contents(
+            $this->tempDir . '/.import-state.json',
+            json_encode($state, JSON_PRETTY_PRINT),
+        );
+    }
+
+    /**
+     * Read a value from the SQLite database using the MySQL-on-SQLite driver.
+     */
+    private function querySqlite(string $dbPath, string $sql, string $dbName): array
+    {
+        $polyfills = resolve_sqlite_integration_path("/php-polyfills.php");
+        $driver = resolve_sqlite_integration_path("/wp-pdo-mysql-on-sqlite.php");
+        require_once $polyfills;
+        require_once $driver;
+
+        $dsn = "mysql-on-sqlite:path={$dbPath};dbname={$dbName}";
+        $pdo = new \WP_PDO_MySQL_On_SQLite($dsn, null, null, [
+            \PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION,
+            \PDO::ATTR_DEFAULT_FETCH_MODE => \PDO::FETCH_ASSOC,
+        ]);
+
+        $sqlite_pdo = $pdo->get_connection()->get_pdo();
+        $sqlite_pdo->sqliteCreateFunction('FROM_BASE64', function ($data) {
+            return $data === null ? null : base64_decode($data);
+        }, 1);
+
+        return $pdo->query($sql)->fetchAll();
+    }
+
+    /**
+     * --new-site-url rewrites siteurl and home in a SQLite target.
+     */
+    public function testNewSiteUrlRewritesSiteurlAndHomeInSqlite(): void
+    {
+        $oldUrl = 'https://old-site.example.com';
+        $newUrl = 'https://brand-new.example.com';
+        $exportUrl = 'https://old-site.example.com/?site-export-api';
+        $sqlitePath = $this->tempDir . '/database/wordpress.sqlite';
+
+        // Prepare db.sql
+        file_put_contents($this->tempDir . '/db.sql', $this->buildSqlDump($oldUrl));
+        $this->writeState();
+
+        // Run db-apply via ImportClient
+        $client = new \ImportClient(
+            $exportUrl,
+            $this->tempDir,
+            $this->tempDir . '/fs-root',
+        );
+        $client->run([
+            'command' => 'db-apply',
+            'abort' => false,
+            'verbose' => false,
+            'secret' => null,
+            'tuning_config' => [],
+            'target_engine' => 'sqlite',
+            'target_sqlite_path' => $sqlitePath,
+            'target_db' => 'wp_test',
+            'new_site_url' => $newUrl,
+        ]);
+
+        // Verify siteurl and home were rewritten
+        $rows = $this->querySqlite(
+            $sqlitePath,
+            "SELECT option_name, option_value FROM wp_options WHERE option_name IN ('siteurl', 'home') ORDER BY option_name",
+            'wp_test',
+        );
+
+        $this->assertCount(2, $rows, 'Expected siteurl and home rows');
+        foreach ($rows as $row) {
+            $this->assertSame(
+                $newUrl,
+                $row['option_value'],
+                "Expected {$row['option_name']} to be rewritten to {$newUrl}, got: {$row['option_value']}",
+            );
+        }
+
+        // Verify non-URL options are not clobbered
+        $blogname = $this->querySqlite(
+            $sqlitePath,
+            "SELECT option_value FROM wp_options WHERE option_name = 'blogname'",
+            'wp_test',
+        );
+        $this->assertSame('My Test Blog', $blogname[0]['option_value']);
+    }
+
+    /**
+     * --new-site-url with an HTTP source also rewrites HTTPS variants.
+     */
+    public function testNewSiteUrlRewritesBothSchemes(): void
+    {
+        // The DB stores https:// but the export is served over http.
+        // --new-site-url should still rewrite both variants.
+        $httpsUrl = 'https://old-site.example.com';
+        $httpUrl  = 'http://old-site.example.com';
+        $newUrl   = 'https://new-site.example.com';
+        $exportUrl = 'http://old-site.example.com/?site-export-api';
+        $sqlitePath = $this->tempDir . '/database/wordpress.sqlite';
+
+        // Build dump with HTTPS siteurl — note that the export URL uses HTTP
+        file_put_contents($this->tempDir . '/db.sql', $this->buildSqlDump($httpsUrl));
+        $this->writeState();
+
+        $client = new \ImportClient(
+            $exportUrl,
+            $this->tempDir,
+            $this->tempDir . '/fs-root',
+        );
+        $client->run([
+            'command' => 'db-apply',
+            'abort' => false,
+            'verbose' => false,
+            'secret' => null,
+            'tuning_config' => [],
+            'target_engine' => 'sqlite',
+            'target_sqlite_path' => $sqlitePath,
+            'target_db' => 'wp_test',
+            'new_site_url' => $newUrl,
+        ]);
+
+        $rows = $this->querySqlite(
+            $sqlitePath,
+            "SELECT option_name, option_value FROM wp_options WHERE option_name IN ('siteurl', 'home') ORDER BY option_name",
+            'wp_test',
+        );
+
+        $this->assertCount(2, $rows);
+        foreach ($rows as $row) {
+            $this->assertSame(
+                $newUrl,
+                $row['option_value'],
+                "Expected {$row['option_name']} to be rewritten from HTTPS variant, got: {$row['option_value']}",
+            );
+        }
+    }
+
+    /**
+     * Subpath URLs are correctly rewritten (e.g. /wp-content/uploads/...).
+     */
+    public function testNewSiteUrlRewritesSubpathUrls(): void
+    {
+        $oldUrl = 'https://old-site.example.com';
+        $newUrl = 'https://new-site.example.com';
+        $exportUrl = 'https://old-site.example.com/?site-export-api';
+        $sqlitePath = $this->tempDir . '/database/wordpress.sqlite';
+
+        // Build a dump with a post that references the old URL in content
+        $sql = $this->buildSqlDump($oldUrl);
+
+        // Add wp_posts table with content containing old URLs
+        $sql .= "DROP TABLE IF EXISTS `wp_posts`;\n";
+        $sql .= "CREATE TABLE `wp_posts` ("
+            . "`ID` bigint(20) unsigned NOT NULL AUTO_INCREMENT, "
+            . "`post_content` longtext NOT NULL, "
+            . "`post_title` varchar(255) NOT NULL DEFAULT '', "
+            . "PRIMARY KEY (`ID`)"
+            . ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;\n";
+
+        $content = '<p>Visit <a href="https://old-site.example.com/about">About</a></p>'
+            . '<!-- wp:image {"url":"https://old-site.example.com/wp-content/uploads/photo.jpg"} -->';
+        $sql .= sprintf(
+            "INSERT INTO `wp_posts` VALUES (1, FROM_BASE64('%s'), FROM_BASE64('%s'));\n",
+            base64_encode($content),
+            base64_encode('Test Post'),
+        );
+
+        file_put_contents($this->tempDir . '/db.sql', $sql);
+        $this->writeState([
+            'preflight' => [
+                'data' => [
+                    'database' => ['wp' => ['table_prefix' => 'wp_']],
+                ],
+            ],
+        ]);
+
+        $client = new \ImportClient(
+            $exportUrl,
+            $this->tempDir,
+            $this->tempDir . '/fs-root',
+        );
+        $client->run([
+            'command' => 'db-apply',
+            'abort' => false,
+            'verbose' => false,
+            'secret' => null,
+            'tuning_config' => [],
+            'target_engine' => 'sqlite',
+            'target_sqlite_path' => $sqlitePath,
+            'target_db' => 'wp_test',
+            'new_site_url' => $newUrl,
+        ]);
+
+        // Verify post_content URLs were rewritten
+        $posts = $this->querySqlite(
+            $sqlitePath,
+            "SELECT post_content FROM wp_posts WHERE ID = 1",
+            'wp_test',
+        );
+
+        $this->assertCount(1, $posts);
+        $postContent = $posts[0]['post_content'];
+        $this->assertStringContainsString('https://new-site.example.com/about', $postContent);
+        $this->assertStringContainsString('https://new-site.example.com/wp-content/uploads/photo.jpg', $postContent);
+        $this->assertStringNotContainsString('old-site.example.com', $postContent);
+    }
+}

--- a/tests/e2e/tests/import-36-url-rewriting.test.js
+++ b/tests/e2e/tests/import-36-url-rewriting.test.js
@@ -204,13 +204,12 @@ describe('Import: URL Rewriting', () => {
             `Expected serialized PHP format, got: ${val.substring(0, 10)}`
         );
         // Verify s:N: byte lengths are correct for the target domain URL.
-        // The URL-aware rewriter normalizes bare domains by adding a trailing
-        // slash (https://target.example.com → https://target.example.com/),
-        // so the serialized length is one more than TARGET_DOMAIN.length.
-        const targetWithSlash = TARGET_DOMAIN + '/';
-        const targetLen = targetWithSlash.length;
+        // The rewriter preserves the original URL's trailing-slash style,
+        // so a bare origin like "https://target.example.com" stays without
+        // a trailing slash.
+        const targetLen = TARGET_DOMAIN.length;
         assert.ok(
-            val.includes(`s:${targetLen}:"${targetWithSlash}"`),
+            val.includes(`s:${targetLen}:"${TARGET_DOMAIN}"`),
             `Expected correct s:N: prefix for target URL (s:${targetLen}:), got: ${val}`
         );
     });


### PR DESCRIPTION
## Summary

When `db-apply --new-site-url` rewrites `siteurl` and `home`, the WHATWG URL parser normalizes the empty path to `/`, so origin-only URLs like `https://example.com` become `https://example.com/`. That trailing slash causes WordPress canonical redirect issues.

The root cause was in `WPURL::replace_base_url` in the data-liberation library. Its trailing-slash preservation logic checked the parsed pathname but missed the case where the pathname is just `/` (which is how the WHATWG parser represents an empty path). The fix uses the raw URL string to determine whether a trailing slash was actually present in the source text.

The fix landed upstream in `wp-php-toolkit/data-liberation v0.5.1`. This PR upgrades all wp-php-toolkit dependencies from v0.4.x to v0.5.1 and adds integration tests that exercise the full `--new-site-url` + SQLite flow.

## Test plan

- [ ] `testNewSiteUrlRewritesSiteurlAndHomeInSqlite` — siteurl/home rewritten without trailing slash
- [ ] `testNewSiteUrlRewritesBothSchemes` — HTTP export URL still rewrites HTTPS values in DB
- [ ] `testNewSiteUrlRewritesSubpathUrls` — post content URLs with paths are preserved
- [ ] E2E import-36 serialized PHP test expects no trailing slash on bare domains
- [ ] All 258 PHPUnit tests pass, all E2E tests pass