### PR TITLE
Fix WP Cloud shared theme symlink remapping during import

### DIFF
--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -960,13 +960,8 @@ class ImportClient
     private $follow_symlinks = true;
 
     /**
-     * Memoized lookups for "does remote index contain this path or a child path?"
+     * Memoized lookups for "does remote index contain this path or any descendant path?"
      * keyed by normalized absolute path.
-     *
-     * Cost model:
-     * - First lookup for a unique path: O(N) time to scan .import-remote-index.jsonl
-     * - Repeated lookup for the same path: O(1) time
-     * - Extra memory: O(U), where U is the number of distinct queried prefixes
      *
      * @var array<string,bool>
      */
@@ -7691,74 +7686,6 @@ class ImportClient
     }
 
     /**
-     * Return true if the remote index contains $path or any entry under it.
-     *
-     * This is used when rebuilding a symlink whose original target was an
-     * absolute path outside fs-root. If that absolute target was indexed from
-     * the source (for example via --follow-symlinks), we know the importer has
-     * a local mirror of that subtree and can safely relink to the mirror.
-     *
-     * Cost model:
-     * - Cache miss: O(N) time, where N is the number of lines in
-     *   .import-remote-index.jsonl
-     * - Cache hit: O(1) time
-     * - Additional memory across the import: O(U), where U is the number of
-     *   distinct normalized prefixes checked here
-     *
-     * Practical cost is low because this helper only runs on the uncommon
-     * absolute-symlink remap path, not for every imported file.
-     *
-     * We intentionally pay this lazily because the remap path is uncommon.
-     * Building a full prefix index up front would turn lookups into O(1), but
-     * would add eager O(N) preprocessing and larger resident memory for every
-     * import, including imports that never need symlink-target remapping.
-     */
-    private function remote_index_contains_path_prefix(string $path): bool
-    {
-        $path = rtrim(normalize_path($path), "/");
-        if ($path === "") {
-            return false;
-        }
-
-        if (isset($this->remote_index_prefix_cache[$path])) {
-            return $this->remote_index_prefix_cache[$path];
-        }
-
-        if (!file_exists($this->remote_index_file)) {
-            $this->remote_index_prefix_cache[$path] = false;
-            return false;
-        }
-
-        $h = fopen($this->remote_index_file, "r");
-        if (!$h) {
-            $this->remote_index_prefix_cache[$path] = false;
-            return false;
-        }
-
-        $prefix = $path . "/";
-        $found = false;
-        while (($line = fgets($h)) !== false) {
-            try {
-                $entry = $this->parse_index_line($line);
-            } catch (RuntimeException $e) {
-                continue;
-            }
-            if ($entry === null) {
-                continue;
-            }
-            $entry_path = $entry["path"];
-            if ($entry_path === $path || str_starts_with($entry_path, $prefix)) {
-                $found = true;
-                break;
-            }
-        }
-        fclose($h);
-
-        $this->remote_index_prefix_cache[$path] = $found;
-        return $found;
-    }
-
-    /**
      * Map an absolute remote symlink target to the local fs-root mirror when possible.
      *
      * Example:
@@ -7827,6 +7754,55 @@ class ImportClient
         );
 
         return $mapped_relative;
+    }
+
+    /**
+     * Checks if the remote index contains $path or any descendant under it.
+     * Runs a memoized O(N) scan of .import-remote-index.jsonl.
+     */
+    private function remote_index_contains_path_prefix(string $path): bool
+    {
+        $path = rtrim(normalize_path($path), "/");
+        if ($path === "") {
+            return false;
+        }
+
+        if (isset($this->remote_index_prefix_cache[$path])) {
+            return $this->remote_index_prefix_cache[$path];
+        }
+
+        if (!file_exists($this->remote_index_file)) {
+            $this->remote_index_prefix_cache[$path] = false;
+            return false;
+        }
+
+        $h = fopen($this->remote_index_file, "r");
+        if (!$h) {
+            $this->remote_index_prefix_cache[$path] = false;
+            return false;
+        }
+
+        $prefix = $path . "/";
+        $found = false;
+        while (($line = fgets($h)) !== false) {
+            try {
+                $entry = $this->parse_index_line($line);
+            } catch (RuntimeException $e) {
+                continue;
+            }
+            if ($entry === null) {
+                continue;
+            }
+            $entry_path = $entry["path"];
+            if ($entry_path === $path || str_starts_with($entry_path, $prefix)) {
+                $found = true;
+                break;
+            }
+        }
+        fclose($h);
+
+        $this->remote_index_prefix_cache[$path] = $found;
+        return $found;
     }
 
     /**

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -8059,11 +8059,6 @@ class ImportClient
         }
 
         $local_path = $this->remote_path_to_local_path_within_import_root($path);
-        $target_for_local = $this->map_absolute_symlink_target_for_local_mirror(
-            $path,
-            $local_path,
-            $target,
-        );
 
         // Skip if anything already exists at this path — regular file, symlink
         // (even to a file), or directory.  This preserves hosting symlinks like

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -960,6 +960,14 @@ class ImportClient
     private $follow_symlinks = true;
 
     /**
+     * Memoized lookups for "does remote index contain this path or a child path?"
+     * keyed by normalized absolute path.
+     *
+     * @var array<string,bool>
+     */
+    private $remote_index_prefix_cache = [];
+
+    /**
      * @var string Controls behavior when the fs root is non-empty at import start.
      *
      * 'error' (default): throw an error if the fs root is non-empty.
@@ -7678,6 +7686,106 @@ class ImportClient
     }
 
     /**
+     * Return true if the remote index contains $path or any entry under it.
+     *
+     * Used when recreating symlinks with absolute targets: if a target path
+     * was indexed (e.g. discovered via --follow-symlinks), we can map it to
+     * its local mirror under fs-root and keep the symlink working locally.
+     */
+    private function remote_index_contains_path_prefix(string $path): bool
+    {
+        $path = rtrim(normalize_path($path), "/");
+        if ($path === "") {
+            return false;
+        }
+
+        if (isset($this->remote_index_prefix_cache[$path])) {
+            return $this->remote_index_prefix_cache[$path];
+        }
+
+        if (!file_exists($this->remote_index_file)) {
+            $this->remote_index_prefix_cache[$path] = false;
+            return false;
+        }
+
+        $h = fopen($this->remote_index_file, "r");
+        if (!$h) {
+            $this->remote_index_prefix_cache[$path] = false;
+            return false;
+        }
+
+        $prefix = $path . "/";
+        $found = false;
+        while (($line = fgets($h)) !== false) {
+            try {
+                $entry = $this->parse_index_line($line);
+            } catch (RuntimeException $e) {
+                continue;
+            }
+            if ($entry === null) {
+                continue;
+            }
+            $entry_path = $entry["path"];
+            if ($entry_path === $path || str_starts_with($entry_path, $prefix)) {
+                $found = true;
+                break;
+            }
+        }
+        fclose($h);
+
+        $this->remote_index_prefix_cache[$path] = $found;
+        return $found;
+    }
+
+    /**
+     * Map an absolute remote symlink target to the local fs-root mirror when possible.
+     *
+     * For followed external directories (e.g. /tmp/shared-theme), file contents are
+     * downloaded under fs-root/tmp/shared-theme/..., but the original absolute target
+     * would point outside fs-root and fail validation. When the target was indexed,
+     * rewrite it to a relative symlink into the mirrored local path.
+     */
+    private function map_absolute_symlink_target_for_local_mirror(
+        string $path,
+        string $local_path,
+        string $target
+    ): string {
+        if (!str_starts_with($target, "/")) {
+            return $target;
+        }
+
+        $root = $this->get_filesystem_root_path();
+        $normalized_target = normalize_path($target);
+
+        // Already points inside fs-root, keep as-is.
+        if (path_is_within_root($normalized_target, $root)) {
+            return $target;
+        }
+
+        // Only rewrite when symlink-following is enabled and the target path
+        // was actually indexed from the source.
+        if (
+            !$this->follow_symlinks ||
+            !$this->remote_index_contains_path_prefix($normalized_target)
+        ) {
+            return $target;
+        }
+
+        $mapped_absolute = $root . $normalized_target;
+        $mapped_relative = self::compute_relative_path(
+            dirname($local_path),
+            $mapped_absolute
+        );
+
+        $this->audit_log(
+            "SYMLINK TARGET REMAP | {$path}: {$target} -> {$mapped_relative}",
+            false,
+        );
+
+        return $mapped_relative;
+    }
+
+    /**
      * Return canonical fs root path, creating it if it doesn't exist.
      */
     private function get_filesystem_root_path(): string
