### PR TITLE
Redesign CLI help around mirroring

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -87,8 +87,8 @@ jobs:
           echo "=== Importer preflight ==="
           timeout 30 php "$IMPORTER_PATH" preflight "${BASE}&directory=${DIR}" /tmp/e2e-smoke --secret="${SECRET}" 2>&1 | head -50 || echo "EXIT: $?"
 
-          echo "=== Importer files-sync ==="
-          timeout 30 php "$IMPORTER_PATH" files-sync "${BASE}&directory=${DIR}" /tmp/e2e-smoke --secret="${SECRET}" 2>&1 | head -50 || echo "EXIT: $?"
+          echo "=== Importer files-pull ==="
+          timeout 30 php "$IMPORTER_PATH" files-pull "${BASE}&directory=${DIR}" /tmp/e2e-smoke --secret="${SECRET}" 2>&1 | head -50 || echo "EXIT: $?"
 
       - name: Run E2E tests
         env:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,7 +104,7 @@ The file indexer (`endpoint_file_index` in `export.php`) prevents duplicate trav
 
 ### Non-Empty fs-root Handling (`--on-fs-root-nonempty`)
 
-By default, `files-sync` refuses to start if `--fs-root` is non-empty (to prevent accidental overwrites). The `--on-fs-root-nonempty` flag controls this behavior:
+By default, `files-pull` refuses to start if `--fs-root` is non-empty (to prevent accidental overwrites). The `--on-fs-root-nonempty` flag controls this behavior:
 
 - `--on-fs-root-nonempty=error` (default): throw an error and abort.
 - `--on-fs-root-nonempty=preserve-local`: import into the non-empty directory while preserving all existing local content.

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ This first builds a full index of the remote directory tree, then streams every 
 It can be interrupted and resumed at any time — just re-run the same command:
 
 ```bash
-php reprint.phar files-sync "$URL" --state-dir="$STATE_DIR" --fs-root="$FS_ROOT" --secret="$SECRET"
+php reprint.phar files-pull "$URL" --state-dir="$STATE_DIR" --fs-root="$FS_ROOT" --secret="$SECRET"
 ```
 
 The command returns one of three exit codes:
@@ -131,7 +131,7 @@ Which is to say, you'll need to wrap it in a loop that runs until failure or ful
 
 **Non-empty local fs-root**
 
-By default, `files-sync` refuses to start if `--fs-root` is non-empty. If you need to use a non-empty local fs-root,
+By default, `files-pull` refuses to start if `--fs-root` is non-empty. If you need to use a non-empty local fs-root,
 the `--on-fs-root-nonempty` flag controls this behavior. It takes the following values:
 
 - `--on-fs-root-nonempty=error` (default): throw an error and abort.
@@ -144,7 +144,7 @@ and you want to bring the site online before downloading all the uploads:
 
 ```bash
 # Step 1: download only essential files (code, config, themes, plugins)
-php reprint.phar files-sync "$URL" --state-dir="$STATE_DIR" --fs-root="$FS_ROOT" --secret="$SECRET" \
+php reprint.phar files-pull "$URL" --state-dir="$STATE_DIR" --fs-root="$FS_ROOT" --secret="$SECRET" \
     --filter=essential-files
 ```
 
@@ -154,7 +154,7 @@ files are done, the sync marks itself **complete**. The skipped file list stays 
 
 ```bash
 # Step 2: download the uploads
-php reprint.phar files-sync "$URL" --state-dir="$STATE_DIR" --fs-root="$FS_ROOT" --secret="$SECRET" \
+php reprint.phar files-pull "$URL" --state-dir="$STATE_DIR" --fs-root="$FS_ROOT" --secret="$SECRET" \
     --filter=skipped-earlier
 ```
 
@@ -172,7 +172,7 @@ The uploads directory is detected from preflight data (`uploads.basedir`), falli
 By default, this streams a SQL dump into `$STATE_DIR/db.sql`:
 
 ```bash
-php reprint.phar db-sync "$URL" --state-dir="$STATE_DIR" --fs-root="$FS_ROOT" --secret="$SECRET"
+php reprint.phar db-pull "$URL" --state-dir="$STATE_DIR" --fs-root="$FS_ROOT" --secret="$SECRET"
 ```
 
 You can also pipe the SQL directly to stdout or stream it into a MySQL server
@@ -180,11 +180,11 @@ without writing a file to disk. Use `--sql-output` to choose the mode:
 
 ```bash
 # Pipe to stdout — useful for feeding into mysql CLI or another tool
-php reprint.phar db-sync "$URL" --state-dir="$STATE_DIR" --fs-root="$FS_ROOT" --secret="$SECRET" \
+php reprint.phar db-pull "$URL" --state-dir="$STATE_DIR" --fs-root="$FS_ROOT" --secret="$SECRET" \
     --sql-output=stdout | mysql -u root my_database
 
 # Stream directly into MySQL — no intermediate file, no pipe
-php reprint.phar db-sync "$URL" --state-dir="$STATE_DIR" --fs-root="$FS_ROOT" --secret="$SECRET" \
+php reprint.phar db-pull "$URL" --state-dir="$STATE_DIR" --fs-root="$FS_ROOT" --secret="$SECRET" \
     --sql-output=mysql --mysql-database=my_database --mysql-host=127.0.0.1 --mysql-user=root --mysql-password=secret
 ```
 
@@ -218,19 +218,19 @@ The command returns one of three exit codes:
 
 While the database was being dumped, some files may have changed.
 
-First, we must abort the previous files-sync. Otherwise, it would just
+First, we must abort the previous files-pull. Otherwise, it would just
 tell us it's completed and refuse to proceed:
 
 ```bash
-php reprint.phar files-sync "$URL" --state-dir="$STATE_DIR" --fs-root="$FS_ROOT" --secret="$SECRET" --abort
+php reprint.phar files-pull "$URL" --state-dir="$STATE_DIR" --fs-root="$FS_ROOT" --secret="$SECRET" --abort
 ```
 
-From here, we can run the `files-sync` command again. It will index
+From here, we can run the `files-pull` command again. It will index
 the remote filesystem once again, compute which files have changed
 since the initial sync, and apply that delta in the local directory:
 
 ```bash
-php reprint.phar files-sync "$URL" --state-dir="$STATE_DIR" --fs-root="$FS_ROOT" --secret="$SECRET"
+php reprint.phar files-pull "$URL" --state-dir="$STATE_DIR" --fs-root="$FS_ROOT" --secret="$SECRET"
 ```
 
 The command returns one of three exit codes:
@@ -307,7 +307,7 @@ php reprint.phar apply-runtime --state-dir="$STATE_DIR" \
 
 The command accepts either `--fs-root` (the raw download directory — the remote
 `document_root` path is appended automatically) or `--flat-document-root` (a
-directory created by `flat-document-root`, used as-is). These are mutually exclusive.
+directory created by `flat-docroot`, used as-is). These are mutually exclusive.
 
 Host and port default to the URL rewrite target from `db-apply` (so the server
 listens on the same address the database was rewritten to). Override with
@@ -383,7 +383,7 @@ The file contains a flat JSON object:
 {
   "step": 2,
   "steps": 4,
-  "command": "files-sync",
+  "command": "files-pull",
   "status": "in_progress",
   "phase": "index",
   "error": null,
@@ -395,7 +395,7 @@ The file contains a flat JSON object:
 |-----------|-------------------|-------------|
 | `step`    | `int \| null`     | Current pipeline step (1-indexed). `null` when `--step` is not passed. |
 | `steps`   | `int \| null`     | Total pipeline steps. `null` when `--steps` is not passed. |
-| `command` | `string \| null`  | Current command name (`preflight`, `files-sync`, `db-sync`, etc.). |
+| `command` | `string \| null`  | Current command name (`preflight`, `files-pull`, `db-pull`, etc.). |
 | `status`  | `string`          | One of `in_progress`, `partial`, `complete`, `error`, `aborted`. |
 | `phase`   | `string \| null`  | Sub-phase within the command (e.g. `index`, `diff`, `fetch`, `fetch-skipped`), or `null`. Derived from the internal state's `stage` field. |
 | `error`   | `string \| null`  | Error message when `status` is `error`, otherwise `null`. |
@@ -426,7 +426,7 @@ If the JSON is invalid on load, the importer renames it to
 
 ```jsonc
 {
-  "command": "files-sync",         // active command
+  "command": "files-pull",         // active command
   "status": "in_progress",        // "in_progress" | "complete" | null
   "cursor": "...",                 // server-side cursor (opaque string)
   "stage": "streaming",           // current phase within the command
@@ -485,7 +485,7 @@ tell you where the pipeline is. The `stage` field gives finer granularity
 
 #### `.import-volatile-files.json` — files that changed during sync
 
-During `files-sync`, a file on the source may be modified while the importer is
+During `files-pull`, a file on the source may be modified while the importer is
 streaming it. When that happens, the server returns a different content hash than
 expected and the importer records the file in `.import-volatile-files.json`
 instead of failing.
@@ -500,7 +500,7 @@ was detected as changed:
 }
 ```
 
-At the end of `files-sync`, the importer prints a summary of volatile files so
+At the end of `files-pull`, the importer prints a summary of volatile files so
 the caller can decide what to do — re-run the sync, ignore them, or ask the user.
 Files that are subsequently downloaded successfully are automatically removed
 from the tracker. The file is deleted entirely once all entries are cleared.
@@ -531,17 +531,16 @@ php reprint.phar <command> <URL> --state-dir=DIR --fs-root=DIR [options]
 
 * `preflight` — Runs the preflight check and prints the full result as JSON. Exits with code 0 if OK, code 1 if not.
 * `preflight-assert` — Runs the preflight check and prints a human-readable pass/fail summary. Exits with code 0 if migration looks feasible, code 1 if not.
-* `files-sync` — Sync files. Auto-detects initial vs delta based on state: downloads the full tree on first run, only changes on subsequent runs.
-* `files-index` — Optional. It's a standalone command to index the full remote file index without fetching file contents. `files-sync` does it implicitly
-                  so this is mostly useful for testing and diagnostics.
-* `db-sync` — Downloads the database as a SQL dump. Defaults to writing `db.sql`; use `--sql-output=stdout` or `--sql-output=mysql` to stream elsewhere.
+* `files-pull` — Pull all files (initial) or only changes (delta). Runs files-index if needed.
+* `files-index` — Index all remote files (initial) or detect changes (delta). No file contents downloaded.
+* `db-pull` — Pull the database as a SQL dump. Defaults to writing `db.sql`; use `--sql-output=stdout` or `--sql-output=mysql` to stream elsewhere.
 * `db-apply` — Applies `db.sql` to a target MySQL or SQLite database. Accepts `--rewrite-url FROM TO` (repeatable) to rewrite domains during import.
-* `db-domains` — Lists domains discovered in the SQL dump. Reads `.import-domains.json` if available (written by `db-sync`), otherwise scans `db.sql`.
+* `db-domains` — Lists domains discovered in the SQL dump. Reads `.import-domains.json` if available (written by `db-pull`), otherwise scans `db.sql`.
 * `db-index` — Indexes database tables and their statistics (name, row count, size) to `db-tables.jsonl`.
-* `flat-document-root` — Creates a standard WordPress directory layout using symlinks. Useful when the source site has a non-standard layout (e.g. WP Cloud with ABSPATH separate from wp-content).
+* `flat-docroot` — Reassemble pulled files into a standard WordPress directory layout using symlinks. Useful when the source site has a non-standard layout (e.g. WP Cloud with ABSPATH separate from wp-content).
 * `apply-runtime` — Generates server configuration files (`runtime.php`, `start.sh` or `nginx.conf`) from preflight data. See [Step 6](#step-6--generate-runtime-configuration).
 
-All commands except `preflight-assert` support `--abort` to abort the current sync and exit. For `files-sync`, this clears sync progress but keeps the local index and downloaded files — the next run performs a delta sync. For `db-sync` and `db-index`, it clears the output file so the next run starts from scratch. Interrupted commands automatically resume from the last saved cursor.
+All commands except `preflight-assert` support `--abort` to abort the current sync and exit. For `files-pull`, this clears sync progress but keeps the local index and downloaded files — the next run performs a delta sync. For `db-pull` and `db-index`, it clears the output file so the next run starts from scratch. Interrupted commands automatically resume from the last saved cursor.
 
 # Architecture
 

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -978,7 +978,7 @@ class ImportClient
     private $fs_root_nonempty_behavior = 'error';
 
     /**
-     * Controls which files are downloaded during files-sync.
+     * Controls which files are downloaded during files-pull.
      *
      *   "none"             — download everything (default)
      *   "essential-files"  — skip uploads, download only code/config/themes/plugins
@@ -1262,7 +1262,7 @@ class ImportClient
         );
 
         if ($this->is_tty && !$this->verbose_mode) {
-            fwrite($this->progress_fd, "{$count} file(s) changed during sync and need re-syncing (run files-sync again):\n");
+            fwrite($this->progress_fd, "{$count} file(s) changed during sync and need re-syncing (run files-pull again):\n");
         }
 
         foreach ($files as $path => $changes) {
@@ -1280,7 +1280,7 @@ class ImportClient
                 "type" => "volatile_files",
                 "files" => $files,
                 "count" => $count,
-                "message" => "{$count} file(s) changed during sync and need re-syncing (run files-sync again)",
+                "message" => "{$count} file(s) changed during sync and need re-syncing (run files-pull again)",
             ],
             true,
         );
@@ -1352,7 +1352,7 @@ class ImportClient
      * Run the import process with explicit command validation.
      *
      * @param array $options Options:
-     *   - command: Required. One of: files-sync, files-index, db-sync, db-index, preflight, preflight-assert
+     *   - command: Required. One of: files-pull, files-index, db-pull, db-index, preflight, preflight-assert
      *   - abort: Optional. Clear state for the command and exit immediately
      *   - verbose: Optional. Enable verbose output
      */
@@ -1660,10 +1660,10 @@ class ImportClient
             case "files-pull":
                 // Clear sync progress (cursor, stage, status) and transient
                 // files, but keep the local index and downloaded files intact.
-                // This way the next `files-sync` sees a completed local index
+                // This way the next `files-pull` sees a completed local index
                 // and runs a delta sync rather than re-downloading everything.
                 $this->audit_log(
-                    "RESTART | Clearing files-sync progress (keeping local index and files)",
+                    "RESTART | Clearing files-pull progress (keeping local index and files)",
                     true,
                 );
                 $this->reset_state();
@@ -1723,7 +1723,7 @@ class ImportClient
 
             case "db-pull":
                 $this->audit_log(
-                    "RESTART | Clearing db-sync state",
+                    "RESTART | Clearing db-pull state",
                     true,
                 );
                 $this->reset_state();
@@ -1734,7 +1734,7 @@ class ImportClient
                     if (file_exists($sql_file)) {
                         unlink($sql_file);
                         $this->audit_log(
-                            "FILE DELETE | {$sql_file} | abort db-sync",
+                            "FILE DELETE | {$sql_file} | abort db-pull",
                         );
                     }
                 }
@@ -1742,14 +1742,14 @@ class ImportClient
                 if (file_exists($tables_file)) {
                     unlink($tables_file);
                     $this->audit_log(
-                        "FILE DELETE | {$tables_file} | abort db-sync",
+                        "FILE DELETE | {$tables_file} | abort db-pull",
                     );
                 }
                 $domains_file = $this->state_dir . "/.import-domains.json";
                 if (file_exists($domains_file)) {
                     unlink($domains_file);
                     $this->audit_log(
-                        "FILE DELETE | {$domains_file} | abort db-sync",
+                        "FILE DELETE | {$domains_file} | abort db-pull",
                     );
                 }
                 break;
@@ -2345,12 +2345,12 @@ class ImportClient
     }
 
     /**
-     * Command: files-sync
+     * Command: files-pull
      *
      * Unified file synchronization that auto-detects initial vs delta mode:
-     * - No prior completed files-sync → initial mode (index all, fetch all)
-     * - Prior completed files-sync → delta mode (re-index, diff, fetch changes)
-     * - In-progress files-sync → resume from saved state
+     * - No prior completed files-pull → initial mode (index all, fetch all)
+     * - Prior completed files-pull → delta mode (re-index, diff, fetch changes)
+     * - In-progress files-pull → resume from saved state
      *
      * Both modes share the same pipeline: index → diff → fetch.
      */
