### PR TITLE
Show actionable error messages for HTTP failures

### DIFF
--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -8839,7 +8839,13 @@ class ImportClient
             if ($server_msg === null) {
                 return [
                     'code' => 'AUTH_FAILED',
-                    'message' => "Authentication failed (HTTP {$http_code}).",
+                    'message' =>
+                        "The server rejected the request (HTTP {$http_code}) " .
+                        "but did not say why. This is unusual — the exporter " .
+                        "plugin always explains authentication failures.\n\n" .
+                        "A server-level firewall, .htaccess rule, or security " .
+                        "plugin may be blocking the request before it reaches " .
+                        "WordPress.",
                 ];
             }
 

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -8801,21 +8801,25 @@ class ImportClient
     private function diagnose_http_error(int $http_code, ?string $body, ?string $redirect_url = null): array
     {
         $body = $body !== null && $body !== false ? trim($body) : '';
-        $looks_like_html = $body !== '' && (
-            stripos($body, '<html') !== false ||
-            stripos($body, '<!doctype') !== false ||
-            // Starts with a tag but not a JSON brace
-            (str_starts_with($body, '<') && !str_starts_with($body, '{'))
-        );
 
-        // Try to extract a JSON error message from the body.
+        // Try JSON first — when the exporter is responding, the body
+        // is always a JSON object with an "error" field.
         $server_msg = null;
-        if ($body !== '' && !$looks_like_html) {
+        $is_json = false;
+        if ($body !== '') {
             $decoded = json_decode($body, true);
-            if (is_array($decoded) && isset($decoded['error'])) {
-                $server_msg = $decoded['error'];
+            if (is_array($decoded)) {
+                $is_json = true;
+                $server_msg = $decoded['error'] ?? null;
             }
         }
+
+        // Only guess HTML when json_decode didn't parse anything.
+        $looks_like_html = !$is_json && $body !== '' && (
+            stripos($body, '<html') !== false ||
+            stripos($body, '<!doctype') !== false ||
+            str_starts_with($body, '<')
+        );
 
         // ── Redirects ────────────────────────────────────────────
         if ($http_code >= 300 && $http_code < 400) {

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -1584,15 +1584,12 @@ class ImportClient
                     $this->exit_code = 2;
                 }
             } catch (Exception $e) {
-                $progress = [
+                $this->output_progress([
                     "status" => "error",
                     "error" => $e->getMessage(),
+                    "error_code" => $this->last_error_code,
                     "message" => "Error: " . $e->getMessage(),
-                ];
-                if ($this->last_error_code !== null) {
-                    $progress["error_code"] = $this->last_error_code;
-                }
-                $this->output_progress($progress);
+                ]);
                 $this->write_status_file($e->getMessage());
                 throw $e;
             }
@@ -1644,15 +1641,12 @@ class ImportClient
                 $this->exit_code = 2;
             }
         } catch (Exception $e) {
-            $progress = [
+            $this->output_progress([
                 "status" => "error",
                 "error" => $e->getMessage(),
+                "error_code" => $this->last_error_code,
                 "message" => "Error: " . $e->getMessage(),
-            ];
-            if ($this->last_error_code !== null) {
-                $progress["error_code"] = $this->last_error_code;
-            }
-            $this->output_progress($progress);
+            ]);
             $this->write_status_file($e->getMessage());
             throw $e;
         }

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -8800,7 +8800,7 @@ class ImportClient
      */
     private function diagnose_http_error(int $http_code, ?string $body, ?string $redirect_url = null): array
     {
-        $body = $body !== null && $body !== false ? trim($body) : '';
+        $body = ($body !== null && $body !== false) ? $body : '';
 
         $decoded = json_decode($body, true);
         $server_msg = is_array($decoded) ? ($decoded['error'] ?? null) : null;

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -8945,10 +8945,11 @@ class ImportClient
         if ($looks_like_html) {
             return [
                 'code' => 'HTML_RESPONSE',
+                'http_code' => $http_code,
                 'message' =>
                     "The exporter plugin is not installed on the remote site. " .
-                    "The server returned an HTML page instead of a JSON API " .
-                    "response.\n\n" .
+                    "The server returned an HTML page (HTTP {$http_code}) " .
+                    "instead of a JSON API response.\n\n" .
                     "Run `php reprint.phar install-exporter` for setup " .
                     "instructions.",
             ];

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -8802,20 +8802,10 @@ class ImportClient
     {
         $body = $body !== null && $body !== false ? trim($body) : '';
 
-        // Try JSON first — when the exporter is responding, the body
-        // is always a JSON object with an "error" field.
-        $server_msg = null;
-        $is_json = false;
-        if ($body !== '') {
-            $decoded = json_decode($body, true);
-            if (is_array($decoded)) {
-                $is_json = true;
-                $server_msg = $decoded['error'] ?? null;
-            }
-        }
+        $decoded = json_decode($body, true);
+        $server_msg = is_array($decoded) ? ($decoded['error'] ?? null) : null;
 
-        // Only guess HTML when json_decode didn't parse anything.
-        $looks_like_html = !$is_json && $body !== '' && (
+        $looks_like_html = !is_array($decoded) && $body !== '' && (
             stripos($body, '<html') !== false ||
             stripos($body, '<!doctype') !== false ||
             str_starts_with($body, '<')

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -1010,6 +1010,9 @@ class ImportClient
     /** @var bool Whether the last curl request timed out. */
     private $last_curl_timeout = false;
 
+    /** @var string|null Machine-readable error code from the last diagnose_http_error() call. */
+    public $last_error_code = null;
+
     /** @var int|null Current step in a multi-step pipeline (1-indexed). Set via --step. */
     private $pipeline_step = null;
 
@@ -1581,11 +1584,15 @@ class ImportClient
                     $this->exit_code = 2;
                 }
             } catch (Exception $e) {
-                $this->output_progress([
+                $progress = [
                     "status" => "error",
                     "error" => $e->getMessage(),
                     "message" => "Error: " . $e->getMessage(),
-                ]);
+                ];
+                if ($this->last_error_code !== null) {
+                    $progress["error_code"] = $this->last_error_code;
+                }
+                $this->output_progress($progress);
                 $this->write_status_file($e->getMessage());
                 throw $e;
             }
@@ -1637,11 +1644,15 @@ class ImportClient
                 $this->exit_code = 2;
             }
         } catch (Exception $e) {
-            $this->output_progress([
+            $progress = [
                 "status" => "error",
                 "error" => $e->getMessage(),
                 "message" => "Error: " . $e->getMessage(),
-            ]);
+            ];
+            if ($this->last_error_code !== null) {
+                $progress["error_code"] = $this->last_error_code;
+            }
+            $this->output_progress($progress);
             $this->write_status_file($e->getMessage());
             throw $e;
         }
@@ -8960,9 +8971,12 @@ class ImportClient
 
     /**
      * Format a diagnosed error as a single string for display.
+     * Also stores the error code on the instance for output_progress
+     * and write_status_file to pick up.
      */
     private function format_diagnosed_error(array $diagnosis): string
     {
+        $this->last_error_code = $diagnosis['code'];
         return $diagnosis['message'];
     }
 
@@ -9901,6 +9915,7 @@ class ImportClient
             "status" => $status,
             "phase" => $phase,
             "error" => $error,
+            "error_code" => $error !== null ? $this->last_error_code : null,
             "ts" => microtime(true),
         ];
 
