### PR TITLE
Strip WP Cloud production drop-ins and auto-detect extra directories

### DIFF
--- a/packages/streaming-importer/src/import.php
+++ b/packages/streaming-importer/src/import.php
@@ -3824,6 +3824,10 @@ class ImportClient
             $this->audit_log("APPLY-RUNTIME | {$line}");
         }
 
+        // Persist which paths were removed so callers can inspect state.
+        $this->state["apply"]["paths_removed"] = $manifest->paths_to_remove;
+        $this->save_state($this->state);
+
         // Output the summary and manifest as structured JSON for callers,
         // and print the human-readable summary to stderr.
         $this->output_progress([
@@ -9297,6 +9301,7 @@ class ImportClient
                 "target_user" => null,
                 "target_pass" => null,
                 "target_sqlite_path" => null,
+                "paths_removed" => [],
             ],
             // SQL output mode (file, stdout, mysql) — persisted for resume
             "sql_output" => null,

--- a/packages/streaming-importer/src/import.php
+++ b/packages/streaming-importer/src/import.php
@@ -989,6 +989,9 @@ class ImportClient
      */
     private $filter = "none";
 
+    /** @var string|null Extra remote directory to include in the export (--extra-directory). */
+    private $extra_directory = null;
+
     /** @var AdaptiveTuner|null Adjusts request pacing based on server response times and errors. */
     private $tuner = null;
 
@@ -1357,6 +1360,7 @@ class ImportClient
     {
         $this->verbose_mode = $options["verbose"] ?? false;
         $this->follow_symlinks = $options["follow_symlinks"] ?? true;
+        $this->extra_directory = $options["extra_directory"] ?? null;
         if (isset($options["fs_root_nonempty_behavior"])) {
             $this->fs_root_nonempty_behavior = $options["fs_root_nonempty_behavior"];
             if (!in_array($this->fs_root_nonempty_behavior, ['error', 'preserve-local'])) {
@@ -3798,6 +3802,24 @@ class ImportClient
             $summary[] = "Copied sqlite-database-integration to {$abs_output_dir}/sqlite-database-integration";
         }
 
+        // Remove production drop-ins and mu-plugins that would crash
+        // the local site.  The host analyzer declares these — they
+        // depend on infrastructure (Memcached servers, multisite APIs)
+        // not available outside the original hosting environment.
+        foreach ($manifest->paths_to_remove as $rel_path) {
+            $full_path = $abs_fs_root . '/' . ltrim($rel_path, '/');
+            if (!file_exists($full_path) && !is_link($full_path)) {
+                continue;
+            }
+            if (is_dir($full_path) && !is_link($full_path)) {
+                self::rmdir_recursive($full_path);
+            } else {
+                unlink($full_path);
+            }
+            $summary[] = "Removed production drop-in: {$rel_path}";
+            $this->audit_log("APPLY-RUNTIME | removed {$rel_path} (production-only)");
+        }
+
         foreach ($summary as $line) {
             $this->audit_log("APPLY-RUNTIME | {$line}");
         }
@@ -3811,6 +3833,8 @@ class ImportClient
             "webhost" => $webhost,
             "webhost_source" => $manifest->source,
             "target_engine" => $target_engine,
+            "paths_removed" => $manifest->paths_to_remove,
+            "extra_directories" => $manifest->extra_directories,
             "message" => "apply-runtime complete (runtime: {$runtime})",
         ]);
 
@@ -8331,6 +8355,24 @@ class ImportClient
             "content_dir" => rtrim($preflight["database"]["wp"]["paths_urls"]["content_dir"] ?? "", "/"),
         ];
 
+        if ($this->extra_directory !== null && $this->extra_directory !== "") {
+            $extra_paths["extra_directory"] = rtrim($this->extra_directory, "/");
+        }
+
+        // auto_prepend_file / auto_append_file may point to directories
+        // outside the WordPress roots (e.g. /scripts/env.php on Atomic).
+        // Include those directories so the remote exporter traverses them.
+        $ini_all = $preflight["runtime"]["ini_get_all"] ?? [];
+        foreach (["auto_prepend_file", "auto_append_file"] as $ini_key) {
+            $ini_path = $ini_all[$ini_key] ?? "";
+            if (is_string($ini_path) && $ini_path !== "" && $ini_path[0] === "/") {
+                $ini_dir = rtrim(dirname($ini_path), "/");
+                if ($ini_dir !== "" && $ini_dir !== "/") {
+                    $extra_paths[$ini_key] = $ini_dir;
+                }
+            }
+        }
+
         foreach ($extra_paths as $label => $path) {
             if ($path === "") {
                 continue;
@@ -10046,6 +10088,14 @@ if (
             'valid_values' => ['none', 'essential-files', 'skipped-earlier'],
             'help' => 'Filter which files to download (none|essential-files|skipped-earlier)',
             'commands' => ['files-sync'],
+        ],
+        [
+            'name' => 'extra-directory',
+            'type' => 'value',
+            'target' => 'extra_directory',
+            'placeholder' => 'DIR',
+            'help' => 'Additional remote directory to include in the export',
+            'commands' => ['files-sync', 'files-index'],
         ],
 
         // ── db-sync options ──────────────────────────────────────

--- a/packages/streaming-importer/src/import.php
+++ b/packages/streaming-importer/src/import.php
@@ -3825,7 +3825,7 @@ class ImportClient
         }
 
         // Persist which paths were removed so callers can inspect state.
-        $this->state["apply"]["paths_removed"] = $manifest->paths_to_remove;
+        $this->state["apply"]["remote_paths_removed_from_local_site"] = $manifest->paths_to_remove;
         $this->save_state($this->state);
 
         // Output the summary and manifest as structured JSON for callers,
@@ -9301,7 +9301,7 @@ class ImportClient
                 "target_user" => null,
                 "target_pass" => null,
                 "target_sqlite_path" => null,
-                "paths_removed" => [],
+                "remote_paths_removed_from_local_site" => [],
             ],
             // SQL output mode (file, stdout, mysql) — persisted for resume
             "sql_output" => null,