@@ -2381,11 +2381,11 @@ class ImportClient
                 if (!$has_skipped) {
                     throw new RuntimeException(
                         "--filter=skipped-earlier was requested but there is no skipped file list. " .
-                            "Run files-sync with --filter=essential-files first.",
+                            "Run files-pull with --filter=essential-files first.",
                     );
                 }
                 $this->audit_log(
-                    "FETCH SKIPPED | files-sync was complete — downloading previously skipped files",
+                    "FETCH SKIPPED | files-pull was complete — downloading previously skipped files",
                     true,
                 );
                 if ($this->is_tty && !$this->verbose_mode) {
@@ -2412,12 +2412,12 @@ class ImportClient
                 ? " (some files were skipped — re-run with --filter=skipped-earlier to download them)"
                 : "";
             $this->audit_log(
-                sprintf("files-sync already complete: %d files indexed%s", $index_size, $skipped_note),
+                sprintf("files-pull already complete: %d files indexed%s", $index_size, $skipped_note),
                 true,
             );
 
             if ($this->is_tty && !$this->verbose_mode) {
-                fwrite($this->progress_fd, "files-sync already complete: {$index_size} files indexed\n");
+                fwrite($this->progress_fd, "files-pull already complete: {$index_size} files indexed\n");
                 if ($has_skipped) {
                     fwrite($this->progress_fd, "Some files were skipped. Re-run with --filter=skipped-earlier to download them.\n");
                 } else {
@@ -2430,7 +2430,7 @@ class ImportClient
                 "command" => "files-pull",
                 "files_indexed" => $index_size,
                 "has_skipped" => $has_skipped,
-                "message" => "files-sync already complete: {$index_size} files indexed",
+                "message" => "files-pull already complete: {$index_size} files indexed",
             ], true);
             return;
         }
@@ -2441,7 +2441,7 @@ class ImportClient
         if ($this->filter === "skipped-earlier") {
             throw new RuntimeException(
                 "--filter=skipped-earlier was requested but there is no completed sync with skipped files. " .
-                    "Run files-sync with --filter=essential-files first.",
+                    "Run files-pull with --filter=essential-files first.",
             );
         }
 
@@ -2463,7 +2463,7 @@ class ImportClient
             $stage = $this->state["stage"] ?? "index";
             $this->audit_log(
                 sprintf(
-                    "RESUME files-sync | stage=%s | indexed_files=%d",
+                    "RESUME files-pull | stage=%s | indexed_files=%d",
                     $stage,
                     $index_size,
                 ),
@@ -2471,7 +2471,7 @@ class ImportClient
             );
 
             if ($this->is_tty && !$this->verbose_mode) {
-                fwrite($this->progress_fd, "Resuming files-sync\n");
+                fwrite($this->progress_fd, "Resuming files-pull\n");
                 fwrite($this->progress_fd, "  Stage: {$stage}\n");
                 fwrite($this->progress_fd, "  Already indexed: {$index_size} files\n");
             }
@@ -2481,7 +2481,7 @@ class ImportClient
                 "command" => "files-pull",
                 "stage" => $stage,
                 "index_size" => $index_size,
-                "message" => "Resuming files-sync (stage: {$stage}, indexed: {$index_size} files)",
+                "message" => "Resuming files-pull (stage: {$stage}, indexed: {$index_size} files)",
             ], true);
         } else {
             // Starting fresh — validate that target directory is empty.
@@ -2508,12 +2508,12 @@ class ImportClient
                 $index_size = $this->index_count();
     
                 $this->audit_log(
-                    "START files-sync (delta) | index_files={$index_size}",
+                    "START files-pull (delta) | index_files={$index_size}",
                     true,
                 );
 
                 if ($this->is_tty && !$this->verbose_mode) {
-                    fwrite($this->progress_fd, "Starting files-sync (delta)\n");
+                    fwrite($this->progress_fd, "Starting files-pull (delta)\n");
                     fwrite($this->progress_fd, "  Index contains: {$index_size} files\n");
                     fwrite($this->progress_fd, "  Stage: index\n");
                 }
@@ -2523,22 +2523,22 @@ class ImportClient
                     "command" => "files-pull",
                     "delta" => true,
                     "index_size" => $index_size,
-                    "message" => "Starting files-sync (delta, {$index_size} files indexed)",
+                    "message" => "Starting files-pull (delta, {$index_size} files indexed)",
                 ], true);
             } else {
                 $this->audit_log(
-                    "START files-sync ({$this->fs_root_nonempty_behavior} mode, ".($is_empty ? 'empty directory' : 'non-empty directory').")",
+                    "START files-pull ({$this->fs_root_nonempty_behavior} mode, ".($is_empty ? 'empty directory' : 'non-empty directory').")",
                     true,
                 );
 
                 if ($this->is_tty && !$this->verbose_mode) {
-                    fwrite($this->progress_fd, "Starting files-sync\n");
+                    fwrite($this->progress_fd, "Starting files-pull\n");
                 }
                 $this->output_progress([
                     "type" => "lifecycle",
                     "event" => "starting",
                     "command" => "files-pull",
-                    "message" => "Starting files-sync",
+                    "message" => "Starting files-pull",
                 ], true);
             }
         }
@@ -2559,7 +2559,7 @@ class ImportClient
 
         $this->clear_progress_line();
         $index_size = $this->index_count();
-        $label = $is_delta ? "files-sync (delta)" : "files-pull";
+        $label = $is_delta ? "files-pull (delta)" : "files-pull";
 
         $this->audit_log(
             sprintf("%s complete: %d files indexed", $label, $index_size),
@@ -3227,7 +3227,7 @@ class ImportClient
     }
 
     /**
-     * Command: db-sync
+     * Command: db-pull
      *
      * Rules:
      * - Stream next portion of SQL from last saved cursor
@@ -3254,16 +3254,16 @@ class ImportClient
                 $sql_exists = file_exists($sql_file);
                 if ($sql_exists) {
                     throw new RuntimeException(
-                        "db-sync already completed and db.sql exists. Use --abort flag to start over.",
+                        "db-pull already completed and db.sql exists. Use --abort flag to start over.",
                     );
                 } else {
                     throw new RuntimeException(
-                        "db-sync marked complete but db.sql is missing. Use --abort flag to re-sync.",
+                        "db-pull marked complete but db.sql is missing. Use --abort flag to re-sync.",
                     );
                 }
             } else {
                 throw new RuntimeException(
-                    "db-sync already completed. Use --abort flag to start over.",
+                    "db-pull already completed. Use --abort flag to start over.",
                 );
             }
         }
@@ -3272,7 +3272,7 @@ class ImportClient
             $stage = $this->state["stage"] ?? "db-index";
             $this->audit_log(
                 sprintf(
-                    "RESUME db-sync | stage=%s | cursor=%s",
+                    "RESUME db-pull | stage=%s | cursor=%s",
                     $stage,
                     !empty($this->state["cursor"])
                         ? substr($this->state["cursor"], 0, 20) . "..."
@@ -3282,14 +3282,14 @@ class ImportClient
             );
 
             if ($this->is_tty && !$this->verbose_mode) {
-                fwrite($this->progress_fd, "Resuming db-sync (stage: {$stage})\n");
+                fwrite($this->progress_fd, "Resuming db-pull (stage: {$stage})\n");
             }
             $this->output_progress([
                 "type" => "lifecycle",
                 "event" => "resuming",
                 "command" => "db-pull",
                 "stage" => $stage,
-                "message" => "Resuming db-sync (stage: {$stage})",
+                "message" => "Resuming db-pull (stage: {$stage})",
             ], true);
         } else {
             // Starting fresh
@@ -3301,16 +3301,16 @@ class ImportClient
             $this->state["db_index"] = $this->default_state()["db_index"];
             $this->save_state($this->state);
 
-            $this->audit_log("START db-sync", true);
+            $this->audit_log("START db-pull", true);
 
             if ($this->is_tty && !$this->verbose_mode) {
-                fwrite($this->progress_fd, "Starting db-sync\n");
+                fwrite($this->progress_fd, "Starting db-pull\n");
             }
             $this->output_progress([
                 "type" => "lifecycle",
                 "event" => "starting",
                 "command" => "db-pull",
-                "message" => "Starting db-sync",
+                "message" => "Starting db-pull",
             ], true);
         }
 
@@ -3335,7 +3335,7 @@ class ImportClient
 
             $tables = (int) ($this->state["db_index"]["tables"] ?? 0);
             $this->audit_log(
-                sprintf("db-sync db-index stage complete: %d tables", $tables),
+                sprintf("db-pull db-index stage complete: %d tables", $tables),
             );
 
             // Transition to sql stage
@@ -3362,10 +3362,10 @@ class ImportClient
         $this->state["status"] = "complete";
         $this->save_state($this->state);
 
-        $this->audit_log("db-sync complete", true);
+        $this->audit_log("db-pull complete", true);
 
         if ($this->is_tty && !$this->verbose_mode) {
-            fwrite($this->progress_fd, "db-sync complete\n");
+            fwrite($this->progress_fd, "db-pull complete\n");
             if ($this->sql_output_mode === "file") {
                 fwrite($this->progress_fd, "SQL file: {$sql_file}\n");
             } elseif ($this->sql_output_mode === "stdout") {
@@ -3381,7 +3381,7 @@ class ImportClient
             "command" => "db-pull",
             "sql_output_mode" => $this->sql_output_mode,
             "audit_log" => $this->audit_log,
-            "message" => "db-sync complete",
+            "message" => "db-pull complete",
         ];
         if ($this->sql_output_mode === "file") {
             $db_sync_complete["sql_file"] = $sql_file;
@@ -3406,7 +3406,7 @@ class ImportClient
         $sql_file = $this->state_dir . "/db.sql";
 
         if (file_exists($domains_file)) {
-            // Fast path: domains were already discovered during db-sync
+            // Fast path: domains were already discovered during db-pull
             $domains = json_decode(file_get_contents($domains_file), true);
             if (!is_array($domains)) {
                 throw new RuntimeException(
@@ -3414,7 +3414,7 @@ class ImportClient
                 );
             }
         } elseif (file_exists($sql_file)) {
-            // Scan db.sql for domains using the same pipeline as db-sync
+            // Scan db.sql for domains using the same pipeline as db-pull
             $query_stream = new \WP_MySQL_Naive_Query_Stream();
             $domain_collector = new \DomainCollector();
 
@@ -3455,7 +3455,7 @@ class ImportClient
             );
         } else {
             throw new RuntimeException(
-                "No domain data found. Run db-sync first, or place a db.sql file in {$this->state_dir}.",
+                "No domain data found. Run db-pull first, or place a db.sql file in {$this->state_dir}.",
             );
         }
 
@@ -3859,7 +3859,7 @@ class ImportClient
      * missing locally.
      *
      * The proxy is active in two cases:
-     * - files-sync is still incomplete
+     * - files-pull is still incomplete
      * - a prior --filter=essential-files run left skipped uploads on disk
      */
     private function maybe_enable_remote_upload_proxy(RuntimeManifest $manifest, array $preflight_data): void