@@ -11079,11 +11094,13 @@ if (
         exit($client->exit_code);
     } catch (\Throwable $e) {
         $is_tty = function_exists("posix_isatty") && posix_isatty(STDERR);
+        $error_code = isset($client) ? $client->last_error_code : null;
         if ($is_tty) {
             fwrite(STDERR, "\nError: " . $e->getMessage() . "\n");
         } else {
             $error = [
                 "error" => $e->getMessage(),
+                "error_code" => $error_code,
                 "exception" => get_class($e),
                 "file" => $e->getFile(),
                 "line" => $e->getLine(),

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -8825,7 +8825,72 @@ class ImportClient
 
         // ── Authentication / authorization ───────────────────────
         if ($http_code === 401 || $http_code === 403) {
-            return $this->diagnose_auth_error($http_code, $server_msg);
+            if ($this->hmac_client === null) {
+                return [
+                    'code' => 'AUTH_NO_SECRET',
+                    'message' =>
+                        "The remote site requires authentication but no --secret " .
+                        "was provided.\n\n" .
+                        "Pass --secret=YOUR_SECRET using the same secret that is " .
+                        "configured in the Site Export plugin on the remote site.",
+                ];
+            }
+
+            if ($server_msg === null) {
+                return [
+                    'code' => 'AUTH_FAILED',
+                    'message' => "Authentication failed (HTTP {$http_code}).",
+                ];
+            }
+
+            // The server tells us exactly what went wrong. Map each known
+            // HMAC error to a targeted message.
+
+            if (str_contains($server_msg, 'HMAC signature verification failed')) {
+                return [
+                    'code' => 'AUTH_SECRET_MISMATCH',
+                    'message' =>
+                        "The shared secret does not match. The --secret value must " .
+                        "be identical to the one configured in the Site Export " .
+                        "plugin settings (wp-admin → Site Export).",
+                ];
+            }
+
+            if (str_contains($server_msg, 'timestamp expired')) {
+                return [
+                    'code' => 'AUTH_CLOCK_SKEW',
+                    'message' =>
+                        "The request was rejected because the clocks are out of " .
+                        "sync. {$server_msg}\n\n" .
+                        "Make sure this machine's clock is accurate (run `date` " .
+                        "to check).",
+                ];
+            }
+
+            if (str_contains($server_msg, 'Content hash mismatch')) {
+                return [
+                    'code' => 'AUTH_CONTENT_TAMPERED',
+                    'message' =>
+                        "The request body was modified between this machine and " .
+                        "the server. A proxy, CDN, or firewall may be altering " .
+                        "requests in transit.",
+                ];
+            }
+
+            if (str_contains($server_msg, 'Missing X-Auth-')) {
+                return [
+                    'code' => 'AUTH_HEADERS_STRIPPED',
+                    'message' =>
+                        "The server did not receive the authentication headers " .
+                        "({$server_msg}). A proxy, CDN, or security plugin may " .
+                        "be stripping custom headers from the request.",
+                ];
+            }
+
+            return [
+                'code' => 'AUTH_FAILED',
+                'message' => "Authentication failed: {$server_msg}",
+            ];
         }
 
         // ── Export not configured (503 from exporter) ────────────
@@ -8890,83 +8955,6 @@ class ImportClient
             'message' => $server_msg
                 ? "HTTP error {$http_code}: {$server_msg}"
                 : "Unexpected HTTP status {$http_code}.",
-        ];
-    }
-
-    /**
-     * Diagnose a 401/403 authentication error by parsing the server's
-     * error message. The exporter returns specific HMAC failure reasons
-     * that we can turn into precise advice.
-     */
-    private function diagnose_auth_error(int $http_code, ?string $server_msg): array
-    {
-        // No --secret was passed but the server requires one.
-        if ($this->hmac_client === null) {
-            return [
-                'code' => 'AUTH_NO_SECRET',
-                'message' =>
-                    "The remote site requires authentication but no --secret " .
-                    "was provided.\n\n" .
-                    "Pass --secret=YOUR_SECRET using the same secret that is " .
-                    "configured in the Site Export plugin on the remote site.",
-            ];
-        }
-
-        if ($server_msg === null) {
-            return [
-                'code' => 'AUTH_FAILED',
-                'message' => "Authentication failed (HTTP {$http_code}).",
-            ];
-        }
-
-        // The server tells us exactly what went wrong. Map each known
-        // HMAC error to a targeted message.
-
-        if (str_contains($server_msg, 'HMAC signature verification failed')) {
-            return [
-                'code' => 'AUTH_SECRET_MISMATCH',
-                'message' =>
-                    "The shared secret does not match. The --secret value must " .
-                    "be identical to the one configured in the Site Export " .
-                    "plugin settings (wp-admin → Site Export).",
-            ];
-        }
-
-        if (str_contains($server_msg, 'timestamp expired')) {
-            return [
-                'code' => 'AUTH_CLOCK_SKEW',
-                'message' =>
-                    "The request was rejected because the clocks are out of " .
-                    "sync. {$server_msg}\n\n" .
-                    "Make sure this machine's clock is accurate (run `date` " .
-                    "to check).",
-            ];
-        }
-
-        if (str_contains($server_msg, 'Content hash mismatch')) {
-            return [
-                'code' => 'AUTH_CONTENT_TAMPERED',
-                'message' =>
-                    "The request body was modified between this machine and " .
-                    "the server. A proxy, CDN, or firewall may be altering " .
-                    "requests in transit.",
-            ];
-        }
-
-        if (str_contains($server_msg, 'Missing X-Auth-')) {
-            return [
-                'code' => 'AUTH_HEADERS_STRIPPED',
-                'message' =>
-                    "The server did not receive the authentication headers " .
-                    "({$server_msg}). A proxy, CDN, or security plugin may " .
-                    "be stripping custom headers from the request.",
-            ];
-        }
-
-        // Unknown auth error — show the server's message as-is.
-        return [
-            'code' => 'AUTH_FAILED',
-            'message' => "Authentication failed: {$server_msg}",
         ];
     }
 

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -8787,6 +8787,117 @@ class ImportClient
     }
 
     /**
+     * Diagnose an HTTP error and return a user-friendly message with
+     * actionable advice. Used by fetch_json() and fetch_streaming() to
+     * turn opaque "HTTP 403" messages into something a non-expert can
+     * act on.
+     *
+     * Returns ['message' => ..., 'suggestion' => ..., 'code' => ...].
+     */
+    private function diagnose_http_error(int $http_code, ?string $body): array
+    {
+        $body = $body !== null && $body !== false ? trim($body) : '';
+        $looks_like_html = $body !== '' && (
+            stripos($body, '<html') !== false ||
+            stripos($body, '<!doctype') !== false ||
+            // Starts with a tag but not a JSON brace
+            (str_starts_with($body, '<') && !str_starts_with($body, '{'))
+        );
+
+        // Try to extract a JSON error message from the body.
+        $server_msg = null;
+        if ($body !== '' && !$looks_like_html) {
+            $decoded = json_decode($body, true);
+            if (is_array($decoded) && isset($decoded['error'])) {
+                $server_msg = $decoded['error'];
+            }
+        }
+
+        // ── Redirects ────────────────────────────────────────────
+        if ($http_code >= 300 && $http_code < 400) {
+            return [
+                'code' => 'REDIRECT',
+                'message' => "The server returned a redirect (HTTP {$http_code}) instead of the export API response.",
+                'suggestion' =>
+                    "Double-check the site URL — make sure you are using the canonical URL " .
+                    "(http vs https, www vs non-www). " .
+                    "Reprint does not follow redirects to avoid silently connecting to the wrong server.",
+            ];
+        }
+
+        // ── Authentication / authorization ───────────────────────
+        if ($http_code === 401 || $http_code === 403) {
+            $msg = $server_msg ?? "Authentication failed (HTTP {$http_code}).";
+            return [
+                'code' => 'AUTH_FAILED',
+                'message' => $msg,
+                'suggestion' =>
+                    "Double-check that --secret matches the secret configured in the " .
+                    "Site Export plugin settings on the remote site.",
+            ];
+        }
+
+        // ── Not found ────────────────────────────────────────────
+        if ($http_code === 404) {
+            return [
+                'code' => 'NOT_FOUND',
+                'message' => "The export API was not found at this URL (HTTP 404).",
+                'suggestion' =>
+                    "Make sure the exporter plugin is installed and activated " .
+                    "on the remote site. Run `php reprint.phar install-exporter` for setup instructions.",
+            ];
+        }
+
+        // ── Server errors ────────────────────────────────────────
+        if ($http_code >= 500) {
+            $msg = $server_msg
+                ? "The remote server returned an error: {$server_msg}"
+                : "The remote server returned an internal error (HTTP {$http_code}).";
+            return [
+                'code' => 'SERVER_ERROR',
+                'message' => $msg,
+                'suggestion' =>
+                    "This is a problem on the remote server, not on your side. " .
+                    "Check the remote server's PHP error log for details.",
+            ];
+        }
+
+        // ── HTML response on 200 (plugin not installed / wrong URL) ──
+        if ($http_code === 200 && $looks_like_html) {
+            return [
+                'code' => 'HTML_RESPONSE',
+                'message' => "The server returned an HTML page instead of JSON.",
+                'suggestion' =>
+                    "The exporter plugin is probably not installed, or the URL " .
+                    "points to a regular web page instead of the export API. " .
+                    "Run `php reprint.phar install-exporter` for setup instructions.",
+            ];
+        }
+
+        // ── Fallback ─────────────────────────────────────────────
+        return [
+            'code' => 'HTTP_ERROR',
+            'message' => $server_msg
+                ? "HTTP error {$http_code}: {$server_msg}"
+                : "Unexpected HTTP status {$http_code}.",
+            'suggestion' => null,
+        ];
+    }
+
+    /**
+     * Format a diagnosed error as a single string.
+     * Combines the message and suggestion into one readable block.
+     */
+    private function format_diagnosed_error(array $diagnosis): string
+    {
+        $out = $diagnosis['message'];
+        if ($diagnosis['suggestion']) {
+            $out .= "\n\n" . $diagnosis['suggestion'];
+        }
+        return $out;
+    }
+
+    /**
      * Fetch a JSON response for a lightweight request (non-streaming).
      */
     private function fetch_json(string $url): array
