### PR TITLE
Stop pruning parent roots from file_index traversal

### DIFF
--- a/packages/streaming-exporter/src/export.php
+++ b/packages/streaming-exporter/src/export.php
@@ -2847,7 +2847,15 @@ function endpoint_file_index(
         if (!empty($extra_roots)) {
             sort($extra_roots, SORT_STRING);
             foreach ($extra_roots as $root) {
-                if (should_skip_index_root($root, $ordered)) {
+                // Skip exact duplicates of already-ordered roots.
+                // Do NOT skip parent roots — on hosts like wp.com Atomic
+                // the document root (/srv/htdocs) is a parent of the
+                // primary root (/srv/htdocs/__wp__) but contains a separate
+                // wp-content with the site's actual plugins and themes.
+                // The during-traversal dedup in the main loop already
+                // prevents re-entering child roots (i.e. when traversing
+                // /srv/htdocs we won't descend back into __wp__/).
+                if (in_array($root, $ordered, true)) {
                     continue;
                 }
                 $ordered[] = $root;

--- a/tests/FileIndexDedupTest.php
+++ b/tests/FileIndexDedupTest.php
@@ -21,28 +21,57 @@ final class FileIndexDedupTest extends TestCase
         parent::tearDown();
     }
 
-    public function testFileIndexSkipsExtraRootsThatAreParentsOfThePrimaryRoot(): void
+    /**
+     * Simulates the wp.com Atomic layout where ABSPATH (__wp__) is a child
+     * of the document root, but the document root also contains a separate
+     * wp-content directory with the site's actual plugins.
+     *
+     * Both roots must be traversed: __wp__ for WordPress core, and the
+     * document root for wp-content.  When traversing the document root,
+     * the __wp__ subdirectory should NOT be re-entered (handled by the
+     * during-traversal dedup).
+     */
+    public function testFileIndexTraversesParentRootWithSeparateContent(): void
     {
+        // Layout:
+        //   tempDir/
+        //   ├── parent-only.txt
+        //   └── srv/htdocs/           ← document root (parent root)
+        //       ├── __wp__/           ← ABSPATH (child root)
+        //       │   └── core.txt
+        //       └── wp-content/
+        //           └── plugin.txt    ← site's actual plugin (MUST be indexed)
         $docroot = $this->tempDir . '/srv/htdocs';
-        mkdir($docroot, 0755, true);
-        file_put_contents($docroot . '/site.txt', 'site');
+        $abspath = $docroot . '/__wp__';
+        mkdir($abspath, 0755, true);
+        mkdir($docroot . '/wp-content', 0755, true);
+        file_put_contents($abspath . '/core.txt', 'core');
+        file_put_contents($docroot . '/wp-content/plugin.txt', 'plugin');
         file_put_contents($this->tempDir . '/parent-only.txt', 'parent');
         $docrootReal = realpath($docroot);
-        $tempDirReal = realpath($this->tempDir);
+        $abspathReal = realpath($abspath);
 
         $this->assertNotFalse($docrootReal);
-        $this->assertNotFalse($tempDirReal);
+        $this->assertNotFalse($abspathReal);
 
         $paths = $this->runFileIndex(
-            [$docroot, $this->tempDir],
-            $docroot,
+            [$abspath, $docroot],
+            $abspath,
         );
 
-        $this->assertContains($docrootReal . '/site.txt', $paths);
-        $this->assertNotContains(
-            $tempDirReal . '/parent-only.txt',
+        // WordPress core file from __wp__ must be present
+        $this->assertContains($abspathReal . '/core.txt', $paths);
+        // Site's wp-content from the document root must be present
+        $this->assertContains(
+            $docrootReal . '/wp-content/plugin.txt',
             $paths,
-            'The index should not expose files from a parent root that only re-enters the primary root',
+            'The index must include wp-content from the parent document root',
+        );
+        // Files above the document root should not leak
+        $this->assertNotContains(
+            realpath($this->tempDir) . '/parent-only.txt',
+            $paths,
+            'Files above the document root should not be indexed',
         );
     }
 


### PR DESCRIPTION
## Summary

On wp.com Atomic, the document root (`/srv/htdocs`) is a parent of the primary ABSPATH root (`/srv/htdocs/__wp__`), but contains a **separate** `wp-content/` with the site's actual plugins and themes.

Commit 90055c5 pruned parent roots from the file_index traversal list to prevent duplicate entries. But this dropped the document root entirely — the exporter only scanned `__wp__/` (WordPress core), losing all site plugins, themes, and uploads from the index. That's why imports only got ~3700 files.

The during-traversal dedup already handles this: when scanning `/srv/htdocs/`, the `__wp__/` subdirectory is skipped because it matches a configured root. Parent roots don't need to be removed from the initial list.

## Test plan

- `php vendor/bin/phpunit -c tests/phpunit.xml tests/FileIndexDedupTest.php tests/ExportHttpServerTest.php`
- Import a site hosted on wp.com Atomic and verify plugins appear in the file index