### PR TITLE
Rename WordPress plugin to Reprint Exporter

### DIFF
--- a/packages/reprint-exporter/composer.json
+++ b/packages/reprint-exporter/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "wp-php-toolkit/reprint-exporter",
-    "description": "Streaming export engine used by the Site Export WordPress plugin",
+    "description": "Streaming export engine used by the Reprint Exporter WordPress plugin",
     "type": "library",
     "license": "GPL-2.0-or-later",
     "require": {

--- a/reprint-exporter-wp/README.md
+++ b/reprint-exporter-wp/README.md
@@ -1,4 +1,4 @@
-# Reprint — WordPress Plugin
+# Reprint Exporter — WordPress Plugin
 
 When working from this monorepo checkout, run `composer install` in
 `reprint-exporter-wp/` to populate the bundled `vendor/` directory used by the

--- a/reprint-exporter-wp/composer.json
+++ b/reprint-exporter-wp/composer.json
@@ -1,6 +1,6 @@
 {
-    "name": "wp-php-toolkit/site-export-plugin",
-    "description": "WordPress plugin wrapper for the streaming exporter package",
+    "name": "wp-php-toolkit/reprint-exporter-plugin",
+    "description": "Reprint Exporter – WordPress plugin wrapper for the streaming exporter package",
     "type": "project",
     "license": "GPL-2.0-or-later",
     "minimum-stability": "dev",

--- a/reprint-exporter-wp/index.php
+++ b/reprint-exporter-wp/index.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * Plugin Name: Site Export
+ * Plugin Name: Reprint Exporter
  * Plugin URI: https://github.com/WordPress/playground-tools
- * Description: Exposes a site export API with HMAC-authenticated endpoints for database and file synchronization.
+ * Description: Reprint Exporter – exposes a site export API with HMAC-authenticated endpoints for database and file synchronization.
  * Version: 1.0.0
  * Author: WordPress Contributors
  * License: GPL-2.0-or-later

--- a/reprint-exporter-wp/lib.php
+++ b/reprint-exporter-wp/lib.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Site Export library – constants and function declarations, no request handling.
+ * Reprint Exporter library – constants and function declarations, no request handling.
  *
  * Require this file to get access to the export API functions without
  * triggering any HTTP dispatch.
@@ -167,7 +167,7 @@ function _site_export_verify_hmac(string $secret): ?string {
     }
 
     if (!class_exists('Site_Export_HMAC_Server')) {
-        return 'Site Export runtime is incomplete. Run composer install in reprint-exporter-wp or rebuild the release package.';
+        return 'Reprint Exporter runtime is incomplete. Run composer install in reprint-exporter-wp or rebuild the release package.';
     }
 
     $server = new Site_Export_HMAC_Server($secret, SITE_EXPORT_TIMESTAMP_TOLERANCE);
@@ -192,7 +192,7 @@ function _site_export_default_authenticate(): void {
     }
 
     if (empty($secret) || !is_string($secret)) {
-        _site_export_error(503, 'Export not configured. Please configure the shared secret in WordPress admin under Tools > Site Export.');
+        _site_export_error(503, 'Export not configured. Please configure the shared secret in WordPress admin under Tools > Reprint Exporter.');
     }
 
     $auth_error = _site_export_verify_hmac($secret);
@@ -252,7 +252,7 @@ function _site_export_handle_api_request(array $options = []): void {
             'line' => $errline,
             'type' => $errno,
         ];
-        error_log('Site Export API error: ' . json_encode($error));
+        error_log('Reprint Exporter API error: ' . json_encode($error));
         http_response_code(500);
         @header('Content-Type: application/json');
         echo json_encode($error);
@@ -265,7 +265,7 @@ function _site_export_handle_api_request(array $options = []): void {
             'file' => $e->getFile(),
             'line' => $e->getLine(),
         ];
-        error_log('Site Export API exception: ' . json_encode($error));
+        error_log('Reprint Exporter API exception: ' . json_encode($error));
         http_response_code(500);
         @header('Content-Type: application/json');
         echo json_encode($error);
@@ -285,7 +285,7 @@ function _site_export_handle_api_request(array $options = []): void {
     if ($export_runtime === null) {
         _site_export_error(
             500,
-            'Site Export runtime is incomplete. Run composer install in reprint-exporter-wp or rebuild the release package.'
+            'Reprint Exporter runtime is incomplete. Run composer install in reprint-exporter-wp or rebuild the release package.'
         );
     }
 

--- a/reprint-exporter-wp/wordpress/site-export.php
+++ b/reprint-exporter-wp/wordpress/site-export.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Admin interface for Site Export plugin.
+ * Admin interface for Reprint Exporter plugin.
  *
  * This plugin provides a WordPress admin UI for configuring the export API.
  * The export API is triggered via `?site-export-api` during plugin load,
@@ -58,8 +58,8 @@ class Site_Export_Plugin {
      */
     public function add_admin_menu() {
         add_menu_page(
-            'Site Export',
-            'Site Export',
+            'Reprint Exporter',
+            'Reprint Exporter',
             'manage_options',
             'site-export',
             [$this, 'render_admin_page'],
@@ -68,7 +68,7 @@ class Site_Export_Plugin {
     }
 
     /**
-     * Add "Site Export" link to the admin bar.
+     * Add "Reprint Exporter" link to the admin bar.
      */
     public function add_admin_bar_node($wp_admin_bar) {
         if (!current_user_can('manage_options')) {
@@ -77,9 +77,9 @@ class Site_Export_Plugin {
 
         $wp_admin_bar->add_node([
             'id'    => 'site-export',
-            'title' => 'Site Export',
+            'title' => 'Reprint Exporter',
             'href'  => admin_url('admin.php?page=site-export'),
-            'meta'  => ['title' => 'Site Export'],
+            'meta'  => ['title' => 'Reprint Exporter'],
         ]);
     }
 
@@ -250,7 +250,7 @@ class Site_Export_Plugin {
         </style>
 
         <div class="site-export-wrap">
-            <h1>Site Export</h1>
+            <h1>Reprint Exporter</h1>
             <p class="subtitle">Allow an external tool to download your site's database and files.</p>
 
             <?php settings_errors('site_export'); ?>


### PR DESCRIPTION
The WordPress plugin was still called "Site Export" everywhere – plugin header,
admin menu, admin bar, error messages, composer metadata, and README. This
renames all user-visible strings to "Reprint Exporter" so the plugin name
matches the project name.

Internal constants (`SITE_EXPORT_*`) and function prefixes (`_site_export_*`)
are deliberately left unchanged to keep this a safe metadata-only rename.