### PR TITLE
Output start.json with structured mount paths

### DIFF
--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -3842,6 +3842,15 @@ class ImportClient
         $this->state["apply"]["remote_paths_removed_from_local_site"] = $manifest->paths_to_remove;
         $this->save_state($this->state);
 
+        // Read the structured start config if the applier wrote one.
+        // Playground CLI writes start.json with mount paths as seen by
+        // this PHP process — callers (e.g. Studio) map them to host paths.
+        $start_config_path = $abs_output_dir . '/start.json';
+        $start_config = null;
+        if (file_exists($start_config_path)) {
+            $start_config = json_decode(file_get_contents($start_config_path), true);
+        }
+
         // Output the summary and manifest as structured JSON for callers,
         // and print the human-readable summary to stderr.
         $this->output_progress([
@@ -3853,6 +3862,7 @@ class ImportClient
             "target_engine" => $target_engine,
             "paths_removed" => $manifest->paths_to_remove,
             "extra_directories" => $manifest->extra_directories,
+            "start_config" => $start_config,
             "message" => "apply-runtime complete (runtime: {$runtime})",
         ]);
 

--- a/packages/reprint-importer/src/lib/target-runtime/class-playground-cli-applier.php
+++ b/packages/reprint-importer/src/lib/target-runtime/class-playground-cli-applier.php
@@ -6,6 +6,7 @@
  * 1. {output_dir}/runtime.php     — constants, server vars, route handlers
  * 2. {output_dir}/blueprint.json  — minimal Playground Blueprint
  * 3. {output_dir}/start.sh        — shell script with the full CLI invocation
+ * 4. {output_dir}/start.json      — structured config for programmatic consumers
  *
  * Unlike nginx-fpm and php-builtin which write server config files,
  * Playground CLI handles most configuration through command-line flags.
@@ -97,6 +98,21 @@ class PlaygroundCliApplier implements RuntimeApplier
         write_runtime_file($start_path, $start_script);
         chmod($start_path, 0755);
         $summary[] = "Wrote {$start_path}";
