### PR TITLE
Emit download-list-based files_done and files_total in progress records

### DIFF
--- a/packages/streaming-importer/src/import.php
+++ b/packages/streaming-importer/src/import.php
@@ -924,6 +924,10 @@ class ImportClient
     /** @var int Running count of files imported in the current invocation. */
     private $files_imported = 0;
 
+    /** @var int|null Cached index size, set once before the fetch phase to
+     *  avoid re-reading the index file on every progress record. */
+    private $cached_index_count = null;
+
     /**
      * @var array Persistent import state loaded from / saved to $state_file.
      * Keys: command, status, cursor, stage, preflight, version, follow_symlinks,
@@ -2444,6 +2448,7 @@ class ImportClient
         if ($has_progress) {
             $this->files_imported = 0;
             $index_size = $this->index_count();
+            $this->cached_index_count = $index_size;
 
             $stage = $this->state["stage"] ?? "index";
             $this->audit_log(
@@ -2491,6 +2496,7 @@ class ImportClient
             if ($is_delta) {
                 $this->files_imported = 0;
                 $index_size = $this->index_count();
+                $this->cached_index_count = $index_size;
                 $this->audit_log(
                     "START files-sync (delta) | index_files={$index_size}",
                     true,
@@ -2543,6 +2549,7 @@ class ImportClient
 
         $this->clear_progress_line();
         $index_size = $this->index_count();
+        $this->cached_index_count = $index_size;
         $label = $is_delta ? "files-sync (delta)" : "files-sync";
 
         $this->audit_log(
@@ -7465,6 +7472,7 @@ class ImportClient
             $this->output_progress([
                 "type" => "file_progress",
                 "files_imported" => $this->files_imported,
+                "files_indexed" => $this->cached_index_count,
                 "path" => $path,
                 "size" => $file_size,
                 "message" => $file_progress_message,
@@ -8897,10 +8905,15 @@ class ImportClient
                 // Output heartbeat every second (only in verbose/non-TTY mode)
                 if ($now - $last_heartbeat >= 1.0) {
                     if ($this->verbose_mode || !$this->is_tty) {
-                        fwrite($this->progress_fd, json_encode([
+                        $heartbeat = [
                             "heartbeat" => true,
                             "bytes_received" => $bytes_received,
-                        ]) . "\n");
+                        ];
+                        if ($this->cached_index_count !== null) {
+                            $heartbeat["files_imported"] = $this->files_imported;
+                            $heartbeat["files_indexed"] = $this->cached_index_count;
+                        }
+                        fwrite($this->progress_fd, json_encode($heartbeat) . "\n");
                     }
                     $last_heartbeat = $now;
                 }

--- a/packages/streaming-importer/src/import.php
+++ b/packages/streaming-importer/src/import.php
@@ -928,6 +928,16 @@ class ImportClient
      *  avoid re-reading the index file on every progress record. */
     private $cached_index_count = null;
 
+    /** @var int|null Total entries in the current download list.  Set once
+     *  at the start of download_files_from_list() by counting lines. */
+    private $download_list_total = null;
+
+    /** @var int|null Entries already processed (before the current offset)
+     *  in the download list.  Computed at list start and incremented after
+     *  each batch completes.  This is the cumulative, restart-safe counter
+     *  that consumers should display as "files done". */
+    private $download_list_done = null;
+
     /**
      * @var array Persistent import state loaded from / saved to $state_file.
      * Keys: command, status, cursor, stage, preflight, version, follow_symlinks,
@@ -5743,6 +5753,31 @@ class ImportClient
      * @param string $state_key   Key in $this->state that holds fetch progress
      *                            (e.g. "fetch" or "fetch_skipped").
      */
