### PR TITLE
Add E2E test for symlink cycle detection

### DIFF
--- a/tests/e2e/site-registry.json
+++ b/tests/e2e/site-registry.json
@@ -102,7 +102,7 @@
       "port": 8111
     },
     "symlink-cycle": {
-      "port": 8112
+      "port": 8113
     }
   }
 }

--- a/tests/e2e/site-registry.json
+++ b/tests/e2e/site-registry.json
@@ -5,36 +5,104 @@
   "dbHost": "127.0.0.1",
   "wpVersion": "6.7",
   "sites": {
-    "basic":             { "port": 8081 },
-    "symlinks-outside":  { "port": 8082 },
-    "custom-wp-content": { "port": 8083 },
-    "chmod-denied":      { "port": 8084 },
-    "mysql-restricted":  { "port": 8085 },
-    "circular-symlinks": { "port": 8086 },
-    "file-changes":      { "port": 8087 },
-    "dir-deleted":       { "port": 8088 },
-    "volatile-file":     { "port": 8089 },
-    "emoji-paths":       { "port": 8090 },
-    "large-directory":   { "port": 8091 },
-    "hmac-errors":       { "port": 8092 },
-    "sha1-verify":       { "port": 8093 },
-    "http-errors":       { "port": 8094 },
-    "request-cutoff":    { "port": 8095 },
-    "gzip-corrupt":      { "port": 8096 },
-    "redirect-301":      { "port": 8097, "nginx": "redirect", "redirectTo": 8081 },
-    "buffered":          { "port": 8098, "nginx": "buffered" },
-    "error-chunks":      { "port": 8099 },
-    "import-failures":   { "port": 8100 },
-    "follow-symlinks":   { "port": 8101 },
-    "sqlite":            { "port": 8102 },
-    "large-single-file": { "port": 8103 },
-    "file-deletions":    { "port": 8104 },
-    "file-type-swaps":   { "port": 8105 },
-    "file-type-cache":   { "port": 8106 },
-    "preserve-local":    { "port": 8107 },
-    "url-rewriting":     { "port": 8108 },
-    "wpcloud-flatten":   { "port": 8109 },
-    "defer-uploads":     { "port": 8110 },
-    "symlinked-abspath": { "port": 8111 }
+    "basic": {
+      "port": 8081
+    },
+    "symlinks-outside": {
+      "port": 8082
+    },
+    "custom-wp-content": {
+      "port": 8083
+    },
+    "chmod-denied": {
+      "port": 8084
+    },
+    "mysql-restricted": {
+      "port": 8085
+    },
+    "circular-symlinks": {
+      "port": 8086
+    },
+    "file-changes": {
+      "port": 8087
+    },
+    "dir-deleted": {
+      "port": 8088
+    },
+    "volatile-file": {
+      "port": 8089
+    },
+    "emoji-paths": {
+      "port": 8090
+    },
+    "large-directory": {
+      "port": 8091
+    },
+    "hmac-errors": {
+      "port": 8092
+    },
+    "sha1-verify": {
+      "port": 8093
+    },
+    "http-errors": {
+      "port": 8094
+    },
+    "request-cutoff": {
+      "port": 8095
+    },
+    "gzip-corrupt": {
+      "port": 8096
+    },
+    "redirect-301": {
+      "port": 8097,
+      "nginx": "redirect",
+      "redirectTo": 8081
+    },
+    "buffered": {
+      "port": 8098,
+      "nginx": "buffered"
+    },
+    "error-chunks": {
+      "port": 8099
+    },
+    "import-failures": {
+      "port": 8100
+    },
+    "follow-symlinks": {
+      "port": 8101
+    },
+    "sqlite": {
+      "port": 8102
+    },
+    "large-single-file": {
+      "port": 8103
+    },
+    "file-deletions": {
+      "port": 8104
+    },
+    "file-type-swaps": {
+      "port": 8105
+    },
+    "file-type-cache": {
+      "port": 8106
+    },
+    "preserve-local": {
+      "port": 8107
+    },
+    "url-rewriting": {
+      "port": 8108
+    },
+    "wpcloud-flatten": {
+      "port": 8109
+    },
+    "defer-uploads": {
+      "port": 8110
+    },
+    "symlinked-abspath": {
+      "port": 8111
+    },
+    "symlink-cycle": {
+      "port": 8112
+    }
   }
 }

