### PR TITLE
Resolve ABSPATH with realpath() to fix flat-document-root on Atomic

### DIFF
--- a/packages/streaming-exporter/src/export.php
+++ b/packages/streaming-exporter/src/export.php
@@ -1651,10 +1651,25 @@ function endpoint_preflight(array $config): array
                             }
                         }
 
+                        // Use realpath() to resolve any symlinks in
+                        // ABSPATH (e.g. /wordpress -> /srv/wpcloud/core/6.9.4
+                        // on WP Cloud). This matches the convention used for
+                        // all other paths below and ensures the importer can
+                        // find the directory at the resolved location where
+                        // files are actually downloaded.
+                        $abspath_raw = defined("ABSPATH")
+                            ? rtrim(ABSPATH, "/")
+                            : null;
+                        $abspath_resolved = null;
+                        if ($abspath_raw !== null) {
+                            $abspath_real = realpath($abspath_raw);
+                            $abspath_resolved = $abspath_real !== false
+                                ? rtrim($abspath_real, "/")
+                                : $abspath_raw;
+                        }
+
                         $paths_urls = [
-                            "abspath" => defined("ABSPATH")
-                                ? rtrim(ABSPATH, "/")
-                                : null,
+                            "abspath" => $abspath_resolved,
                             "wp_admin_path" => $wp_admin_path,
                             "wp_includes_path" => $wp_includes_path,
                             "content_dir" => defined("WP_CONTENT_DIR")

--- a/tests/e2e/site-registry.json
+++ b/tests/e2e/site-registry.json
@@ -34,6 +34,7 @@
     "preserve-local":    { "port": 8107 },
     "url-rewriting":     { "port": 8108 },
     "wpcloud-flatten":   { "port": 8109 },
-    "defer-uploads":     { "port": 8110 }
+    "defer-uploads":     { "port": 8110 },
+    "symlinked-abspath": { "port": 8111 }
   }
 }