+    /**
+     * Count non-empty lines in a JSONL file, optionally up to a byte limit.
+     */
+    private function count_jsonl_lines(string $file, int $up_to_byte = -1): int
+    {
+        if (!is_file($file)) {
+            return 0;
+        }
+        $handle = fopen($file, "r");
+        if (!$handle) {
+            return 0;
+        }
+        $count = 0;
+        while (($line = fgets($handle)) !== false) {
+            if ($up_to_byte >= 0 && ftell($handle) > $up_to_byte) {
+                break;
+            }
+            if (trim($line) !== "") {
+                $count++;
+            }
+        }
+        fclose($handle);
+        return $count;
+    }
+
     private function download_files_from_list(
         string $list_file,
         string $state_key
@@ -5753,6 +5788,17 @@ class ImportClient
 
         if (filesize($list_file) === 0) {
             return true;
+        }
+
+        // Compute download list counters once at the start of each list.
+        // These survive across batches within one invocation and are
+        // recomputed on restart from the state file's byte offset.
+        if ($this->download_list_total === null) {
+            $offset = (int) ($this->state[$state_key]["offset"] ?? 0);
+            $this->download_list_total = $this->count_jsonl_lines($list_file);
+            $this->download_list_done = $offset > 0
+                ? $this->count_jsonl_lines($list_file, $offset)
+                : 0;
         }
         $fetch_state = $this->state[$state_key] ?? $this->default_state()[$state_key];
         $batch_file = $fetch_state["batch_file"] ?? null;
@@ -5794,6 +5840,22 @@ class ImportClient
         if (file_exists($batch_file)) {
             @unlink($batch_file);
             $this->audit_log("FILE DELETE | {$batch_file} | fetch batch complete");
+        }
+
+        // Advance the done counter by the number of entries in this batch.
+        if ($this->download_list_done !== null) {
+            $handle = fopen($list_file, "r");
+            if ($handle) {
+                fseek($handle, $batch_offset);
+                $batch_entries = 0;
+                while (ftell($handle) < $next_offset && ($line = fgets($handle)) !== false) {
+                    if (trim($line) !== "") {
+                        $batch_entries++;
+                    }
+                }
+                fclose($handle);
+                $this->download_list_done += $batch_entries;
+            }
         }
 
         $this->state[$state_key] = [
@@ -7469,14 +7531,25 @@ class ImportClient
 
             $file_progress_message = sprintf("[%d files] %s", $this->files_imported, $this->display_path($path));
             $this->show_progress_line($file_progress_message);
-            $this->output_progress([
+            $progress_record = [
                 "type" => "file_progress",
                 "files_imported" => $this->files_imported,
-                "files_indexed" => $this->cached_index_count,
                 "path" => $path,
                 "size" => $file_size,
                 "message" => $file_progress_message,
-            ]);
+            ];
+            // Emit globally-stable download list counters so consumers can
+            // display an accurate X/Y that never resets or over-counts.
+            // files_done = entries fully processed across all invocations
+            //   (batch boundary value + files written in the current batch).
+            // files_total = total entries in the download list (fixed once
+            //   the diff phase is done).
+            if ($this->download_list_total !== null) {
+                $progress_record["files_total"] = $this->download_list_total;
+                $progress_record["files_done"] =
+                    ($this->download_list_done ?? 0) + $this->files_imported;
+            }
+            $this->output_progress($progress_record);
         }
 
         // Skip body/close for files being preserved
@@ -8908,10 +8981,12 @@ class ImportClient
                         $heartbeat = [
                             "heartbeat" => true,
                             "bytes_received" => $bytes_received,
+                            "files_imported" => $this->files_imported,
                         ];
-                        if ($this->cached_index_count !== null) {
-                            $heartbeat["files_imported"] = $this->files_imported;
-                            $heartbeat["files_indexed"] = $this->cached_index_count;
+                        if ($this->download_list_total !== null) {
+                            $heartbeat["files_total"] = $this->download_list_total;
+                            $heartbeat["files_done"] =
+                                ($this->download_list_done ?? 0) + $this->files_imported;
                         }
                         fwrite($this->progress_fd, json_encode($heartbeat) . "\n");
                     }

--- a/packages/streaming-importer/src/import.php
+++ b/packages/streaming-importer/src/import.php
@@ -7529,26 +7529,18 @@ class ImportClient
                 false,
             );
 
-            $file_progress_message = sprintf("[%d files] %s", $this->files_imported, $this->display_path($path));
+            $files_done = ($this->download_list_done ?? 0) + $this->files_imported;
+            $file_progress_message = sprintf("[%d files] %s", $files_done, $this->display_path($path));
             $this->show_progress_line($file_progress_message);
             $progress_record = [
                 "type" => "file_progress",
-                "files_imported" => $this->files_imported,
-                "files_indexed" => $this->cached_index_count,
+                "files_done" => $files_done,
                 "path" => $path,
                 "size" => $file_size,
                 "message" => $file_progress_message,
             ];