@@ -8834,23 +8945,34 @@ class ImportClient
         @curl_close($ch);
 
         if ($http_code !== 200) {
+            $diagnosis = $this->diagnose_http_error($http_code, $body);
             return [
                 "ok" => false,
                 "http_code" => $http_code,
                 "elapsed" => $elapsed,
                 "body" => $body,
                 "json" => null,
-                "error" => "HTTP error {$http_code}" .
-                    ($body ? ": " . substr($body, 0, 500) : ""),
+                "error" => $this->format_diagnosed_error($diagnosis),
+                "error_code" => $diagnosis['code'],
             ];
         }
 
         $json = null;
         $json_error = null;
+        $error_code = null;
         if ($body !== false && $body !== "") {
             $json = json_decode($body, true);
             if ($json === null && json_last_error() !== JSON_ERROR_NONE) {
-                $json_error = "Invalid JSON: " . json_last_error_msg();
+                // HTTP 200 but body isn't valid JSON — likely an HTML page
+                // from a site that doesn't have the exporter installed.
+                $diagnosis = $this->diagnose_http_error(200, $body);
+                if ($diagnosis['code'] === 'HTML_RESPONSE') {
+                    $json_error = $this->format_diagnosed_error($diagnosis);
+                    $error_code = $diagnosis['code'];
+                } else {
+                    $json_error = "Invalid JSON: " . json_last_error_msg();
+                    $error_code = 'INVALID_JSON';
+                }
             }
         }
 
@@ -8861,6 +8983,7 @@ class ImportClient
             "body" => $body,
             "json" => $json,
             "error" => $json_error,
+            "error_code" => $error_code,
         ];
     }
 