--- a/packages/streaming-importer/src/lib/host/analyzers/class-wpcloud-host-analyzer.php
+++ b/packages/streaming-importer/src/lib/host/analyzers/class-wpcloud-host-analyzer.php
@@ -92,6 +92,13 @@ class WpcloudHostAnalyzer implements HostAnalyzer
         // infrastructure: object-cache.php talks to a Memcached server
         // that doesn't exist locally, wpcomsh* mu-plugins depend on
         // multisite functions and wp.com API endpoints.
+        //
+        // TODO: Consider removing all drop-ins unconditionally, not just
+        // WP Cloud ones. Drop-ins (object-cache.php, advanced-cache.php,
+        // db.php, etc.) typically integrate platform-specific software
+        // (Memcached, Redis, custom DB layers) that won't be available
+        // in a local environment. This is host-specific today, but the
+        // problem is universal.
         $manifest->paths_to_remove = [
             'wp-content/object-cache.php',
             'wp-content/mu-plugins/wpcomsh',

--- a/packages/streaming-importer/src/lib/host/analyzers/class-wpcloud-host-analyzer.php
+++ b/packages/streaming-importer/src/lib/host/analyzers/class-wpcloud-host-analyzer.php
@@ -88,7 +88,49 @@ class WpcloudHostAnalyzer implements HostAnalyzer
             'description' => 'Generate missing WordPress thumbnail sizes from originals using GD',
         ];
 
+        // Production drop-ins and mu-plugins that depend on WP Cloud
+        // infrastructure: object-cache.php talks to a Memcached server
+        // that doesn't exist locally, wpcomsh* mu-plugins depend on
+        // multisite functions and wp.com API endpoints.
+        $manifest->paths_to_remove = [
+            'wp-content/object-cache.php',
+            'wp-content/mu-plugins/wpcomsh',
+            'wp-content/mu-plugins/wpcomsh-dev',
+            'wp-content/mu-plugins/wpcomsh-loader.php',
+        ];
+
+        // auto_prepend_file on Atomic points to /scripts/env.php — a
+        // directory outside the WordPress roots.  Record it so that
+        // files-sync downloads it and the runtime applier can mount it.
+        $manifest->extra_directories = $this->detect_extra_directories($preflight_data);
+
         return $manifest;
+    }
+
+    /**
+     * Detect directories outside the WordPress roots that need to be
+     * downloaded and mounted.  Currently reads auto_prepend_file and
+     * auto_append_file from PHP INI.
+     *
+     * @return string[]  Absolute remote directory paths (e.g. ['/scripts'])
+     */
+    private function detect_extra_directories(array $preflight_data): array
+    {
+        $ini_all = $preflight_data['runtime']['ini_get_all'] ?? [];
+        $dirs = [];
+
+        foreach (['auto_prepend_file', 'auto_append_file'] as $key) {
+            $path = $ini_all[$key] ?? '';
+            if (!is_string($path) || $path === '' || $path[0] !== '/') {
+                continue;
+            }
+            $dir = rtrim(dirname($path), '/');
+            if ($dir !== '' && $dir !== '/') {
+                $dirs[] = $dir;
+            }
+        }
+
+        return array_values(array_unique($dirs));
     }
 
     private function build_constants(array $preflight_data): array

