### PR TITLE
Revert client-side dedup, add server-side cycle detection

### DIFF
--- a/packages/streaming-exporter/src/export.php
+++ b/packages/streaming-exporter/src/export.php
@@ -2898,9 +2898,7 @@ function endpoint_file_index(
         );
         $gz->sync();
         $stop = false;
-        // Track resolved real paths of directories we've entered to detect
-        // symlink cycles (e.g. /srv/htdocs/srv -> /srv -> contains htdocs/).
-        $visited_realpaths = [];
+        // Cycle detection uses the traversal stack — see below.
         while (!$stop) {
             if (empty($stack)) {
                 $status = "complete";
@@ -2988,14 +2986,23 @@ function endpoint_file_index(
             $stack[$frame_index]["dir"] = $current_real;
             $current_dir = $current_real;
 
-            // Cycle detection: skip directories whose realpath we've already
-            // traversed.  This catches symlink loops like /srv/htdocs/srv ->
-            // /srv (which contains htdocs/ again).
-            if (isset($visited_realpaths[$current_real])) {
+            // Cycle detection: skip this directory if its realpath is already
+            // an ancestor in the current traversal stack.  This catches
+            // symlink loops (e.g. /srv/htdocs/srv -> /srv -> contains
+            // htdocs/ again) without blocking legitimate symlinks that
+            // point to a directory visited in a sibling branch.
+            $is_cycle = false;
+            for ($i = 0; $i < $frame_index; $i++) {
+                $ancestor_real = realpath($stack[$i]["dir"]);
+                if ($ancestor_real !== false && $ancestor_real === $current_real) {
+                    $is_cycle = true;
+                    break;
+                }
+            }
+            if ($is_cycle) {
                 array_pop($stack);
                 continue;
             }
-            $visited_realpaths[$current_real] = true;
 
             clearstatcache(true, $current_real);
             $entries = @scandir($current_real, SCANDIR_SORT_ASCENDING);

--- a/packages/streaming-exporter/src/export.php
+++ b/packages/streaming-exporter/src/export.php
@@ -2898,6 +2898,9 @@ function endpoint_file_index(
         );
         $gz->sync();
         $stop = false;
+        // Track resolved real paths of directories we've entered to detect
+        // symlink cycles (e.g. /srv/htdocs/srv -> /srv -> contains htdocs/).
+        $visited_realpaths = [];
         while (!$stop) {
             if (empty($stack)) {
                 $status = "complete";
@@ -2984,6 +2987,16 @@ function endpoint_file_index(
             // This keeps root dirs and symlink-followed dirs consistent.
             $stack[$frame_index]["dir"] = $current_real;
             $current_dir = $current_real;
+
+            // Cycle detection: skip directories whose realpath we've already
+            // traversed.  This catches symlink loops like /srv/htdocs/srv ->
+            // /srv (which contains htdocs/ again).
+            if (isset($visited_realpaths[$current_real])) {
+                array_pop($stack);
+                continue;
+            }
+            $visited_realpaths[$current_real] = true;
+
             clearstatcache(true, $current_real);
             $entries = @scandir($current_real, SCANDIR_SORT_ASCENDING);
             if ($entries === false) {

--- a/packages/streaming-importer/src/import.php
+++ b/packages/streaming-importer/src/import.php
@@ -5643,14 +5643,6 @@ class ImportClient
         $this->begin_index_updates();
         $processed = 0;
 
-        // Track directory prefixes whose content is already reachable via
-        // another path.  When a symlink's target is inside the document root
-        // (or inside an already-covered prefix), everything under the symlink
-        // is a duplicate and can be skipped.  Sorted longest-first so the
-        // prefix check can short-circuit.
-        $covered_prefixes = [];
-        $skipped_as_duplicate = 0;
-
         while (($line = fgets($remote_handle)) !== false) {
             if ($this->shutdown_requested) {
                 break;
@@ -5663,68 +5655,6 @@ class ImportClient
             $remote_offset = ftell($remote_handle);
             $remote = $this->parse_index_line($line);
             if (!$remote) {
-                continue;
-            }
-
-            // When a symlink points to a directory that is already indexed
-            // through another path, mark the symlink's path as a covered
-            // prefix so all files under it are skipped as duplicates.
-            if ($remote["type"] === "link" && isset($remote["target"])) {
-                $target = $remote["target"];
-                $symlink_path = $remote["path"];
-
-                // A symlink is redundant when its target is already reachable:
-                // either the target is under the document root (which is always
-                // indexed) or under another covered prefix.
-                $target_already_covered = false;
-                foreach ($covered_prefixes as $prefix) {
-                    if (str_starts_with($symlink_path . "/", $prefix . "/")) {
-                        // This symlink is already inside a covered subtree.
-                        $target_already_covered = true;
-                        break;
-                    }
-                    if (str_starts_with($target . "/", $prefix . "/") || $target === $prefix) {
-                        $target_already_covered = true;
-                        break;
-                    }
-                }
-
-                if (!$target_already_covered) {
-                    // Check if the target is under the document root (the primary
-                    // tree being indexed).  The document root is the first path
-                    // component from the index entries (typically /srv/htdocs).
-                    $doc_root_raw = $this->state["preflight"]["data"]["runtime"]["document_root"] ?? null;
-                    if (is_string($doc_root_raw) && str_starts_with($doc_root_raw, "base64:")) {
-                        $doc_root_raw = base64_decode(substr($doc_root_raw, 7));
-                    }
-                    if ($doc_root_raw && str_starts_with($target . "/", $doc_root_raw . "/")) {
-                        $target_already_covered = true;
-                    }
-                }
-
-                if ($target_already_covered) {
-                    $covered_prefixes[] = $symlink_path;
-                    $this->audit_log(
-                        "DEDUP | Skipping symlink subtree {$symlink_path} -> {$target} (target already covered)",
-                        false,
-                    );
-                }
-            }
-
-            // Skip files under covered prefixes — they're duplicates
-            // reachable through the original (non-symlink) path.
-            // The symlink entry itself ($remote["path"] === $prefix) must
-            // NOT be skipped — it needs to reach the download list so the
-            // symlink is recreated locally.  Only children are duplicates.
-            $is_duplicate = false;
-            foreach ($covered_prefixes as $prefix) {
-                if (str_starts_with($remote["path"] . "/", $prefix . "/")) {
-                    $is_duplicate = true;
-                    break;
-                }
-            }
-            if ($is_duplicate) {
-                $skipped_as_duplicate++;
                 continue;
             }
 
@@ -5798,17 +5728,6 @@ class ImportClient
         fclose($download_handle);
         if ($skipped_handle !== null) {
             fclose($skipped_handle);
-        }
-
-        if ($skipped_as_duplicate > 0) {
-            $this->audit_log(
-                sprintf(
-                    "DEDUP | Skipped %d duplicate entries from %d covered symlink prefixes",
-                    $skipped_as_duplicate,
-                    count($covered_prefixes),
-                ),
-                true,
-            );
         }
 
         $this->state["diff"] = [
@@ -6243,19 +6162,12 @@ class ImportClient
             throw new RuntimeException("Invalid index path (base64 decode failed)");
         }
         assert_valid_path($path, "index path");
-        $entry = [
+        return [
             "path" => $path,
             "ctime" => (int) ($data["ctime"] ?? 0),
             "size" => (int) ($data["size"] ?? 0),
             "type" => (string) ($data["type"] ?? "file"),
         ];
-        if ($entry["type"] === "link" && isset($data["target"])) {
-            $target = base64_decode($data["target"], true);
-            if ($target !== false && $target !== "") {
-                $entry["target"] = $target;
-            }
-        }
-        return $entry;
     }
 
     /**


### PR DESCRIPTION
## Summary

Reverts #102 and #103 (client-side symlink path dedup) and replaces them with server-side cycle detection in the file indexer.

The client-side approach guessed at duplicates by manipulating path strings — checking if a path "re-entered" the document root or was "outside" it. This was a heuristic, not ground truth, and it was fragile.

The real fix: the server-side indexer (`endpoint_file_index`) now tracks the `realpath()` of every directory it enters in a `$visited_realpaths` set. When a directory's realpath has already been visited, the traversal skips it. This catches symlink cycles at the source — the remote index will never contain duplicate entries from loops like `/srv/htdocs/srv` → `/srv` → contains `htdocs/` again.

The client receives a clean index and needs no dedup logic.

## Test plan

- Import a WP.com Atomic site with `--follow-symlinks`
- Verify the remote index no longer contains recursive entries like `/srv/htdocs/srv/htdocs/*`
- Verify the download list is ~49K instead of ~101K
- All 122 existing tests pass