-            // Emit globally-stable download list counters so consumers can
-            // display an accurate X/Y that never resets or over-counts.
-            // files_done = entries fully processed across all invocations
-            //   (batch boundary value + files written in the current batch).
-            // files_total = total entries in the download list (fixed once
-            //   the diff phase is done).
             if ($this->download_list_total !== null) {
                 $progress_record["files_total"] = $this->download_list_total;
-                $progress_record["files_done"] =
-                    ($this->download_list_done ?? 0) + $this->files_imported;
             }
             $this->output_progress($progress_record);
         }
@@ -8982,12 +8974,11 @@ class ImportClient
                         $heartbeat = [
                             "heartbeat" => true,
                             "bytes_received" => $bytes_received,
-                            "files_imported" => $this->files_imported,
+                            "files_done" =>
+                                ($this->download_list_done ?? 0) + $this->files_imported,
                         ];
                         if ($this->download_list_total !== null) {
                             $heartbeat["files_total"] = $this->download_list_total;
-                            $heartbeat["files_done"] =
-                                ($this->download_list_done ?? 0) + $this->files_imported;
                         }
                         fwrite($this->progress_fd, json_encode($heartbeat) . "\n");
                     }

--- a/packages/streaming-importer/src/import.php
+++ b/packages/streaming-importer/src/import.php
@@ -924,12 +924,8 @@ class ImportClient
     /** @var int Running count of files imported in the current invocation. */
     private $files_imported = 0;
 
-    /** @var int|null Cached index size, set once before the fetch phase to
-     *  avoid re-reading the index file on every progress record. */
-    private $cached_index_count = null;
-
     /** @var int|null Total entries in the current download list.  Set once
-     *  at the start of download_files_from_list() by counting lines. */
+     *  at the start of download_files_from_list() by counting newlines. */
     private $download_list_total = null;
 
     /** @var int|null Entries already processed (before the current offset)
@@ -2458,7 +2454,7 @@ class ImportClient
         if ($has_progress) {
             $this->files_imported = 0;
             $index_size = $this->index_count();
-            $this->cached_index_count = $index_size;
+
 
             $stage = $this->state["stage"] ?? "index";
             $this->audit_log(
@@ -2506,7 +2502,7 @@ class ImportClient
             if ($is_delta) {
                 $this->files_imported = 0;
                 $index_size = $this->index_count();
-                $this->cached_index_count = $index_size;
+    
                 $this->audit_log(
                     "START files-sync (delta) | index_files={$index_size}",
                     true,
@@ -2559,7 +2555,6 @@ class ImportClient
 
         $this->clear_progress_line();
         $index_size = $this->index_count();
-        $this->cached_index_count = $index_size;
         $label = $is_delta ? "files-sync (delta)" : "files-sync";
 
         $this->audit_log(
@@ -5754,9 +5749,14 @@ class ImportClient
      *                            (e.g. "fetch" or "fetch_skipped").
      */
     /**
-     * Count non-empty lines in a JSONL file, optionally up to a byte limit.
+     * Count newlines in a file using buffered reads.  Much faster than
+     * fgets() on large JSONL files because it never allocates per-line
+     * strings — just scans raw bytes in 64 KB chunks.
+     *
+     * @param string $file       Path to the file.
+     * @param int    $up_to_byte Stop after this byte offset (-1 = entire file).
      */