@@ -9169,7 +9292,6 @@ class ImportClient
                     "curl_errno" => 0,
                 ]);
             }
-            $error_msg = "HTTP error {$http_code}";
 
             // Log what we received
             $this->audit_log(
@@ -9178,30 +9300,15 @@ class ImportClient
                 true,
             );
 
-            // Try to parse error response as JSON
+            $diagnosis = $this->diagnose_http_error($http_code, $error_body);
+            $error_msg = $this->format_diagnosed_error($diagnosis);
+
+            // Append stack trace from the server if available.
             if ($error_body) {
                 $error_data = json_decode($error_body, true);
-                if ($error_data && isset($error_data["error"])) {
-                    $error_msg .= ": " . $error_data["error"];
-                    if (isset($error_data["trace"])) {
-                        $error_msg .=
-                            "\n\nStack trace:\n" . $error_data["trace"];
-                    }
-                } else {
-                    // Not JSON, show raw body
-                    $error_msg .=
-                        "\n\nResponse: " . substr($error_body, 0, 1000);
+                if (is_array($error_data) && isset($error_data["trace"])) {
+                    $error_msg .= "\n\nServer stack trace:\n" . $error_data["trace"];
                 }
-            } else {
-                // No error body captured - server might have sent multipart response
-                // Check server error log for details
-                $error_msg .=
-                    "\n\nNo error body received. Check server error log at:\n";
-                $error_msg .=
-                    "  " .
-                    dirname(parse_url($url, PHP_URL_PATH)) .
-                    "/error_log\n";
-                $error_msg .= "  or enable display_errors on the server";
             }
 
             throw new RuntimeException($error_msg);
@@ -10900,17 +11007,22 @@ if (
         $client->run($options ?? []);
         exit($client->exit_code);
     } catch (\Throwable $e) {
-        $error = [
-            "error" => $e->getMessage(),
-            "exception" => get_class($e),
-            "file" => $e->getFile(),
-            "line" => $e->getLine(),
-        ];
-        $json = json_encode($error);
-        if ($json === false) {
-            $json = '{"error":"' . addslashes($e->getMessage()) . '","exception":"' . get_class($e) . '"}';
+        $is_tty = function_exists("posix_isatty") && posix_isatty(STDERR);
+        if ($is_tty) {
+            fwrite(STDERR, "\nError: " . $e->getMessage() . "\n");
+        } else {
+            $error = [
+                "error" => $e->getMessage(),
+                "exception" => get_class($e),
+                "file" => $e->getFile(),
+                "line" => $e->getLine(),
+            ];
+            $json = json_encode($error);
+            if ($json === false) {
+                $json = '{"error":"' . addslashes($e->getMessage()) . '","exception":"' . get_class($e) . '"}';
+            }
+            fwrite(STDERR, $json . "\n");
         }
-        fwrite(STDERR, $json . "\n");
         exit(1);
     }
 }

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -8813,14 +8813,18 @@ class ImportClient
 
         // ── Redirects ────────────────────────────────────────────
         if ($http_code >= 300 && $http_code < 400) {
-            $target = $redirect_url ? " to {$redirect_url}" : '';
-            return [
-                'code' => 'REDIRECT',
-                'message' =>
-                    "The server redirected{$target} (HTTP {$http_code}).\n\n" .
-                    "Reprint does not follow redirects to avoid silently connecting " .
-                    "to the wrong server. Retry with the target URL above.",
-            ];
+            $msg = $redirect_url
+                ? "Wrong URL. The server redirected to {$redirect_url} " .
+                  "(HTTP {$http_code}).\n\n" .
+                  "Reprint does not follow redirects to avoid silently " .
+                  "connecting to the wrong server. Retry with the target " .
+                  "URL above."
+                : "Wrong URL. The server returned a redirect (HTTP {$http_code}) " .
+                  "instead of the export API.\n\n" .
+                  "Reprint does not follow redirects. Check whether the site " .
+                  "uses http vs https or www vs non-www and retry with the " .
+                  "canonical URL.";
+            return ['code' => 'REDIRECT', 'message' => $msg];
         }
 
         // ── Authentication / authorization ───────────────────────
@@ -8829,9 +8833,9 @@ class ImportClient
                 return [
                     'code' => 'AUTH_NO_SECRET',
                     'message' =>
-                        "The remote site requires authentication but no --secret " .
-                        "was provided.\n\n" .
-                        "Pass --secret=YOUR_SECRET using the same secret that is " .
+                        "No --secret was provided. The remote site requires " .
+                        "authentication.\n\n" .
+                        "Pass --secret=YOUR_SECRET using the same secret " .
                         "configured in the Site Export plugin on the remote site.",
                 ];
             }
@@ -8840,12 +8844,11 @@ class ImportClient
                 return [
                     'code' => 'AUTH_FAILED',
                     'message' =>
-                        "The server rejected the request (HTTP {$http_code}) " .
-                        "but did not say why. This is unusual — the exporter " .
-                        "plugin always explains authentication failures.\n\n" .
-                        "A server-level firewall, .htaccess rule, or security " .
-                        "plugin may be blocking the request before it reaches " .
-                        "WordPress.",
+                        "The request was blocked (HTTP {$http_code}) but the " .
+                        "server did not say why. The exporter plugin always " .
+                        "explains authentication failures, so something " .
+                        "upstream is blocking the request — a server-level " .
+                        "firewall, .htaccess rule, or security plugin.",
                 ];
             }
 
@@ -8856,9 +8859,9 @@ class ImportClient
                 return [
                     'code' => 'AUTH_SECRET_MISMATCH',
                     'message' =>
-                        "The shared secret does not match. The --secret value must " .
-                        "be identical to the one configured in the Site Export " .
-                        "plugin settings (wp-admin → Site Export).",
+                        "Wrong shared secret. The --secret value does not match " .
+                        "the one configured in the Site Export plugin settings " .
+                        "(wp-admin → Site Export).",
                 ];
             }
 
@@ -8866,10 +8869,9 @@ class ImportClient
                 return [
                     'code' => 'AUTH_CLOCK_SKEW',
                     'message' =>
-                        "The request was rejected because the clocks are out of " .
-                        "sync. {$server_msg}\n\n" .
-                        "Make sure this machine's clock is accurate (run `date` " .
-                        "to check).",
+                        "Clock out of sync. {$server_msg}\n\n" .
+                        "Check this machine's clock (run `date`) and compare " .
+                        "it with the server's time.",
                 ];
             }
 
