### PR TITLE
Sync plugin version with git release tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,10 +32,7 @@ jobs:
         run: ./bin/build-reprint-phar.sh
 
       - name: Stamp plugin version from git tag
-        run: |
-          VERSION="${GITHUB_REF_NAME#v}"
-          sed -i "s/Version: 0\.0\.0-dev/Version: $VERSION/" reprint-exporter-wp/index.php
-          sed -i "s/'0\.0\.0-dev'/'$VERSION'/" reprint-exporter-wp/lib.php
+        run: ./bin/stamp-plugin-version.sh "${GITHUB_REF_NAME#v}"
 
       - name: Package reprint-exporter-wp.zip
         run: cd reprint-exporter-wp && zip -r ../reprint-exporter-wp.zip . -x '*/secret.php'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,12 @@ jobs:
       - name: Build reprint.phar
         run: ./bin/build-reprint-phar.sh
 
+      - name: Stamp plugin version from git tag
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          sed -i "s/Version: 0\.0\.0-dev/Version: $VERSION/" reprint-exporter-wp/index.php
+          sed -i "s/'0\.0\.0-dev'/'$VERSION'/" reprint-exporter-wp/lib.php
+
       - name: Package reprint-exporter-wp.zip
         run: cd reprint-exporter-wp && zip -r ../reprint-exporter-wp.zip . -x '*/secret.php'
 

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -83,3 +83,17 @@ jobs:
           git tag "v${{ steps.version.outputs.value }}"
           git push origin "v${{ steps.version.outputs.value }}"
           echo "Tagged and pushed v${{ steps.version.outputs.value }}"
+
+      - name: Bump trunk to next dev version
+        run: |
+          VERSION="${{ steps.version.outputs.value }}"
+          IFS='.' read -r MAJOR MINOR PATCH <<< "$VERSION"
+          NEXT_DEV="${MAJOR}.$((MINOR + 1)).0-dev"
+
+          git checkout trunk
+          sed -i "s/Version: [0-9][0-9.]*\(-dev\)\{0,1\}/Version: $NEXT_DEV/" reprint-exporter-wp/index.php
+          sed -i "s/SITE_EXPORT_VERSION', '[0-9][0-9.]*\(-dev\)\{0,1\}'/SITE_EXPORT_VERSION', '$NEXT_DEV'/" reprint-exporter-wp/lib.php
+
+          git add reprint-exporter-wp/index.php reprint-exporter-wp/lib.php
+          git commit -m "Bump plugin version to $NEXT_DEV after v$VERSION release"
+          git push origin trunk

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -91,8 +91,7 @@ jobs:
           NEXT_DEV="${MAJOR}.$((MINOR + 1)).0-dev"
 
           git checkout trunk
-          sed -i "s/Version: [0-9][0-9.]*\(-dev\)\{0,1\}/Version: $NEXT_DEV/" reprint-exporter-wp/index.php
-          sed -i "s/SITE_EXPORT_VERSION', '[0-9][0-9.]*\(-dev\)\{0,1\}'/SITE_EXPORT_VERSION', '$NEXT_DEV'/" reprint-exporter-wp/lib.php
+          ./bin/stamp-plugin-version.sh "$NEXT_DEV"
 
           git add reprint-exporter-wp/index.php reprint-exporter-wp/lib.php
           git commit -m "Bump plugin version to $NEXT_DEV after v$VERSION release"

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -88,7 +88,7 @@ jobs:
         run: |
           VERSION="${{ steps.version.outputs.value }}"
           IFS='.' read -r MAJOR MINOR PATCH <<< "$VERSION"
-          NEXT_DEV="${MAJOR}.$((MINOR + 1)).0-dev"
+          NEXT_DEV="${MAJOR}.${MINOR}.$((PATCH + 1))-dev"
 
           git checkout trunk
           ./bin/stamp-plugin-version.sh "$NEXT_DEV"

--- a/bin/stamp-plugin-version.sh
+++ b/bin/stamp-plugin-version.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+#
+# Stamps a version string into the WordPress plugin header and the
+# SITE_EXPORT_VERSION constant.
+#
+# Usage:
+#   ./bin/stamp-plugin-version.sh 0.2.0        # release
+#   ./bin/stamp-plugin-version.sh 0.3.0-dev    # dev bump
+#
+set -euo pipefail
+
+if [ $# -ne 1 ]; then
+    echo "Usage: $0 <version>" >&2
+    exit 1
+fi
+
+VERSION="$1"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+INDEX="$PROJECT_ROOT/reprint-exporter-wp/index.php"
+LIB="$PROJECT_ROOT/reprint-exporter-wp/lib.php"
+
+# Match any version string (with or without -dev suffix) in both locations.
+# Use a temp-file suffix for sed -i portability (macOS vs GNU).
+sed -i.bak "s/Version: [0-9][0-9.]*\(-dev\)\{0,1\}/Version: $VERSION/" "$INDEX" && rm -f "$INDEX.bak"
+sed -i.bak "s/SITE_EXPORT_VERSION', '[0-9][0-9.]*\(-dev\)\{0,1\}'/SITE_EXPORT_VERSION', '$VERSION'/" "$LIB" && rm -f "$LIB.bak"
+
+# Verify the stamp took effect — fail loudly if it didn't.
+if ! grep -q "Version: $VERSION" "$INDEX"; then
+    echo "Error: failed to stamp version in index.php" >&2
+    exit 1
+fi
+if ! grep -q "'$VERSION'" "$LIB"; then
+    echo "Error: failed to stamp version in lib.php" >&2
+    exit 1
+fi
+
+echo "Stamped plugin version: $VERSION"

--- a/reprint-exporter-wp/index.php
+++ b/reprint-exporter-wp/index.php
@@ -3,7 +3,7 @@
  * Plugin Name: Reprint Exporter
  * Plugin URI: https://github.com/WordPress/playground-tools
  * Description: Reprint Exporter – exposes a site export API with HMAC-authenticated endpoints for database and file synchronization.
- * Version: 1.0.0
+ * Version: 0.0.0-dev
  * Author: WordPress Contributors
  * License: GPL-2.0-or-later
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/reprint-exporter-wp/lib.php
+++ b/reprint-exporter-wp/lib.php
@@ -11,7 +11,7 @@ if (!defined('ABSPATH')) {
 }
 
 if (!defined('SITE_EXPORT_VERSION')) {
-    define('SITE_EXPORT_VERSION', '1.0.0');
+    define('SITE_EXPORT_VERSION', '0.0.0-dev');
 }
 if (!defined('SITE_EXPORT_PLUGIN_DIR')) {
     define('SITE_EXPORT_PLUGIN_DIR', plugin_dir_path(__FILE__));


### PR DESCRIPTION
## Summary

The WordPress plugin had a hardcoded `Version: 1.0.0` that never changed between releases. This wires it up to the existing tag-based release workflow so the version stays in sync with git tags.

**In the repo** (trunk), the version now reads `0.0.0-dev` — both in the plugin header (`index.php`) and the `SITE_EXPORT_VERSION` constant (`lib.php`). This makes it immediately obvious when someone is running an unreleased build.

**At release time**, the `release.yml` workflow stamps the real semver from the git tag (e.g. `v0.1.42` → `0.1.42`) into both files before packaging the zip.

**After tagging**, the `tag-release.yml` workflow bumps trunk to the next patch dev version (e.g. `v0.1.42` → `0.1.43-dev`) so the development version is always one step ahead of the latest release.

Both workflows use a shared `bin/stamp-plugin-version.sh` script that does the sed replacement and verifies it took effect.