### PR TITLE
Output preflight result as single-line JSON

### DIFF
--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -2116,7 +2116,7 @@ class ImportClient
             exit(1);
         }
         // @TODO: Store paths as base64 strings, not raw strings, since paths can contain arbitrary bytes
-        echo json_encode($entry, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . "\n";
+        echo json_encode($entry, JSON_UNESCAPED_SLASHES) . "\n";
         $ok = ($entry["http_code"] ?? 0) === 200 && !empty($entry["data"]["ok"]);
         $this->write_status_file($ok ? null : "Preflight failed");
         exit($ok ? 0 : 1);

--- a/tests/e2e/tests/import-45-runtime-file-download.test.js
+++ b/tests/e2e/tests/import-45-runtime-file-download.test.js
@@ -25,6 +25,7 @@ import { execSync } from 'node:child_process';
 describe('Import: Runtime file download', () => {
     const site = 'runtime-download';
     let tempDir;
+    let preflightResult;
 
     function importUrlWithDirectory() {
         return `${getSiteUrl(site)}&directory=${getSiteDir(site)}`;
@@ -54,11 +55,11 @@ describe('Import: Runtime file download', () => {
 
         tempDir = createTempDir('e2e-runtime-download');
 
-        const result = runImporter(importUrlWithDirectory(), tempDir, 'preflight', {
+        preflightResult = runImporter(importUrlWithDirectory(), tempDir, 'preflight', {
             secret: getSiteSecret(site),
         });
-        assert.equal(result.exitCode, 0,
-            `Expected exit 0\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);
+        assert.equal(preflightResult.exitCode, 0,
+            `Expected exit 0\nstderr: ${preflightResult.stderr}\nstdout: ${preflightResult.stdout}`);
     });
 
     afterAll(() => {
@@ -94,6 +95,24 @@ describe('Import: Runtime file download', () => {
         assert.ok(
             savedPath.includes('env.php'),
             `Saved path should contain env.php, got: ${savedPath}`,
+        );
+    });
+
+    it('preflight stdout is single-line JSON (not pretty-printed)', () => {
+        const lines = preflightResult.stdout.trim().split('\n');
+        const lastLine = lines[lines.length - 1];
+        let parsed;
+        try {
+            parsed = JSON.parse(lastLine);
+        } catch {
+            assert.fail(
+                `Last stdout line is not valid JSON: ${lastLine.substring(0, 200)}`,
+            );
+        }
+        assert.ok(parsed.timestamp, 'Parsed result should have a timestamp field');
+        assert.ok(
+            !lastLine.includes('\n'),
+            'Preflight result must be a single line so last-line trackers can capture it',
         );
     });
 


### PR DESCRIPTION
## Summary

Studio's reprint-child process tracks only the last complete stdout line to avoid buffering thousands of JSON-L progress lines in memory. The preflight command used `JSON_PRETTY_PRINT`, so the last line was just `}`, which caused `parseReprintJson` to fail with "The remote site did not respond with a recognized format."

Removing `JSON_PRETTY_PRINT` makes the output a single JSON-L line that the last-line tracker captures correctly. This was introduced when Studio switched from full-buffer to last-line tracking in `eeeffa0e`.

## Test plan

- Run `studio site pull-reprint` against a WP.com Atomic site and verify preflight succeeds
- Run `reprint preflight` from the CLI and verify the output is valid single-line JSON