@@ -3898,7 +3898,7 @@ class ImportClient
     /**
      * Decide whether runtime should proxy missing uploads from the source.
      *
-     * Once files-sync is fully complete and no skipped uploads remain, the
+     * Once files-pull is fully complete and no skipped uploads remain, the
      * proxy is disabled so requests are served only from local files.
      */
     private function should_enable_remote_upload_proxy(): bool
@@ -4713,7 +4713,7 @@ class ImportClient
         $sql_file = $this->state_dir . "/db.sql";
         if (!file_exists($sql_file)) {
             throw new RuntimeException(
-                "db.sql not found in {$this->state_dir}. Run db-sync first.",
+                "db.sql not found in {$this->state_dir}. Run db-pull first.",
             );
         }
 
@@ -4864,7 +4864,7 @@ class ImportClient
         $save_every = 100;
         $stmts_since_save = 0;
 
-        // Load pre-computed statement count from db-sync for progress reporting
+        // Load pre-computed statement count from db-pull for progress reporting
         $sql_stats_file = $this->state_dir . "/.import-sql-stats.json";
         $statements_total = null;
         if (file_exists($sql_stats_file)) {
@@ -10104,7 +10104,7 @@ if (
             'commands' => [],
         ],
 
-        // ── files-sync options ───────────────────────────────────
+        // ── files-pull options ───────────────────────────────────
         [
             'name' => 'filter',
             'type' => 'value',
@@ -10123,7 +10123,7 @@ if (
             'commands' => ['files-pull', 'files-index'],
         ],
 
-        // ── db-sync options ──────────────────────────────────────
+        // ── db-pull options ──────────────────────────────────────
         [
             'name' => 'max-allowed-packet',
             'type' => 'value',
@@ -10862,7 +10862,6 @@ if (
 
     $command = $argv[1];
 
-    // Command aliases — maps user-facing names and legacy names to
     // Legacy command names that still work on the CLI.
     $command_aliases = [
         "files-sync" => "files-pull",

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -1371,6 +1371,18 @@ class ImportClient
             }
         }
         $command = $options["command"] ?? null;
+
+        // Apply legacy command aliases so callers using old names still work.
+        static $command_aliases = [
+            "files-sync" => "files-pull",
+            "db-sync" => "db-pull",
+            "flat-document-root" => "flat-docroot",
+            "flatten-docroot" => "flat-docroot",
+        ];
+        if ($command && isset($command_aliases[$command])) {
+            $command = $command_aliases[$command];
+        }
+
         $abort = $options["abort"] ?? false;
         $this->pipeline_step = $options["pipeline_step"] ?? null;
         $this->pipeline_steps = $options["pipeline_steps"] ?? null;

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -1377,7 +1377,7 @@ class ImportClient
 
         if (!$command) {
             throw new InvalidArgumentException(
-                "Command is required. Valid commands: files-sync, files-index, files-stats, db-sync, db-index, db-domains, db-apply, preflight, preflight-assert, flat-document-root",
+                "Command is required. Valid commands: files-pull, files-index, files-stats, db-pull, db-index, db-domains, db-apply, preflight, preflight-assert, flat-docroot, apply-runtime",
             );
         }
 
@@ -1397,7 +1397,7 @@ class ImportClient
             ])
         ) {
             throw new InvalidArgumentException(
-                "Invalid command: {$command}. Valid commands: files-sync, files-index, files-stats, db-sync, db-index, db-domains, db-apply, preflight, preflight-assert, flat-document-root, apply-runtime",
+                "Invalid command: {$command}. Valid commands: files-pull, files-index, files-stats, db-pull, db-index, db-domains, db-apply, preflight, preflight-assert, flat-docroot, apply-runtime",
             );
         }
 