--- a/tests/e2e/tests/import-43-symlink-cycle-detection.test.js
+++ b/tests/e2e/tests/import-43-symlink-cycle-detection.test.js
@@ -1,0 +1,135 @@
+/**
+ * Test 43: Symlink cycle detection in the file indexer
+ *
+ * When --follow-symlinks is active, the server-side indexer follows
+ * symlinks into directories.  If a symlink creates a cycle (pointing
+ * back to an ancestor directory), the indexer must detect it and stop
+ * rather than producing an infinite (or massively duplicated) index.
+ *
+ * This test creates two cycle patterns seen on WP.com Atomic sites:
+ *
+ *   1. A self-referencing symlink: siteDir/loop -> siteDir
+ *      Following it once leads back to the same directory.
+ *
+ *   2. A symlink to a parent: siteDir/sub/parent -> siteDir
+ *      Following it from inside a subdirectory leads back to the root.
+ *
+ * Without cycle detection the index would grow without bound (or until
+ * the OS path length limit).  With it, each real directory is visited
+ * at most once per branch of the traversal tree.
+ */
+import { describe, it, beforeAll, afterAll } from 'vitest';
+import assert from 'node:assert/strict';
+import {
+    existsSync, readFileSync, writeFileSync, mkdirSync,
+    symlinkSync,
+} from 'node:fs';
+import { join } from 'node:path';
+import {
+    runImporter, createTempDir, cleanupTempDir,
+    getSiteUrl, getSiteSecret, getSiteDir,
+    countJsonlLines,
+    fsRootDir,
+} from '../lib/test-helpers.js';
+import { ensureSite } from '../lib/site-setup.js';
+
+describe('Import: Symlink cycle detection', () => {
+    const site = 'symlink-cycle';
+    let tempDir;
+
+    beforeAll(async () => {
+        await ensureSite(site, {
+            afterCreate: async (siteDir) => {
+                // Pattern 1: self-referencing symlink (like /srv/htdocs/srv -> /srv)
+                symlinkSync('.', join(siteDir, 'loop'));
+
+                // Pattern 2: subdirectory with a symlink back to the root
+                mkdirSync(join(siteDir, 'sub'), { recursive: true });
+                writeFileSync(join(siteDir, 'sub', 'child.txt'), 'child file');
+                symlinkSync('..', join(siteDir, 'sub', 'parent'));
+
+                // A regular file to verify indexing still works
+                writeFileSync(join(siteDir, 'marker.txt'), 'marker');
+            },
+        });
+
+        tempDir = createTempDir('e2e-symlink-cycle');
+    });
+
+    afterAll(() => {
+        cleanupTempDir(tempDir);
+    });
+
+    function importUrl() {
+        return `${getSiteUrl(site)}&directory=${getSiteDir(site)}`;
+    }
+
+    it('files-sync completes without hanging', () => {
+        const result = runImporter(importUrl(), tempDir, 'files-sync', {
+            secret: getSiteSecret(site),
+            extraArgs: ['--follow-symlinks'],
+        });
+        assert.equal(
+            result.exitCode, 0,
+            `files-sync should complete (not hang on cycle)\nstderr: ${result.stderr}`,
+        );
+    });
+
+    it('index does not contain massively duplicated entries', () => {
+        // A WordPress site has ~4000-6000 files.  Without cycle detection
+        // the self-symlink would double that on every depth level.  With
+        // cycle detection the total should stay in the normal range.
+        const remoteIndex = join(tempDir, '.import-remote-index.jsonl');
+        assert.ok(existsSync(remoteIndex), 'Remote index should exist');
+
+        const count = countJsonlLines(remoteIndex);
+        // The site has ~4-6K real files.  Allow up to 2x for one level
+        // of symlink following, but not 3x+ which indicates a cycle leak.
+        assert.ok(
+            count < 15000,
+            `Expected fewer than 15000 index entries (cycle detection should ` +
+            `prevent duplication), got ${count}`,
+        );
+    });
+
+    it('the marker file is indexed exactly once per reachable path', () => {
+        const remoteIndex = join(tempDir, '.import-remote-index.jsonl');
+        const content = readFileSync(remoteIndex, 'utf-8');
+        const lines = content.split('\n').filter(l => l.trim());
+
+        // Decode all paths and count how many end with /marker.txt
+        let markerCount = 0;
+        for (const line of lines) {
+            const entry = JSON.parse(line);
+            const path = Buffer.from(entry.path, 'base64').toString('utf-8');
+            if (path.endsWith('/marker.txt')) {
+                markerCount++;
+            }
+        }
+
+        // marker.txt should appear a bounded number of times:
+        // once for the real path, possibly once more through the
+        // first-level symlink follow.  But NOT dozens of times from
+        // recursive symlink expansion.
+        assert.ok(
+            markerCount <= 3,
+            `marker.txt should appear at most 3 times in the index ` +
+            `(real path + one symlink level), got ${markerCount}`,
+        );
+    });
+
+    it('regular files are still downloaded correctly', () => {
+        const importedRoot = fsRootDir(tempDir);
+        const siteDir = getSiteDir(site);
+        const markerPath = join(importedRoot, siteDir, 'marker.txt');
+        assert.ok(
+            existsSync(markerPath),
+            `marker.txt should be downloaded at ${markerPath}`,
+        );
+        assert.equal(
+            readFileSync(markerPath, 'utf-8'),
+            'marker',
+            'marker.txt content should match',
+        );
+    });
+});


### PR DESCRIPTION
## Summary

Tests the server-side cycle detection added in #105 with two cycle patterns seen on WP.com Atomic sites:

1. **Self-referencing symlink**: `siteDir/loop -> siteDir` (like `/srv/htdocs/srv -> /srv`)
2. **Subdirectory symlink to parent**: `siteDir/sub/parent -> siteDir`

Verifies:
- `files-sync` completes without hanging on infinite recursion
- Remote index stays below 15K entries (no cycle explosion — a normal WP site has ~4-6K files)
- `marker.txt` appears at most 3 times (real path + one symlink level, not dozens)
- Regular files are still downloaded correctly

Follows #105 which added the ancestor-in-stack cycle detection.