--- a/tests/e2e/tests/import-42-symlinked-abspath-flatten.test.js
+++ b/tests/e2e/tests/import-42-symlinked-abspath-flatten.test.js
@@ -68,11 +68,18 @@ describe('Import: Flat Document Root with symlinked ABSPATH', () => {
                 // Create the symlink: siteDir/wordpress -> /tmp/e2e-symlinked-core
                 symlinkSync(CORE_DIR, join(siteDir, 'wordpress'));
 
-                // Rewrite index.php to bootstrap WP through the symlink, just
-                // like Atomic's document root index.php does.
+                // Rewrite index.php to pre-define ABSPATH through the symlink
+                // before loading wp-blog-header.php.  This mirrors Atomic's
+                // custom bootstrap: ABSPATH is set to the symlink path, not
+                // wp-load.php's __DIR__ (which PHP resolves to the real path).
+                //
+                // With ABSPATH already defined, wp-load.php skips its own
+                // definition and finds wp-config.php "one level up" from
+                // ABSPATH (dirname(siteDir/wordpress/) == siteDir).
                 writeFileSync(join(siteDir, 'index.php'), `<?php
 define('WP_USE_THEMES', true);
-require __DIR__ . '/wordpress/wp-blog-header.php';
+define('ABSPATH', __DIR__ . '/wordpress/');
+require ABSPATH . 'wp-blog-header.php';
 `);
 
                 // Rewrite wp-config.php so ABSPATH goes through the symlink.

--- a/tests/e2e/tests/import-42-symlinked-abspath-flatten.test.js
+++ b/tests/e2e/tests/import-42-symlinked-abspath-flatten.test.js
@@ -53,10 +53,10 @@ describe('Import: Flat Document Root with symlinked ABSPATH', () => {
                 mkdirSync(CORE_DIR, { recursive: true });
 
                 // Move WP core files into the separate core directory.
-                // Keep wp-content in the site dir (not behind the symlink).
+                // Keep wp-content and index.php in the site dir.
                 for (const entry of ['wp-admin', 'wp-includes', 'wp-load.php',
                     'wp-settings.php', 'wp-blog-header.php', 'wp-cron.php',
-                    'wp-login.php', 'wp-signup.php', 'index.php', 'xmlrpc.php',
+                    'wp-login.php', 'wp-signup.php', 'xmlrpc.php',
                     'wp-activate.php', 'wp-comments-post.php', 'wp-links-opml.php',
                     'wp-mail.php', 'wp-trackback.php']) {
                     const src = join(siteDir, entry);
@@ -67,6 +67,13 @@ describe('Import: Flat Document Root with symlinked ABSPATH', () => {
 
                 // Create the symlink: siteDir/wordpress -> /tmp/e2e-symlinked-core
                 symlinkSync(CORE_DIR, join(siteDir, 'wordpress'));
+
+                // Rewrite index.php to bootstrap WP through the symlink, just
+                // like Atomic's document root index.php does.
+                writeFileSync(join(siteDir, 'index.php'), `<?php
+define('WP_USE_THEMES', true);
+require __DIR__ . '/wordpress/wp-blog-header.php';
+`);
 
                 // Rewrite wp-config.php so ABSPATH goes through the symlink.
                 // This is the key: __DIR__ is the site dir, so ABSPATH becomes

--- a/tests/e2e/tests/import-42-symlinked-abspath-flatten.test.js
+++ b/tests/e2e/tests/import-42-symlinked-abspath-flatten.test.js
@@ -21,8 +21,8 @@
 import { describe, it, beforeAll, afterAll } from 'vitest';
 import assert from 'node:assert/strict';
 import {
-    existsSync, readFileSync, readlinkSync,
-    mkdirSync, symlinkSync, lstatSync,
+    existsSync, readFileSync, writeFileSync,
+    mkdirSync, symlinkSync,
 } from 'node:fs';
 import { execSync } from 'node:child_process';
 import { join } from 'node:path';
@@ -71,7 +71,12 @@ describe('Import: Flat Document Root with symlinked ABSPATH', () => {
                 // Rewrite wp-config.php so ABSPATH goes through the symlink.
                 // This is the key: __DIR__ is the site dir, so ABSPATH becomes
                 // {siteDir}/wordpress/ — an unresolved symlink path.
-                const wpConfig = `<?php
+                //
+                // WP_CONTENT_DIR must be set explicitly because WordPress defaults
+                // it to ABSPATH . 'wp-content', which would resolve through the
+                // symlink to CORE_DIR/wp-content (doesn't exist). The real
+                // wp-content stays in the site dir.
+                writeFileSync(join(siteDir, 'wp-config.php'), `<?php
 define('DB_HOST', '127.0.0.1');
 define('DB_NAME', 'e2e_symlinked_abspath');
 define('DB_USER', 'e2e_admin');
@@ -86,15 +91,13 @@ define('AUTH_SALT',        'e2e-test-salt-1');
 define('SECURE_AUTH_SALT', 'e2e-test-salt-2');
 define('LOGGED_IN_SALT',   'e2e-test-salt-3');
 define('NONCE_SALT',       'e2e-test-salt-4');
+define('WP_CONTENT_DIR', __DIR__ . '/wp-content');
 $table_prefix = 'wp_';
 if ( ! defined( 'ABSPATH' ) ) {
     define( 'ABSPATH', __DIR__ . '/wordpress/' );
 }
 require_once ABSPATH . 'wp-settings.php';
-`;
-                execSync(`cat > "${join(siteDir, 'wp-config.php')}" << 'WPEOF'
-${wpConfig}
-WPEOF`);
+`);
             },
             afterPermissions: async () => {
                 execSync(`sudo chown -R nginx:nginx ${CORE_DIR}`);

--- a/tests/e2e/tests/import-42-symlinked-abspath-flatten.test.js
+++ b/tests/e2e/tests/import-42-symlinked-abspath-flatten.test.js
@@ -1,0 +1,208 @@
+/**
+ * Test 42: flat-document-root when ABSPATH goes through a symlink
+ *
+ * Simulates a WordPress.com Atomic-like environment where:
+ * - WP core files live in a separate directory (/tmp/e2e-symlinked-core/)
+ * - The site has a symlink (wordpress/) pointing to that directory
+ * - wp-config.php defines ABSPATH as __DIR__ . '/wordpress/' — through the symlink
+ *
+ * Before the fix, the exporter reported the unresolved symlink path as abspath
+ * (e.g. /srv/e2e-sites/symlinked-abspath/wordpress). The importer would download
+ * files under the resolved real path (/tmp/e2e-symlinked-core/...) but then
+ * flat-document-root would try to find the ABSPATH directory at the unresolved
+ * symlink path in fs-root — which is a broken symlink locally — and fail with
+ * "WordPress ABSPATH directory not found".
+ *
+ * The fix: the exporter now applies realpath() to ABSPATH, matching the convention
+ * used for all other paths (content_dir, plugins_dir, etc.). This ensures flat-
+ * document-root looks for the directory at the resolved location where the files
+ * were actually downloaded.
+ */
+import { describe, it, beforeAll, afterAll } from 'vitest';
+import assert from 'node:assert/strict';
+import {
+    existsSync, readFileSync, readlinkSync,
+    mkdirSync, symlinkSync, lstatSync,
+} from 'node:fs';
+import { execSync } from 'node:child_process';
+import { join } from 'node:path';
+import {
+    runImporter, createTempDir, cleanupTempDir,
+    getSiteUrl, getSiteSecret, getSiteDir,
+    fsRootDir,
+} from '../lib/test-helpers.js';
+import { ensureSite } from '../lib/site-setup.js';
+
+const CORE_DIR = '/tmp/e2e-symlinked-core';
+
+describe('Import: Flat Document Root with symlinked ABSPATH', () => {
+    const site = 'symlinked-abspath';
+    let tempDir;
+
+    beforeAll(async () => {
+        await ensureSite(site, {
+            afterCreate: async (siteDir) => {
+                // Simulate Atomic-like layout:
+                //   /tmp/e2e-symlinked-core/  — real directory with WP core files
+                //   {siteDir}/wordpress/       — symlink to /tmp/e2e-symlinked-core/
+                //   {siteDir}/wp-config.php    — defines ABSPATH as __DIR__ . '/wordpress/'
+                //
+                // This means ABSPATH resolves through a symlink, just like Atomic's
+                // /wordpress symlink.
+                execSync(`sudo rm -rf ${CORE_DIR}`);
+                mkdirSync(CORE_DIR, { recursive: true });
+
+                // Move WP core files into the separate core directory.
+                // Keep wp-content in the site dir (not behind the symlink).
+                for (const entry of ['wp-admin', 'wp-includes', 'wp-load.php',
+                    'wp-settings.php', 'wp-blog-header.php', 'wp-cron.php',
+                    'wp-login.php', 'wp-signup.php', 'index.php', 'xmlrpc.php',
+                    'wp-activate.php', 'wp-comments-post.php', 'wp-links-opml.php',
+                    'wp-mail.php', 'wp-trackback.php']) {
+                    const src = join(siteDir, entry);
+                    if (existsSync(src)) {
+                        execSync(`mv "${src}" "${CORE_DIR}/${entry}"`);
+                    }
+                }
+
+                // Create the symlink: siteDir/wordpress -> /tmp/e2e-symlinked-core
+                symlinkSync(CORE_DIR, join(siteDir, 'wordpress'));
+
+                // Rewrite wp-config.php so ABSPATH goes through the symlink.
+                // This is the key: __DIR__ is the site dir, so ABSPATH becomes
+                // {siteDir}/wordpress/ — an unresolved symlink path.
+                const wpConfig = `<?php
+define('DB_HOST', '127.0.0.1');
+define('DB_NAME', 'e2e_symlinked_abspath');
+define('DB_USER', 'e2e_admin');
+define('DB_PASSWORD', 'e2e_password');
+define('DB_CHARSET', 'utf8mb4');
+define('DB_COLLATE', '');
+define('AUTH_KEY',         'e2e-test-key-1');
+define('SECURE_AUTH_KEY',  'e2e-test-key-2');
+define('LOGGED_IN_KEY',    'e2e-test-key-3');
+define('NONCE_KEY',        'e2e-test-key-4');
+define('AUTH_SALT',        'e2e-test-salt-1');
+define('SECURE_AUTH_SALT', 'e2e-test-salt-2');
+define('LOGGED_IN_SALT',   'e2e-test-salt-3');
+define('NONCE_SALT',       'e2e-test-salt-4');
+$table_prefix = 'wp_';
+if ( ! defined( 'ABSPATH' ) ) {
+    define( 'ABSPATH', __DIR__ . '/wordpress/' );
+}
+require_once ABSPATH . 'wp-settings.php';
+`;
+                execSync(`cat > "${join(siteDir, 'wp-config.php')}" << 'WPEOF'
+${wpConfig}
+WPEOF`);
+            },
+            afterPermissions: async () => {
+                execSync(`sudo chown -R nginx:nginx ${CORE_DIR}`);
+            },
+        });
+
+        tempDir = createTempDir('e2e-symlinked-abspath');
+    });
+
+    afterAll(() => {
+        cleanupTempDir(tempDir);
+    });
+
+    function importUrl() {
+        return `${getSiteUrl(site)}&directory=${getSiteDir(site)}`;
+    }
+
+    it('preflight reports resolved (realpath) abspath, not the symlink path', () => {
+        const result = runImporter(importUrl(), tempDir, 'preflight', {
+            secret: getSiteSecret(site),
+        });
+        assert.equal(result.exitCode, 0, `preflight failed:\n${result.stderr}`);
+
+        const state = JSON.parse(readFileSync(join(tempDir, '.import-state.json'), 'utf-8'));
+        const pathsUrls = state.preflight?.data?.database?.wp?.paths_urls;
+        assert.ok(pathsUrls, 'Expected paths_urls in preflight data');
+
+        // The critical assertion: abspath should be the resolved real path
+        // (/tmp/e2e-symlinked-core), NOT the symlink path (.../symlinked-abspath/wordpress).
+        assert.ok(
+            pathsUrls.abspath?.includes('e2e-symlinked-core'),
+            `Expected abspath to be the resolved real path containing 'e2e-symlinked-core', ` +
+            `got: ${pathsUrls.abspath}`,
+        );
+        assert.ok(
+            !pathsUrls.abspath?.includes('symlinked-abspath/wordpress'),
+            `abspath should NOT contain the unresolved symlink path 'symlinked-abspath/wordpress', ` +
+            `got: ${pathsUrls.abspath}`,
+        );
+    });
+
+    it('files-sync completes with follow_symlinks', () => {
+        const result = runImporter(importUrl(), tempDir, 'files-sync', {
+            secret: getSiteSecret(site),
+            extraArgs: ['--follow-symlinks'],
+        });
+        assert.equal(result.exitCode, 0, `files-sync failed:\n${result.stderr}`);
+    });
+
+    it('WP core files exist at the resolved path in fs-root', () => {
+        const state = JSON.parse(readFileSync(join(tempDir, '.import-state.json'), 'utf-8'));
+        const abspath = state.preflight?.data?.database?.wp?.paths_urls?.abspath;
+        assert.ok(abspath, 'abspath not found in state');
+
+        const localAbspath = join(fsRootDir(tempDir), abspath);
+        assert.ok(
+            existsSync(localAbspath),
+            `ABSPATH directory should exist at resolved path: ${localAbspath}`,
+        );
+        assert.ok(
+            existsSync(join(localAbspath, 'wp-admin')),
+            'wp-admin should exist under resolved abspath',
+        );
+        assert.ok(
+            existsSync(join(localAbspath, 'wp-includes')),
+            'wp-includes should exist under resolved abspath',
+        );
+    });
+
+    describe('flat-document-root', () => {
+        let flattenTo;
+
+        beforeAll(() => {
+            flattenTo = join(tempDir, 'flattened');
+            const result = runImporter(importUrl(), tempDir, 'flat-document-root', {
+                secret: getSiteSecret(site),
+                extraArgs: [`--flatten-to=${flattenTo}`],
+            });
+            assert.equal(
+                result.exitCode, 0,
+                `flat-document-root failed:\n${result.stderr}\n${result.stdout}`,
+            );
+        });
+
+        it('creates a working flattened layout', () => {
+            assert.ok(existsSync(join(flattenTo, 'wp-load.php')), 'wp-load.php should exist');
+            assert.ok(existsSync(join(flattenTo, 'index.php')), 'index.php should exist');
+        });
+
+        it('wp-admin is traversable', () => {
+            assert.ok(
+                existsSync(join(flattenTo, 'wp-admin', 'admin.php')),
+                'wp-admin/admin.php should be accessible through flatten-to',
+            );
+        });
+
+        it('wp-includes is traversable', () => {
+            assert.ok(
+                existsSync(join(flattenTo, 'wp-includes', 'version.php')),
+                'wp-includes/version.php should be accessible through flatten-to',
+            );
+        });
+
+        it('wp-content is accessible', () => {
+            assert.ok(
+                existsSync(join(flattenTo, 'wp-content')),
+                'wp-content should be accessible through flatten-to',
+            );
+        });
+    });
+});

--- a/tests/e2e/tests/import-42-symlinked-abspath-flatten.test.js
+++ b/tests/e2e/tests/import-42-symlinked-abspath-flatten.test.js
@@ -1,30 +1,30 @@
 /**
  * Test 42: flat-document-root when ABSPATH goes through a symlink
  *
- * Simulates a WordPress.com Atomic-like environment where:
- * - WP core files live in a separate directory (/tmp/e2e-symlinked-core/)
- * - The site has a symlink (wordpress/) pointing to that directory
- * - wp-config.php defines ABSPATH as __DIR__ . '/wordpress/' — through the symlink
+ * Simulates a WordPress.com Atomic-like environment where ABSPATH is
+ * accessed through a symlink. On Atomic, /wordpress is a symlink, so
+ * ABSPATH (e.g. /wordpress/core/6.9.4/) resolves to a different real path.
  *
- * Before the fix, the exporter reported the unresolved symlink path as abspath
- * (e.g. /srv/e2e-sites/symlinked-abspath/wordpress). The importer would download
- * files under the resolved real path (/tmp/e2e-symlinked-core/...) but then
- * flat-document-root would try to find the ABSPATH directory at the unresolved
- * symlink path in fs-root — which is a broken symlink locally — and fail with
- * "WordPress ABSPATH directory not found".
+ * Setup:
+ * - Standard WP install at siteDir
+ * - siteDir/wp-core is a symlink pointing to siteDir itself
+ * - index.php pre-defines ABSPATH as siteDir/wp-core/ (through the symlink)
+ * - realpath(ABSPATH) resolves to siteDir (the real path)
  *
- * The fix: the exporter now applies realpath() to ABSPATH, matching the convention
- * used for all other paths (content_dir, plugins_dir, etc.). This ensures flat-
- * document-root looks for the directory at the resolved location where the files
- * were actually downloaded.
+ * Before the fix, the exporter reported the unresolved symlink path as
+ * abspath. The importer would download files under the resolved real path
+ * but flat-document-root would look at the unresolved symlink path in
+ * fs-root and fail.
+ *
+ * The fix: the exporter now applies realpath() to ABSPATH, matching the
+ * convention used for all other paths (content_dir, plugins_dir, etc.).
  */
 import { describe, it, beforeAll, afterAll } from 'vitest';
 import assert from 'node:assert/strict';
 import {
     existsSync, readFileSync, writeFileSync,
-    mkdirSync, symlinkSync,
+    symlinkSync,
 } from 'node:fs';
-import { execSync } from 'node:child_process';
 import { join } from 'node:path';
 import {
     runImporter, createTempDir, cleanupTempDir,
@@ -33,8 +33,6 @@ import {
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
-const CORE_DIR = '/tmp/e2e-symlinked-core';
-
 describe('Import: Flat Document Root with symlinked ABSPATH', () => {
     const site = 'symlinked-abspath';
     let tempDir;
@@ -42,79 +40,23 @@ describe('Import: Flat Document Root with symlinked ABSPATH', () => {
     beforeAll(async () => {
         await ensureSite(site, {
             afterCreate: async (siteDir) => {
-                // Simulate Atomic-like layout:
-                //   /tmp/e2e-symlinked-core/  — real directory with WP core files
-                //   {siteDir}/wordpress/       — symlink to /tmp/e2e-symlinked-core/
-                //   {siteDir}/wp-config.php    — defines ABSPATH as __DIR__ . '/wordpress/'
-                //
-                // This means ABSPATH resolves through a symlink, just like Atomic's
-                // /wordpress symlink.
-                execSync(`sudo rm -rf ${CORE_DIR}`);
-                mkdirSync(CORE_DIR, { recursive: true });
-
-                // Move WP core files into the separate core directory.
-                // Keep wp-content and index.php in the site dir.
-                for (const entry of ['wp-admin', 'wp-includes', 'wp-load.php',
-                    'wp-settings.php', 'wp-blog-header.php', 'wp-cron.php',
-                    'wp-login.php', 'wp-signup.php', 'xmlrpc.php',
-                    'wp-activate.php', 'wp-comments-post.php', 'wp-links-opml.php',
-                    'wp-mail.php', 'wp-trackback.php']) {
-                    const src = join(siteDir, entry);
-                    if (existsSync(src)) {
-                        execSync(`mv "${src}" "${CORE_DIR}/${entry}"`);
-                    }
-                }
-
-                // Create the symlink: siteDir/wordpress -> /tmp/e2e-symlinked-core
-                symlinkSync(CORE_DIR, join(siteDir, 'wordpress'));
+                // Create a symlink that points back to the site directory itself.
+                // This means siteDir/wp-core/wp-load.php is the same file as
+                // siteDir/wp-load.php — just accessed through a symlink.
+                symlinkSync('.', join(siteDir, 'wp-core'));
 
                 // Rewrite index.php to pre-define ABSPATH through the symlink
-                // before loading wp-blog-header.php.  This mirrors Atomic's
-                // custom bootstrap: ABSPATH is set to the symlink path, not
-                // wp-load.php's __DIR__ (which PHP resolves to the real path).
+                // before wp-load.php can define it.  This mirrors Atomic's
+                // custom bootstrap where ABSPATH goes through a symlink.
                 //
-                // With ABSPATH already defined, wp-load.php skips its own
-                // definition and finds wp-config.php "one level up" from
-                // ABSPATH (dirname(siteDir/wordpress/) == siteDir).
+                // With ABSPATH pre-defined, wp-load.php skips its own
+                // definition and finds wp-config.php at ABSPATH/wp-config.php
+                // (which resolves through the symlink back to siteDir).
                 writeFileSync(join(siteDir, 'index.php'), `<?php
 define('WP_USE_THEMES', true);
-define('ABSPATH', __DIR__ . '/wordpress/');
+define('ABSPATH', __DIR__ . '/wp-core/');
 require ABSPATH . 'wp-blog-header.php';
 `);
-
-                // Rewrite wp-config.php so ABSPATH goes through the symlink.
-                // This is the key: __DIR__ is the site dir, so ABSPATH becomes
-                // {siteDir}/wordpress/ — an unresolved symlink path.
-                //
-                // WP_CONTENT_DIR must be set explicitly because WordPress defaults
-                // it to ABSPATH . 'wp-content', which would resolve through the
-                // symlink to CORE_DIR/wp-content (doesn't exist). The real
-                // wp-content stays in the site dir.
-                writeFileSync(join(siteDir, 'wp-config.php'), `<?php
-define('DB_HOST', '127.0.0.1');
-define('DB_NAME', 'e2e_symlinked_abspath');
-define('DB_USER', 'e2e_admin');
-define('DB_PASSWORD', 'e2e_password');
-define('DB_CHARSET', 'utf8mb4');
-define('DB_COLLATE', '');
-define('AUTH_KEY',         'e2e-test-key-1');
-define('SECURE_AUTH_KEY',  'e2e-test-key-2');
-define('LOGGED_IN_KEY',    'e2e-test-key-3');
-define('NONCE_KEY',        'e2e-test-key-4');
-define('AUTH_SALT',        'e2e-test-salt-1');
-define('SECURE_AUTH_SALT', 'e2e-test-salt-2');
-define('LOGGED_IN_SALT',   'e2e-test-salt-3');
-define('NONCE_SALT',       'e2e-test-salt-4');
-define('WP_CONTENT_DIR', __DIR__ . '/wp-content');
-$table_prefix = 'wp_';
-if ( ! defined( 'ABSPATH' ) ) {
-    define( 'ABSPATH', __DIR__ . '/wordpress/' );
-}
-require_once ABSPATH . 'wp-settings.php';
-`);
-            },
-            afterPermissions: async () => {
-                execSync(`sudo chown -R nginx:nginx ${CORE_DIR}`);
             },
         });
 
@@ -129,7 +71,7 @@ require_once ABSPATH . 'wp-settings.php';
         return `${getSiteUrl(site)}&directory=${getSiteDir(site)}`;
     }
 
-    it('preflight reports resolved (realpath) abspath, not the symlink path', () => {
+    it('preflight reports resolved abspath, not the symlink path', () => {
         const result = runImporter(importUrl(), tempDir, 'preflight', {
             secret: getSiteSecret(site),
         });
@@ -140,15 +82,15 @@ require_once ABSPATH . 'wp-settings.php';
         assert.ok(pathsUrls, 'Expected paths_urls in preflight data');
 
         // The critical assertion: abspath should be the resolved real path
-        // (/tmp/e2e-symlinked-core), NOT the symlink path (.../symlinked-abspath/wordpress).
+        // (the site directory), NOT the unresolved symlink path with /wp-core/.
         assert.ok(
-            pathsUrls.abspath?.includes('e2e-symlinked-core'),
-            `Expected abspath to be the resolved real path containing 'e2e-symlinked-core', ` +
+            !pathsUrls.abspath?.includes('/wp-core'),
+            `abspath should NOT contain the unresolved symlink path '/wp-core', ` +
             `got: ${pathsUrls.abspath}`,
         );
         assert.ok(
-            !pathsUrls.abspath?.includes('symlinked-abspath/wordpress'),
-            `abspath should NOT contain the unresolved symlink path 'symlinked-abspath/wordpress', ` +
+            pathsUrls.abspath?.includes('symlinked-abspath'),
+            `Expected abspath to contain the site directory name, ` +
             `got: ${pathsUrls.abspath}`,
         );
     });


### PR DESCRIPTION
## Summary

On WordPress.com Atomic, `/wordpress` is a symlink. The exporter was the only preflight path NOT resolved with `realpath()` — all other paths (`content_dir`, `plugins_dir`, `wp_admin_path`, etc.) already were. This inconsistency meant the importer downloaded files under the resolved real path but `flat-document-root` looked for ABSPATH at the unresolved symlink path, which is a broken symlink locally.

The fix applies `realpath()` to ABSPATH in the exporter, matching the convention already used for every other path. Falls back to the raw value if `realpath()` fails (shouldn't happen since ABSPATH exists on the source server).

## Test plan

- New E2E test (import-42) simulates the Atomic layout: WP core behind a symlink, ABSPATH defined through it
- Verifies preflight reports the resolved real path, not the symlink path
- Verifies flat-document-root succeeds (would have failed without the fix)