@@ -10472,17 +10472,34 @@ if (
      */
     function _cli_render_main_help(array $option_defs, array $command_info): void
     {
+        if (function_exists("posix_isatty") && posix_isatty(STDOUT)) {
+            // Colored ASCII art banner — each letter clearly separated.
+            $re = "\033[35m";              // magenta (Re)
+            $pr = "\033[38;5;63m";         // WP Blueberry ~#3858E9 (Print)
+            $r  = "\033[0m";
+            echo "{$re} ___         {$pr}___         _          _   {$r}\n";
+            echo "{$re}| _ \\  ___  {$pr}| _ \\  _ _  (_)  _ _   | |_ {$r}\n";
+            echo "{$re}|   / / -_) {$pr}|  _/ | '_| | | | ' \\  |  _|{$r}\n";
+            echo "{$re}|_|_\\ \\___| {$pr}|_|   |_|   |_| |_||_|  \\__|{$r}\n";
+            echo "\n";
+        }
+        echo "Mirror any WordPress site over HTTP.\n";
         echo "Version " . get_importer_version() . "\n";
         echo "\n";
-        echo "Usage: php import.php <command> <remote-url> --state-dir=DIR --fs-root=DIR [options]\n";
+        echo "Usage: reprint <command> <remote-url> --state-dir=DIR --fs-root=DIR [options]\n";
         echo "\n";
         echo "Commands:\n";
-        $max_len = max(array_map('strlen', array_keys($command_info)));
+        $display_names = [];
         foreach ($command_info as $name => $info) {
-            echo "  " . str_pad($name, $max_len + 2) . $info["short"] . "\n";
+            $display_names[] = $info["display"] ?? $name;
+        }
+        $max_len = max(array_map('strlen', $display_names));
+        foreach ($command_info as $name => $info) {
+            $display = $info["display"] ?? $name;
+            echo "  " . str_pad($display, $max_len + 2) . $info["short"] . "\n";
         }
         echo "\n";
-        echo "Run 'php import.php <command> --help' for command-specific help.\n";
+        echo "Run 'reprint <command> --help' for command-specific help.\n";
         echo "\n";
 
         $required = array_filter($option_defs, fn($d) => ($d['help_section'] ?? null) === 'required');
@@ -10524,7 +10541,8 @@ if (
         }
 
         $info = $command_info[$command];
-        echo "Usage: php import.php {$command} <remote-url> --state-dir=DIR --fs-root=DIR [options]\n";
+        $display = $info["display"] ?? $command;
+        echo "Usage: reprint {$display} <remote-url> --state-dir=DIR --fs-root=DIR [options]\n";
         echo "\n";
         echo $info["description"];
 
@@ -10622,20 +10640,22 @@ if (
     // every declared option for a command is guaranteed to appear.
     $command_info = [
         "files-sync" => [
-            "short" => "Sync files (auto-detects initial vs delta)",
+            "display" => "files-pull",
+            "short" => "Pull files from the remote site (index + download)",
             "description" =>
-                "Streams files from the remote server into the --fs-root directory.\n" .
-                "Auto-detects whether to run an initial or delta sync based on state:\n" .
+                "Indexes the remote directory tree and downloads files into --fs-root.\n" .
+                "Runs three stages: index → diff → fetch.\n" .
+                "Auto-detects whether this is a fresh pull or a follow-up:\n" .
                 "\n" .
-                "  - No prior sync: downloads the full directory tree (initial)\n" .
-                "  - Completed sync: re-indexes and downloads only changes (delta)\n" .
-                "  - Interrupted sync: resumes from the last saved cursor\n",
+                "  - First run: indexes and downloads the full directory tree\n" .
+                "  - After a completed pull: re-indexes and downloads only changes (delta)\n" .
+                "  - After an interruption: resumes from the last saved cursor\n",
             "extra" =>
                 "Filter modes:\n" .
-                "  none             Download all files (default)\n" .
-                "  essential-files   Skip uploads, download only code/config/themes/plugins.\n" .
+                "  none             Pull all files (default)\n" .
+                "  essential-files   Skip uploads, pull only code/config/themes/plugins.\n" .
                 "                    The skipped file list is saved for later retrieval.\n" .
-                "  skipped-earlier   Download only files skipped by a prior essential-files run.\n" .
+                "  skipped-earlier   Pull only files skipped by a prior essential-files run.\n" .
                 "\n" .
                 "Output files:\n" .
                 "  (fs-root)/                              Downloaded files\n" .
@@ -10647,32 +10667,36 @@ if (
                 "  .import-audit.log                       Audit log\n",
         ],
         "files-index" => [
-            "short" => "Download the remote file index without fetching file contents",
+            "short" => "Pull the remote file index (metadata only, no file contents)",
             "description" =>
-                "Traverses the full remote directory tree and writes each entry\n" .
-                "to .import-index.jsonl. Does not download any file data.\n",
+                "Streams the full remote directory tree over HTTP and writes each\n" .
+                "entry (path, size, ctime, type) to .import-remote-index.jsonl.\n" .
+                "When symlink-following is enabled, recursively discovers and indexes\n" .
+                "additional directories outside the primary roots.\n" .
+                "\n" .
+                "Does not download any file contents.\n",
             "extra" => null,
         ],
         "files-stats" => [
-            "short" => "Show file count and total size of indexed and pending files",
+            "short" => "Show file counts and sizes from the local index",
             "description" =>
-                "Reads the remote file index and download list to report:\n" .
+                "Reads local index files to report (no network calls):\n" .
                 "\n" .
                 "  - Total indexed files and their combined size\n" .
                 "  - Files not yet downloaded and their combined size\n" .
                 "\n" .
                 "Output is JSON with 'indexed' and 'pending' sections.\n" .
-                "The <remote-url> parameter is kept for CLI consistency but ignored.\n" .
-                "\n" .
-                "Requires a prior files-index or files-sync run.\n",
+                "Requires a prior files-index or files-pull run.\n",
             "extra" => null,
         ],
         "db-sync" => [
-            "short" => "Download the database as a SQL dump",
+            "display" => "db-pull",
+            "short" => "Pull the database as a SQL dump (index + download)",
             "description" =>
-                "Streams the full database dump into --state-dir/db.sql (default),\n" .
-                "to stdout for piping, or directly into a MySQL connection.\n" .
-                "Automatically resumes from the last cursor if interrupted.\n",
+                "Indexes remote tables, then streams the full SQL dump into\n" .
+                "--state-dir/db.sql (default), to stdout, or directly into a\n" .
+                "MySQL connection. Resumes from the last cursor if interrupted.\n" .
+                "Discovered domains are cached for later use by db-apply.\n",
             "extra" =>
                 "Output modes:\n" .
                 "  file    Write to --state-dir/db.sql (default)\n" .
@@ -10680,65 +10704,65 @@ if (
                 "  mysql   Stream directly into a MySQL connection\n",
         ],
         "db-index" => [
-            "short" => "Index database tables and their statistics",
+            "short" => "Pull table metadata from the remote database",
             "description" =>
-                "Streams table metadata (name, estimated rows, data size) into\n" .
-                "--state-dir/db-tables.jsonl. Useful for planning and diagnostics.\n",
+                "Fetches table metadata (name, estimated rows, data size) from\n" .
+                "the remote server and writes it to --state-dir/db-tables.jsonl.\n" .
+                "Useful for planning before a full db-pull.\n",
             "extra" =>
                 "Output files:\n" .
                 "  db-tables.jsonl  One JSON object per table\n",
         ],
         "db-domains" => [
-            "short" => "List domains discovered in the SQL dump",
+            "short" => "Extract domains from the pulled SQL dump",
             "description" =>
                 "Prints domains found in the SQL dump, one per line.\n" .
                 "\n" .
-                "If .import-domains.json exists (written by db-sync), it is read\n" .
-                "directly. Otherwise, db.sql is scanned for domains and the result\n" .
-                "is saved for future calls.\n" .
-                "\n" .
-                "The <remote-url> parameter is kept for CLI consistency but ignored.\n" .
+                "If .import-domains.json exists (cached by db-pull), it is read\n" .
+                "directly. Otherwise, db.sql is scanned and the result is cached\n" .
+                "for future calls. No network calls.\n" .
                 "\n" .
                 "Example:\n" .
-                "  php import.php db-domains - --state-dir=/path/to/state\n",
+                "  reprint db-domains - --state-dir=/path/to/state\n",
             "extra" => null,
         ],
         "db-apply" => [
-            "short" => "Apply SQL dump to a target MySQL or SQLite database with URL rewriting",
+            "short" => "Import the SQL dump into a local MySQL or SQLite database",
             "description" =>
-                "Reads <local-path>/db.sql, optionally rewrites URLs, and executes\n" .
-                "all statements against a target MySQL or SQLite database. Resumable.\n" .
-                "\n" .
-                "The <remote-url> parameter is kept for CLI consistency but ignored.\n",
+                "Reads db.sql from --state-dir, optionally rewrites URLs, and executes\n" .
+                "all statements against a target database. Resumable. Saves target\n" .
+                "database credentials to state for use by apply-runtime.\n",
             "extra" =>
                 "MySQL example:\n" .
-                "  php import.php db-apply - /path/to/import \\\n" .
+                "  reprint db-apply - --state-dir=./state --fs-root=./files \\\n" .
                 "    --target-user=root --target-db=wp_new \\\n" .
                 "    --rewrite-url https://old.com https://new.com\n" .
                 "\n" .
                 "SQLite example:\n" .
-                "  php import.php db-apply - /path/to/import \\\n" .
+                "  reprint db-apply - --state-dir=./state --fs-root=./files \\\n" .
                 "    --target-engine=sqlite --target-sqlite-path=/path/to/db.sqlite \\\n" .
                 "    --rewrite-url https://old.com https://new.com\n",
         ],
         "preflight" => [
-            "short" => "Run preflight check and print the full result as JSON",
+            "short" => "Probe the remote site and cache its environment",
             "description" =>
-                "Contacts the export server and collects environment details:\n" .
+                "Contacts the remote site and collects environment details:\n" .
                 "PHP/MySQL versions, memory limits, filesystem access, database\n" .
-                "connectivity, WordPress version, plugins, themes, and directory layout.\n" .
+                "connectivity, WordPress version, plugins, themes, directory layout,\n" .
+                "and runtime scripts (auto_prepend_file, auto_append_file).\n" .
                 "\n" .
-                "Prints the full preflight response as pretty-printed JSON.\n" .
-                "Exits 0 if the server reported OK, 1 otherwise.\n",
+                "Results are saved to state for use by later commands.\n" .
+                "Prints the full response as pretty-printed JSON.\n" .
+                "Exits 0 if the site reported OK, 1 otherwise.\n",
             "extra" => null,
         ],
         "preflight-assert" => [
-            "short" => "Check if migration is feasible (exits 0 or 1)",
+            "short" => "Verify the remote site can be mirrored (exits 0 or 1)",
             "description" =>
-                "Runs the same preflight check as the preflight command, then\n" .
-                "evaluates key assertions:\n" .
+                "Runs the same check as the preflight command, then evaluates\n" .
+                "key assertions:\n" .
                 "\n" .
-                "  - Server responded with HTTP 200\n" .
+                "  - Remote site responded with HTTP 200\n" .
                 "  - Preflight OK flag is set\n" .
                 "  - Filesystem directories are accessible\n" .
                 "  - Database connection works\n" .
@@ -10747,40 +10771,38 @@ if (
             "extra" => null,
         ],
         "flat-document-root" => [
-            "short" => "Create a vanilla WordPress directory layout using symlinks",
+            "display" => "flat-docroot",
+            "short" => "Reassemble pulled files into a standard WordPress layout",
             "description" =>
-                "Creates a directory at --flatten-to that mirrors the standard\n" .
-                "WordPress directory structure by analyzing preflight path data\n" .
-                "and symlinking each component from where it actually lives.\n" .
+                "Creates a directory at --flatten-to with symlinks that map the\n" .
+                "pulled files back into a vanilla WordPress directory structure.\n" .
                 "\n" .
-                "Uses preflight paths_urls (ABSPATH, WP_CONTENT_DIR, WP_PLUGIN_DIR,\n" .
-                "WPMU_PLUGIN_DIR, uploads basedir) to locate each WordPress component\n" .
-                "within the import fs root, even when they reside in different parent\n" .
+                "Uses preflight paths (ABSPATH, WP_CONTENT_DIR, WP_PLUGIN_DIR,\n" .
+                "WPMU_PLUGIN_DIR, uploads basedir) to locate each component\n" .
+                "within --fs-root, even when they reside in different parent\n" .
                 "directories on the source server (e.g. WP Cloud with ABSPATH at\n" .
                 "/srv/htdocs and WP_CONTENT_DIR at /tmp/__wp__/wp-content).\n" .
                 "\n" .
-                "Requires a prior preflight run to detect the WordPress directory layout.\n" .
-                "\n" .
-                "The command is idempotent: re-running refreshes all symlinks.\n" .
+                "No files are copied — only symlinks are created. Idempotent.\n" .
                 "If a path that should be a symlink is a regular file or directory,\n" .
                 "the command stops with an error unless --force is specified.\n",
             "extra" => null,
         ],
         "apply-runtime" => [
-            "short" => "Generate server configuration for the imported site",
+            "short" => "Generate server config and prepare the site to run locally",
             "description" =>
-                "Reads the source site's environment from preflight data and generates\n" .
-                "the configuration files needed to serve the imported site on your\n" .
-                "target server. This bridges the gap between 'files are on disk' and\n" .
-                "'the site actually works' — setting PHP constants, INI directives,\n" .
-                "and error handlers (like on-the-fly thumbnail generation).\n" .
+                "Generates server configuration (runtime.php, nginx.conf or start.sh)\n" .
+                "from preflight data and removes production-only drop-ins and mu-plugins\n" .
+                "that would crash outside the original host.\n" .
+                "\n" .
+                "If db-apply was run first, embeds the target database credentials\n" .
+                "into runtime.php automatically.\n" .
                 "\n" .
                 "Does not require a remote URL — reads only from local state.\n" .
-                "Requires a prior preflight run to detect the source host.\n" .
                 "\n" .
                 "Pass --fs-root for the raw download directory (the remote document_root\n" .
                 "path is appended automatically), or --flat-document-root for a directory\n" .
-                "created by flat-document-root (used as-is). These are mutually exclusive.\n",
+                "created by flat-docroot (used as-is). These are mutually exclusive.\n",
             "extra" =>
                 "Runtime modes:\n" .
                 "  nginx-fpm      — writes runtime.php + nginx.conf\n" .
@@ -10813,11 +10835,11 @@ if (
                 "\n" .
                 "Examples:\n" .
                 "  # From raw download directory:\n" .
-                "  php import.php apply-runtime --state-dir=./state \\\n" .
+                "  reprint apply-runtime --state-dir=./state \\\n" .
                 "    --fs-root=./files --output-dir=./runtime --runtime=php-builtin\n" .
                 "\n" .
                 "  # From flattened layout:\n" .
-                "  php import.php apply-runtime --state-dir=./state \\\n" .
+                "  reprint apply-runtime --state-dir=./state \\\n" .
                 "    --flat-document-root=./flat --output-dir=./runtime --runtime=php-builtin\n" .
                 "\n" .
                 "  bash ./runtime/start.sh\n",
@@ -10832,8 +10854,12 @@ if (
 
     $command = $argv[1];
 
-    // Backward-compatible command aliases (not advertised in help)
+    // Command aliases — maps user-facing names and legacy names to
+    // the internal command names used by run() and state files.
     $command_aliases = [
+        "files-pull" => "files-sync",
+        "db-pull" => "db-sync",
+        "flat-docroot" => "flat-document-root",
         "flatten-docroot" => "flat-document-root",
     ];
     if (isset($command_aliases[$command])) {
@@ -10859,7 +10885,7 @@ if (
         $remote_url = $argv[2] ?? null;
         if (!$remote_url) {
             fwrite(STDERR, "Error: <remote-url> is required\n");
-            fwrite(STDERR, "Usage: php import.php {$command} <remote-url> --state-dir=DIR --fs-root=DIR [options]\n");
+            fwrite(STDERR, "Usage: reprint {$command} <remote-url> --state-dir=DIR --fs-root=DIR [options]\n");
             exit(1);
         }
         $option_start_index = 3;
@@ -10872,7 +10898,7 @@ if (
 
     if (!$state_dir) {
         fwrite(STDERR, "Error: --state-dir=DIR is required\n");
-        fwrite(STDERR, "Usage: php import.php {$command} <remote-url> --state-dir=DIR --fs-root=DIR [options]\n");
+        fwrite(STDERR, "Usage: reprint {$command} <remote-url> --state-dir=DIR --fs-root=DIR [options]\n");
         exit(1);
     }
 
@@ -10885,7 +10911,7 @@ if (
     }
     if (!$fs_root && !$flat_document_root) {
         fwrite(STDERR, "Error: --fs-root=DIR is required\n");
-        fwrite(STDERR, "Usage: php import.php {$command} <remote-url> --state-dir=DIR --fs-root=DIR [options]\n");
+        fwrite(STDERR, "Usage: reprint {$command} <remote-url> --state-dir=DIR --fs-root=DIR [options]\n");
         exit(1);
     }
     if (!$fs_root) {

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -10472,17 +10472,15 @@ if (
      */
     function _cli_render_main_help(array $option_defs, array $command_info): void
     {
-        if (function_exists("posix_isatty") && posix_isatty(STDOUT)) {
-            // Colored ASCII art banner — each letter clearly separated.
-            $re = "\033[35m";              // magenta (Re)
-            $pr = "\033[38;5;63m";         // WP Blueberry ~#3858E9 (Print)
-            $r  = "\033[0m";
-            echo "{$re} ___         {$pr}___         _          _   {$r}\n";
-            echo "{$re}| _ \\  ___  {$pr}| _ \\  _ _  (_)  _ _   | |_ {$r}\n";
-            echo "{$re}|   / / -_) {$pr}|  _/ | '_| | | | ' \\  |  _|{$r}\n";
-            echo "{$re}|_|_\\ \\___| {$pr}|_|   |_|   |_| |_||_|  \\__|{$r}\n";
-            echo "\n";
-        }
+        $is_tty = function_exists("posix_isatty") && posix_isatty(STDOUT);
+        $re = $is_tty ? "\033[35m" : "";              // magenta (Re)
+        $pr = $is_tty ? "\033[38;5;63m" : "";         // WP Blueberry ~#3858E9 (Print)
+        $r  = $is_tty ? "\033[0m" : "";
+        echo "{$re} ___         {$pr}___         _          _   {$r}\n";
+        echo "{$re}| _ \\  ___  {$pr}| _ \\  _ _  (_)  _ _   | |_ {$r}\n";
+        echo "{$re}|   / / -_) {$pr}|  _/ | '_| | | | ' \\  |  _|{$r}\n";
+        echo "{$re}|_|_\\ \\___| {$pr}|_|   |_|   |_| |_||_|  \\__|{$r}\n";
+        echo "\n";
         echo "Mirror any WordPress site over HTTP.\n";
         echo "Version " . get_importer_version() . "\n";
         echo "\n";

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -10641,15 +10641,16 @@ if (
     $command_info = [
         "files-sync" => [
             "display" => "files-pull",
-            "short" => "Pull files from the remote site (index + download)",
+            "short" => "Pull files from the remote site, runs files-index if needed",
             "description" =>
-                "Indexes the remote directory tree and downloads files into --fs-root.\n" .
-                "Runs three stages: index → diff → fetch.\n" .
-                "Auto-detects whether this is a fresh pull or a follow-up:\n" .
+                "Downloads files from the remote site into --fs-root.\n" .
                 "\n" .
-                "  - First run: indexes and downloads the full directory tree\n" .
-                "  - After a completed pull: re-indexes and downloads only changes (delta)\n" .
-                "  - After an interruption: resumes from the last saved cursor\n",
+                "On the first run, indexes the full remote directory tree and then\n" .
+                "downloads every file. On subsequent runs, re-indexes the remote tree,\n" .
+                "diffs against the local index, and downloads only what changed.\n" .
+                "Interrupted pulls resume from the last saved cursor.\n" .
+                "\n" .
+                "Runs files-index internally when no index exists yet.\n",
             "extra" =>
                 "Filter modes:\n" .
                 "  none             Pull all files (default)\n" .

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -3603,7 +3603,7 @@ class ImportClient
      * The effective fs root is --fs-root + the remote site's document_root
      * prefix (from preflight). For example, if the remote document_root is
      * /srv/htdocs and --fs-root is ./files, the effective fs root is
-     * ./files/srv/htdocs. If the site was flattened with flat-document-root,
+     * ./files/srv/htdocs. If the site was flattened with flat-docroot,
      * pass the flattened directory as --fs-root directly and the prefix
      * is not applied.
      */
@@ -3666,7 +3666,7 @@ class ImportClient
                 throw new RuntimeException(
                     "Effective fs root does not exist: {$effective_fs_root}\n" .
                     "The remote document_root was: {$remote_doc_root}\n" .
-                    "If you used flat-document-root, pass the flattened directory " .
+                    "If you used flat-docroot, pass the flattened directory " .
                     "with --flat-document-root instead of --fs-root."
                 );
             }
@@ -3945,7 +3945,7 @@ class ImportClient
     }
 
     /**
-     * Command: flat-document-root
+     * Command: flat-docroot
      *
      * Creates a directory at the specified --flatten-to path that mirrors
      * a vanilla WordPress installation layout by symlinking entries from
@@ -3967,7 +3967,7 @@ class ImportClient
         $flatten_to = $options["flatten_to"] ?? null;
         if (empty($flatten_to)) {
             throw new InvalidArgumentException(
-                "flat-document-root requires --flatten-to=PATH",
+                "flat-docroot requires --flatten-to=PATH",
             );
         }
 

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -10639,6 +10639,33 @@ if (
     // The Options: section itself is generated from $option_defs so that
     // every declared option for a command is guaranteed to appear.
     $command_info = [
+        "preflight" => [
+            "short" => "Probe the remote site and cache its environment",
+            "description" =>
+                "Contacts the remote site and collects environment details:\n" .
+                "PHP/MySQL versions, memory limits, filesystem access, database\n" .
+                "connectivity, WordPress version, plugins, themes, directory layout,\n" .
+                "and runtime scripts (auto_prepend_file, auto_append_file).\n" .
+                "\n" .
+                "Results are saved to state for use by later commands.\n" .
+                "Prints the full response as pretty-printed JSON.\n" .
+                "Exits 0 if the site reported OK, 1 otherwise.\n",
+            "extra" => null,
+        ],
+        "preflight-assert" => [
+            "short" => "Verify the remote site can be mirrored (exits 0 or 1)",
+            "description" =>
+                "Runs the same check as the preflight command, then evaluates\n" .
+                "key assertions:\n" .
+                "\n" .
+                "  - Remote site responded with HTTP 200\n" .
+                "  - Preflight OK flag is set\n" .
+                "  - Filesystem directories are accessible\n" .
+                "  - Database connection works\n" .
+                "\n" .
+                "Prints a PASS/FAIL summary and exits 0 if all checks pass, 1 if not.\n",
+            "extra" => null,
+        ],
         "files-sync" => [
             "display" => "files-pull",
             "short" => "Pull all files (initial) or only changes (delta)",
@@ -10668,10 +10695,15 @@ if (
                 "  .import-audit.log                       Audit log\n",
         ],
         "files-index" => [
-            "short" => "Pull the remote file index (metadata only, no file contents)",
+            "short" => "Index all remote files (initial) or detect changes (delta)",
             "description" =>
                 "Streams the full remote directory tree over HTTP and writes each\n" .
                 "entry (path, size, ctime, type) to .import-remote-index.jsonl.\n" .
+                "\n" .
+                "On the first run, builds the complete index. On subsequent runs,\n" .
+                "re-indexes and diffs against the prior snapshot to produce a\n" .
+                "download list of changed files.\n" .
+                "\n" .
                 "When symlink-following is enabled, recursively discovers and indexes\n" .
                 "additional directories outside the primary roots.\n" .
                 "\n" .
@@ -10743,33 +10775,6 @@ if (
                 "  reprint db-apply - --state-dir=./state --fs-root=./files \\\n" .
                 "    --target-engine=sqlite --target-sqlite-path=/path/to/db.sqlite \\\n" .
                 "    --rewrite-url https://old.com https://new.com\n",
-        ],
-        "preflight" => [
-            "short" => "Probe the remote site and cache its environment",
-            "description" =>
-                "Contacts the remote site and collects environment details:\n" .
-                "PHP/MySQL versions, memory limits, filesystem access, database\n" .
-                "connectivity, WordPress version, plugins, themes, directory layout,\n" .
-                "and runtime scripts (auto_prepend_file, auto_append_file).\n" .
-                "\n" .
-                "Results are saved to state for use by later commands.\n" .
-                "Prints the full response as pretty-printed JSON.\n" .
-                "Exits 0 if the site reported OK, 1 otherwise.\n",
-            "extra" => null,
-        ],
-        "preflight-assert" => [
-            "short" => "Verify the remote site can be mirrored (exits 0 or 1)",
-            "description" =>
-                "Runs the same check as the preflight command, then evaluates\n" .
-                "key assertions:\n" .
-                "\n" .
-                "  - Remote site responded with HTTP 200\n" .
-                "  - Preflight OK flag is set\n" .
-                "  - Filesystem directories are accessible\n" .
-                "  - Database connection works\n" .
-                "\n" .
-                "Prints a PASS/FAIL summary and exits 0 if all checks pass, 1 if not.\n",
-            "extra" => null,
         ],
         "flat-document-root" => [
             "display" => "flat-docroot",

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -10641,7 +10641,7 @@ if (
     $command_info = [
         "files-sync" => [
             "display" => "files-pull",
-            "short" => "Pull files from the remote site, runs files-index if needed",
+            "short" => "Pull all files (initial) or only changes (delta)",
             "description" =>
                 "Downloads files from the remote site into --fs-root.\n" .
                 "\n" .

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -1403,18 +1403,6 @@ class ImportClient
 
         $this->state = $this->load_state();
 
-        // Migrate legacy command names stored in state files from older versions.
-        $legacy_commands = [
-            "files-sync" => "files-pull",
-            "db-sync" => "db-pull",
-            "flat-document-root" => "flat-docroot",
-        ];
-        $state_cmd = $this->state["command"] ?? null;
-        if ($state_cmd && isset($legacy_commands[$state_cmd])) {
-            $this->state["command"] = $legacy_commands[$state_cmd];
-            $this->save_state($this->state);
-        }
-
         // Persist follow_symlinks in state so it survives across invocations.
         // If explicitly set on CLI, store it.  Otherwise, restore from persisted state.
         if (isset($options["follow_symlinks"])) {
@@ -3899,7 +3887,7 @@ class ImportClient
             "handler" => "remote-upload-proxy",
             "path_pattern" => "/wp-content/uploads/.*",
             "condition" => "file_not_found",
-            "description" => "Proxy missing uploads from the source site until files-sync completes",
+            "description" => "Proxy missing uploads from the source site until files-pull completes",
         ];
         $this->audit_log(
             "APPLY-RUNTIME | enabled remote upload proxy ({$base_url})",
@@ -9657,7 +9645,20 @@ class ImportClient
         }
 
         $state = $this->normalize_state($state);
-        return $this->decode_state_paths($state);
+        $state = $this->decode_state_paths($state);
+
+        // Migrate legacy command names from older state files.
+        static $legacy_commands = [
+            "files-sync" => "files-pull",
+            "db-sync" => "db-pull",
+            "flat-document-root" => "flat-docroot",
+        ];
+        $state_cmd = $state["command"] ?? null;
+        if ($state_cmd && isset($legacy_commands[$state_cmd])) {
+            $state["command"] = $legacy_commands[$state_cmd];
+        }
+
+        return $state;
     }
 
     /**

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -1383,16 +1383,16 @@ class ImportClient
 
         if (
             !in_array($command, [
-                "files-sync",
+                "files-pull",
                 "files-index",
-                "db-sync",
+                "db-pull",
                 "db-index",
                 "db-domains",
                 "db-apply",
                 "files-stats",
                 "preflight",
                 "preflight-assert",
-                "flat-document-root",
+                "flat-docroot",
                 "apply-runtime",
             ])
         ) {
@@ -1402,6 +1402,18 @@ class ImportClient
         }
 
         $this->state = $this->load_state();
+
+        // Migrate legacy command names stored in state files from older versions.
+        $legacy_commands = [
+            "files-sync" => "files-pull",
+            "db-sync" => "db-pull",
+            "flat-document-root" => "flat-docroot",
+        ];
+        $state_cmd = $this->state["command"] ?? null;
+        if ($state_cmd && isset($legacy_commands[$state_cmd])) {
+            $this->state["command"] = $legacy_commands[$state_cmd];
+            $this->save_state($this->state);
+        }
 
         // Persist follow_symlinks in state so it survives across invocations.
         // If explicitly set on CLI, store it.  Otherwise, restore from persisted state.
@@ -1560,7 +1572,7 @@ class ImportClient
             $this->run_files_stats();
             return;
         }
-        if ($command === "flat-document-root") {
+        if ($command === "flat-docroot") {
             $this->run_flat_document_root($options);
             return;
         }
@@ -1612,7 +1624,7 @@ class ImportClient
                     $this->run_preflight_assert();
                     return;
 
-                case "files-sync":
+                case "files-pull":
                     $this->run_files_sync();
                     break;
 
@@ -1620,7 +1632,7 @@ class ImportClient
                     $this->run_files_index();
                     break;
 
-                case "db-sync":
+                case "db-pull":
                     $this->run_db_sync();
                     break;
                 case "db-index":
@@ -1657,7 +1669,7 @@ class ImportClient
     private function handle_abort(string $command): void
     {
         switch ($command) {
-            case "files-sync":
+            case "files-pull":
                 // Clear sync progress (cursor, stage, status) and transient
                 // files, but keep the local index and downloaded files intact.
                 // This way the next `files-sync` sees a completed local index
@@ -1721,7 +1733,7 @@ class ImportClient
                 $this->save_state($this->state);
                 break;
 
-            case "db-sync":
+            case "db-pull":
                 $this->audit_log(
                     "RESTART | Clearing db-sync state",
                     true,
@@ -2358,11 +2370,11 @@ class ImportClient
     {
         $state_command = $this->state["command"] ?? null;
         $current_status =
-            $state_command === "files-sync"
+            $state_command === "files-pull"
                 ? $this->state["status"] ?? null
                 : null;
         $has_progress =
-            $state_command === "files-sync" &&
+            $state_command === "files-pull" &&
             $current_status !== null &&
             $current_status !== "complete";
 
@@ -2394,7 +2406,7 @@ class ImportClient
                 $this->output_progress([
                     "type" => "lifecycle",
                     "event" => "starting",
-                    "command" => "files-sync",
+                    "command" => "files-pull",
                     "stage" => "fetch-skipped",
                     "message" => "Downloading previously skipped files",
                 ], true);
@@ -2427,7 +2439,7 @@ class ImportClient
             $this->output_progress([
                 "type" => "lifecycle",
                 "event" => "already_complete",
-                "command" => "files-sync",
+                "command" => "files-pull",
                 "files_indexed" => $index_size,
                 "has_skipped" => $has_skipped,
                 "message" => "files-sync already complete: {$index_size} files indexed",
@@ -2478,7 +2490,7 @@ class ImportClient
             $this->output_progress([
                 "type" => "lifecycle",
                 "event" => "resuming",
-                "command" => "files-sync",
+                "command" => "files-pull",
                 "stage" => $stage,
                 "index_size" => $index_size,
                 "message" => "Resuming files-sync (stage: {$stage}, indexed: {$index_size} files)",
@@ -2494,7 +2506,7 @@ class ImportClient
                 );
             }
 
-            $this->state["command"] = "files-sync";
+            $this->state["command"] = "files-pull";
             $this->state["status"] = "in_progress";
             $this->state["stage"] = "index";
             $this->state["diff"] = $this->default_state()["diff"];
@@ -2520,7 +2532,7 @@ class ImportClient
                 $this->output_progress([
                     "type" => "lifecycle",
                     "event" => "starting",
-                    "command" => "files-sync",
+                    "command" => "files-pull",
                     "delta" => true,
                     "index_size" => $index_size,
                     "message" => "Starting files-sync (delta, {$index_size} files indexed)",
@@ -2537,13 +2549,13 @@ class ImportClient
                 $this->output_progress([
                     "type" => "lifecycle",
                     "event" => "starting",
-                    "command" => "files-sync",
+                    "command" => "files-pull",
                     "message" => "Starting files-sync",
                 ], true);
             }
         }
 
-        $this->state["command"] = "files-sync";
+        $this->state["command"] = "files-pull";
         $this->state["status"] = "in_progress";
         $this->save_state($this->state);
 
@@ -2559,7 +2571,7 @@ class ImportClient
 
         $this->clear_progress_line();
         $index_size = $this->index_count();
-        $label = $is_delta ? "files-sync (delta)" : "files-sync";
+        $label = $is_delta ? "files-sync (delta)" : "files-pull";
 
         $this->audit_log(
             sprintf("%s complete: %d files indexed", $label, $index_size),
@@ -2573,7 +2585,7 @@ class ImportClient
         $this->output_progress([
             "type" => "lifecycle",
             "event" => "complete",
-            "command" => "files-sync",
+            "command" => "files-pull",
             "delta" => $is_delta,
             "files_indexed" => $index_size,
             "audit_log" => $this->audit_log,
@@ -3241,10 +3253,10 @@ class ImportClient
         $sql_file = $this->state_dir . "/db.sql";
 
         $has_progress =
-            $state_command === "db-sync" &&
+            $state_command === "db-pull" &&
             ($this->state["status"] ?? null) === "in_progress";
         $current_status =
-            $state_command === "db-sync"
+            $state_command === "db-pull"
                 ? $this->state["status"] ?? null
                 : null;
 
@@ -3287,13 +3299,13 @@ class ImportClient
             $this->output_progress([
                 "type" => "lifecycle",
                 "event" => "resuming",
-                "command" => "db-sync",
+                "command" => "db-pull",
                 "stage" => $stage,
                 "message" => "Resuming db-sync (stage: {$stage})",
             ], true);
         } else {
             // Starting fresh
-            $this->state["command"] = "db-sync";
+            $this->state["command"] = "db-pull";
             $this->state["status"] = "in_progress";
             $this->state["cursor"] = null;
             $this->state["stage"] = "db-index";
@@ -3309,12 +3321,12 @@ class ImportClient
             $this->output_progress([
                 "type" => "lifecycle",
                 "event" => "starting",
-                "command" => "db-sync",
+                "command" => "db-pull",
                 "message" => "Starting db-sync",
             ], true);
         }
 
-        $this->state["command"] = "db-sync";
+        $this->state["command"] = "db-pull";
         $this->save_state($this->state);
 
         // Stage 1: db-index (table metadata for progress estimation)
@@ -3378,7 +3390,7 @@ class ImportClient
         $db_sync_complete = [
             "type" => "lifecycle",
             "event" => "complete",
-            "command" => "db-sync",
+            "command" => "db-pull",
             "sql_output_mode" => $this->sql_output_mode,
             "audit_log" => $this->audit_log,
             "message" => "db-sync complete",
@@ -3910,7 +3922,7 @@ class ImportClient
             return true;
         }
 
-        if (($this->state["command"] ?? null) !== "files-sync") {
+        if (($this->state["command"] ?? null) !== "files-pull") {
             return false;
         }
 
@@ -10007,7 +10019,7 @@ if (
             'placeholder' => 'TOKEN',
             'help' => 'HMAC shared secret for export API authentication',
             'help_section' => 'global',
-            'commands' => ['files-sync', 'files-index', 'db-sync', 'db-index', 'preflight', 'preflight-assert'],
+            'commands' => ['files-pull', 'files-index', 'db-pull', 'db-index', 'preflight', 'preflight-assert'],
         ],
         [
             'name' => 'abort',
@@ -10015,7 +10027,7 @@ if (
             'target' => 'abort',
             'help' => 'Abort current sync and exit (preserves downloaded files)',
             'help_section' => 'global',
-            'commands' => ['files-sync', 'files-index', 'db-sync', 'db-index', 'db-apply'],
+            'commands' => ['files-pull', 'files-index', 'db-pull', 'db-index', 'db-apply'],
         ],
         [
             'name' => 'verbose',
@@ -10024,7 +10036,7 @@ if (
             'short' => 'v',
             'help' => 'Show detailed request/response logs',
             'help_section' => 'global',
-            'commands' => ['files-sync', 'files-index', 'db-sync', 'db-index', 'db-apply', 'flat-document-root', 'apply-runtime'],
+            'commands' => ['files-pull', 'files-index', 'db-pull', 'db-index', 'db-apply', 'flat-docroot', 'apply-runtime'],
         ],
         [
             'name' => 'no-follow-symlinks',
@@ -10033,7 +10045,7 @@ if (
             'flag_value' => false,
             'help' => 'Do not follow symlinks pointing outside root directories',
             'help_section' => 'global',
-            'commands' => ['files-sync'],
+            'commands' => ['files-pull'],
         ],
         [
             'name' => 'follow-symlinks',
@@ -10050,7 +10062,7 @@ if (
             'placeholder' => 'MODE',
             'help' => 'What to do when fs root is non-empty (error|preserve-local)',
             'help_section' => 'global',
-            'commands' => ['files-sync'],
+            'commands' => ['files-pull'],
             'aliases' => ['on-docroot-nonempty'],
         ],
         [
@@ -10099,7 +10111,7 @@ if (
             'placeholder' => 'MODE',
             'valid_values' => ['none', 'essential-files', 'skipped-earlier'],
             'help' => 'Filter which files to download (none|essential-files|skipped-earlier)',
-            'commands' => ['files-sync'],
+            'commands' => ['files-pull'],
         ],
         [
             'name' => 'extra-directory',
@@ -10107,7 +10119,7 @@ if (
             'target' => 'extra_directory',
             'placeholder' => 'DIR',
             'help' => 'Additional remote directory to include in the export',
-            'commands' => ['files-sync', 'files-index'],
+            'commands' => ['files-pull', 'files-index'],
         ],
 
         // ── db-sync options ──────────────────────────────────────
@@ -10118,7 +10130,7 @@ if (
             'placeholder' => 'SIZE',
             'cast' => 'size',
             'help' => 'Client max_allowed_packet (e.g. 16M, 64M)',
-            'commands' => ['db-sync'],
+            'commands' => ['db-pull'],
         ],
         [
             'name' => 'sql-output',
@@ -10126,7 +10138,7 @@ if (
             'target' => 'sql_output',
             'placeholder' => 'MODE',
             'help' => 'Output mode: file (default), stdout, mysql',
-            'commands' => ['db-sync'],
+            'commands' => ['db-pull'],
         ],
         [
             'name' => 'mysql-host',
@@ -10134,7 +10146,7 @@ if (
             'target' => 'mysql_host',
             'placeholder' => 'HOST',
             'help' => 'MySQL host (default: 127.0.0.1, for --sql-output=mysql)',
-            'commands' => ['db-sync'],
+            'commands' => ['db-pull'],
         ],
         [
             'name' => 'mysql-port',
@@ -10142,7 +10154,7 @@ if (
             'target' => 'mysql_port',
             'placeholder' => 'PORT',
             'help' => 'MySQL port (default: 3306, for --sql-output=mysql)',
-            'commands' => ['db-sync'],
+            'commands' => ['db-pull'],
         ],
         [
             'name' => 'mysql-user',
@@ -10150,7 +10162,7 @@ if (
             'target' => 'mysql_user',
             'placeholder' => 'USER',
             'help' => 'MySQL user (default: root, for --sql-output=mysql)',
-            'commands' => ['db-sync'],
+            'commands' => ['db-pull'],
         ],
         [
             'name' => 'mysql-password',
@@ -10158,7 +10170,7 @@ if (
             'target' => 'mysql_password',
             'placeholder' => 'PASS',
             'help' => 'MySQL password (or set MYSQL_PASSWORD env)',
-            'commands' => ['db-sync'],
+            'commands' => ['db-pull'],
         ],
         [
             'name' => 'mysql-database',
@@ -10166,7 +10178,7 @@ if (
             'target' => 'mysql_database',
             'placeholder' => 'DB',
             'help' => 'MySQL database (required for --sql-output=mysql)',
-            'commands' => ['db-sync'],
+            'commands' => ['db-pull'],
         ],
 
         // ── db-apply options ─────────────────────────────────────
@@ -10244,21 +10256,21 @@ if (
             'commands' => ['db-apply'],
         ],
 
-        // ── flat-document-root options ───────────────────────────
+        // ── flat-docroot options ────────────────────────────────
         [
             'name' => 'flatten-to',
             'type' => 'value',
             'target' => 'flatten_to',
             'placeholder' => 'PATH',
             'help' => 'Target directory for the flattened layout (required)',
-            'commands' => ['flat-document-root'],
+            'commands' => ['flat-docroot'],
         ],
         [
             'name' => 'force',
             'type' => 'flag',
             'target' => 'force',
             'help' => 'Remove conflicting non-symlink files and replace with symlinks',
-            'commands' => ['flat-document-root'],
+            'commands' => ['flat-docroot'],
         ],
 
         // ── apply-runtime options ────────────────────────────────
@@ -10487,14 +10499,9 @@ if (
         echo "Usage: reprint <command> <remote-url> --state-dir=DIR --fs-root=DIR [options]\n";
         echo "\n";
         echo "Commands:\n";
-        $display_names = [];
+        $max_len = max(array_map('strlen', array_keys($command_info)));
         foreach ($command_info as $name => $info) {
-            $display_names[] = $info["display"] ?? $name;
-        }
-        $max_len = max(array_map('strlen', $display_names));
-        foreach ($command_info as $name => $info) {
-            $display = $info["display"] ?? $name;
-            echo "  " . str_pad($display, $max_len + 2) . $info["short"] . "\n";
+            echo "  " . str_pad($name, $max_len + 2) . $info["short"] . "\n";
         }
         echo "\n";
         echo "Run 'reprint <command> --help' for command-specific help.\n";
@@ -10539,8 +10546,7 @@ if (
         }
 
         $info = $command_info[$command];
-        $display = $info["display"] ?? $command;
-        echo "Usage: reprint {$display} <remote-url> --state-dir=DIR --fs-root=DIR [options]\n";
+        echo "Usage: reprint {$command} <remote-url> --state-dir=DIR --fs-root=DIR [options]\n";
         echo "\n";
         echo $info["description"];
 
@@ -10664,8 +10670,7 @@ if (
                 "Prints a PASS/FAIL summary and exits 0 if all checks pass, 1 if not.\n",
             "extra" => null,
         ],
-        "files-sync" => [
-            "display" => "files-pull",
+        "files-pull" => [
             "short" => "Pull all files (initial) or only changes (delta)",
             "description" =>
                 "Downloads files from the remote site into --fs-root.\n" .
@@ -10720,8 +10725,7 @@ if (
                 "Requires a prior files-index or files-pull run.\n",
             "extra" => null,
         ],
-        "db-sync" => [
-            "display" => "db-pull",
+        "db-pull" => [
             "short" => "Pull the database as a SQL dump (index + download)",
             "description" =>
                 "Indexes remote tables, then streams the full SQL dump into\n" .
@@ -10774,8 +10778,7 @@ if (
                 "    --target-engine=sqlite --target-sqlite-path=/path/to/db.sqlite \\\n" .
                 "    --rewrite-url https://old.com https://new.com\n",
         ],
-        "flat-document-root" => [
-            "display" => "flat-docroot",
+        "flat-docroot" => [
             "short" => "Reassemble pulled files into a standard WordPress layout",
             "description" =>
                 "Creates a directory at --flatten-to with symlinks that map the\n" .
@@ -10859,12 +10862,12 @@ if (
     $command = $argv[1];
 
     // Command aliases — maps user-facing names and legacy names to
-    // the internal command names used by run() and state files.
+    // Legacy command names that still work on the CLI.
     $command_aliases = [
-        "files-pull" => "files-sync",
-        "db-pull" => "db-sync",
-        "flat-docroot" => "flat-document-root",
-        "flatten-docroot" => "flat-document-root",
+        "files-sync" => "files-pull",
+        "db-sync" => "db-pull",
+        "flat-document-root" => "flat-docroot",
+        "flatten-docroot" => "flat-docroot",
     ];
     if (isset($command_aliases[$command])) {
         $command = $command_aliases[$command];

--- a/packages/reprint-importer/src/lib/host/analyzers/class-wpcloud-host-analyzer.php
+++ b/packages/reprint-importer/src/lib/host/analyzers/class-wpcloud-host-analyzer.php
@@ -4,7 +4,7 @@
  *
  * WP Cloud sites have a non-standard directory layout: WordPress core lives
  * at a versioned path (/wordpress/core/X.Y.Z/) and wp-content is a separate
- * tree under /srv/htdocs/. After flat-document-root, the local layout uses a
+ * tree under /srv/htdocs/. After flat-docroot, the local layout uses a
  * __wp__ directory for core.
  *
  * The export only ships original-size uploads, so the manifest declares a
@@ -73,7 +73,7 @@ class WpcloudHostAnalyzer implements HostAnalyzer
         $manifest->constants = $this->build_constants($preflight_data);
         $manifest->server_vars = [
             // WP Cloud uses a __wp__ directory for WordPress core. After
-            // flat-document-root, it lives at {fs-root}/__wp__/.
+            // flat-docroot, it lives at {fs-root}/__wp__/.
             'WP_DIR' => '{fs-root}/__wp__/',
         ];
 

--- a/packages/reprint-importer/src/lib/host/analyzers/class-wpcloud-host-analyzer.php
+++ b/packages/reprint-importer/src/lib/host/analyzers/class-wpcloud-host-analyzer.php
@@ -108,7 +108,7 @@ class WpcloudHostAnalyzer implements HostAnalyzer
 
         // auto_prepend_file on Atomic points to /scripts/env.php — a
         // directory outside the WordPress roots.  Record it so that
-        // files-sync downloads it and the runtime applier can mount it.
+        // files-pull downloads it and the runtime applier can mount it.
         $manifest->extra_directories = $this->detect_extra_directories($preflight_data);
 
         return $manifest;

--- a/packages/reprint-importer/src/lib/target-runtime/class-playground-cli-applier.php
+++ b/packages/reprint-importer/src/lib/target-runtime/class-playground-cli-applier.php
@@ -127,7 +127,7 @@ class PlaygroundCliApplier implements RuntimeApplier
      * corresponding Playground mounts.
      *
      * Some route handlers need importer metadata produced outside the mounted
-     * WordPress tree, for example the files-sync state used by the temporary
+     * WordPress tree, for example the files-pull state used by the temporary
      * remote uploads proxy. Playground can only see files that are mounted
      * explicitly, so we map those constants to /tmp paths in the VM.
      *

--- a/packages/reprint-importer/src/lib/target-runtime/route-handlers/remote-upload-proxy.php
+++ b/packages/reprint-importer/src/lib/target-runtime/route-handlers/remote-upload-proxy.php
@@ -9,7 +9,7 @@ function remote_upload_proxy_code(): string
 {
     return <<<'PHP'
 /**
- * Proxy missing uploads from the source site until files-sync completes.
+ * Proxy missing uploads from the source site until files-pull completes.
  *
  * This runs before WordPress boots. If a request under /wp-content/uploads/
  * is missing locally, it fetches the corresponding source URL with cURL and

--- a/packages/reprint-importer/src/lib/target-runtime/route-handlers/remote-upload-proxy.php
+++ b/packages/reprint-importer/src/lib/target-runtime/route-handlers/remote-upload-proxy.php
@@ -42,7 +42,7 @@ function remote_upload_proxy_code(): string
 				$command = $state['command'] ?? null;
 				$status = $state['status'] ?? null;
 				$proxy_enabled =
-					$command === 'files-sync' &&
+					($command === 'files-pull' || $command === 'files-sync') &&
 					$status !== null &&
 					$status !== 'complete';
 			}

--- a/tests/Import/CurlTimeoutRecoveryTest.php
+++ b/tests/Import/CurlTimeoutRecoveryTest.php
@@ -119,7 +119,7 @@ class CurlTimeoutRecoveryTest extends TestCase
     public function testSqlDownloadTimeoutSavesPartialState()
     {
         $this->writeState([
-            "command" => "db-sync",
+            "command" => "db-pull",
             "status" => "in_progress",
             "stage" => "sql",
             "cursor" => base64_encode('{"table":"wp_posts","pk":42}'),
@@ -160,7 +160,7 @@ class CurlTimeoutRecoveryTest extends TestCase
     public function testFileFetchTimeoutSavesPartialState()
     {
         $this->writeState([
-            "command" => "files-sync",
+            "command" => "files-pull",
             "status" => "in_progress",
             "stage" => "fetch",
             "fetch" => [
@@ -201,7 +201,7 @@ class CurlTimeoutRecoveryTest extends TestCase
     public function testRemoteIndexTimeoutSavesPartialState()
     {
         $this->writeState([
-            "command" => "files-sync",
+            "command" => "files-pull",
             "status" => "in_progress",
             "stage" => "index",
             "index" => [
@@ -249,7 +249,7 @@ class CurlTimeoutRecoveryTest extends TestCase
     public function testDbIndexTimeoutSavesPartialState()
     {
         $this->writeState([
-            "command" => "db-sync",
+            "command" => "db-pull",
             "status" => "in_progress",
             "stage" => "db-index",
             "cursor" => base64_encode('{"table_offset":5}'),
@@ -282,7 +282,7 @@ class CurlTimeoutRecoveryTest extends TestCase
     public function testRunDbSyncExitsPartialOnSqlTimeout()
     {
         $this->writeState([
-            "command" => "db-sync",
+            "command" => "db-pull",
             "status" => "in_progress",
             "stage" => "sql",
             "cursor" => base64_encode('{"table":"wp_posts","pk":42}'),
@@ -334,7 +334,7 @@ class CurlTimeoutRecoveryTest extends TestCase
     public function testTrackConsecutiveTimeoutIncrementsOnNoProgress()
     {
         $this->writeState([
-            "command" => "db-sync",
+            "command" => "db-pull",
             "status" => "in_progress",
             "consecutive_timeouts" => 0,
         ]);
@@ -356,7 +356,7 @@ class CurlTimeoutRecoveryTest extends TestCase
     public function testTrackConsecutiveTimeoutResetsOnProgress()
     {
         $this->writeState([
-            "command" => "db-sync",
+            "command" => "db-pull",
             "status" => "in_progress",
             "consecutive_timeouts" => 2,
         ]);
@@ -374,7 +374,7 @@ class CurlTimeoutRecoveryTest extends TestCase
     public function testTrackConsecutiveTimeoutThrowsAtMax()
     {
         $this->writeState([
-            "command" => "db-sync",
+            "command" => "db-pull",
             "status" => "in_progress",
             "consecutive_timeouts" => 2,
         ]);
@@ -397,7 +397,7 @@ class CurlTimeoutRecoveryTest extends TestCase
     public function testSqlDownloadGivesUpAfterMaxConsecutiveTimeouts()
     {
         $this->writeState([
-            "command" => "db-sync",
+            "command" => "db-pull",
             "status" => "in_progress",
             "stage" => "sql",
             "cursor" => base64_encode('{"table":"wp_posts","pk":42}'),
@@ -423,7 +423,7 @@ class CurlTimeoutRecoveryTest extends TestCase
     public function testFirstTimeoutIncrementsCounterInState()
     {
         $this->writeState([
-            "command" => "db-sync",
+            "command" => "db-pull",
             "status" => "in_progress",
             "stage" => "sql",
             "cursor" => base64_encode('{"table":"wp_posts","pk":42}'),
@@ -454,7 +454,7 @@ class CurlTimeoutRecoveryTest extends TestCase
     public function testSuccessfulRequestResetsCounter()
     {
         $this->writeState([
-            "command" => "files-sync",
+            "command" => "files-pull",
             "status" => "in_progress",
             "stage" => "index",
             "index" => [

--- a/tests/Import/DownloadListProgressTest.php
+++ b/tests/Import/DownloadListProgressTest.php
@@ -143,7 +143,7 @@ class DownloadListProgressTest extends TestCase
         $listFile = $this->writeDownloadList(100);
 
         $this->writeState([
-            "command" => "files-sync",
+            "command" => "files-pull",
             "status" => "in_progress",
             "stage" => "fetch",
         ]);
@@ -168,7 +168,7 @@ class DownloadListProgressTest extends TestCase
         $offset = $this->byteOffsetAfterLines($listFile, 40);
 
         $this->writeState([
-            "command" => "files-sync",
+            "command" => "files-pull",
             "status" => "in_progress",
             "stage" => "fetch",
             "fetch" => [
@@ -202,7 +202,7 @@ class DownloadListProgressTest extends TestCase
         $pastEnd = filesize($listFile) + 1000;
 
         $this->writeState([
-            "command" => "files-sync",
+            "command" => "files-pull",
             "status" => "in_progress",
             "stage" => "fetch",
             "fetch" => [
@@ -236,7 +236,7 @@ class DownloadListProgressTest extends TestCase
 
         // First invocation at offset 30
         $this->writeState([
-            "command" => "files-sync",
+            "command" => "files-pull",
             "status" => "in_progress",
             "stage" => "fetch",
             "fetch" => ["offset" => $offset30, "next_offset" => $offset30, "batch_file" => null, "batch_entries" => 0, "cursor" => null],
@@ -253,7 +253,7 @@ class DownloadListProgressTest extends TestCase
 
         // Second invocation at offset 60
         $this->writeState([
-            "command" => "files-sync",
+            "command" => "files-pull",
             "status" => "in_progress",
             "stage" => "fetch",
             "fetch" => ["offset" => $offset60, "next_offset" => $offset60, "batch_file" => null, "batch_entries" => 0, "cursor" => null],
@@ -280,7 +280,7 @@ class DownloadListProgressTest extends TestCase
         $offset20 = $this->byteOffsetAfterLines($skippedList, 20);
 
         $this->writeState([
-            "command" => "files-sync",
+            "command" => "files-pull",
             "status" => "in_progress",
             "stage" => "fetch-skipped",
             "fetch_skipped" => ["offset" => $offset20, "next_offset" => $offset20, "batch_file" => null, "batch_entries" => 0, "cursor" => null],
@@ -316,7 +316,7 @@ class DownloadListProgressTest extends TestCase
         $listFile = $this->writeDownloadList(10);
 
         $this->writeState([
-            "command" => "files-sync",
+            "command" => "files-pull",
             "status" => "in_progress",
             "stage" => "fetch",
         ]);
@@ -341,7 +341,7 @@ class DownloadListProgressTest extends TestCase
         $offset40 = $this->byteOffsetAfterLines($listFile, 40);
 
         $this->writeState([
-            "command" => "files-sync",
+            "command" => "files-pull",
             "status" => "in_progress",
             "stage" => "fetch",
             "fetch" => ["offset" => $offset40, "next_offset" => $offset40, "batch_file" => null, "batch_entries" => 0, "cursor" => null],

--- a/tests/Import/FilesSyncStateTest.php
+++ b/tests/Import/FilesSyncStateTest.php
@@ -158,7 +158,7 @@ class FilesSyncStateTest extends TestCase
     public function testCompletedFilesSyncRefusesToRerun()
     {
         $this->writeState([
-            "command" => "files-sync",
+            "command" => "files-pull",
             "status" => "complete",
         ]);
 
@@ -169,7 +169,7 @@ class FilesSyncStateTest extends TestCase
 
         $state = $this->readState();
         $this->assertEquals("complete", $state["status"]);
-        $this->assertEquals("files-sync", $state["command"]);
+        $this->assertEquals("files-pull", $state["command"]);
     }
 
     /**
@@ -181,14 +181,14 @@ class FilesSyncStateTest extends TestCase
         file_put_contents($indexFile, $this->indexLine('/wp-login.php', 1000, 100));
 
         $this->writeState([
-            "command" => "files-sync",
+            "command" => "files-pull",
             "status" => "complete",
         ]);
 
         [$client, $reflection] = $this->prepareClient();
 
         $abortMethod = $reflection->getMethod('handle_abort');
-        $abortMethod->invoke($client, 'files-sync');
+        $abortMethod->invoke($client, 'files-pull');
 
         $state = $this->readState();
         $this->assertNotEquals(
@@ -208,13 +208,13 @@ class FilesSyncStateTest extends TestCase
         file_put_contents($indexFile, $this->indexLine('/wp-login.php', 1000, 100));
 
         $this->writeState([
-            "command" => "files-sync",
+            "command" => "files-pull",
             "status" => "complete",
         ]);
 
         // Step 1: abort
         [$client, $reflection] = $this->prepareClient();
-        $reflection->getMethod('handle_abort')->invoke($client, 'files-sync');
+        $reflection->getMethod('handle_abort')->invoke($client, 'files-pull');
 
         // Step 2: new client, try run_files_sync
         [$client2, $reflection2] = $this->prepareClient();
@@ -231,7 +231,7 @@ class FilesSyncStateTest extends TestCase
             $state["status"],
             "After abort + re-run, the sync should start fresh, not report 'already complete'",
         );
-        $this->assertEquals("files-sync", $state["command"]);
+        $this->assertEquals("files-pull", $state["command"]);
     }
 
     // ---------------------------------------------------------------
@@ -261,7 +261,7 @@ class FilesSyncStateTest extends TestCase
         file_put_contents($localFile, 'old content');
 
         $this->writeState([
-            "command" => "files-sync",
+            "command" => "files-pull",
             "status" => "in_progress",
             "stage" => "diff",
         ]);
@@ -299,7 +299,7 @@ class FilesSyncStateTest extends TestCase
         file_put_contents($localFile, 'local drop-in');
 
         $this->writeState([
-            "command" => "files-sync",
+            "command" => "files-pull",
             "status" => "in_progress",
             "stage" => "diff",
         ]);
@@ -335,7 +335,7 @@ class FilesSyncStateTest extends TestCase
         file_put_contents($localFile, 'old content');
 
         $this->writeState([
-            "command" => "files-sync",
+            "command" => "files-pull",
             "status" => "in_progress",
             "stage" => "fetch",
         ]);

--- a/tests/Import/FilesSyncStateTest.php
+++ b/tests/Import/FilesSyncStateTest.php
@@ -7,9 +7,9 @@ use PHPUnit\Framework\TestCase;
 require_once __DIR__ . '/../../importer/import.php';
 
 /**
- * Test files-sync state transitions and preserve-local diff behavior.
+ * Test files-pull state transitions and preserve-local diff behavior.
  *
- * A completed files-sync should refuse to re-run without --abort.
+ * A completed files-pull should refuse to re-run without --abort.
  * After --abort, the next run should start fresh (not "already complete").
  * In preserve-local mode, previously-synced files that changed remotely
  * must still be re-downloaded (not skipped).
@@ -153,7 +153,7 @@ class FilesSyncStateTest extends TestCase
     // ---------------------------------------------------------------
 
     /**
-     * A completed files-sync should refuse to re-run.
+     * A completed files-pull should refuse to re-run.
      */
     public function testCompletedFilesSyncRefusesToRerun()
     {

--- a/tests/Import/LegacyCommandAliasTest.php
+++ b/tests/Import/LegacyCommandAliasTest.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace ImportTests;
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../importer/import.php';
+
+/**
+ * Smoke test: old command names (files-sync, db-sync, flat-document-root)
+ * must continue to work via the alias table and state migration.
+ */
+class LegacyCommandAliasTest extends TestCase
+{
+    private $tempDir;
+    private $stateDir;
+    private $fs_root;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->tempDir = sys_get_temp_dir() . '/import-alias-test-' . uniqid();
+        $this->stateDir = $this->tempDir . '/state';
+        $this->fs_root = $this->tempDir . '/fs-root';
+        mkdir($this->stateDir, 0755, true);
+        mkdir($this->fs_root, 0755, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->recursiveDelete($this->tempDir);
+        parent::tearDown();
+    }
+
+    private function recursiveDelete(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        foreach (scandir($dir) as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $path = $dir . '/' . $item;
+            if (is_link($path)) {
+                unlink($path);
+            } elseif (is_dir($path)) {
+                $this->recursiveDelete($path);
+            } else {
+                unlink($path);
+            }
+        }
+        rmdir($dir);
+    }
+
+    /**
+     * Old command names must be accepted by run() without throwing
+     * "Invalid command". We can't actually complete the sync (no server),
+     * but we verify the command is recognized and dispatched.
+     *
+     * @dataProvider legacyCommandProvider
+     */
+    public function testLegacyCommandNameIsAccepted(string $legacy_name, string $canonical_name): void
+    {
+        $client = new \ImportClient('http://fake.invalid', $this->stateDir, $this->fs_root);
+
+        // Write a preflight so commands that require it don't bail early.
+        file_put_contents(
+            $this->stateDir . '/.import-state.json',
+            json_encode([
+                "preflight" => ["data" => ["ok" => true], "http_code" => 200],
+            ]),
+        );
+
+        try {
+            $client->run(["command" => $legacy_name]);
+        } catch (\Exception $e) {
+            // Expected: network errors, missing preflight fields, etc.
+            // The key assertion is that we did NOT get "Invalid command".
+            $this->assertStringNotContainsString(
+                "Invalid command",
+                $e->getMessage(),
+                "Legacy command '{$legacy_name}' should be accepted, not rejected as invalid",
+            );
+            return;
+        }
+
+        // If it somehow succeeded (unlikely with fake URL), that's fine too.
+        $this->assertTrue(true);
+    }
+
+    public static function legacyCommandProvider(): array
+    {
+        return [
+            'files-sync → files-pull' => ['files-sync', 'files-pull'],
+            'db-sync → db-pull' => ['db-sync', 'db-pull'],
+            'flat-document-root → flat-docroot' => ['flat-document-root', 'flat-docroot'],
+            'flatten-docroot → flat-docroot' => ['flatten-docroot', 'flat-docroot'],
+        ];
+    }
+
+    /**
+     * State files written with old command names must be migrated
+     * to new names when loaded.
+     *
+     * @dataProvider legacyStateProvider
+     */
+    public function testStateMigrationFromLegacyCommandName(string $old_name, string $new_name): void
+    {
+        file_put_contents(
+            $this->stateDir . '/.import-state.json',
+            json_encode(["command" => $old_name, "status" => "in_progress"]),
+        );
+
+        $client = new \ImportClient('http://fake.invalid', $this->stateDir, $this->fs_root);
+        $reflection = new \ReflectionClass($client);
+        $loadState = $reflection->getMethod('load_state');
+        $state = $loadState->invoke($client);
+
+        $this->assertEquals(
+            $new_name,
+            $state["command"],
+            "State with command '{$old_name}' should be migrated to '{$new_name}'",
+        );
+    }
+
+    public static function legacyStateProvider(): array
+    {
+        return [
+            'files-sync → files-pull' => ['files-sync', 'files-pull'],
+            'db-sync → db-pull' => ['db-sync', 'db-pull'],
+            'flat-document-root → flat-docroot' => ['flat-document-root', 'flat-docroot'],
+        ];
+    }
+}

--- a/tests/Import/PlaygroundRemoteUploadProxyRuntimeTest.php
+++ b/tests/Import/PlaygroundRemoteUploadProxyRuntimeTest.php
@@ -30,7 +30,7 @@ class PlaygroundRemoteUploadProxyRuntimeTest extends TestCase
         file_put_contents($this->fsRoot . '/index.php', "<?php echo 'ok';\n");
         $this->stateFile = $stateDir . '/.import-state.json';
         $this->skippedFile = $stateDir . '/.import-download-list-skipped.jsonl';
-        file_put_contents($this->stateFile, "{\"command\":\"files-sync\",\"status\":\"partial\"}\n");
+        file_put_contents($this->stateFile, "{\"command\":\"files-pull\",\"status\":\"partial\"}\n");
         file_put_contents($this->skippedFile, "{\"path\":\"/wp-content/uploads/test.jpg\"}\n");
     }
 

--- a/tests/Import/ProductionDropInRemovalTest.php
+++ b/tests/Import/ProductionDropInRemovalTest.php
@@ -185,7 +185,7 @@ class ProductionDropInRemovalTest extends TestCase
 
     public function testApplyRuntimeRemovesObjectCacheFile(): void
     {
-        $this->writeState(['command' => 'files-sync', 'status' => 'complete']);
+        $this->writeState(['command' => 'files-pull', 'status' => 'complete']);
         $this->createProductionDropIns();
 
         $objectCachePath = $this->fsRoot . '/wp-content/object-cache.php';
@@ -200,7 +200,7 @@ class ProductionDropInRemovalTest extends TestCase
 
     public function testApplyRuntimeRemovesWpcomshDirectory(): void
     {
-        $this->writeState(['command' => 'files-sync', 'status' => 'complete']);
+        $this->writeState(['command' => 'files-pull', 'status' => 'complete']);
         $this->createProductionDropIns();
 
         $wpcomshDir = $this->fsRoot . '/wp-content/mu-plugins/wpcomsh';
@@ -215,7 +215,7 @@ class ProductionDropInRemovalTest extends TestCase
 
     public function testApplyRuntimeRemovesWpcomshDevDirectory(): void
     {
-        $this->writeState(['command' => 'files-sync', 'status' => 'complete']);
+        $this->writeState(['command' => 'files-pull', 'status' => 'complete']);
         $this->createProductionDropIns();
 
         $wpcomshDevDir = $this->fsRoot . '/wp-content/mu-plugins/wpcomsh-dev';
@@ -230,7 +230,7 @@ class ProductionDropInRemovalTest extends TestCase
 
     public function testApplyRuntimeRemovesWpcomshLoaderFile(): void
     {
-        $this->writeState(['command' => 'files-sync', 'status' => 'complete']);
+        $this->writeState(['command' => 'files-pull', 'status' => 'complete']);
         $this->createProductionDropIns();
 
         $loaderPath = $this->fsRoot . '/wp-content/mu-plugins/wpcomsh-loader.php';
@@ -247,7 +247,7 @@ class ProductionDropInRemovalTest extends TestCase
     {
         // Don't create any drop-in files. The removal loop should skip
         // them gracefully without errors.
-        $this->writeState(['command' => 'files-sync', 'status' => 'complete']);
+        $this->writeState(['command' => 'files-pull', 'status' => 'complete']);
         mkdir($this->fsRoot . '/wp-content', 0755, true);
 
         $client = $this->makeClient();
@@ -260,7 +260,7 @@ class ProductionDropInRemovalTest extends TestCase
 
     public function testApplyRuntimePreservesUnrelatedFiles(): void
     {
-        $this->writeState(['command' => 'files-sync', 'status' => 'complete']);
+        $this->writeState(['command' => 'files-pull', 'status' => 'complete']);
         $this->createProductionDropIns();
 
         // Create a legitimate mu-plugin that should NOT be removed.
@@ -276,7 +276,7 @@ class ProductionDropInRemovalTest extends TestCase
 
     public function testApplyRuntimeLogsRemovalsToAuditLog(): void
     {
-        $this->writeState(['command' => 'files-sync', 'status' => 'complete']);
+        $this->writeState(['command' => 'files-pull', 'status' => 'complete']);
         $this->createProductionDropIns();
 
         $client = $this->makeClient();
@@ -302,7 +302,7 @@ class ProductionDropInRemovalTest extends TestCase
 
     public function testApplyRuntimePersistsPathsRemovedToState(): void
     {
-        $this->writeState(['command' => 'files-sync', 'status' => 'complete']);
+        $this->writeState(['command' => 'files-pull', 'status' => 'complete']);
         $this->createProductionDropIns();
 
         $client = $this->makeClient();
@@ -327,7 +327,7 @@ class ProductionDropInRemovalTest extends TestCase
         // Override webhost to 'other' — the DefaultHostAnalyzer should
         // produce an empty paths_to_remove.
         $this->writeState([
-            'command' => 'files-sync',
+            'command' => 'files-pull',
             'status' => 'complete',
             'webhost' => 'other',
             'preflight' => [

--- a/tests/Import/RemoteUploadProxyRuntimeTest.php
+++ b/tests/Import/RemoteUploadProxyRuntimeTest.php
@@ -181,7 +181,7 @@ class RemoteUploadProxyRuntimeTest extends TestCase
     public function testApplyRuntimeAddsProxyWhileFilesSyncIsIncomplete(): void
     {
         $this->writeState([
-            'command' => 'files-sync',
+            'command' => 'files-pull',
             'status' => 'partial',
             'stage' => 'fetch',
         ]);
@@ -199,7 +199,7 @@ class RemoteUploadProxyRuntimeTest extends TestCase
             $runtime,
         );
         $this->assertStringContainsString(
-            "Proxy missing uploads from the source site until files-sync completes.",
+            "Proxy missing uploads from the source site until files-pull completes.",
             $runtime,
         );
     }
@@ -207,7 +207,7 @@ class RemoteUploadProxyRuntimeTest extends TestCase
     public function testApplyRuntimeOmitsProxyAfterFilesSyncCompletes(): void
     {
         $this->writeState([
-            'command' => 'files-sync',
+            'command' => 'files-pull',
             'status' => 'complete',
             'filter' => 'none',
         ]);

--- a/tests/e2e/lib/test-helpers.js
+++ b/tests/e2e/lib/test-helpers.js
@@ -222,7 +222,7 @@ export function fsRootDir(outputDir) {
  * Run the importer CLI.
  * @param {string} url - Export URL
  * @param {string} outputDir - Local output directory (state files live here; fs-root is outputDir/fs-root)
- * @param {string} command - Import command (files-sync, db-sync, etc.)
+ * @param {string} command - Import command (files-pull, db-pull, etc.)
  * @param {Object} options - Additional options
  * @returns {Object} { stdout, stderr, exitCode }
  */

--- a/tests/e2e/tests/import-01-basic-file-sync.test.js
+++ b/tests/e2e/tests/import-01-basic-file-sync.test.js
@@ -43,7 +43,7 @@ describe('Import: Basic File Sync', () => {
         const stateFile = join(tempDir, '.import-state.json');
         assert.ok(existsSync(stateFile), 'Expected .import-state.json to exist');
         const state = JSON.parse(readFileSync(stateFile, 'utf-8'));
-        assert.equal(state.command, 'files-sync');
+        assert.equal(state.command, 'files-pull');
         assert.equal(state.status, 'complete');
     });
 

--- a/tests/e2e/tests/import-25-state-corruption.test.js
+++ b/tests/e2e/tests/import-25-state-corruption.test.js
@@ -96,7 +96,7 @@ describe('Import: State Corruption', () => {
 
             const stateFile = join(tempDir, '.import-state.json');
             const state = JSON.parse(readFileSync(stateFile, 'utf-8'));
-            assert.equal(state.command, 'files-sync', 'Expected command to be updated');
+            assert.equal(state.command, 'files-pull', 'Expected command to be updated');
             assert.equal(state.status, 'complete');
         });
     });

--- a/tests/e2e/tests/import-40-defer-uploads.test.js
+++ b/tests/e2e/tests/import-40-defer-uploads.test.js
@@ -81,7 +81,7 @@ describe('Import: --filter', () => {
 
         it('state shows complete with filter persisted', () => {
             const state = JSON.parse(readFileSync(join(tempDir, '.import-state.json'), 'utf-8'));
-            assert.equal(state.command, 'files-sync');
+            assert.equal(state.command, 'files-pull');
             assert.equal(state.status, 'complete');
             assert.equal(state.filter, 'essential-files');
         });


### PR DESCRIPTION
## Summary

The --help output gets a visual and conceptual refresh to match what RePrint actually is: a tool for mirroring remote WordPress sites.

- Colored ASCII art banner + tagline on TTY, plain ASCII when piped
- Commands renamed to pull-oriented language: `files-pull`, `db-pull`, `flat-docroot` (old names kept as silent aliases everywhere — CLI, `run()`, and state files)
- Every command description rewritten to accurately describe what it does
- Preflight commands listed first since they're the entry point
- README, CLAUDE.md, comments, error messages, and CI workflow updated throughout
- `LegacyCommandAliasTest` smoke test verifies old names are accepted and state files with old names are migrated

Before:
```
files-sync    Sync files (auto-detects initial vs delta)
files-index   Download the remote file index without fetching file contents
db-sync       Download the database as a SQL dump
preflight     Run preflight check and print the full result as JSON
```

After:
```
preflight         Probe the remote site and cache its environment
preflight-assert  Verify the remote site can be mirrored (exits 0 or 1)
files-pull        Pull all files (initial) or only changes (delta)
files-index       Index all remote files (initial) or detect changes (delta)
db-pull           Pull the database as a SQL dump (index + download)
```

## Test plan

- [x] All PHPUnit tests pass (PHP 8.1–8.4)
- [x] All E2E tests pass (PHP 7.4–8.5)
- [x] PHPStan passes
- [x] `LegacyCommandAliasTest` verifies old names work via `run()` and state migration
- [x] E2E tests still use old names as CLI args (testing aliasing end-to-end)