+
+        // 4. Write start.json — structured config for programmatic consumers
+        // (e.g. Studio). The source paths are as seen by this PHP process;
+        // callers running inside a VFS must map them to host paths.
+        $config_path = $output_dir . '/start.json';
+        $config = $this->generate_start_config(
+            $fs_root,
+            $output_dir,
+            $runtime_path,
+            $port,
+            $options,
+            $extra_mounts,
+        );
+        write_runtime_file($config_path, json_encode($config, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . "\n");
+        $summary[] = "Wrote {$config_path}";
 
         $summary[] = '';
         $summary[] = 'Start the server:';
@@ -219,8 +235,66 @@ class PlaygroundCliApplier implements RuntimeApplier
     }
 
     /**
+     * Build a structured config describing the Playground CLI invocation.
+     *
+     * Programmatic consumers (e.g. Studio) read this instead of parsing
+     * start.sh, and map the source paths from whatever filesystem the
+     * importer ran on to the actual host paths.
+     */
+    private function generate_start_config(
+        string $fs_root,
+        string $output_dir,
+        string $runtime_path,
+        int $port,
+        array $options,
+        array $extra_mounts = []
+    ): array {
+        $config = [
+            'mounts_before_install' => [],
+            'mounts' => [],
+            'blueprint' => $output_dir . '/blueprint.json',
+            'port' => $port,
+            'follow_symlinks' => true,
+            'wordpress_install_mode' => 'do-not-attempt-installing',
+        ];
+
+        // WordPress layout mounts. For standard sites this is a single
+        // mount. For WPCloud-style sites, three mounts assemble a standard
+        // layout from separate directories.
+        foreach ($this->build_mounts($fs_root, $options) as $mount) {
+            [$source, $target] = explode(':', $mount, 2);
+            $config['mounts_before_install'][] = [
+                'source' => $source,
+                'target' => $target,
+            ];
+        }
+
+        // Runtime mu-plugin. The 0- prefix ensures it loads before other
+        // mu-plugins. mu-plugins don't need a Plugin Name header.
+        $config['mounts'][] = [
+            'source' => $runtime_path,
+            'target' => self::VFS_ROOT . '/wp-content/mu-plugins/0-playground-runtime.php',
+        ];
+
+        // Additional runtime helper files (e.g. state files for the
+        // remote upload proxy).
+        foreach ($extra_mounts as $mount) {
+            [$source, $target] = explode(':', $mount, 2);
+            $config['mounts'][] = [
+                'source' => $source,
+                'target' => $target,
+            ];
+        }
+
+        return $config;
+    }
+
+    /**
      * Generate a shell script that starts Playground CLI with the right
      * mount points and flags.
+     *
+     * Derived from generate_start_config() so start.sh and start.json
+     * always describe the same invocation.
      */
     private function generate_start_script(
         RuntimeManifest $manifest,
@@ -231,6 +305,8 @@ class PlaygroundCliApplier implements RuntimeApplier
         array $options,
         array $extra_mounts = []
     ): string {
+        $config = $this->generate_start_config($fs_root, $output_dir, $runtime_path, $port, $options, $extra_mounts);
+
         $lines = [];
         $lines[] = '#!/usr/bin/env bash';
         $lines[] = '# Start WordPress Playground CLI for the imported site.';
@@ -247,35 +323,34 @@ class PlaygroundCliApplier implements RuntimeApplier
         // Mount the WordPress directory layout. For standard sites this
         // is a single mount. For WPCloud-style sites, three mounts
         // assemble a standard layout from separate directories.
-        foreach ($this->build_mounts($fs_root, $options) as $mount) {
-            $args[] = '--mount-before-install=' . escapeshellarg($mount);
+        foreach ($config['mounts_before_install'] as $mount) {
+            $args[] = '--mount-before-install=' . escapeshellarg($mount['source'] . ':' . $mount['target']);
         }
 
-        // Mount runtime.php as a mu-plugin. The 0- prefix ensures it loads
-        // before other mu-plugins. mu-plugins don't need a Plugin Name
-        // header and load on every request.
-        $args[] = '--mount=' . escapeshellarg($runtime_path . ':/wordpress/wp-content/mu-plugins/0-playground-runtime.php');
-
-        // Mount additional runtime helper files needed by specific handlers.
-        foreach ($extra_mounts as $mount) {
-            $args[] = '--mount=' . escapeshellarg($mount);
+        // Mount runtime.php as a mu-plugin (0- prefix ensures it loads
+        // first) and any additional runtime helper files (e.g. state
+        // files for the remote upload proxy).
+        foreach ($config['mounts'] as $mount) {
+            $args[] = '--mount=' . escapeshellarg($mount['source'] . ':' . $mount['target']);
         }
 
         // The site is already installed — don't run Playground's WordPress
         // installer or download a fresh copy.
-        $args[] = '--wordpress-install-mode=do-not-attempt-installing';
+        $args[] = '--wordpress-install-mode=' . $config['wordpress_install_mode'];
 
         // Let Playground resolve symlinks within mounted directories.
         // WPCloud sites have symlinks in wp-content/themes, plugins, and
         // mu-plugins pointing to shared host directories — this flag
         // makes them work without needing individual mounts for each.
-        $args[] = '--follow-symlinks';
+        if ($config['follow_symlinks']) {
+            $args[] = '--follow-symlinks';
+        }
 
-        $args[] = '--blueprint=' . escapeshellarg($output_dir . '/blueprint.json');
-        $args[] = '--port=' . $port;
+        $args[] = '--blueprint=' . escapeshellarg($config['blueprint']);
+        $args[] = '--port=' . $config['port'];
 
         $lines[] = 'echo "Starting WordPress Playground CLI..."';
-        $lines[] = 'echo "  http://127.0.0.1:' . $port . '"';
+        $lines[] = 'echo "  http://127.0.0.1:' . $config['port'] . '"';
         $lines[] = 'echo ""';
         $lines[] = '';
         $lines[] = implode(" \\\n    ", $args);

--- a/packages/reprint-importer/src/lib/target-runtime/class-playground-cli-applier.php
+++ b/packages/reprint-importer/src/lib/target-runtime/class-playground-cli-applier.php
@@ -250,6 +250,7 @@ class PlaygroundCliApplier implements RuntimeApplier
         array $extra_mounts = []
     ): array {
         $config = [
+            'document_root' => self::VFS_ROOT,
             'mounts_before_install' => [],
             'mounts' => [],
             'blueprint' => $output_dir . '/blueprint.json',

--- a/tests/Import/PlaygroundRemoteUploadProxyRuntimeTest.php
+++ b/tests/Import/PlaygroundRemoteUploadProxyRuntimeTest.php
@@ -107,5 +107,16 @@ class PlaygroundRemoteUploadProxyRuntimeTest extends TestCase
             "--mount='" . $this->skippedFile . ":/tmp/reprint/.import-download-list-skipped.jsonl'",
             $startSh,
         );
+
+        // start.json should contain the same mounts as structured data.
+        $startJson = json_decode(file_get_contents($this->outputDir . '/start.json'), true);
+        $this->assertNotNull($startJson, 'start.json should be valid JSON');
+
+        $mount_sources = array_column($startJson['mounts'], 'source');
+        $mount_targets = array_column($startJson['mounts'], 'target');
+        $this->assertContains($this->stateFile, $mount_sources);
+        $this->assertContains($this->skippedFile, $mount_sources);
+        $this->assertContains('/tmp/reprint/.import-state.json', $mount_targets);
+        $this->assertContains('/tmp/reprint/.import-download-list-skipped.jsonl', $mount_targets);
     }
 }


### PR DESCRIPTION
## Summary

When apply-runtime runs inside Playground's VFS (as Studio does), the generated start.sh contains VFS paths instead of host paths, making it unusable for starting the server on the host.

This adds a start.json alongside start.sh with structured mount data that programmatic consumers like Studio can read and map to host paths. The JSON separates source and target paths into discrete fields, making path translation straightforward without shell script parsing.

The start.sh is now derived from the same config as start.json so the two outputs can't drift.

## Test plan
- [ ] `composer test -- --filter PlaygroundRemoteUploadProxyRuntimeTest` passes
- [ ] start.json is written with correct structure
- [ ] start.sh output is unchanged