@@ -7951,6 +8059,11 @@ class ImportClient
         }
 
         $local_path = $this->remote_path_to_local_path_within_import_root($path);
+        $target_for_local = $this->map_absolute_symlink_target_for_local_mirror(
+            $path,
+            $local_path,
+            $target,
+        );
 
         // Skip if anything already exists at this path — regular file, symlink
         // (even to a file), or directory.  This preserves hosting symlinks like
@@ -8243,6 +8356,11 @@ class ImportClient
         }
 
         $local_path = $this->remote_path_to_local_path_within_import_root($path);
+        $target_for_local = $this->map_absolute_symlink_target_for_local_mirror(
+            $path,
+            $local_path,
+            $target,
+        );
 
         // In preserve-local mode, if something already exists at the symlink
         // path, keep it — whether it's a file, directory, or another symlink.
@@ -8266,7 +8384,7 @@ class ImportClient
         try {
             $this->assert_symlink_target_within_root(
                 dirname($local_path),
-                $target,
+                $target_for_local,
                 $root
             );
         } catch (RuntimeException $e) {
@@ -8274,7 +8392,7 @@ class ImportClient
             $this->output_progress([
                 "type" => "symlink_error",
                 "path" => $path,
-                "target" => $target,
+                "target" => $target_for_local,
                 "error" => $e->getMessage(),
                 "message" => "Symlink error: {$path} -> {$target}",
             ]);
@@ -8293,7 +8411,7 @@ class ImportClient
                 $this->output_progress([
                     "type" => "symlink_error",
                     "path" => $path,
-                    "target" => $target,
+                    "target" => $target_for_local,
                     "error" => "Failed to replace existing path",
                     "message" => "Symlink error: {$path} -> {$target}",
                 ]);
@@ -8319,7 +8437,7 @@ class ImportClient
                 $this->output_progress([
                     "type" => "symlink_error",
                     "path" => $path,
-                    "target" => $target,
+                    "target" => $target_for_local,
                     "error" => "Failed to create parent directory",
                     "message" => "Symlink error: {$path} -> {$target}",
                 ]);
@@ -8328,17 +8446,17 @@ class ImportClient
         }
 
         // Create symlink