@@ -8877,9 +8879,9 @@ class ImportClient
                 return [
                     'code' => 'AUTH_CONTENT_TAMPERED',
                     'message' =>
-                        "The request body was modified between this machine and " .
-                        "the server. A proxy, CDN, or firewall may be altering " .
-                        "requests in transit.",
+                        "Request body was modified in transit. A proxy, CDN, " .
+                        "or firewall between this machine and the server is " .
+                        "altering the request content.",
                 ];
             }
 
@@ -8887,9 +8889,10 @@ class ImportClient
                 return [
                     'code' => 'AUTH_HEADERS_STRIPPED',
                     'message' =>
-                        "The server did not receive the authentication headers " .
-                        "({$server_msg}). A proxy, CDN, or security plugin may " .
-                        "be stripping custom headers from the request.",
+                        "Authentication headers were stripped. The server " .
+                        "reported: {$server_msg}\n\n" .
+                        "A proxy, CDN, or security plugin is removing custom " .
+                        "HTTP headers before they reach WordPress.",
                 ];
             }
 
@@ -8903,44 +8906,34 @@ class ImportClient
         if ($http_code === 503 && $server_msg !== null) {
             return [
                 'code' => 'EXPORT_NOT_CONFIGURED',
-                'message' => $server_msg,
+                'message' =>
+                    "The exporter plugin is installed but not configured. " .
+                    "The server reported: {$server_msg}",
             ];
         }
 
         // ── Not found ────────────────────────────────────────────
         if ($http_code === 404) {
+            $msg = "The exporter plugin is not installed on the remote site.";
             if ($looks_like_html) {
-                return [
-                    'code' => 'NOT_FOUND',
-                    'message' =>
-                        "The export API was not found (HTTP 404). The server " .
-                        "returned an HTML page, which means the exporter plugin " .
-                        "is not installed on the remote site.\n\n" .
-                        "Run `php reprint.phar install-exporter` for setup instructions.",
-                ];
+                $msg .= " The server returned an HTML 404 page instead of " .
+                         "the export API.";
+            } else {
+                $msg .= " The server returned HTTP 404.";
             }
-            return [
-                'code' => 'NOT_FOUND',
-                'message' =>
-                    "The export API was not found at this URL (HTTP 404).\n\n" .
-                    "Make sure the exporter plugin is installed and activated " .
-                    "on the remote site. Run `php reprint.phar install-exporter` " .
-                    "for setup instructions.",
-            ];
+            $msg .= "\n\nRun `php reprint.phar install-exporter` for setup " .
+                     "instructions.";
+            return ['code' => 'NOT_FOUND', 'message' => $msg];
         }
 
         // ── Server errors ────────────────────────────────────────
         if ($http_code >= 500) {
             $msg = $server_msg
-                ? "The remote server returned an error: {$server_msg}"
-                : "The remote server returned an internal error (HTTP {$http_code}).";
-            return [
-                'code' => 'SERVER_ERROR',
-                'message' =>
-                    $msg . "\n\n" .
-                    "This is a problem on the remote server. " .
-                    "Check its PHP error log for details.",
-            ];
+                ? "The remote server crashed: {$server_msg}"
+                : "The remote server crashed (HTTP {$http_code}).";
+            $msg .= "\n\nThis is a problem on the remote server. " .
+                     "Check its PHP error log for details.";
+            return ['code' => 'SERVER_ERROR', 'message' => $msg];
         }
 
         // ── HTML response on 200 (plugin not installed / wrong URL) ──
@@ -8948,10 +8941,11 @@ class ImportClient
             return [
                 'code' => 'HTML_RESPONSE',
                 'message' =>
-                    "The server returned an HTML page instead of the export API " .
-                    "response. The exporter plugin is not installed, or the URL " .
-                    "points to a regular web page.\n\n" .
-                    "Run `php reprint.phar install-exporter` for setup instructions.",
+                    "The exporter plugin is not installed on the remote site. " .
+                    "The server returned an HTML page instead of a JSON API " .
+                    "response.\n\n" .
+                    "Run `php reprint.phar install-exporter` for setup " .
+                    "instructions.",
             ];
         }
 

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -8792,9 +8792,13 @@ class ImportClient
      * turn opaque "HTTP 403" messages into something a non-expert can
      * act on.
      *
-     * Returns ['message' => ..., 'suggestion' => ..., 'code' => ...].
+     * Returns ['message' => ..., 'code' => ...].
+     *
+     * @param int         $http_code    HTTP status code (0 for connection failures).
+     * @param string|null $body         Response body (may be HTML, JSON, or empty).
+     * @param string|null $redirect_url The Location header / CURLINFO_REDIRECT_URL for 3xx responses.
      */
