### PR TITLE
Extract export HTTP dispatcher into package

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -319,11 +319,11 @@
         },
         {
             "name": "wp-php-toolkit/streaming-exporter",
-            "version": "dev-codex/extract-hmac-server",
+            "version": "dev-codex/extract-export-dispatcher",
             "dist": {
                 "type": "path",
                 "url": "packages/streaming-exporter",
-                "reference": "6d3897da519786d1705b1952f43816e8a83eb45f"
+                "reference": "2131bfb359f8e04244d912d5eeddb55c284ce52e"
             },
             "require": {
                 "ext-pdo": "*",
@@ -342,6 +342,7 @@
                     "src/class-file-tree-producer.php",
                     "src/class-hmac-client.php",
                     "src/class-hmac-server.php",
+                    "src/class-http-server.php",
                     "src/class-sqlite-driver-pdo.php"
                 ],
                 "files": [

--- a/packages/streaming-exporter/composer.json
+++ b/packages/streaming-exporter/composer.json
@@ -19,6 +19,7 @@
             "src/class-file-tree-producer.php",
             "src/class-hmac-client.php",
             "src/class-hmac-server.php",
+            "src/class-http-server.php",
             "src/class-sqlite-driver-pdo.php"
         ],
         "files": [

--- a/packages/streaming-exporter/src/class-http-server.php
+++ b/packages/streaming-exporter/src/class-http-server.php
@@ -103,8 +103,7 @@ final class Site_Export_HTTP_Server {
     public function normalize_config(array $config, array $server = []): array {
         if (
             $this->default_directory !== null &&
-            !isset($config['directory']) &&
-            !isset($config['list_dir'])
+            !isset($config['directory'])
         ) {
             $config['directory'] = $this->default_directory;
         }

--- a/packages/streaming-exporter/src/class-http-server.php
+++ b/packages/streaming-exporter/src/class-http-server.php
@@ -1,0 +1,232 @@
+<?php
+
+/**
+ * HTTP dispatcher for the Site Export API.
+ */
+final class Site_Export_HTTP_Server {
+
+    /** @var array<string, callable> */
+    private $handlers;
+
+    /** @var callable */
+    private $budget_factory;
+
+    /** @var callable */
+    private $body_reader;
+
+    /** @var string */
+    private $cursor_header_name;
+
+    /** @var string|null */
+    private $default_directory;
+
+    public function __construct(array $options = []) {
+        $this->handlers = $options['handlers'] ?? $this->default_handlers();
+        $this->budget_factory = $options['budget_factory'] ?? [$this, 'default_budget_factory'];
+        $this->body_reader = $options['body_reader'] ?? static function (): string {
+            $body = file_get_contents('php://input');
+            return $body === false ? '' : $body;
+        };
+        $this->cursor_header_name = $options['cursor_header_name'] ?? 'HTTP_X_EXPORT_CURSOR';
+        $this->default_directory = $options['default_directory'] ?? null;
+    }
+
+    public function handle_request(array $request = []): void {
+        $server = $request['server'] ?? $_SERVER;
+        $body = array_key_exists('body', $request) ? (string) $request['body'] : call_user_func($this->body_reader);
+        $config = $request['config'] ?? $this->parse_http_config(
+            $request['get'] ?? $_GET,
+            $request['post'] ?? $_POST,
+            $server,
+            $body
+        );
+        $config = $this->normalize_config($config, $server);
+        $this->dispatch($config);
+    }
+
+    /**
+     * @param array<string, mixed> $get
+     * @param array<string, mixed> $post
+     * @param array<string, mixed> $server
+     * @return array<string, mixed>
+     */
+    public function parse_http_config(array $get = [], array $post = [], array $server = [], string $body = ''): array {
+        $config = [];
+        $params = array_merge($get, $post);
+
+        $content_type = $server['CONTENT_TYPE'] ?? '';
+        $content_type_main = strtolower(trim((string) strtok((string) $content_type, ';')));
+        if ($content_type_main === 'application/json' && $body !== '') {
+            $json_data = json_decode($body, true);
+            if (is_array($json_data)) {
+                $params = array_merge($json_data, $params);
+            }
+        }
+
+        foreach ($params as $key => $value) {
+            $key = str_replace('-', '_', (string) $key);
+
+            if (
+                in_array($key, [
+                    'max_execution_time',
+                    'min_ctime',
+                    'chunk_size',
+                    'fragments_per_batch',
+                    'batch_size',
+                    'db_query_time_limit',
+                    'tables_per_batch',
+                ], true)
+            ) {
+                $value = (int) $value;
+            } elseif (in_array($key, ['memory_threshold'], true)) {
+                $value = (float) $value;
+            } elseif (in_array($key, ['create_table_query', 'db_unbuffered', 'follow_symlinks'], true)) {
+                $value = filter_var($value, FILTER_VALIDATE_BOOLEAN);
+            } elseif ($key === 'paths' && is_string($value)) {
+                $decoded = json_decode($value, true);
+                if (is_array($decoded)) {
+                    $value = $decoded;
+                }
+            }
+
+            $config[$key] = $value;
+        }
+
+        return $config;
+    }
+
+    /**
+     * @param array<string, mixed> $config
+     * @param array<string, mixed> $server
+     * @return array<string, mixed>
+     */
+    public function normalize_config(array $config, array $server = []): array {
+        if (
+            $this->default_directory !== null &&
+            !isset($config['directory']) &&
+            !isset($config['list_dir'])
+        ) {
+            $config['directory'] = $this->default_directory;
+        }
+
+        if (!isset($config['cursor']) && isset($server[$this->cursor_header_name])) {
+            $config['cursor'] = $server[$this->cursor_header_name];
+        }
+
+        if (isset($config['cursor']) && $config['cursor'] !== '' && $config['cursor'] !== null) {
+            $config['cursor'] = $this->decode_cursor((string) $config['cursor']);
+        }
+
+        $endpoint = $config['endpoint'] ?? null;
+        if (!is_string($endpoint) || $endpoint === '') {
+            throw new InvalidArgumentException(
+                "endpoint parameter is required. Valid endpoints: " . $this->get_valid_endpoints_message()
+            );
+        }
+
+        return $config;
+    }
+
+    public function decode_cursor(string $cursor_b64): string {
+        $cursor_json = base64_decode($cursor_b64, true);
+        if ($cursor_json === false) {
+            throw new InvalidArgumentException(
+                'Cursor must be base64-encoded. Received invalid base64: ' . substr($cursor_b64, 0, 50)
+            );
+        }
+
+        $cursor_data = json_decode($cursor_json, true);
+        if ($cursor_data === null && json_last_error() !== JSON_ERROR_NONE) {
+            throw new InvalidArgumentException(
+                'Cursor must be valid JSON after base64 decoding. JSON error: ' . json_last_error_msg()
+            );
+        }
+
+        return $cursor_json;
+    }
+
+    /**
+     * @param array<string, mixed> $config
+     * @return mixed
+     */
+    public function create_resource_budget(array $config) {
+        return call_user_func($this->budget_factory, $config);
+    }
+
+    /**
+     * @param array<string, mixed> $config
+     * @param mixed $budget
+     */
+    public function dispatch(array $config, $budget = null): void {
+        $endpoint = $config['endpoint'] ?? null;
+        if (!is_string($endpoint) || $endpoint === '') {
+            throw new InvalidArgumentException(
+                "endpoint parameter is required. Valid endpoints: " . $this->get_valid_endpoints_message()
+            );
+        }
+
+        if (!isset($this->handlers[$endpoint])) {
+            throw new InvalidArgumentException(
+                "Invalid endpoint: '{$endpoint}'. Valid endpoints: " . $this->get_valid_endpoints_message()
+            );
+        }
+
+        $handler = $this->handlers[$endpoint];
+        if ($endpoint === 'preflight') {
+            call_user_func($handler, $config);
+            return;
+        }
+
+        if ($budget === null) {
+            $budget = $this->create_resource_budget($config);
+        }
+
+        call_user_func($handler, $config, $budget);
+    }
+
+    /**
+     * @return array<string, callable>
+     */
+    private function default_handlers(): array {
+        return [
+            'file_index' => 'endpoint_file_index',
+            'file_fetch' => 'endpoint_file_fetch',
+            'sql_chunk' => 'endpoint_sql_chunk',
+            'db_index' => 'endpoint_db_index',
+            'preflight' => 'endpoint_preflight',
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $config
+     * @return mixed
+     */
+    private function default_budget_factory(array $config) {
+        $max_execution_time = require_int_range(
+            'max_execution_time',
+            (int) ($config['max_execution_time'] ?? 5),
+            1,
+            60
+        );
+        $memory_threshold = require_float_range(
+            'memory_threshold',
+            (float) ($config['memory_threshold'] ?? 0.8),
+            0.1,
+            0.95
+        );
+
+        $memory_limit = ini_get('memory_limit');
+        $max_memory = $memory_limit === '-1' ? PHP_INT_MAX : parse_size((string) $memory_limit);
+
+        return new ResourceBudget(
+            microtime(true),
+            $max_execution_time,
+            $max_memory,
+            $memory_threshold
+        );
+    }
+
+    private function get_valid_endpoints_message(): string {
+        return "'" . implode("', '", array_keys($this->handlers)) . "'";
+    }
+}

--- a/packages/streaming-exporter/src/export.php
+++ b/packages/streaming-exporter/src/export.php
@@ -376,6 +376,7 @@ function create_sqlite_pdo_adapter()
 }
 
 require_once __DIR__ . "/utils.php";
+require_once __DIR__ . "/class-http-server.php";
 
 /**
  * Emits an error chunk into a gzip multipart stream.
@@ -3377,49 +3378,11 @@ function position_after_entry(array $entries, string $after): int
  */
 function parse_http_config(): array
 {
-    $config = [];
-    $params = array_merge($_GET, $_POST);
-
-    $content_type = $_SERVER["CONTENT_TYPE"] ?? "";
-    $content_type_main = strtolower(trim((string) strtok($content_type, ";")));
-    if ($content_type_main === "application/json") {
-        $json_body = file_get_contents("php://input");
-        if ($json_body !== false && $json_body !== "") {
-            $json_data = json_decode($json_body, true);
-            if (is_array($json_data)) {
-                $params = array_merge($json_data, $params);
-            }
-        }
+    $body = file_get_contents('php://input');
+    if ($body === false) {
+        $body = '';
     }
 
-    foreach ($params as $key => $value) {
-        $key = str_replace("-", "_", $key);
-
-        if (
-            in_array($key, [
-                "max_execution_time",
-                "min_ctime",
-                "chunk_size",
-                "fragments_per_batch",
-                "batch_size",
-                "db_query_time_limit",
-                "tables_per_batch",
-            ])
-        ) {
-            $value = (int) $value;
-        } elseif (in_array($key, ["memory_threshold"])) {
-            $value = (float) $value;
-        } elseif (in_array($key, ["create_table_query", "db_unbuffered", "follow_symlinks"])) {
-            $value = filter_var($value, FILTER_VALIDATE_BOOLEAN);
-        } elseif ($key === "paths" && is_string($value)) {
-            $decoded = json_decode($value, true);
-            if (is_array($decoded)) {
-                $value = $decoded;
-            }
-        }
-
-        $config[$key] = $value;
-    }
-
-    return $config;
+    $server = new Site_Export_HTTP_Server();
+    return $server->parse_http_config($_GET, $_POST, $_SERVER, $body);
 }

--- a/tests/ExportHttpServerTest.php
+++ b/tests/ExportHttpServerTest.php
@@ -44,6 +44,21 @@ final class ExportHttpServerTest extends TestCase
         $this->assertSame('{"offset":10}', $config['cursor']);
     }
 
+    public function testNormalizeConfigAppliesDefaultDirectoryEvenWhenListDirPresent(): void
+    {
+        $server = new Site_Export_HTTP_Server([
+            'default_directory' => '/srv/site',
+        ]);
+
+        $config = $server->normalize_config(
+            ['endpoint' => 'file_index', 'list_dir' => '/srv/site/wp-content'],
+            []
+        );
+
+        $this->assertSame('/srv/site', $config['directory']);
+        $this->assertSame('/srv/site/wp-content', $config['list_dir']);
+    }
+
     public function testNormalizeConfigRejectsInvalidCursor(): void
     {
         $server = new Site_Export_HTTP_Server();

--- a/tests/ExportHttpServerTest.php
+++ b/tests/ExportHttpServerTest.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+final class ExportHttpServerTest extends TestCase
+{
+    public function testParsesJsonBodyAndCastsKnownTypes(): void
+    {
+        $server = new Site_Export_HTTP_Server();
+        $config = $server->parse_http_config(
+            ['endpoint' => 'file_index'],
+            [],
+            ['CONTENT_TYPE' => 'application/json; charset=utf-8'],
+            json_encode([
+                'paths' => ['a', 'b'],
+                'max_execution_time' => '7',
+                'memory_threshold' => '0.7',
+                'create_table_query' => 'true',
+            ]) ?: ''
+        );
+
+        $this->assertSame('file_index', $config['endpoint']);
+        $this->assertSame(['a', 'b'], $config['paths']);
+        $this->assertSame(7, $config['max_execution_time']);
+        $this->assertSame(0.7, $config['memory_threshold']);
+        $this->assertTrue($config['create_table_query']);
+    }
+
+    public function testNormalizeConfigAppliesDefaultDirectoryAndDecodesCursorHeader(): void
+    {
+        $server = new Site_Export_HTTP_Server([
+            'default_directory' => '/srv/site',
+        ]);
+        $cursor = base64_encode(json_encode(['offset' => 10]) ?: '');
+
+        $config = $server->normalize_config(
+            ['endpoint' => 'file_index'],
+            ['HTTP_X_EXPORT_CURSOR' => $cursor]
+        );
+
+        $this->assertSame('/srv/site', $config['directory']);
+        $this->assertSame('{"offset":10}', $config['cursor']);
+    }
+
+    public function testNormalizeConfigRejectsInvalidCursor(): void
+    {
+        $server = new Site_Export_HTTP_Server();
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Cursor must be base64-encoded');
+
+        $server->normalize_config(
+            ['endpoint' => 'file_index'],
+            ['HTTP_X_EXPORT_CURSOR' => '!!!not-base64!!!']
+        );
+    }
+
+    public function testDispatchRoutesPreflightWithoutBudget(): void
+    {
+        $calls = [];
+        $server = new Site_Export_HTTP_Server([
+            'handlers' => [
+                'preflight' => function (array $config) use (&$calls): void {
+                    $calls[] = ['preflight', $config];
+                },
+            ],
+        ]);
+
+        $server->dispatch(['endpoint' => 'preflight']);
+
+        $this->assertCount(1, $calls);
+        $this->assertSame('preflight', $calls[0][0]);
+        $this->assertSame(['endpoint' => 'preflight'], $calls[0][1]);
+    }
+
+    public function testDispatchRoutesStreamingEndpointsWithCreatedBudget(): void
+    {
+        $calls = [];
+        $server = new Site_Export_HTTP_Server([
+            'handlers' => [
+                'file_index' => function (array $config, $budget) use (&$calls): void {
+                    $calls[] = [$config, $budget];
+                },
+            ],
+            'budget_factory' => static function (array $config): array {
+                return ['from' => $config['endpoint']];
+            },
+        ]);
+
+        $server->dispatch(['endpoint' => 'file_index']);
+
+        $this->assertCount(1, $calls);
+        $this->assertSame(['endpoint' => 'file_index'], $calls[0][0]);
+        $this->assertSame(['from' => 'file_index'], $calls[0][1]);
+    }
+
+    public function testDispatchRejectsUnknownEndpoints(): void
+    {
+        $server = new Site_Export_HTTP_Server([
+            'handlers' => [
+                'preflight' => static function (): void {},
+            ],
+        ]);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("Invalid endpoint: 'sql_chunk'. Valid endpoints: 'preflight'");
+
+        $server->dispatch(['endpoint' => 'sql_chunk']);
+    }
+
+    public function testHandleRequestUsesParsedConfigAndDispatches(): void
+    {
+        $calls = [];
+        $server = new Site_Export_HTTP_Server([
+            'handlers' => [
+                'preflight' => function (array $config) use (&$calls): void {
+                    $calls[] = $config;
+                },
+            ],
+        ]);
+
+        $server->handle_request([
+            'get' => ['endpoint' => 'preflight'],
+            'post' => [],
+            'server' => ['REQUEST_METHOD' => 'GET'],
+            'body' => '',
+        ]);
+
+        $this->assertSame([['endpoint' => 'preflight']], $calls);
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -22,5 +22,9 @@ if (!class_exists('Site_Export_HMAC_Server')) {
     require_once __DIR__ . '/../packages/streaming-exporter/src/class-hmac-server.php';
 }
 
+if (!class_exists('Site_Export_HTTP_Server')) {
+    require_once __DIR__ . '/../packages/streaming-exporter/src/class-http-server.php';
+}
+
 // Load the test base class
 require_once __DIR__ . '/FileSyncProducer/FileSyncProducerTestBase.php';

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -21,6 +21,7 @@
         </testsuite>
         <testsuite name="Export Utility Tests">
             <file>BuildPdoDsnTest.php</file>
+            <file>ExportHttpServerTest.php</file>
             <file>HmacServerTest.php</file>
             <file>SiteExportSecretTest.php</file>
         </testsuite>

--- a/wordpress-plugin/composer.lock
+++ b/wordpress-plugin/composer.lock
@@ -319,11 +319,11 @@
         },
         {
             "name": "wp-php-toolkit/streaming-exporter",
-            "version": "dev-codex/extract-hmac-server",
+            "version": "dev-codex/extract-export-dispatcher",
             "dist": {
                 "type": "path",
                 "url": "../packages/streaming-exporter",
-                "reference": "6d3897da519786d1705b1952f43816e8a83eb45f"
+                "reference": "2131bfb359f8e04244d912d5eeddb55c284ce52e"
             },
             "require": {
                 "ext-pdo": "*",
@@ -342,6 +342,7 @@
                     "src/class-file-tree-producer.php",
                     "src/class-hmac-client.php",
                     "src/class-hmac-server.php",
+                    "src/class-http-server.php",
                     "src/class-sqlite-driver-pdo.php"
                 ],
                 "files": [

--- a/wordpress-plugin/lib.php
+++ b/wordpress-plugin/lib.php
@@ -276,11 +276,6 @@ function _site_export_handle_api_request(array $options = []): void {
     $authenticate = $options['authenticate'] ?? '_site_export_default_authenticate';
     $authenticate();
 
-    // -- Set up defaults for export.php --
-    if (!isset($_GET['directory']) && !isset($_POST['directory'])) {
-        $_GET['directory'] = ABSPATH;
-    }
-
     // export.php has its own SECRET_KEY guard — satisfy it since we already
     // verified the request via HMAC above.
     define('SECRET_KEY', 'hmac_authenticated');
@@ -298,96 +293,10 @@ function _site_export_handle_api_request(array $options = []): void {
 
     // -- Dispatch --
     try {
-        $config = parse_http_config();
-
-        if (!isset($config['cursor'])) {
-            $config['cursor'] = $_SERVER['HTTP_X_EXPORT_CURSOR'] ?? null;
-        }
-
-        if (isset($config['cursor']) && $config['cursor'] !== '' && $config['cursor'] !== null) {
-            $cursor_b64 = $config['cursor'];
-            $cursor_json = base64_decode($cursor_b64, true);
-
-            if ($cursor_json === false) {
-                throw new InvalidArgumentException(
-                    'Cursor must be base64-encoded. Received invalid base64: ' . substr($cursor_b64, 0, 50)
-                );
-            }
-
-            $cursor_data = json_decode($cursor_json, true);
-            if ($cursor_data === null && json_last_error() !== JSON_ERROR_NONE) {
-                throw new InvalidArgumentException(
-                    'Cursor must be valid JSON after base64 decoding. JSON error: ' . json_last_error_msg()
-                );
-            }
-
-            $config['cursor'] = $cursor_json;
-        }
-
-        $endpoint = $config['endpoint'] ?? null;
-        if (!$endpoint) {
-            throw new InvalidArgumentException(
-                "endpoint parameter is required. Valid endpoints: 'file_index', 'file_fetch', 'sql_chunk', 'db_index', 'preflight'"
-            );
-        }
-
-        $max_execution_time = (int) ($config['max_execution_time'] ?? 5);
-        $memory_threshold = (float) ($config['memory_threshold'] ?? 0.8);
-
-        $max_execution_time = require_int_range(
-            'max_execution_time',
-            $max_execution_time,
-            1,
-            60
-        );
-
-        $memory_threshold = require_float_range(
-            'memory_threshold',
-            $memory_threshold,
-            0.1,
-            0.95
-        );
-
-        $memory_limit = ini_get('memory_limit');
-        if ($memory_limit === '-1') {
-            $max_memory = PHP_INT_MAX;
-        } else {
-            $max_memory = parse_size($memory_limit);
-        }
-
-        $budget = new ResourceBudget(
-            microtime(true),
-            $max_execution_time,
-            $max_memory,
-            $memory_threshold,
-        );
-
-        switch ($endpoint) {
-            case 'file_index':
-                endpoint_file_index($config, $budget);
-                break;
-
-            case 'file_fetch':
-                endpoint_file_fetch($config, $budget);
-                break;
-
-            case 'sql_chunk':
-                endpoint_sql_chunk($config, $budget);
-                break;
-
-            case 'db_index':
-                endpoint_db_index($config, $budget);
-                break;
-
-            case 'preflight':
-                endpoint_preflight($config);
-                break;
-
-            default:
-                throw new InvalidArgumentException(
-                    "Invalid endpoint: '{$endpoint}'. Valid endpoints: 'file_index', 'file_fetch', 'sql_chunk', 'db_index', 'preflight'"
-                );
-        }
+        $server = new Site_Export_HTTP_Server([
+            'default_directory' => ABSPATH,
+        ]);
+        $server->handle_request();
     } catch (Exception $e) {
         if (!headers_sent()) {
             http_response_code(400);


### PR DESCRIPTION
## Summary
- add `Site_Export_HTTP_Server` to `wp-php-toolkit/streaming-exporter` as a reusable request parser, normalizer, budget builder, and endpoint dispatcher
- refactor the WordPress plugin to delegate config parsing, cursor decoding, budget construction, and endpoint routing to the package API
- add focused unit coverage for request parsing, cursor validation, dispatch behavior, and export utility integration

## Testing
- `php -l packages/streaming-exporter/src/class-http-server.php`
- `php -l packages/streaming-exporter/src/export.php`
- `php -l wordpress-plugin/lib.php`
- `composer analyze`
- `cd tests && ../vendor/bin/phpunit --colors --testdox --testsuite "Export Utility Tests"`