-        $symlink_result = symlink($target, $local_path);
+        $symlink_result = symlink($target_for_local, $local_path);
         if (true !== $symlink_result || !is_link($local_path)) {
             // Log error and skip this symlink
             $this->audit_log(
-                "Failed to create symlink: {$local_path} -> {$target}",
+                "Failed to create symlink: {$local_path} -> {$target_for_local}",
                 true,
             );
             $this->output_progress([
                 "type" => "symlink_error",
                 "path" => $path,
-                "target" => $target,
+                "target" => $target_for_local,
                 "error" => "Failed to create symlink",
                 "message" => "Symlink error: {$path} -> {$target}",
             ]);
@@ -8350,7 +8468,7 @@ class ImportClient
             @touch($local_path, $ctime);
         }
 
-        $this->audit_log("Symlink: {$path} -> {$target}", false);
+        $this->audit_log("Symlink: {$path} -> {$target_for_local}", false);
 
         if ($ctime > 0) {
             $this->upsert_index_entry($path, $ctime, 0, "link");
@@ -8359,8 +8477,8 @@ class ImportClient
         $this->output_progress([
             "type" => "symlink",
             "path" => $path,
-            "target" => $target,
-            "message" => "Symlink: {$path} -> {$target}",
+            "target" => $target_for_local,
+            "message" => "Symlink: {$path} -> {$target_for_local}",
         ]);
     }
 

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -963,6 +963,11 @@ class ImportClient
      * Memoized lookups for "does remote index contain this path or a child path?"
      * keyed by normalized absolute path.
      *