--- a/packages/streaming-importer/src/lib/host/class-runtime-manifest.php
+++ b/packages/streaming-importer/src/lib/host/class-runtime-manifest.php
@@ -66,6 +66,34 @@ class RuntimeManifest
     public bool $has_db_constants = false;
 
     /**
+     * Paths relative to the fs-root that should be removed after
+     * flattening because they depend on production infrastructure not
+     * available locally.  Examples: Memcached-backed object-cache
+     * drop-ins, hosting-specific mu-plugins.
+     *
+     * Each entry is a relative path like 'wp-content/object-cache.php'
+     * or 'wp-content/mu-plugins/wpcomsh'.  Directories are removed
+     * recursively.  The audit log records every removal.
+     *
+     * @var string[]
+     */
+    public array $paths_to_remove = [];
+
+    /**
+     * Directories outside the WordPress root that must be mounted into
+     * the virtual filesystem at their original absolute paths.  Each
+     * entry maps an absolute remote path (e.g. '/scripts') to the
+     * corresponding host-side directory under fs-root/raw.
+     *
+     * Populated from auto_prepend_file / auto_append_file INI values
+     * during host analysis.  The target runtime applier decides how to
+     * surface these (e.g. --mount-before-install in Playground CLI).
+     *
+     * @var string[]  Absolute remote directory paths (e.g. ['/scripts'])
+     */
+    public array $extra_directories = [];
+
+    /**
      * SQLite database configuration.  When non-null, the target uses
      * SQLite instead of MySQL.  The runtime layer copies the plugin
      * into the output directory and generates a lazy-loading $wpdb

--- a/tests/Import/ExportDirectoryAutoDetectTest.php
+++ b/tests/Import/ExportDirectoryAutoDetectTest.php
@@ -1,0 +1,296 @@
+<?php
+
+namespace ImportTests;
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../importer/import.php';
+
+/**
+ * Verify that get_export_directories() auto-includes directories from
+ * auto_prepend_file and auto_append_file INI values when they point
+ * outside the WordPress roots.
+ */
+class ExportDirectoryAutoDetectTest extends TestCase
+{
+    private $tempDir;
+    private $stateDir;
+    private $fsRoot;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->tempDir = sys_get_temp_dir() . '/export-dir-autodetect-' . uniqid();
+        $this->stateDir = $this->tempDir . '/state';
+        $this->fsRoot = $this->tempDir . '/fs-root';
+
+        mkdir($this->stateDir, 0755, true);
+        mkdir($this->fsRoot, 0755, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->recursiveDelete($this->tempDir);
+        parent::tearDown();
+    }
+
+    private function recursiveDelete(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+
+        foreach (scandir($dir) as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+
+            $path = $dir . '/' . $item;
+            if (is_link($path) || is_file($path)) {
+                unlink($path);
+                continue;
+            }
+
+            if (is_dir($path)) {
+                $this->recursiveDelete($path);
+            }
+        }
+
+        rmdir($dir);
+    }
+
+    private function writeState(array $state): void
+    {
+        $defaults = [
+            'command' => null,
+            'status' => null,
+            'cursor' => null,
+            'stage' => null,
+            'preflight' => [
+                'http_code' => 200,
+                'data' => [
+                    'runtime' => [
+                        'document_root' => '/srv/htdocs',
+                        'ini_get_all' => [],
+                    ],
+                    'database' => [
+                        'wp' => [
+                            'siteurl' => 'https://source.example',
+                            'home' => 'https://source.example',
+                            'paths_urls' => [
+                                'abspath' => '/srv/htdocs/',
+                                'content_dir' => '/srv/htdocs/wp-content',
+                                'uploads' => [
+                                    'baseurl' => 'https://source.example/wp-content/uploads',
+                                ],
+                                'home_url' => 'https://source.example',
+                                'site_url' => 'https://source.example',
+                            ],
+                        ],
+                    ],
+                    'wp_detect' => [
+                        'roots' => [
+                            ['path' => '/srv/htdocs'],
+                        ],
+                    ],
+                ],
+            ],
+            'webhost' => 'other',
+            'follow_symlinks' => false,
+            'fs_root_nonempty_behavior' => 'error',
+            'filter' => 'none',
+            'max_allowed_packet' => null,
+        ];
+
+        file_put_contents(
+            $this->stateDir . '/.import-state.json',
+            json_encode(array_replace_recursive($defaults, $state), JSON_PRETTY_PRINT),
+        );
+    }
+
+    private function makeClient(): \ImportClient
+    {
+        return new \ImportClient('https://source.example/export.php', $this->stateDir, $this->fsRoot);
+    }
+
+    private function callPrivate(\ImportClient $client, string $method, array $args = [])
+    {
+        $reflection = new \ReflectionClass($client);
+        $method_reflection = $reflection->getMethod($method);
+        return $method_reflection->invoke($client, ...$args);
+    }
+
+    private function setPrivate(\ImportClient $client, string $property, $value): void
+    {
+        $reflection = new \ReflectionClass($client);
+        $property_reflection = $reflection->getProperty($property);
+        $property_reflection->setValue($client, $value);
+    }
+
+    private function loadClientState(\ImportClient $client): void
+    {
+        $state = $this->callPrivate($client, 'load_state');
+        $this->setPrivate($client, 'state', $state);
+    }
+
+    private function getExportDirectories(\ImportClient $client): array
+    {
+        return $this->callPrivate($client, 'get_export_directories');
+    }
+
+    public function testAutoIncludesAutoPrependFileDirectory(): void
+    {
+        $this->writeState([
+            'preflight' => [
+                'data' => [
+                    'runtime' => [
+                        'ini_get_all' => [
+                            'auto_prepend_file' => '/scripts/env.php',
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $client = $this->makeClient();
+        $this->loadClientState($client);
+        $dirs = $this->getExportDirectories($client);
+
+        $this->assertContains('/scripts', $dirs);
+    }
+
+    public function testAutoIncludesAutoAppendFileDirectory(): void
+    {
+        $this->writeState([
+            'preflight' => [
+                'data' => [
+                    'runtime' => [
+                        'ini_get_all' => [
+                            'auto_append_file' => '/logging/tracker.php',
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $client = $this->makeClient();
+        $this->loadClientState($client);
+        $dirs = $this->getExportDirectories($client);
+
+        $this->assertContains('/logging', $dirs);
+    }
+
+    public function testDoesNotDuplicateDirectoryAlreadyCoveredByRoots(): void
+    {
+        // auto_prepend_file points inside a directory that is already a
+        // wp_detect root — it should not be added again.
+        $this->writeState([
+            'preflight' => [
+                'data' => [
+                    'runtime' => [
+                        'ini_get_all' => [
+                            'auto_prepend_file' => '/srv/htdocs/wp-config.php',
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $client = $this->makeClient();
+        $this->loadClientState($client);
+        $dirs = $this->getExportDirectories($client);
+
+        // /srv/htdocs is already a root, so the directory derived from
+        // auto_prepend_file (/srv/htdocs) should not be added twice.
+        $count = array_count_values($dirs);
+        $this->assertSame(1, $count['/srv/htdocs'] ?? 0);
+    }
+
+    public function testIgnoresEmptyAutoPrependFile(): void
+    {
+        $this->writeState([
+            'preflight' => [
+                'data' => [
+                    'runtime' => [
+                        'ini_get_all' => [
+                            'auto_prepend_file' => '',
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $client = $this->makeClient();
+        $this->loadClientState($client);
+        $dirs = $this->getExportDirectories($client);
+
+        // Only the wp_detect root should be present.
+        $this->assertSame(['/srv/htdocs'], $dirs);
+    }
+
+    public function testIgnoresRelativeAutoPrependPath(): void
+    {
+        $this->writeState([
+            'preflight' => [
+                'data' => [
+                    'runtime' => [
+                        'ini_get_all' => [
+                            'auto_prepend_file' => 'relative/env.php',
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $client = $this->makeClient();
+        $this->loadClientState($client);
+        $dirs = $this->getExportDirectories($client);
+
+        $this->assertSame(['/srv/htdocs'], $dirs);
+    }
+
+    public function testIgnoresRootSlashDirectory(): void
+    {
+        $this->writeState([
+            'preflight' => [
+                'data' => [
+                    'runtime' => [
+                        'ini_get_all' => [
+                            'auto_prepend_file' => '/env.php',
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $client = $this->makeClient();
+        $this->loadClientState($client);
+        $dirs = $this->getExportDirectories($client);
+
+        // dirname('/env.php') = '/' — should not be added.
+        $this->assertNotContains('/', $dirs);
+    }
+
+    public function testIncludesBothPrependAndAppendDirectories(): void
+    {
+        $this->writeState([
+            'preflight' => [
+                'data' => [
+                    'runtime' => [
+                        'ini_get_all' => [
+                            'auto_prepend_file' => '/scripts/env.php',
+                            'auto_append_file' => '/logging/tracker.php',
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $client = $this->makeClient();
+        $this->loadClientState($client);
+        $dirs = $this->getExportDirectories($client);
+
+        $this->assertContains('/scripts', $dirs);
+        $this->assertContains('/logging', $dirs);
+    }
+}

--- a/tests/Import/ProductionDropInRemovalTest.php
+++ b/tests/Import/ProductionDropInRemovalTest.php
@@ -1,0 +1,335 @@
+<?php
+
+namespace ImportTests;
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../importer/import.php';
+
+/**
+ * Verify that run_apply_runtime removes production drop-ins declared in
+ * the host analyzer's paths_to_remove manifest field, and logs each removal.
+ */
+class ProductionDropInRemovalTest extends TestCase
+{
+    private $tempDir;
+    private $stateDir;
+    private $fsRoot;
+    private $outputDir;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->tempDir = sys_get_temp_dir() . '/production-drop-in-removal-' . uniqid();
+        $this->stateDir = $this->tempDir . '/state';
+        $this->fsRoot = $this->tempDir . '/fs-root';
+        $this->outputDir = $this->tempDir . '/runtime';
+
+        mkdir($this->stateDir, 0755, true);
+        mkdir($this->fsRoot, 0755, true);
+        mkdir($this->outputDir, 0755, true);
+        file_put_contents($this->fsRoot . '/index.php', "<?php echo 'ok';\n");
+    }
+
+    protected function tearDown(): void
+    {
+        $this->recursiveDelete($this->tempDir);
+        parent::tearDown();
+    }
+
+    private function recursiveDelete(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+
+        foreach (scandir($dir) as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+
+            $path = $dir . '/' . $item;
+            if (is_link($path) || is_file($path)) {
+                unlink($path);
+                continue;
+            }
+
+            if (is_dir($path)) {
+                $this->recursiveDelete($path);
+            }
+        }
+
+        rmdir($dir);
+    }
+
+    private function writeState(array $state): void
+    {
+        $defaults = [
+            'command' => null,
+            'status' => null,
+            'cursor' => null,
+            'stage' => null,
+            'preflight' => [
+                'http_code' => 200,
+                'data' => [
+                    'runtime' => [
+                        'document_root' => '/srv/htdocs',
+                        'env_names' => ['PRIVACY_MODEL'],
+                        'ini_get_all' => [
+                            'auto_prepend_file' => '',
+                        ],
+                    ],
+                    'filesystem' => [
+                        'directories' => [
+                            ['path' => '/srv/htdocs/__wp__', 'exists' => true],
+                        ],
+                    ],
+                    'wp_detect' => [
+                        'roots' => [
+                            ['path' => '/srv/htdocs/__wp__'],
+                        ],
+                    ],
+                    'database' => [
+                        'wp' => [
+                            'siteurl' => 'https://source.example',
+                            'home' => 'https://source.example',
+                            'paths_urls' => [
+                                'abspath' => '/wordpress/core/6.7.2/',
+                                'content_dir' => '/srv/htdocs/wp-content',
+                                'uploads' => [
+                                    'baseurl' => 'https://source.example/wp-content/uploads',
+                                ],
+                                'home_url' => 'https://source.example',
+                                'site_url' => 'https://source.example',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            'webhost' => 'wpcloud',
+            'follow_symlinks' => false,
+            'fs_root_nonempty_behavior' => 'error',
+            'filter' => 'none',
+            'max_allowed_packet' => null,
+        ];
+
+        file_put_contents(
+            $this->stateDir . '/.import-state.json',
+            json_encode(array_replace_recursive($defaults, $state), JSON_PRETTY_PRINT),
+        );
+    }
+
+    private function makeClient(): \ImportClient
+    {
+        return new \ImportClient('https://source.example/export.php', $this->stateDir, $this->fsRoot);
+    }
+
+    private function callPrivate(\ImportClient $client, string $method, array $args = [])
+    {
+        $reflection = new \ReflectionClass($client);
+        $method_reflection = $reflection->getMethod($method);
+        return $method_reflection->invoke($client, ...$args);
+    }
+
+    private function setPrivate(\ImportClient $client, string $property, $value): void
+    {
+        $reflection = new \ReflectionClass($client);
+        $property_reflection = $reflection->getProperty($property);
+        $property_reflection->setValue($client, $value);
+    }
+
+    private function loadClientState(\ImportClient $client): void
+    {
+        $state = $this->callPrivate($client, 'load_state');
+        $this->setPrivate($client, 'state', $state);
+    }
+
+    private function runApplyRuntime(\ImportClient $client): void
+    {
+        ob_start();
+        try {
+            $this->callPrivate($client, 'run_apply_runtime', [[
+                'runtime' => 'php-builtin',
+                'output_dir' => $this->outputDir,
+                'flat_document_root' => $this->fsRoot,
+            ]]);
+        } finally {
+            ob_end_clean();
+        }
+    }
+
+    /**
+     * Create the production drop-in files that WpcloudHostAnalyzer declares
+     * for removal, so we can verify they get deleted.
+     */
+    private function createProductionDropIns(): void
+    {
+        // object-cache.php (file)
+        $wpContent = $this->fsRoot . '/wp-content';
+        mkdir($wpContent, 0755, true);
+        file_put_contents($wpContent . '/object-cache.php', "<?php // Memcached object cache\n");
+
+        // wpcomsh directory with files inside
+        $muPlugins = $wpContent . '/mu-plugins';
+        mkdir($muPlugins . '/wpcomsh', 0755, true);
+        file_put_contents($muPlugins . '/wpcomsh/wpcomsh.php', "<?php // wpcomsh\n");
+        file_put_contents($muPlugins . '/wpcomsh/functions.php', "<?php // functions\n");
+
+        // wpcomsh-dev directory
+        mkdir($muPlugins . '/wpcomsh-dev', 0755, true);
+        file_put_contents($muPlugins . '/wpcomsh-dev/wpcomsh-dev.php', "<?php // wpcomsh-dev\n");
+
+        // wpcomsh-loader.php (file)
+        file_put_contents($muPlugins . '/wpcomsh-loader.php', "<?php // wpcomsh loader\n");
+    }
+
+    public function testApplyRuntimeRemovesObjectCacheFile(): void
+    {
+        $this->writeState(['command' => 'files-sync', 'status' => 'complete']);
+        $this->createProductionDropIns();
+
+        $objectCachePath = $this->fsRoot . '/wp-content/object-cache.php';
+        $this->assertFileExists($objectCachePath);
+
+        $client = $this->makeClient();
+        $this->loadClientState($client);
+        $this->runApplyRuntime($client);
+
+        $this->assertFileDoesNotExist($objectCachePath);
+    }
+
+    public function testApplyRuntimeRemovesWpcomshDirectory(): void
+    {
+        $this->writeState(['command' => 'files-sync', 'status' => 'complete']);
+        $this->createProductionDropIns();
+
+        $wpcomshDir = $this->fsRoot . '/wp-content/mu-plugins/wpcomsh';
+        $this->assertDirectoryExists($wpcomshDir);
+
+        $client = $this->makeClient();
+        $this->loadClientState($client);
+        $this->runApplyRuntime($client);
+
+        $this->assertDirectoryDoesNotExist($wpcomshDir);
+    }
+
+    public function testApplyRuntimeRemovesWpcomshDevDirectory(): void
+    {
+        $this->writeState(['command' => 'files-sync', 'status' => 'complete']);
+        $this->createProductionDropIns();
+
+        $wpcomshDevDir = $this->fsRoot . '/wp-content/mu-plugins/wpcomsh-dev';
+        $this->assertDirectoryExists($wpcomshDevDir);
+
+        $client = $this->makeClient();
+        $this->loadClientState($client);
+        $this->runApplyRuntime($client);
+
+        $this->assertDirectoryDoesNotExist($wpcomshDevDir);
+    }
+
+    public function testApplyRuntimeRemovesWpcomshLoaderFile(): void
+    {
+        $this->writeState(['command' => 'files-sync', 'status' => 'complete']);
+        $this->createProductionDropIns();
+
+        $loaderPath = $this->fsRoot . '/wp-content/mu-plugins/wpcomsh-loader.php';
+        $this->assertFileExists($loaderPath);
+
+        $client = $this->makeClient();
+        $this->loadClientState($client);
+        $this->runApplyRuntime($client);
+
+        $this->assertFileDoesNotExist($loaderPath);
+    }
+
+    public function testApplyRuntimeToleratesMissingDropIns(): void
+    {
+        // Don't create any drop-in files. The removal loop should skip
+        // them gracefully without errors.
+        $this->writeState(['command' => 'files-sync', 'status' => 'complete']);
+        mkdir($this->fsRoot . '/wp-content', 0755, true);
+
+        $client = $this->makeClient();
+        $this->loadClientState($client);
+
+        // Should not throw.
+        $this->runApplyRuntime($client);
+        $this->assertTrue(true);
+    }
+
+    public function testApplyRuntimePreservesUnrelatedFiles(): void
+    {
+        $this->writeState(['command' => 'files-sync', 'status' => 'complete']);
+        $this->createProductionDropIns();
+
+        // Create a legitimate mu-plugin that should NOT be removed.
+        $muPlugins = $this->fsRoot . '/wp-content/mu-plugins';
+        file_put_contents($muPlugins . '/my-custom-plugin.php', "<?php // custom\n");
+
+        $client = $this->makeClient();
+        $this->loadClientState($client);
+        $this->runApplyRuntime($client);
+
+        $this->assertFileExists($muPlugins . '/my-custom-plugin.php');
+    }
+
+    public function testApplyRuntimeLogsRemovalsToAuditLog(): void
+    {
+        $this->writeState(['command' => 'files-sync', 'status' => 'complete']);
+        $this->createProductionDropIns();
+
+        $client = $this->makeClient();
+        $this->loadClientState($client);
+        $this->runApplyRuntime($client);
+
+        // The audit log records every removal.
+        $auditLog = file_get_contents($this->stateDir . '/.import-audit.log');
+
+        $this->assertStringContainsString(
+            'removed wp-content/object-cache.php (production-only)',
+            $auditLog,
+        );
+        $this->assertStringContainsString(
+            'removed wp-content/mu-plugins/wpcomsh (production-only)',
+            $auditLog,
+        );
+        $this->assertStringContainsString(
+            'removed wp-content/mu-plugins/wpcomsh-loader.php (production-only)',
+            $auditLog,
+        );
+    }
+
+    public function testNonWpcloudHostDoesNotRemoveAnything(): void
+    {
+        // Override webhost to 'other' — the DefaultHostAnalyzer should
+        // produce an empty paths_to_remove.
+        $this->writeState([
+            'command' => 'files-sync',
+            'status' => 'complete',
+            'webhost' => 'other',
+            'preflight' => [
+                'data' => [
+                    'runtime' => [
+                        'document_root' => '',
+                        'env_names' => [],
+                        'ini_get_all' => [],
+                    ],
+                    'filesystem' => ['directories' => []],
+                    'wp_detect' => ['roots' => []],
+                ],
+            ],
+        ]);
+
+        // Create an object-cache.php that a non-wpcloud host should leave alone.
+        $wpContent = $this->fsRoot . '/wp-content';
+        mkdir($wpContent, 0755, true);
+        file_put_contents($wpContent . '/object-cache.php', "<?php // Redis object cache\n");
+
+        $client = $this->makeClient();
+        $this->loadClientState($client);
+        $this->runApplyRuntime($client);
+
+        $this->assertFileExists($wpContent . '/object-cache.php');
+    }
+}

--- a/tests/Import/ProductionDropInRemovalTest.php
+++ b/tests/Import/ProductionDropInRemovalTest.php
@@ -315,11 +315,11 @@ class ProductionDropInRemovalTest extends TestCase
             true,
         );
 
-        $this->assertArrayHasKey('paths_removed', $state['apply']);
-        $this->assertContains('wp-content/object-cache.php', $state['apply']['paths_removed']);
-        $this->assertContains('wp-content/mu-plugins/wpcomsh', $state['apply']['paths_removed']);
-        $this->assertContains('wp-content/mu-plugins/wpcomsh-dev', $state['apply']['paths_removed']);
-        $this->assertContains('wp-content/mu-plugins/wpcomsh-loader.php', $state['apply']['paths_removed']);
+        $this->assertArrayHasKey('remote_paths_removed_from_local_site', $state['apply']);
+        $this->assertContains('wp-content/object-cache.php', $state['apply']['remote_paths_removed_from_local_site']);
+        $this->assertContains('wp-content/mu-plugins/wpcomsh', $state['apply']['remote_paths_removed_from_local_site']);
+        $this->assertContains('wp-content/mu-plugins/wpcomsh-dev', $state['apply']['remote_paths_removed_from_local_site']);
+        $this->assertContains('wp-content/mu-plugins/wpcomsh-loader.php', $state['apply']['remote_paths_removed_from_local_site']);
     }
 
     public function testNonWpcloudHostDoesNotRemoveAnything(): void

--- a/tests/Import/ProductionDropInRemovalTest.php
+++ b/tests/Import/ProductionDropInRemovalTest.php
@@ -300,6 +300,28 @@ class ProductionDropInRemovalTest extends TestCase
         );
     }
 
+    public function testApplyRuntimePersistsPathsRemovedToState(): void
+    {
+        $this->writeState(['command' => 'files-sync', 'status' => 'complete']);
+        $this->createProductionDropIns();
+
+        $client = $this->makeClient();
+        $this->loadClientState($client);
+        $this->runApplyRuntime($client);
+
+        // Re-read the state file to verify paths_removed was persisted.
+        $state = json_decode(
+            file_get_contents($this->stateDir . '/.import-state.json'),
+            true,
+        );
+
+        $this->assertArrayHasKey('paths_removed', $state['apply']);
+        $this->assertContains('wp-content/object-cache.php', $state['apply']['paths_removed']);
+        $this->assertContains('wp-content/mu-plugins/wpcomsh', $state['apply']['paths_removed']);
+        $this->assertContains('wp-content/mu-plugins/wpcomsh-dev', $state['apply']['paths_removed']);
+        $this->assertContains('wp-content/mu-plugins/wpcomsh-loader.php', $state['apply']['paths_removed']);
+    }
+
     public function testNonWpcloudHostDoesNotRemoveAnything(): void
     {
         // Override webhost to 'other' — the DefaultHostAnalyzer should

--- a/tests/Import/WpcloudHostAnalyzerTest.php
+++ b/tests/Import/WpcloudHostAnalyzerTest.php
@@ -1,0 +1,211 @@
+<?php
+
+namespace ImportTests;
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../packages/streaming-importer/src/lib/host/class-runtime-manifest.php';
+require_once __DIR__ . '/../../packages/streaming-importer/src/lib/host/interface-host-analyzer.php';
+require_once __DIR__ . '/../../packages/streaming-importer/src/lib/host/functions.php';
+require_once __DIR__ . '/../../packages/streaming-importer/src/lib/host/analyzers/class-wpcloud-host-analyzer.php';
+
+class WpcloudHostAnalyzerTest extends TestCase
+{
+    /**
+     * Build a minimal preflight_data structure that scores as WP Cloud.
+     */
+    private function wpcloudPreflight(array $overrides = []): array
+    {
+        $defaults = [
+            'runtime' => [
+                'document_root' => '/srv/htdocs',
+                'env_names' => ['PRIVACY_MODEL'],
+                'ini_get_all' => [
+                    'auto_prepend_file' => '',
+                    'auto_append_file' => '',
+                ],
+            ],
+            'filesystem' => [
+                'directories' => [
+                    ['path' => '/srv/htdocs/__wp__', 'exists' => true],
+                ],
+            ],
+            'wp_detect' => [
+                'roots' => [
+                    ['path' => '/srv/htdocs/__wp__'],
+                ],
+            ],
+            'database' => [
+                'wp' => [
+                    'paths_urls' => [
+                        'abspath' => '/wordpress/core/6.7.2/',
+                        'content_dir' => '/srv/htdocs/wp-content',
+                    ],
+                ],
+            ],
+        ];
+
+        return array_replace_recursive($defaults, $overrides);
+    }
+
+    public function testAnalyzePopulatesPathsToRemove(): void
+    {
+        $analyzer = new \WpcloudHostAnalyzer();
+        $manifest = $analyzer->analyze($this->wpcloudPreflight());
+
+        $this->assertContains('wp-content/object-cache.php', $manifest->paths_to_remove);
+        $this->assertContains('wp-content/mu-plugins/wpcomsh', $manifest->paths_to_remove);
+        $this->assertContains('wp-content/mu-plugins/wpcomsh-dev', $manifest->paths_to_remove);
+        $this->assertContains('wp-content/mu-plugins/wpcomsh-loader.php', $manifest->paths_to_remove);
+    }
+
+    public function testAnalyzeDetectsExtraDirectoryFromAutoPrependFile(): void
+    {
+        $preflight = $this->wpcloudPreflight([
+            'runtime' => [
+                'ini_get_all' => [
+                    'auto_prepend_file' => '/scripts/env.php',
+                ],
+            ],
+        ]);
+
+        $analyzer = new \WpcloudHostAnalyzer();
+        $manifest = $analyzer->analyze($preflight);
+
+        $this->assertContains('/scripts', $manifest->extra_directories);
+    }
+
+    public function testAnalyzeDetectsExtraDirectoryFromAutoAppendFile(): void
+    {
+        $preflight = $this->wpcloudPreflight([
+            'runtime' => [
+                'ini_get_all' => [
+                    'auto_append_file' => '/logging/tracker.php',
+                ],
+            ],
+        ]);
+
+        $analyzer = new \WpcloudHostAnalyzer();
+        $manifest = $analyzer->analyze($preflight);
+
+        $this->assertContains('/logging', $manifest->extra_directories);
+    }
+
+    public function testAnalyzeDeduplicatesExtraDirectories(): void
+    {
+        $preflight = $this->wpcloudPreflight([
+            'runtime' => [
+                'ini_get_all' => [
+                    'auto_prepend_file' => '/scripts/env.php',
+                    'auto_append_file' => '/scripts/cleanup.php',
+                ],
+            ],
+        ]);
+
+        $analyzer = new \WpcloudHostAnalyzer();
+        $manifest = $analyzer->analyze($preflight);
+
+        // Both point to /scripts — should appear only once.
+        $this->assertCount(1, $manifest->extra_directories);
+        $this->assertSame(['/scripts'], $manifest->extra_directories);
+    }
+
+    public function testAnalyzeIgnoresEmptyIniValues(): void
+    {
+        $preflight = $this->wpcloudPreflight([
+            'runtime' => [
+                'ini_get_all' => [
+                    'auto_prepend_file' => '',
+                    'auto_append_file' => '',
+                ],
+            ],
+        ]);
+
+        $analyzer = new \WpcloudHostAnalyzer();
+        $manifest = $analyzer->analyze($preflight);
+
+        $this->assertEmpty($manifest->extra_directories);
+    }
+
+    public function testAnalyzeIgnoresRelativeIniPaths(): void
+    {
+        $preflight = $this->wpcloudPreflight([
+            'runtime' => [
+                'ini_get_all' => [
+                    'auto_prepend_file' => 'relative/path.php',
+                ],
+            ],
+        ]);
+
+        $analyzer = new \WpcloudHostAnalyzer();
+        $manifest = $analyzer->analyze($preflight);
+
+        $this->assertEmpty($manifest->extra_directories);
+    }
+
+    public function testAnalyzeIgnoresRootSlashOnly(): void
+    {
+        $preflight = $this->wpcloudPreflight([
+            'runtime' => [
+                'ini_get_all' => [
+                    'auto_prepend_file' => '/env.php',
+                ],
+            ],
+        ]);
+
+        $analyzer = new \WpcloudHostAnalyzer();
+        $manifest = $analyzer->analyze($preflight);
+
+        // dirname('/env.php') is '/' — should be ignored.
+        $this->assertEmpty($manifest->extra_directories);
+    }
+
+    public function testAnalyzeDeclaresThumbnailerRoute(): void
+    {
+        $analyzer = new \WpcloudHostAnalyzer();
+        $manifest = $analyzer->analyze($this->wpcloudPreflight());
+
+        $handlers = array_column($manifest->routes, 'handler');
+        $this->assertContains('wpcloud-thumbnail-generator', $handlers);
+    }
+
+    public function testAnalyzeSetsWpDirServerVar(): void
+    {
+        $analyzer = new \WpcloudHostAnalyzer();
+        $manifest = $analyzer->analyze($this->wpcloudPreflight());
+
+        $this->assertArrayHasKey('WP_DIR', $manifest->server_vars);
+        $this->assertSame('{fs-root}/__wp__/', $manifest->server_vars['WP_DIR']);
+    }
+
+    public function testScoreIdentifiesWpcloudSite(): void
+    {
+        $preflight = $this->wpcloudPreflight();
+        $score = \WpcloudHostAnalyzer::score($preflight);
+
+        // __wp__ dir (0.5) + WP root at __wp__ (0.4) + PRIVACY_MODEL (0.5) = 1.0 (capped)
+        $this->assertGreaterThanOrEqual(0.5, $score);
+    }
+
+    public function testScoreRejectsNonWpcloudSite(): void
+    {
+        $preflight = [
+            'runtime' => [
+                'document_root' => '/var/www/html',
+                'env_names' => [],
+                'ini_get_all' => [],
+            ],
+            'filesystem' => [
+                'directories' => [],
+            ],
+            'wp_detect' => [
+                'roots' => [
+                    ['path' => '/var/www/html'],
+                ],
+            ],
+        ];
+
+        $score = \WpcloudHostAnalyzer::score($preflight);
+        $this->assertLessThan(0.5, $score);
+    }
+}


### PR DESCRIPTION
## Summary

WP Cloud (Atomic) sites ship with production infrastructure that doesn't work locally: a Memcached-backed object-cache.php, wpcomsh mu-plugins that depend on multisite and wp.com APIs, and an `auto_prepend_file` pointing to `/scripts/env.php` outside the WordPress roots.

This PR teaches the importer to handle all three at the manifest level so every downstream runtime (Playground CLI, nginx-fpm, php-builtin) benefits automatically:

- **RuntimeManifest** gains `paths_to_remove` (relative paths to delete after flattening) and `extra_directories` (absolute remote directories to download and mount).
- **WpcloudHostAnalyzer** populates both: it marks `object-cache.php`, `wpcomsh`, `wpcomsh-dev`, and `wpcomsh-loader.php` for removal, and auto-detects directories from `auto_prepend_file` / `auto_append_file` INI values.
- **import.php** acts on the manifest after `apply-runtime`: it removes the declared paths (with audit logging) and auto-includes extra directories in the export file list so they get downloaded without callers needing to pass `--extra-directory`.

## Test plan

- [ ] Import a WP Cloud site and verify object-cache.php and wpcomsh mu-plugins are removed from the flattened output
- [ ] Verify the audit log records each removal
- [ ] Verify `/scripts` (or whatever `auto_prepend_file` points to) is auto-detected and downloaded
- [ ] Import a non-WP Cloud site and verify no paths are removed and no extra directories are added