-    private function count_jsonl_lines(string $file, int $up_to_byte = -1): int
+    private function count_newlines(string $file, int $up_to_byte = -1): int
     {
         if (!is_file($file)) {
             return 0;
@@ -5766,13 +5766,15 @@ class ImportClient
             return 0;
         }
         $count = 0;
-        while (($line = fgets($handle)) !== false) {
-            if ($up_to_byte >= 0 && ftell($handle) > $up_to_byte) {
+        $chunk_size = 65536;
+        $remaining = $up_to_byte >= 0 ? $up_to_byte : PHP_INT_MAX;
+        while ($remaining > 0 && !feof($handle)) {
+            $data = fread($handle, min($chunk_size, $remaining));
+            if ($data === false || $data === '') {
                 break;
             }
-            if (trim($line) !== "") {
-                $count++;
-            }
+            $count += substr_count($data, "\n");
+            $remaining -= strlen($data);
         }
         fclose($handle);
         return $count;
@@ -5795,9 +5797,9 @@ class ImportClient
         // recomputed on restart from the state file's byte offset.
         if ($this->download_list_total === null) {
             $offset = (int) ($this->state[$state_key]["offset"] ?? 0);
-            $this->download_list_total = $this->count_jsonl_lines($list_file);
+            $this->download_list_total = $this->count_newlines($list_file);
             $this->download_list_done = $offset > 0
-                ? $this->count_jsonl_lines($list_file, $offset)
+                ? $this->count_newlines($list_file, $offset)
                 : 0;
         }
         $fetch_state = $this->state[$state_key] ?? $this->default_state()[$state_key];
@@ -5805,6 +5807,8 @@ class ImportClient
         $batch_offset = (int) ($fetch_state["offset"] ?? 0);
         $next_offset = (int) ($fetch_state["next_offset"] ?? 0);
         $cursor = $fetch_state["cursor"] ?? null;
+
+        $batch_entries = (int) ($fetch_state["batch_entries"] ?? 0);
 
         if ($batch_file === null || !file_exists($batch_file)) {
             $batch = $this->prepare_fetch_batch($list_file, $batch_offset);
@@ -5814,11 +5818,13 @@ class ImportClient
             $batch_file = $batch["file"];
             $batch_offset = $batch["offset"];
             $next_offset = $batch["next_offset"];
+            $batch_entries = $batch["entries"];
             $cursor = null;
             $this->state[$state_key] = [
                 "offset" => $batch_offset,
                 "next_offset" => $next_offset,
                 "batch_file" => $batch_file,
+                "batch_entries" => $batch_entries,
                 "cursor" => null,
             ];
             $this->save_state($this->state);
@@ -5842,20 +5848,9 @@ class ImportClient
             $this->audit_log("FILE DELETE | {$batch_file} | fetch batch complete");
         }
 
-        // Advance the done counter by the number of entries in this batch.
+        // Advance the done counter by the known batch size.
         if ($this->download_list_done !== null) {
-            $handle = fopen($list_file, "r");
-            if ($handle) {
-                fseek($handle, $batch_offset);
-                $batch_entries = 0;
-                while (ftell($handle) < $next_offset && ($line = fgets($handle)) !== false) {
-                    if (trim($line) !== "") {
-                        $batch_entries++;
-                    }
-                }
-                fclose($handle);
-                $this->download_list_done += $batch_entries;
-            }
+            $this->download_list_done += $batch_entries;
         }
 
         $this->state[$state_key] = [
@@ -5882,8 +5877,9 @@ class ImportClient
      *
      * @param string $list_file Path to the JSONL download list.
      * @param int    $offset    Byte offset into the download list file.
-     * @return array{file: string, offset: int, next_offset: int}|null
-     *         The temp file path and byte offsets, or null if no paths remain.
+     * @return array{file: string, offset: int, next_offset: int, entries: int}|null
+     *         The temp file path, byte offsets, and entry count, or null if
+     *         no paths remain.
      */
     private function prepare_fetch_batch(string $list_file, int $offset): ?array
     {
@@ -5924,6 +5920,7 @@ class ImportClient
         //   - A bare JSON string:   "/path/to/file"
         //   - A JSON object:        {"path": "<base64-encoded path>"}
         $bytes = 0;
+        $entries = 0;
         $first = true;
         fwrite($out, "[");
         $bytes = 1;
@@ -5974,6 +5971,7 @@ class ImportClient
                     throw new RuntimeException("Failed to write fetch batch file (disk full?)");
                 }
                 $bytes += strlen($chunk);
+                $entries++;
                 $first = false;
                 break;
             }
@@ -5982,6 +5980,7 @@ class ImportClient
                 throw new RuntimeException("Failed to write fetch batch file (disk full?)");
             }
             $bytes += strlen($chunk);
+            $entries++;
             $first = false;
         }
         fwrite($out, "]");
@@ -6001,6 +6000,7 @@ class ImportClient
             "file" => $tmp,
             "offset" => $offset,
             "next_offset" => $next_offset,
+            "entries" => $entries,
         ];
     }
 