+     * Cost model:
+     * - First lookup for a unique path: O(N) time to scan .import-remote-index.jsonl
+     * - Repeated lookup for the same path: O(1) time
+     * - Extra memory: O(U), where U is the number of distinct queried prefixes
+     *
      * @var array<string,bool>
      */
     private $remote_index_prefix_cache = [];
@@ -7688,9 +7693,25 @@ class ImportClient
     /**
      * Return true if the remote index contains $path or any entry under it.
      *
-     * Used when recreating symlinks with absolute targets: if a target path
-     * was indexed (e.g. discovered via --follow-symlinks), we can map it to
-     * its local mirror under fs-root and keep the symlink working locally.
+     * This is used when rebuilding a symlink whose original target was an
+     * absolute path outside fs-root. If that absolute target was indexed from
+     * the source (for example via --follow-symlinks), we know the importer has
+     * a local mirror of that subtree and can safely relink to the mirror.
+     *
+     * Cost model:
+     * - Cache miss: O(N) time, where N is the number of lines in
+     *   .import-remote-index.jsonl
+     * - Cache hit: O(1) time
+     * - Additional memory across the import: O(U), where U is the number of
+     *   distinct normalized prefixes checked here
+     *
+     * Practical cost is low because this helper only runs on the uncommon
+     * absolute-symlink remap path, not for every imported file.
+     *
+     * We intentionally pay this lazily because the remap path is uncommon.
+     * Building a full prefix index up front would turn lookups into O(1), but
+     * would add eager O(N) preprocessing and larger resident memory for every
+     * import, including imports that never need symlink-target remapping.
      */
     private function remote_index_contains_path_prefix(string $path): bool
     {
@@ -7740,10 +7761,33 @@ class ImportClient
     /**
      * Map an absolute remote symlink target to the local fs-root mirror when possible.
      *
-     * For followed external directories (e.g. /tmp/shared-theme), file contents are
-     * downloaded under fs-root/tmp/shared-theme/..., but the original absolute target
-     * would point outside fs-root and fail validation. When the target was indexed,
-     * rewrite it to a relative symlink into the mirrored local path.
+     * Example:
+     *
+     * Source site:
+     *
+     *   /srv/source-site/
+     *   `-- wp-content/
+     *       `-- themes/
+     *           `-- indice -> /tmp/e2e-shared-themes/pub/indice
+     *
+     *   /tmp/e2e-shared-themes/pub/indice/
+     *   |-- style.css
+     *   `-- index.php
+     *
+     * Local import state:
+     *
+     *   <state-dir>/fs-root/
+     *   |-- tmp/e2e-shared-themes/pub/indice/
+     *   |   |-- style.css
+     *   |   `-- index.php
+     *   `-- srv/source-site/wp-content/themes/
+     *       `-- indice -> ../../../tmp/e2e-shared-themes/pub/indice
+     *
+     * Without this remap, the recreated link would still point to
+     * /tmp/e2e-shared-themes/pub/indice, which is outside fs-root and rejected
+     * by assert_symlink_target_within_root(). When the absolute target was
+     * already indexed from the source, we instead point the symlink at the
+     * mirrored local copy under fs-root.
      */
     private function map_absolute_symlink_target_for_local_mirror(
         string $path,

--- a/tests/e2e/site-registry.json
+++ b/tests/e2e/site-registry.json
@@ -102,7 +102,7 @@
       "port": 8111
     },
     "wpcloud-shared-theme-symlink": {
-      "port": 8112
+      "port": 8118
     },
     "sql-crash": {
       "port": 8113

--- a/tests/e2e/site-registry.json
+++ b/tests/e2e/site-registry.json
@@ -101,6 +101,9 @@
     "symlinked-abspath": {
       "port": 8111
     },
+    "wpcloud-shared-theme-symlink": {
+      "port": 8112
+    },
     "sql-crash": {
       "port": 8113
     },

--- a/tests/e2e/tests/import-46-wpcloud-shared-theme-symlink.test.js
+++ b/tests/e2e/tests/import-46-wpcloud-shared-theme-symlink.test.js
@@ -51,6 +51,7 @@ describe('Import: Shared theme symlink remains working', () => {
 
     async function ensureApiReachable() {
         const apiUrl = getSiteUrl(site);
+        const apiPort = Number(new URL(apiUrl).port || 80);
         try {
             await fetch(apiUrl, { method: 'GET' });
             return;
@@ -60,7 +61,7 @@ describe('Import: Shared theme symlink remains working', () => {
         }
 
         const docRoot = getSiteDir(site);
-        fallbackApiServer = spawn('php', ['-S', '127.0.0.1:8112', '-t', docRoot], {
+        fallbackApiServer = spawn('php', ['-S', `127.0.0.1:${apiPort}`, '-t', docRoot], {
             stdio: 'ignore',
         });
 

--- a/tests/e2e/tests/import-46-wpcloud-shared-theme-symlink.test.js
+++ b/tests/e2e/tests/import-46-wpcloud-shared-theme-symlink.test.js
@@ -1,0 +1,173 @@
+/**
+ * Test 46: shared theme symlink portability
+ *
+ * Reproduces a WP Cloud-like layout where a site theme entry in
+ * wp-content/themes is a symlink to a shared absolute path.
+ *
+ * Source:
+ *   wp-content/themes/indice -> /tmp/e2e-shared-themes/pub/indice
+ *
+ * The source symlink is valid and readable. After import, the target should
+ * still have a working theme entry at wp-content/themes/indice.
+ *
+ * Current behavior: the importer rejects absolute symlink targets outside the
+ * local fs-root, so the theme entry is missing or non-working on target.
+ */
+import { describe, it, beforeAll, afterAll } from 'vitest';
+import assert from 'node:assert/strict';
+import {
+    existsSync, lstatSync, mkdirSync, readFileSync,
+    rmSync, symlinkSync, writeFileSync,
+} from 'node:fs';
+import { execSync, spawn } from 'node:child_process';
+import { join } from 'node:path';
+import { setTimeout as sleep } from 'node:timers/promises';
+import {
+    createTempDir, cleanupTempDir, fsRootDir,
+    getSiteDir, getSiteSecret, getSiteUrl, runImporter,
+} from '../lib/test-helpers.js';
+import { ensureSite } from '../lib/site-setup.js';
+
+const SHARED_THEME_ROOT = '/tmp/e2e-shared-themes';
+const SHARED_THEME_DIR = join(SHARED_THEME_ROOT, 'pub', 'indice');
+
+describe('Import: Shared theme symlink remains working', () => {
+    const site = 'wpcloud-shared-theme-symlink';
+    let tempDir;
+    let fallbackApiServer = null;
+
+    function prepareSharedThemeTree() {
+        rmSync(SHARED_THEME_ROOT, { recursive: true, force: true });
+        mkdirSync(SHARED_THEME_DIR, { recursive: true });
+        writeFileSync(
+            join(SHARED_THEME_DIR, 'style.css'),
+            '/* Shared indice theme */\n',
+        );
+        writeFileSync(
+            join(SHARED_THEME_DIR, 'index.php'),
+            '<?php // shared indice theme\n',
+        );
+    }
+
+    async function ensureApiReachable() {
+        const apiUrl = getSiteUrl(site);
+        try {
+            await fetch(apiUrl, { method: 'GET' });
+            return;
+        } catch (_) {
+            // If local infra does not expose this port yet, serve plugin API
+            // directly via PHP built-in server for this test.
+        }
+
+        const docRoot = getSiteDir(site);
+        fallbackApiServer = spawn('php', ['-S', '127.0.0.1:8112', '-t', docRoot], {
+            stdio: 'ignore',
+        });
+
+        const deadline = Date.now() + 15000;
+        while (Date.now() < deadline) {
+            if (fallbackApiServer.exitCode !== null) {
+                throw new Error(`Fallback API server exited early with code ${fallbackApiServer.exitCode}`);
+            }
+            try {
+                await fetch(apiUrl, { method: 'GET' });
+                return;
+            } catch (_) {
+                await sleep(100);
+            }
+        }
+
+        throw new Error('Timed out waiting for fallback API server');
+    }
+
+    beforeAll(async () => {
+        // Recreate this site from scratch so the copied plugin bundle always
+        // matches the current workspace (including vendor runtime files).
+        execSync(`sudo rm -rf "${getSiteDir(site)}"`, { timeout: 30000 });
+
+        await ensureSite(site, {
+            afterCreate: async (siteDir) => {
+                prepareSharedThemeTree();
+
+                const themesDir = join(siteDir, 'wp-content', 'themes');
+                mkdirSync(themesDir, { recursive: true });
+
+                const indiceLocalPath = join(themesDir, 'indice');
+                rmSync(indiceLocalPath, { recursive: true, force: true });
+                symlinkSync(SHARED_THEME_DIR, indiceLocalPath);
+            },
+        });
+        prepareSharedThemeTree();
+        await ensureApiReachable();
+
+        tempDir = createTempDir('e2e-wpcloud-shared-theme-symlink');
+    });
+
+    afterAll(() => {
+        cleanupTempDir(tempDir);
+        rmSync(SHARED_THEME_ROOT, { recursive: true, force: true });
+        if (fallbackApiServer && fallbackApiServer.exitCode === null) {
+            fallbackApiServer.kill('SIGTERM');
+        }
+    });
+
+    function importUrl() {
+        return `${getSiteUrl(site)}&directory=${getSiteDir(site)}`;
+    }
+
+    it('precondition: source has a working theme symlink', () => {
+        const sourceIndice = join(getSiteDir(site), 'wp-content', 'themes', 'indice');
+        assert.ok(lstatSync(sourceIndice).isSymbolicLink(), 'Source indice should be a symlink');
+        assert.ok(
+            existsSync(join(sourceIndice, 'style.css')),
+            'Source symlink should resolve to a readable style.css',
+        );
+    });
+
+    it('files-sync completes', () => {
+        const result = runImporter(importUrl(), tempDir, 'files-sync', {
+            secret: getSiteSecret(site),
+            extraArgs: ['--follow-symlinks'],
+        });
+        assert.equal(
+            result.exitCode,
+            0,
+            `files-sync failed:\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+        );
+    });
+
+    it('target keeps a working wp-content/themes/indice entry', () => {
+        const importedIndice = join(
+            fsRootDir(tempDir),
+            getSiteDir(site),
+            'wp-content',
+            'themes',
+            'indice',
+        );
+
+        // Expected behavior: the theme entry should be present and working
+        // after import, matching the source site's functional symlink.
+        assert.ok(existsSync(importedIndice), 'Imported indice entry should exist');
+        assert.ok(lstatSync(importedIndice).isSymbolicLink(), 'Imported indice should be a symlink');
+        assert.ok(
+            existsSync(join(importedIndice, 'style.css')),
+            'Imported indice symlink should resolve to style.css',
+        );
+    });
+
+    it('target can access the followed shared theme files', () => {
+        const followedThemeStyle = join(
+            fsRootDir(tempDir),
+            SHARED_THEME_DIR,
+            'style.css',
+        );
+        assert.ok(
+            existsSync(followedThemeStyle),
+            'Followed shared theme file should be present in fs-root',
+        );
+        assert.ok(
+            readFileSync(followedThemeStyle, 'utf-8').includes('Shared indice theme'),
+            'Followed shared theme file content should match source',
+        );
+    });
+});


### PR DESCRIPTION
## Summary
Fixes WP Cloud-style shared theme symlink imports when the source site uses an absolute symlink target outside the site root, and adds an e2e regression test covering that case.

## Problem
The source site can have a working theme symlink like this:

```text
/srv/e2e-sites/wpcloud-shared-theme-symlink/
└── wp-content/
    └── themes/
        └── indice -> /tmp/e2e-shared-themes/pub/indice

/tmp/e2e-shared-themes/pub/indice/
├── style.css
└── index.php
```

With:

```text
files-sync --follow-symlinks
```

The importer already follows the target content, so the mirrored files end up under `fs-root/tmp/...`, but before this fix the recreated symlink still pointed at the original absolute source path. That absolute target is outside local `fs-root`, so the symlink could not be recreated as a working local link.

Before the fix:

```text
<state-dir>/fs-root/
├── tmp/e2e-shared-themes/pub/indice/style.css   # followed target content exists
└── srv/e2e-sites/wpcloud-shared-theme-symlink/
    └── wp-content/themes/
        └── indice                                # missing / non-working theme entry
```

Expected and now implemented:

```text
<state-dir>/fs-root/
├── tmp/e2e-shared-themes/pub/indice/style.css
└── srv/e2e-sites/wpcloud-shared-theme-symlink/
    └── wp-content/themes/
        └── indice -> ../../../tmp/e2e-shared-themes/pub/indice   # working local mirror link
```

## Fix
In `handle_symlink_chunk()` on the importer side:

- For absolute symlink targets outside `fs-root`, if `--follow-symlinks` is enabled and the target path was indexed from the source, remap that target to the mirrored local path under `fs-root`.
- Create the symlink using a relative target to that mirrored local path.
- Keep the existing security behavior for unrelated absolute targets; they are still rejected if they were not indexed and mirrored.
- The added prefix lookup is low-cost in practice: cache misses are `O(N)` over `.import-remote-index.jsonl`, but this runs only on the uncommon absolute-symlink remap path, and repeated lookups are cached to `O(1)`.

## Regression Coverage
Added an e2e test that reproduces the WP Cloud shared-theme layout and verifies that the imported site keeps a working `wp-content/themes/indice` symlink after `files-sync --follow-symlinks`.

Source layout in the test:

```text
/srv/e2e-sites/wpcloud-shared-theme-symlink/
└── wp-content/
    └── themes/
        └── indice -> /tmp/e2e-shared-themes/pub/indice
```

Imported layout asserted by the test:

```text
<state-dir>/fs-root/
├── tmp/e2e-shared-themes/pub/indice/
│   ├── style.css
│   └── index.php
└── srv/e2e-sites/wpcloud-shared-theme-symlink/wp-content/themes/
    └── indice -> ../../../tmp/e2e-shared-themes/pub/indice
```

## Validation
Ran:

```bash
cd tests/e2e
npm test -- tests/import-46-wpcloud-shared-theme-symlink.test.js
npm test -- tests/import-31-follow-symlinks.test.js
```

CI is passing on this PR, including the full E2E matrix.
