### PR TITLE
Remove mixed type hints for PHP 7.x compat

### DIFF
--- a/packages/streaming-importer/src/import.php
+++ b/packages/streaming-importer/src/import.php
@@ -10204,7 +10204,7 @@ if (
     }
 
     /** @internal */
-    function _cli_cast(string $raw, ?string $cast): mixed
+    function _cli_cast(string $raw, ?string $cast)
     {
         switch ($cast) {
             case 'int':   return (int) $raw;
@@ -10215,7 +10215,7 @@ if (
     }
 
     /** @internal */
-    function _cli_store(array $def, mixed $value, ?string &$state_dir, ?string &$fs_root, array &$options): void
+    function _cli_store(array $def, $value, ?string &$state_dir, ?string &$fs_root, array &$options): void
     {
         $target = $def['target'];
         if ($target === 'state_dir') { $state_dir = $value; return; }


### PR DESCRIPTION
## Summary

The `_cli_cast()` and `_cli_store()` functions used `mixed` type hints introduced in PHP 8.0. On PHP 7.x, `mixed` is interpreted as a class name, causing a fatal TypeError that broke the playground-cli-runtime e2e test.

This removes the two `mixed` type hints so the importer runs on both PHP 7.x and 8.x.

## Test plan

- [ ] `import-41-playground-cli-runtime` e2e test passes in CI