### PR TITLE
Emit structured file counts in progress and heartbeat records

### DIFF
--- a/packages/streaming-importer/src/import.php
+++ b/packages/streaming-importer/src/import.php
@@ -924,6 +924,10 @@ class ImportClient
     /** @var int Running count of files imported in the current invocation. */
     private $files_imported = 0;
 
+    /** @var int|null Cached index size, set once before the fetch phase to
+     *  avoid re-reading the index file on every progress record. */
+    private $cached_index_count = null;
+
     /**
      * @var array Persistent import state loaded from / saved to $state_file.
      * Keys: command, status, cursor, stage, preflight, version, follow_symlinks,
@@ -2444,6 +2448,7 @@ class ImportClient
         if ($has_progress) {
             $this->files_imported = 0;
             $index_size = $this->index_count();
+            $this->cached_index_count = $index_size;
 
             $stage = $this->state["stage"] ?? "index";
             $this->audit_log(
@@ -2491,6 +2496,7 @@ class ImportClient
             if ($is_delta) {
                 $this->files_imported = 0;
                 $index_size = $this->index_count();
+                $this->cached_index_count = $index_size;
                 $this->audit_log(
                     "START files-sync (delta) | index_files={$index_size}",
                     true,
@@ -2543,6 +2549,7 @@ class ImportClient
 
         $this->clear_progress_line();
         $index_size = $this->index_count();
+        $this->cached_index_count = $index_size;
         $label = $is_delta ? "files-sync (delta)" : "files-sync";
 
         $this->audit_log(
@@ -7465,6 +7472,7 @@ class ImportClient
             $this->output_progress([
                 "type" => "file_progress",
                 "files_imported" => $this->files_imported,
+                "files_indexed" => $this->cached_index_count,
                 "path" => $path,
                 "size" => $file_size,
                 "message" => $file_progress_message,
@@ -8897,10 +8905,15 @@ class ImportClient
                 // Output heartbeat every second (only in verbose/non-TTY mode)
                 if ($now - $last_heartbeat >= 1.0) {
                     if ($this->verbose_mode || !$this->is_tty) {
-                        fwrite($this->progress_fd, json_encode([
+                        $heartbeat = [
                             "heartbeat" => true,
                             "bytes_received" => $bytes_received,
-                        ]) . "\n");
+                        ];
+                        if ($this->cached_index_count !== null) {
+                            $heartbeat["files_imported"] = $this->files_imported;
+                            $heartbeat["files_indexed"] = $this->cached_index_count;
+                        }
+                        fwrite($this->progress_fd, json_encode($heartbeat) . "\n");
                     }
                     $last_heartbeat = $now;
                 }


### PR DESCRIPTION
## Summary

Studio's CLI import progress display needs structured `files_imported` and `files_indexed` fields to show a stable "X/Y files" counter. Previously `file_progress` records only had `files_imported` and the total was only available in lifecycle completion events. Heartbeats had no file counts at all, so between file completions the display fell back to the raw message text which danced with every record.

- Cache the index size once before the fetch phase starts (avoids re-reading the index file per record)
- Include `files_imported` and `files_indexed` in `file_progress` records
- Include `files_imported` and `files_indexed` in heartbeat records when available

Consumer-side changes in Automattic/studio are on the `adamziel/stream-import-flow` branch.

## Test plan

- Run `studio site import` against a WP.com site and verify the progress line shows a stable `X/Y files` counter that only increases
- Verify heartbeat records include `files_imported` and `files_indexed` by running with `--verbose`