-    private function diagnose_http_error(int $http_code, ?string $body): array
+    private function diagnose_http_error(int $http_code, ?string $body, ?string $redirect_url = null): array
     {
         $body = $body !== null && $body !== false ? trim($body) : '';
         $looks_like_html = $body !== '' && (
@@ -8815,36 +8819,48 @@ class ImportClient
 
         // ── Redirects ────────────────────────────────────────────
         if ($http_code >= 300 && $http_code < 400) {
+            $target = $redirect_url ? " to {$redirect_url}" : '';
             return [
                 'code' => 'REDIRECT',
-                'message' => "The server returned a redirect (HTTP {$http_code}) instead of the export API response.",
-                'suggestion' =>
-                    "Double-check the site URL — make sure you are using the canonical URL " .
-                    "(http vs https, www vs non-www). " .
-                    "Reprint does not follow redirects to avoid silently connecting to the wrong server.",
+                'message' =>
+                    "The server redirected{$target} (HTTP {$http_code}).\n\n" .
+                    "Reprint does not follow redirects to avoid silently connecting " .
+                    "to the wrong server. Retry with the target URL above.",
             ];
         }
 
         // ── Authentication / authorization ───────────────────────
         if ($http_code === 401 || $http_code === 403) {
-            $msg = $server_msg ?? "Authentication failed (HTTP {$http_code}).";
+            return $this->diagnose_auth_error($http_code, $server_msg);
+        }
+
+        // ── Export not configured (503 from exporter) ────────────
+        if ($http_code === 503 && $server_msg !== null) {
             return [
-                'code' => 'AUTH_FAILED',
-                'message' => $msg,
-                'suggestion' =>
-                    "Double-check that --secret matches the secret configured in the " .
-                    "Site Export plugin settings on the remote site.",
+                'code' => 'EXPORT_NOT_CONFIGURED',
+                'message' => $server_msg,
             ];
         }
 
         // ── Not found ────────────────────────────────────────────
         if ($http_code === 404) {
+            if ($looks_like_html) {
+                return [
+                    'code' => 'NOT_FOUND',
+                    'message' =>
+                        "The export API was not found (HTTP 404). The server " .
+                        "returned an HTML page, which means the exporter plugin " .
+                        "is not installed on the remote site.\n\n" .
+                        "Run `php reprint.phar install-exporter` for setup instructions.",
+                ];
+            }
             return [
                 'code' => 'NOT_FOUND',
-                'message' => "The export API was not found at this URL (HTTP 404).",
-                'suggestion' =>
+                'message' =>
+                    "The export API was not found at this URL (HTTP 404).\n\n" .
                     "Make sure the exporter plugin is installed and activated " .
-                    "on the remote site. Run `php reprint.phar install-exporter` for setup instructions.",
+                    "on the remote site. Run `php reprint.phar install-exporter` " .
+                    "for setup instructions.",
             ];
         }
 
@@ -8855,10 +8871,10 @@ class ImportClient
                 : "The remote server returned an internal error (HTTP {$http_code}).";
             return [
                 'code' => 'SERVER_ERROR',
-                'message' => $msg,
-                'suggestion' =>
-                    "This is a problem on the remote server, not on your side. " .
-                    "Check the remote server's PHP error log for details.",
+                'message' =>
+                    $msg . "\n\n" .
+                    "This is a problem on the remote server. " .
+                    "Check its PHP error log for details.",
             ];
         }
 
@@ -8866,10 +8882,10 @@ class ImportClient
         if ($http_code === 200 && $looks_like_html) {
             return [
                 'code' => 'HTML_RESPONSE',
-                'message' => "The server returned an HTML page instead of JSON.",
-                'suggestion' =>
-                    "The exporter plugin is probably not installed, or the URL " .
-                    "points to a regular web page instead of the export API. " .
+                'message' =>
+                    "The server returned an HTML page instead of the export API " .
+                    "response. The exporter plugin is not installed, or the URL " .
+                    "points to a regular web page.\n\n" .
                     "Run `php reprint.phar install-exporter` for setup instructions.",
             ];
         }
@@ -8880,21 +8896,92 @@ class ImportClient
             'message' => $server_msg
                 ? "HTTP error {$http_code}: {$server_msg}"
                 : "Unexpected HTTP status {$http_code}.",
-            'suggestion' => null,
         ];
     }
 
     /**
-     * Format a diagnosed error as a single string.
-     * Combines the message and suggestion into one readable block.
+     * Diagnose a 401/403 authentication error by parsing the server's
+     * error message. The exporter returns specific HMAC failure reasons
+     * that we can turn into precise advice.
+     */
+    private function diagnose_auth_error(int $http_code, ?string $server_msg): array
+    {
+        // No --secret was passed but the server requires one.
+        if ($this->hmac_client === null) {
+            return [
+                'code' => 'AUTH_NO_SECRET',
+                'message' =>
+                    "The remote site requires authentication but no --secret " .
+                    "was provided.\n\n" .
+                    "Pass --secret=YOUR_SECRET using the same secret that is " .
+                    "configured in the Site Export plugin on the remote site.",
+            ];
+        }
+
+        if ($server_msg === null) {
+            return [
+                'code' => 'AUTH_FAILED',
+                'message' => "Authentication failed (HTTP {$http_code}).",
+            ];
+        }
+
+        // The server tells us exactly what went wrong. Map each known
+        // HMAC error to a targeted message.
+
+        if (str_contains($server_msg, 'HMAC signature verification failed')) {
+            return [
+                'code' => 'AUTH_SECRET_MISMATCH',
+                'message' =>
+                    "The shared secret does not match. The --secret value must " .
+                    "be identical to the one configured in the Site Export " .
+                    "plugin settings (wp-admin → Site Export).",
+            ];
+        }
+
+        if (str_contains($server_msg, 'timestamp expired')) {
+            return [
+                'code' => 'AUTH_CLOCK_SKEW',
+                'message' =>
+                    "The request was rejected because the clocks are out of " .
+                    "sync. {$server_msg}\n\n" .
+                    "Make sure this machine's clock is accurate (run `date` " .
+                    "to check).",
+            ];
+        }
+
+        if (str_contains($server_msg, 'Content hash mismatch')) {
+            return [
+                'code' => 'AUTH_CONTENT_TAMPERED',
+                'message' =>
+                    "The request body was modified between this machine and " .
+                    "the server. A proxy, CDN, or firewall may be altering " .
+                    "requests in transit.",
+            ];
+        }
+
+        if (str_contains($server_msg, 'Missing X-Auth-')) {
+            return [
+                'code' => 'AUTH_HEADERS_STRIPPED',
+                'message' =>
+                    "The server did not receive the authentication headers " .
+                    "({$server_msg}). A proxy, CDN, or security plugin may " .
+                    "be stripping custom headers from the request.",
+            ];
+        }
+
+        // Unknown auth error — show the server's message as-is.
+        return [
+            'code' => 'AUTH_FAILED',
+            'message' => "Authentication failed: {$server_msg}",
+        ];
+    }
+
+    /**
+     * Format a diagnosed error as a single string for display.
      */
     private function format_diagnosed_error(array $diagnosis): string
     {
-        $out = $diagnosis['message'];
-        if ($diagnosis['suggestion']) {
-            $out .= "\n\n" . $diagnosis['suggestion'];
-        }
-        return $out;
+        return $diagnosis['message'];
     }
 
     /**
@@ -8942,10 +9029,11 @@ class ImportClient
         }
 
         $http_code = (int) curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        $redirect_url = curl_getinfo($ch, CURLINFO_REDIRECT_URL) ?: null;
         @curl_close($ch);
 
         if ($http_code !== 200) {
-            $diagnosis = $this->diagnose_http_error($http_code, $body);
+            $diagnosis = $this->diagnose_http_error($http_code, $body, $redirect_url);
             return [
                 "ok" => false,
                 "http_code" => $http_code,
@@ -9272,6 +9360,7 @@ class ImportClient
             }
 
             $http_code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+            $redirect_url = curl_getinfo($ch, CURLINFO_REDIRECT_URL) ?: null;
             $ttfb = (float) curl_getinfo($ch, CURLINFO_STARTTRANSFER_TIME);
             $total_time = (float) curl_getinfo($ch, CURLINFO_TOTAL_TIME);
         } finally {
@@ -9300,7 +9389,7 @@ class ImportClient
                 true,
             );
 
-            $diagnosis = $this->diagnose_http_error($http_code, $error_body);
+            $diagnosis = $this->diagnose_http_error($http_code, $error_body, $redirect_url);
             $error_msg = $this->format_diagnosed_error($diagnosis);
 
             // Append stack trace from the server if available.

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -8941,8 +8941,8 @@ class ImportClient
             return ['code' => 'SERVER_ERROR', 'message' => $msg];
         }
 
-        // ── HTML response on 200 (plugin not installed / wrong URL) ──
-        if ($http_code === 200 && $looks_like_html) {
+        // ── HTML response (plugin not installed / wrong URL) ─────
+        if ($looks_like_html) {
             return [
                 'code' => 'HTML_RESPONSE',
                 'message' =>

--- a/tests/Import/DiagnoseHttpErrorTest.php
+++ b/tests/Import/DiagnoseHttpErrorTest.php
@@ -1,0 +1,266 @@
+<?php
+
+namespace ImportTests;
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../importer/import.php';
+
+/**
+ * Verify that diagnose_http_error() maps HTTP status codes and response
+ * bodies to the correct error codes and actionable messages.
+ */
+class DiagnoseHttpErrorTest extends TestCase
+{
+    private function diagnose(int $http_code, ?string $body = null, ?string $redirect_url = null, bool $has_secret = true): array
+    {
+        $client = new \ImportClient(
+            'http://example.com',
+            sys_get_temp_dir(),
+            sys_get_temp_dir(),
+        );
+
+        $ref = new \ReflectionClass(\ImportClient::class);
+
+        if ($has_secret) {
+            $hmac = $ref->getProperty('hmac_client');
+            // Any truthy object — we just need it non-null.
+            $hmac->setValue($client, new \stdClass());
+        }
+
+        $method = $ref->getMethod('diagnose_http_error');
+        return $method->invoke($client, $http_code, $body, $redirect_url);
+    }
+
+    // ── Redirects ────────────────────────────────────────────────
+
+    public function testRedirectWithTargetUrl()
+    {
+        $result = $this->diagnose(301, '', 'https://example.com/');
+        $this->assertSame('REDIRECT', $result['code']);
+        $this->assertStringContainsString('https://example.com/', $result['message']);
+    }
+
+    public function testRedirectWithoutTargetUrl()
+    {
+        $result = $this->diagnose(302, '');
+        $this->assertSame('REDIRECT', $result['code']);
+        $this->assertStringContainsString('http vs https', $result['message']);
+    }
+
+    public function test307Redirect()
+    {
+        $result = $this->diagnose(307, '', 'https://other.com/');
+        $this->assertSame('REDIRECT', $result['code']);
+    }
+
+    // ── Auth: no secret provided ─────────────────────────────────
+
+    public function testAuthNoSecretProvided()
+    {
+        $result = $this->diagnose(403, '{"error":"Missing X-Auth-Signature header"}', null, false);
+        $this->assertSame('AUTH_NO_SECRET', $result['code']);
+        $this->assertStringContainsString('--secret', $result['message']);
+    }
+
+    public function test401NoSecretProvided()
+    {
+        $result = $this->diagnose(401, '', null, false);
+        $this->assertSame('AUTH_NO_SECRET', $result['code']);
+    }
+
+    // ── Auth: secret mismatch ────────────────────────────────────
+
+    public function testAuthSecretMismatch()
+    {
+        $result = $this->diagnose(403, '{"error":"HMAC signature verification failed"}');
+        $this->assertSame('AUTH_SECRET_MISMATCH', $result['code']);
+        $this->assertStringContainsString('does not match', $result['message']);
+    }
+
+    // ── Auth: clock skew ─────────────────────────────────────────
+
+    public function testAuthClockSkew()
+    {
+        $server_msg = 'Request timestamp expired. Difference: 400.00 seconds, max allowed: 300 seconds';
+        $result = $this->diagnose(403, json_encode(['error' => $server_msg]));
+        $this->assertSame('AUTH_CLOCK_SKEW', $result['code']);
+        $this->assertStringContainsString('400.00 seconds', $result['message']);
+    }
+
+    // ── Auth: content tampered ───────────────────────────────────
+
+    public function testAuthContentTampered()
+    {
+        $result = $this->diagnose(403, '{"error":"Content hash mismatch: body was modified in transit"}');
+        $this->assertSame('AUTH_CONTENT_TAMPERED', $result['code']);
+        $this->assertStringContainsString('modified in transit', $result['message']);
+    }
+
+    // ── Auth: headers stripped ───────────────────────────────────
+
+    public function testAuthHeadersStripped()
+    {
+        $result = $this->diagnose(403, '{"error":"Missing X-Auth-Signature header"}');
+        $this->assertSame('AUTH_HEADERS_STRIPPED', $result['code']);
+        $this->assertStringContainsString('Missing X-Auth-Signature', $result['message']);
+    }
+
+    public function testAuthMissingNonceHeader()
+    {
+        $result = $this->diagnose(403, '{"error":"Missing X-Auth-Nonce header"}');
+        $this->assertSame('AUTH_HEADERS_STRIPPED', $result['code']);
+        $this->assertStringContainsString('Missing X-Auth-Nonce', $result['message']);
+    }
+
+    // ── Auth: unexplained 403 ────────────────────────────────────
+
+    public function testAuthUnexplained403NoBody()
+    {
+        $result = $this->diagnose(403, '');
+        $this->assertSame('AUTH_FAILED', $result['code']);
+        $this->assertStringContainsString('firewall', $result['message']);
+    }
+
+    public function testAuthUnexplained403HtmlBody()
+    {
+        $result = $this->diagnose(403, '<html><body>Forbidden</body></html>');
+        $this->assertSame('AUTH_FAILED', $result['code']);
+    }
+
+    // ── Auth: unknown server message ─────────────────────────────
+
+    public function testAuthUnknownServerMessage()
+    {
+        $result = $this->diagnose(403, '{"error":"Some future error we haven\'t seen"}');
+        $this->assertSame('AUTH_FAILED', $result['code']);
+        $this->assertStringContainsString("Some future error", $result['message']);
+    }
+
+    // ── Export not configured (503) ──────────────────────────────
+
+    public function testExportNotConfigured503()
+    {
+        $body = '{"error":"Export not configured. Please configure the shared secret in WordPress admin under Tools > Site Export."}';
+        $result = $this->diagnose(503, $body);
+        $this->assertSame('EXPORT_NOT_CONFIGURED', $result['code']);
+        $this->assertStringContainsString('not configured', $result['message']);
+    }
+
+    // ── Not found (404) ──────────────────────────────────────────
+
+    public function testNotFound404WithHtml()
+    {
+        $result = $this->diagnose(404, '<html><head><title>404 Not Found</title></head></html>');
+        $this->assertSame('NOT_FOUND', $result['code']);
+        $this->assertStringContainsString('not installed', $result['message']);
+    }
+
+    public function testNotFound404WithEmptyBody()
+    {
+        $result = $this->diagnose(404, '');
+        $this->assertSame('NOT_FOUND', $result['code']);
+        $this->assertStringContainsString('install-exporter', $result['message']);
+    }
+
+    // ── Server errors (500+) ─────────────────────────────────────
+
+    public function testServerError500WithMessage()
+    {
+        $result = $this->diagnose(500, '{"error":"Allowed memory size exhausted"}');
+        $this->assertSame('SERVER_ERROR', $result['code']);
+        $this->assertStringContainsString('memory size exhausted', $result['message']);
+        $this->assertStringContainsString('error log', $result['message']);
+    }
+
+    public function testServerError500NoBody()
+    {
+        $result = $this->diagnose(500, '');
+        $this->assertSame('SERVER_ERROR', $result['code']);
+        $this->assertStringContainsString('500', $result['message']);
+    }
+
+    public function testServerError502()
+    {
+        $result = $this->diagnose(502, '<html>Bad Gateway</html>');
+        $this->assertSame('SERVER_ERROR', $result['code']);
+    }
+
+    // ── HTML response on any status ──────────────────────────────
+
+    public function testHtmlResponseOn200()
+    {
+        $result = $this->diagnose(200, '<html><body>Welcome to WordPress</body></html>');
+        $this->assertSame('HTML_RESPONSE', $result['code']);
+        $this->assertSame(200, $result['http_code']);
+        $this->assertStringContainsString('not installed', $result['message']);
+    }
+
+    public function testHtmlResponseDetectsDoctype()
+    {
+        $result = $this->diagnose(200, '<!DOCTYPE html><html><body>Hello</body></html>');
+        $this->assertSame('HTML_RESPONSE', $result['code']);
+    }
+
+    public function testHtmlResponseDetectsLeadingTag()
+    {
+        // XML-like response that starts with < but isn't JSON
+        $result = $this->diagnose(200, '<?xml version="1.0"?><error>oops</error>');
+        $this->assertSame('HTML_RESPONSE', $result['code']);
+    }
+
+    // ── JSON body takes precedence over HTML heuristics ──────────
+
+    public function testJsonBodyNotMistakenForHtml()
+    {
+        // Valid JSON that happens to contain HTML-like strings
+        $result = $this->diagnose(200, '{"error":"<html> is not allowed"}');
+        // Should NOT be HTML_RESPONSE — the body parsed as valid JSON
+        $this->assertNotSame('HTML_RESPONSE', $result['code']);
+    }
+
+    // ── Fallback ─────────────────────────────────────────────────
+
+    public function testFallbackWithServerMessage()
+    {
+        $result = $this->diagnose(418, '{"error":"I am a teapot"}');
+        $this->assertSame('HTTP_ERROR', $result['code']);
+        $this->assertStringContainsString('teapot', $result['message']);
+        $this->assertStringContainsString('418', $result['message']);
+    }
+
+    public function testFallbackNoBody()
+    {
+        $result = $this->diagnose(418, '');
+        $this->assertSame('HTTP_ERROR', $result['code']);
+        $this->assertStringContainsString('418', $result['message']);
+    }
+
+    // ── Null and false body handling ─────────────────────────────
+
+    public function testNullBody()
+    {
+        $result = $this->diagnose(500, null);
+        $this->assertSame('SERVER_ERROR', $result['code']);
+    }
+
+    // ── error_code is stored on instance ─────────────────────────
+
+    public function testFormatDiagnosedErrorStoresCodeOnInstance()
+    {
+        $client = new \ImportClient(
+            'http://example.com',
+            sys_get_temp_dir(),
+            sys_get_temp_dir(),
+        );
+
+        $ref = new \ReflectionClass(\ImportClient::class);
+        $diagnose = $ref->getMethod('diagnose_http_error');
+        $format = $ref->getMethod('format_diagnosed_error');
+
+        $diagnosis = $diagnose->invoke($client, 404, '');
+        $format->invoke($client, $diagnosis);
+
+        $this->assertSame('NOT_FOUND', $client->last_error_code);
+    }
+}


