### PR TITLE
Always send directory[] to file_index and file_fetch endpoints

### DIFF
--- a/packages/streaming-importer/src/import.php
+++ b/packages/streaming-importer/src/import.php
@@ -5192,8 +5192,9 @@ class ImportClient
         }
 
         $params = $this->get_tuned_params("file_fetch");
+        // Always send directory[] – see comment in download_remote_index().
         $export_dirs = $this->get_export_directories();
-        if (count($export_dirs) > 1) {
+        if (!empty($export_dirs)) {
             $params["directory"] = $export_dirs;
         }
         $url = $this->build_url("file_fetch", $cursor, $params);
@@ -5408,8 +5409,14 @@ class ImportClient
         if ($this->follow_symlinks) {
             $params["follow_symlinks"] = "1";
         }
+        // Always send directory[] to the server when we have export dirs.
+        // Without this parameter, the server falls back to ABSPATH as the
+        // scan root. On managed hosts like wp.com Atomic, ABSPATH points to
+        // a shared WordPress core directory (e.g. /wordpress/core/6.9.4/)
+        // rather than the site's document root, so the scan would miss
+        // wp-content entirely (no plugins, themes, or uploads).
         $export_dirs = $this->get_export_directories();
-        if (count($export_dirs) > 1) {
+        if (!empty($export_dirs)) {
             $params["directory"] = $export_dirs;
         }
         $url = $this->build_url("file_index", $cursor, $params);


### PR DESCRIPTION
## Summary

On managed hosts like wp.com Atomic, `ABSPATH` points to a shared WordPress core directory (e.g. `/wordpress/core/6.9.4/`), not the site's document root (`/srv/htdocs/`). 

When the importer detected only one export directory from preflight, it omitted the `directory[]` parameter from `file_index` and `file_fetch` requests. The server's `normalize_config()` then fell back to `ABSPATH` as the scan root, indexing only WordPress core files (~3700 files) and missing `wp-content` entirely — no plugins, themes, or uploads were imported.

The fix always sends `directory[]` when export dirs are available, ensuring the server scans the correct root directories regardless of what `ABSPATH` resolves to.

## Test plan

- Import a site hosted on wp.com Atomic (wpcomstaging.com URL)
- Verify that wp-content/plugins and wp-content/themes are included in the imported files
- Verify that regular (non-Atomic) WordPress sites still import correctly