--- a/tests/Import/DownloadListProgressTest.php
+++ b/tests/Import/DownloadListProgressTest.php
@@ -1,0 +1,370 @@
+<?php
+
+namespace ImportTests;
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../packages/streaming-importer/src/import.php';
+
+/**
+ * Verify that files_done and files_total progress counters are correct
+ * across multiple invocations (exit-code-2 restarts), with and without
+ * the essential-files filter (which splits the download list into a
+ * main list and a skipped list).
+ */
+class DownloadListProgressTest extends TestCase
+{
+    private $tempDir;
+    private $stateDir;
+    private $fs_root;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->tempDir = sys_get_temp_dir() . '/download-list-progress-test-' . uniqid();
+        $this->stateDir = $this->tempDir . '/state';
+        $this->fs_root = $this->tempDir . '/fs-root';
+        mkdir($this->stateDir, 0755, true);
+        mkdir($this->fs_root, 0755, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->recursiveDelete($this->tempDir);
+        parent::tearDown();
+    }
+
+    private function recursiveDelete(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        foreach (scandir($dir) as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $path = $dir . '/' . $item;
+            if (is_link($path)) {
+                unlink($path);
+            } elseif (is_dir($path)) {
+                $this->recursiveDelete($path);
+            } else {
+                unlink($path);
+            }
+        }
+        rmdir($dir);
+    }
+
+    private function makeClient(): \ImportClient
+    {
+        return new \ImportClient('http://fake.url', $this->stateDir, $this->fs_root);
+    }
+
+    /**
+     * Build a download list JSONL file with N entries.
+     */
+    private function writeDownloadList(int $count, ?string $file = null): string
+    {
+        $file = $file ?? $this->stateDir . '/.import-download-list.jsonl';
+        $handle = fopen($file, 'w');
+        for ($i = 0; $i < $count; $i++) {
+            fwrite($handle, json_encode(["path" => base64_encode("/file-{$i}.txt")]) . "\n");
+        }
+        fclose($handle);
+        return $file;
+    }
+
+    private function writeState(array $state): void
+    {
+        $defaults = [
+            "command" => null,
+            "status" => null,
+            "cursor" => null,
+            "stage" => null,
+            "preflight" => ["data" => ["ok" => true], "http_code" => 200],
+            "remote_protocol_version" => null,
+            "remote_protocol_min_version" => null,
+            "version" => null,
+            "follow_symlinks" => false,
+            "fs_root_nonempty_behavior" => "error",
+            "max_allowed_packet" => null,
+            "fetch" => ["offset" => 0, "next_offset" => 0, "batch_file" => null, "batch_entries" => 0, "cursor" => null],
+            "fetch_skipped" => ["offset" => 0, "next_offset" => 0, "batch_file" => null, "batch_entries" => 0, "cursor" => null],
+        ];
+        file_put_contents(
+            $this->stateDir . '/.import-state.json',
+            json_encode(array_merge($defaults, $state), JSON_PRETTY_PRINT),
+        );
+    }
+
+    private function prepareClient(string $filter = "none"): array
+    {
+        $client = $this->makeClient();
+        $reflection = new \ReflectionClass($client);
+
+        $loadState = $reflection->getMethod('load_state');
+        $stateProperty = $reflection->getProperty('state');
+        $stateProperty->setValue($client, $loadState->invoke($client));
+
+        $ttyProperty = $reflection->getProperty('is_tty');
+        $ttyProperty->setValue($client, false);
+
+        $filterProp = $reflection->getProperty('filter');
+        $filterProp->setValue($client, $filter);
+
+        return [$client, $reflection];
+    }
+
+    private function readCounters(\ImportClient $client, \ReflectionClass $reflection): array
+    {
+        return [
+            'total' => $reflection->getProperty('download_list_total')->getValue($client),
+            'done' => $reflection->getProperty('download_list_done')->getValue($client),
+        ];
+    }
+
+    private function byteOffsetAfterLines(string $file, int $n): int
+    {
+        $handle = fopen($file, 'r');
+        for ($i = 0; $i < $n; $i++) {
+            fgets($handle);
+        }
+        $offset = ftell($handle);
+        fclose($handle);
+        return $offset;
+    }
+
+    // ---------------------------------------------------------------
+    // Tests
+    // ---------------------------------------------------------------
+
+    public function testFreshDownloadShowsZeroDone()
+    {
+        $listFile = $this->writeDownloadList(100);
+
+        $this->writeState([
+            "command" => "files-sync",
+            "status" => "in_progress",
+            "stage" => "fetch",
+        ]);
+
+        [$client, $reflection] = $this->prepareClient();
+
+        $method = $reflection->getMethod('download_files_from_list');
+        try {
+            $method->invoke($client, $listFile, 'fetch');
+        } catch (\Exception $e) {
+            // Expected: network error
+        }
+
+        $counters = $this->readCounters($client, $reflection);
+        $this->assertSame(100, $counters['total']);
+        $this->assertSame(0, $counters['done']);
+    }
+
+    public function testResumedDownloadReflectsOffset()
+    {
+        $listFile = $this->writeDownloadList(100);
+        $offset = $this->byteOffsetAfterLines($listFile, 40);
+
+        $this->writeState([
+            "command" => "files-sync",
+            "status" => "in_progress",
+            "stage" => "fetch",
+            "fetch" => [
+                "offset" => $offset,
+                "next_offset" => $offset,
+                "batch_file" => null,
+                "batch_entries" => 0,
+                "cursor" => null,
+            ],
+        ]);
+
+        [$client, $reflection] = $this->prepareClient();
+
+        try {
+            $reflection->getMethod('download_files_from_list')
+                ->invoke($client, $listFile, 'fetch');
+        } catch (\Exception $e) {
+            // Expected
+        }
+
+        $counters = $this->readCounters($client, $reflection);
+        $this->assertSame(100, $counters['total']);
+        $this->assertSame(40, $counters['done']);
+    }
+
+    public function testDoneNeverExceedsTotal()
+    {
+        $listFile = $this->writeDownloadList(50);
+
+        // Offset past the end of the file
+        $pastEnd = filesize($listFile) + 1000;
+
+        $this->writeState([
+            "command" => "files-sync",
+            "status" => "in_progress",
+            "stage" => "fetch",
+            "fetch" => [
+                "offset" => $pastEnd,
+                "next_offset" => $pastEnd,
+                "batch_file" => null,
+                "batch_entries" => 0,
+                "cursor" => null,
+            ],
+        ]);
+
+        [$client, $reflection] = $this->prepareClient();
+
+        try {
+            $reflection->getMethod('download_files_from_list')
+                ->invoke($client, $listFile, 'fetch');
+        } catch (\Exception $e) {
+            // Expected
+        }
+
+        $counters = $this->readCounters($client, $reflection);
+        $this->assertSame(50, $counters['total']);
+        $this->assertLessThanOrEqual($counters['total'], $counters['done']);
+    }
+
+    public function testCountersStableAcrossInvocations()
+    {
+        $listFile = $this->writeDownloadList(100);
+        $offset30 = $this->byteOffsetAfterLines($listFile, 30);
+        $offset60 = $this->byteOffsetAfterLines($listFile, 60);
+
+        // First invocation at offset 30
+        $this->writeState([
+            "command" => "files-sync",
+            "status" => "in_progress",
+            "stage" => "fetch",
+            "fetch" => ["offset" => $offset30, "next_offset" => $offset30, "batch_file" => null, "batch_entries" => 0, "cursor" => null],
+        ]);
+
+        [$client1, $ref1] = $this->prepareClient();
+        try {
+            $ref1->getMethod('download_files_from_list')->invoke($client1, $listFile, 'fetch');
+        } catch (\Exception $e) {}
+
+        $c1 = $this->readCounters($client1, $ref1);
+        $this->assertSame(100, $c1['total']);
+        $this->assertSame(30, $c1['done']);
+
+        // Second invocation at offset 60
+        $this->writeState([
+            "command" => "files-sync",
+            "status" => "in_progress",
+            "stage" => "fetch",
+            "fetch" => ["offset" => $offset60, "next_offset" => $offset60, "batch_file" => null, "batch_entries" => 0, "cursor" => null],
+        ]);
+
+        [$client2, $ref2] = $this->prepareClient();
+        try {
+            $ref2->getMethod('download_files_from_list')->invoke($client2, $listFile, 'fetch');
+        } catch (\Exception $e) {}
+
+        $c2 = $this->readCounters($client2, $ref2);
+        $this->assertSame(100, $c2['total']);
+        $this->assertSame(60, $c2['done']);
+
+        // done only goes up
+        $this->assertGreaterThan($c1['done'], $c2['done']);
+    }
+
+    public function testSkippedListHasOwnCounters()
+    {
+        $this->writeDownloadList(50);
+        $skippedList = $this->stateDir . '/.import-download-list-skipped.jsonl';
+        $this->writeDownloadList(200, $skippedList);
+        $offset20 = $this->byteOffsetAfterLines($skippedList, 20);
+
+        $this->writeState([
+            "command" => "files-sync",
+            "status" => "in_progress",
+            "stage" => "fetch-skipped",
+            "fetch_skipped" => ["offset" => $offset20, "next_offset" => $offset20, "batch_file" => null, "batch_entries" => 0, "cursor" => null],
+        ]);
+
+        [$client, $reflection] = $this->prepareClient("skipped-earlier");
+
+        try {
+            $reflection->getMethod('download_files_from_list')
+                ->invoke($client, $skippedList, 'fetch_skipped');
+        } catch (\Exception $e) {}
+
+        $counters = $this->readCounters($client, $reflection);
+        $this->assertSame(200, $counters['total']);
+        $this->assertSame(20, $counters['done']);
+    }
+
+    public function testCountNewlinesMatchesLineCount()
+    {
+        $listFile = $this->writeDownloadList(500);
+
+        [$client, $reflection] = $this->prepareClient();
+        $method = $reflection->getMethod('count_newlines');
+
+        $this->assertSame(500, $method->invoke($client, $listFile));
+
+        $offset100 = $this->byteOffsetAfterLines($listFile, 100);
+        $this->assertSame(100, $method->invoke($client, $listFile, $offset100));
+    }
+
+    public function testPrepareFetchBatchReturnsEntryCount()
+    {
+        $listFile = $this->writeDownloadList(10);
+
+        $this->writeState([
+            "command" => "files-sync",
+            "status" => "in_progress",
+            "stage" => "fetch",
+        ]);
+
+        [$client, $reflection] = $this->prepareClient();
+        $batch = $reflection->getMethod('prepare_fetch_batch')
+            ->invoke($client, $listFile, 0);
+
+        $this->assertNotNull($batch);
+        $this->assertSame(10, $batch['entries']);
+        $this->assertSame(0, $batch['offset']);
+        $this->assertGreaterThan(0, $batch['next_offset']);
+
+        if (file_exists($batch['file'])) {
+            @unlink($batch['file']);
+        }
+    }
+
+    public function testFilesDoneIncludesFilesImported()
+    {
+        $listFile = $this->writeDownloadList(100);
+        $offset40 = $this->byteOffsetAfterLines($listFile, 40);
+
+        $this->writeState([
+            "command" => "files-sync",
+            "status" => "in_progress",
+            "stage" => "fetch",
+            "fetch" => ["offset" => $offset40, "next_offset" => $offset40, "batch_file" => null, "batch_entries" => 0, "cursor" => null],
+        ]);
+
+        [$client, $reflection] = $this->prepareClient();
+
+        try {
+            $reflection->getMethod('download_files_from_list')
+                ->invoke($client, $listFile, 'fetch');
+        } catch (\Exception $e) {}
+
+        // Simulate 5 files written in this invocation
+        $reflection->getProperty('files_imported')->setValue($client, 5);
+
+        $done = $reflection->getProperty('download_list_done')->getValue($client);
+        $imported = $reflection->getProperty('files_imported')->getValue($client);
+        $total = $reflection->getProperty('download_list_total')->getValue($client);
+
+        // files_done as emitted in progress records = done + imported
+        $filesDone = $done + $imported;
+        $this->assertSame(45, $filesDone); // 40 from offset + 5 imported
+        $this->assertSame(100, $total);
+        $this->assertLessThanOrEqual($total, $filesDone);
+    }
+}


### PR DESCRIPTION
## Summary

The per-invocation `files_imported` counter resets on exit-code-2 restarts and can exceed the index size (it counts symlink targets and volatile files not in the download list). Every attempt to build a reliable X/Y files display on the consumer side failed because the raw counter doesn't carry the right semantics.

This PR adds two globally-stable counters derived from the download list itself:

- **`files_total`** — total non-empty entries in the JSONL download list. Computed once at the start of `download_files_from_list()`. Fixed once the diff phase completes.

- **`files_done`** — entries already processed (from prior invocations, via the state file's byte offset) plus `files_imported` in the current batch. Cumulative across restarts by construction.

Both are emitted on `file_progress` and heartbeat records. `files_imported` is still emitted for backward compatibility and audit logging.

Supersedes #98 which added `files_indexed` to progress records — that approach was insufficient because the index grows during fetch (symlink targets, volatile files) and doesn't match the download list size.

Consumer-side changes: Automattic/studio branch `adamziel/stream-import-flow`.

## Test plan

- Run `studio site import` against a WP.com site
- Verify the progress line shows `X/Y files` where X grows monotonically up to Y
- Interrupt with Ctrl+C, resume — verify X picks up where it left off, never resets
- Verify Y stays constant throughout the fetch phase