### PR TITLE
Fix flaky E2E test 45 by disabling .user.ini cache

### DIFF
--- a/tests/e2e/ci/setup-infrastructure.sh
+++ b/tests/e2e/ci/setup-infrastructure.sh
@@ -83,6 +83,7 @@ php_admin_value[error_reporting] = E_ALL
 php_admin_value[display_errors] = Off
 php_admin_value[log_errors] = On
 php_admin_value[error_log] = /tmp/php-e2e-errors.log
+php_admin_value[user_ini.cache_ttl] = 0
 
 env[SITE_EXPORT_TEST_MODE] = 1
 EOF


### PR DESCRIPTION
## Summary

Test 45 (runtime file download) writes a `.user.ini` with `auto_prepend_file` during setup, then immediately hits the site over HTTP. PHP-FPM caches per-directory INI files for 300 seconds by default, so if a worker already served a request from that directory, the empty value sticks and the test fails.

This sets `user_ini.cache_ttl = 0` in the E2E FPM pool config so `.user.ini` is re-read on every request.

## Test plan

- CI test 45 should pass consistently on all PHP versions