### PR DESCRIPTION
## Summary

When reprint can't connect to the remote site, the old error messages were generic — "HTTP error 403" followed by a dump of the response body. Users had to guess what went wrong.

Now every failure gets a specific diagnosis that leads with the verdict, then explains how we know, then says what to do:

**Redirects (301/302/307):** Captures the redirect target URL from the Location header and displays it. "Wrong URL. The server redirected to https://example.com/ (HTTP 301)."

**Authentication — each HMAC failure diagnosed separately:**
- `AUTH_NO_SECRET` — "No --secret was provided."
- `AUTH_SECRET_MISMATCH` — "Wrong shared secret."
- `AUTH_CLOCK_SKEW` — "Clock out of sync." with the server's reported time difference
- `AUTH_CONTENT_TAMPERED` — "Request body was modified in transit."
- `AUTH_HEADERS_STRIPPED` — "Authentication headers were stripped." names the missing header
- `AUTH_FAILED` (unexplained) — "The request was blocked but the server did not say why." points to firewall/.htaccess

**Missing plugin:** "The exporter plugin is not installed on the remote site." — detected from 404 or HTML responses on any HTTP status.

**Server errors (500+):** "The remote server crashed: {message}" — surfaces the server's own error.

**Export not configured (503):** "The exporter plugin is installed but not configured."

All error output paths (progress JSON, status file, CLI stderr) include an `error_code` field so consumers can make decisions without parsing the message. TTY users see plain text, non-TTY consumers get structured JSON.

27 tests cover every error code path.

## Test plan

- [x] 27 unit tests in `DiagnoseHttpErrorTest.php` — all pass
- [ ] Point at a URL that 301-redirects → should show the target URL
- [ ] Use wrong `--secret` → should say "Wrong shared secret"
- [ ] Omit `--secret` entirely → should say "No --secret was provided"
- [ ] Point at a site without the plugin → should say plugin isn't installed
- [ ] Pipe output (non-TTY) → JSON should include `error_code`