### PR TITLE
Stop impersonating Chrome to avoid WAF blocks

### DIFF
--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -1839,16 +1839,33 @@ class ImportClient
         $url = $this->build_url("preflight", null, []);
         $this->audit_log("PREFLIGHT REQUEST | {$url}", false);
 
-        $result = $this->fetch_json($url);
-        $payload = $result["json"] ?? null;
+        // Try each User-Agent until one gets a JSON response.
+        // Some WAFs block certain UAs (e.g. browser UAs with custom auth
+        // headers), so we cycle through candidates and remember the winner.
+        $result = null;
+        $payload = null;
+        foreach (self::USER_AGENTS as $ua) {
+            $this->state["user_agent"] = $ua;
+            $result = $this->fetch_json($url);
+            $payload = $result["json"] ?? null;
+            if ($payload !== null) {
+                $this->audit_log("USER-AGENT OK | {$ua}", false);
+                break;
+            }
+            $this->audit_log("USER-AGENT BLOCKED | {$ua}", false);
+        }
 
         $entry = [
             "timestamp" => time(),
+            "url" => $url,
             "http_code" => (int) ($result["http_code"] ?? 0),
             "elapsed" => (float) ($result["elapsed"] ?? 0),
             "ok" => is_array($payload) ? ($payload["ok"] ?? null) : null,
             "data" => $payload,
             "error" => $result["error"] ?? null,
+            "response_body_preview" => $payload === null && isset($result["body"])
+                ? substr((string) $result["body"], 0, 200)
+                : null,
         ];
 
         $this->state["preflight"] = $entry;
@@ -8755,13 +8772,22 @@ class ImportClient
     }
 
     /**
-     * Build the shared browser-mimicry headers used by both fetch_json and
-     * fetch_streaming.  The Accept value differs between the two callers.
+     * User-Agent strings to try during preflight, in order of preference.
+     * Some WAFs block browser UAs that carry custom auth headers, so we
+     * start with an honest non-browser identity and fall back to common
+     * browser strings.
      */
+    private const USER_AGENTS = [
+        "Reprint/1.0",
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36",
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:132.0) Gecko/20100101 Firefox/132.0",
+    ];
+
     private function get_base_headers(string $accept): array
     {
+        $ua = $this->state["user_agent"] ?? self::USER_AGENTS[0];
         return [
-            "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36",
+            "User-Agent: {$ua}",
             "Accept: {$accept}",
             "Accept-Language: en-US,en;q=0.9",
             "Accept-Encoding: gzip, deflate",


### PR DESCRIPTION
## Summary

Some hosting providers run WAFs that block requests combining a browser User-Agent with custom headers like `X-Auth-Signature`. The importer was sending a Chrome UA, so these sites returned an HTML 403 page before the request ever reached WordPress. The exporter never got to respond, and the user saw a generic "something upstream is blocking" error.

The importer now tries three User-Agent strings during preflight — `Reprint/1.0` first, then Chrome, then Firefox — and keeps the first one that gets a JSON response. The winner is persisted in state so all subsequent requests reuse it without retrying.

The preflight error JSON also now includes the requested URL and a 200-byte response body preview to make WAF blocks easier to diagnose.

## Test plan

- [ ] Import from a site behind a WAF (e.g. SiteGround) — confirm preflight succeeds on the first or second UA
- [ ] Import from a site with no WAF — confirm `Reprint/1.0` wins immediately
- [ ] Trigger a preflight failure (wrong secret) and confirm the JSON includes `url` and `response_body_preview`