### PR TITLE
Remove built-in SECRET_KEY check from export.php

### DIFF
--- a/packages/reprint-exporter/src/export.php
+++ b/packages/reprint-exporter/src/export.php
@@ -573,12 +573,6 @@ if (getenv('SITE_EXPORT_TEST_MODE')) {
     }
 }
 
-// This file is a library: it exposes endpoint functions and the
-// Site_Export_HTTP_Server dispatcher. Authentication is the caller's
-// responsibility — reprint-exporter-wp runs HMAC verification in
-// lib.php before requiring this file, and other integrations are
-// expected to do the same before calling any endpoint directly.
-
 require_once __DIR__ . "/class-mysql-dump-producer.php";
 require_once __DIR__ . "/class-file-tree-producer.php";
 

--- a/packages/reprint-exporter/src/export.php
+++ b/packages/reprint-exporter/src/export.php
@@ -520,10 +520,6 @@ register_shutdown_function(function () {
     }
 });
 
-if (file_exists(__DIR__ . "/secrets.php")) {
-    require_once __DIR__ . "/secrets.php";
-}
-
 // ============================================================================
 // E2E Test Hook System (only active when SITE_EXPORT_TEST_MODE env var is set)
 // We don't want anyone to interfere with the export process, which is why those
@@ -577,16 +573,11 @@ if (getenv('SITE_EXPORT_TEST_MODE')) {
     }
 }
 
-$secret_key_input = $_GET["SECRET_KEY"] ?? null;
-if (
-    !defined("SECRET_KEY") ||
-    !is_string($secret_key_input) ||
-    !hash_equals(SECRET_KEY, $secret_key_input)
-) {
-    http_response_code(403);
-    error_log("Invalid secret key");
-    die("Invalid secret key");
-}
+// This file is a library: it exposes endpoint functions and the
+// Site_Export_HTTP_Server dispatcher. Authentication is the caller's
+// responsibility — reprint-exporter-wp runs HMAC verification in
+// lib.php before requiring this file, and other integrations are
+// expected to do the same before calling any endpoint directly.
 
 require_once __DIR__ . "/class-mysql-dump-producer.php";
 require_once __DIR__ . "/class-file-tree-producer.php";

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -12,7 +12,6 @@ parameters:
         - reprint-exporter-wp
     excludePaths:
         analyseAndScan:
-            - packages/reprint-exporter/src/secrets.php
             - packages/reprint-exporter/src/class-sqlite-driver-pdo.php
             - reprint-exporter-wp/wordpress/
             - reprint-exporter-wp/index.php

--- a/reprint-exporter-wp/lib.php
+++ b/reprint-exporter-wp/lib.php
@@ -273,13 +273,11 @@ function _site_export_handle_api_request(array $options = []): void {
     });
 
     // -- Authenticate --
+    // HMAC verification runs here, before export.php is loaded.
+    // export.php is a library — it trusts that the caller has already
+    // authenticated the request.
     $authenticate = $options['authenticate'] ?? '_site_export_default_authenticate';
     $authenticate();
-
-    // export.php has its own SECRET_KEY guard — satisfy it since we already
-    // verified the request via HMAC above.
-    define('SECRET_KEY', 'hmac_authenticated');
-    $_GET['SECRET_KEY'] = SECRET_KEY;
 
     $export_runtime = _site_export_load_exporter_runtime();
     if ($export_runtime === null) {

--- a/reprint-exporter-wp/lib.php
+++ b/reprint-exporter-wp/lib.php
@@ -273,9 +273,6 @@ function _site_export_handle_api_request(array $options = []): void {
     });
 
     // -- Authenticate --
-    // HMAC verification runs here, before export.php is loaded.
-    // export.php is a library — it trusts that the caller has already
-    // authenticated the request.
     $authenticate = $options['authenticate'] ?? '_site_export_default_authenticate';
     $authenticate();
 

--- a/tests/ExportLibraryLoadTest.php
+++ b/tests/ExportLibraryLoadTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Verifies that packages/reprint-exporter/src/export.php behaves as
+ * a library: requiring it does not authenticate requests or terminate
+ * the process on its own.
+ *
+ * Authentication is now the responsibility of the caller (e.g.,
+ * reprint-exporter-wp/lib.php runs HMAC before require).
+ *
+ * Tests run in subprocesses because export.php registers shutdown and
+ * error handlers at module level.
+ */
+final class ExportLibraryLoadTest extends TestCase
+{
+    private const EXPORT_PATH = __DIR__ . '/../packages/reprint-exporter/src/export.php';
+
+    public function testRequiringExportPhpDoesNotRejectMissingSecretKey(): void
+    {
+        $script = <<<'PHP'
+        $_GET['endpoint'] = 'preflight';
+        PHP;
+
+        $result = $this->runExportWith($script);
+
+        $this->assertStringNotContainsString('Invalid secret key', $result['output']);
+        $this->assertStringContainsString('endpoint-handlers-loaded', $result['output']);
+    }
+
+    public function testRequiringExportPhpDefinesEndpointHandlers(): void
+    {
+        $result = $this->runExportWith('');
+
+        $this->assertStringContainsString('endpoint-handlers-loaded', $result['output']);
+    }
+
+    /**
+     * @return array{output:string}
+     */
+    private function runExportWith(string $setup_script): array
+    {
+        $export_path = realpath(self::EXPORT_PATH);
+        $this->assertNotFalse($export_path, 'export.php must exist');
+
+        $php_code = <<<PHP
+        <?php
+        {$setup_script}
+        require '{$export_path}';
+        // If we got here, require() completed without die()ing.
+        // Print a marker indicating endpoint functions are defined.
+        echo function_exists('endpoint_preflight') ? 'endpoint-handlers-loaded' : 'handlers-missing';
+        PHP;
+
+        $tmp_dir = sys_get_temp_dir() . '/export-library-test-' . uniqid();
+        mkdir($tmp_dir, 0755, true);
+
+        try {
+            file_put_contents($tmp_dir . '/run.php', $php_code);
+
+            $descriptors = [
+                0 => ['pipe', 'r'],
+                1 => ['pipe', 'w'],
+                2 => ['pipe', 'w'],
+            ];
+
+            $process = proc_open(
+                [PHP_BINARY, $tmp_dir . '/run.php'],
+                $descriptors,
+                $pipes,
+                $tmp_dir
+            );
+
+            if (!is_resource($process)) {
+                $this->fail('Failed to spawn PHP subprocess');
+            }
+
+            fclose($pipes[0]);
+            $stdout = stream_get_contents($pipes[1]);
+            $stderr = stream_get_contents($pipes[2]);
+            fclose($pipes[1]);
+            fclose($pipes[2]);
+            proc_close($process);
+
+            return ['output' => ($stdout ?: '') . ($stderr ?: '')];
+        } finally {
+            array_map('unlink', glob($tmp_dir . '/*') ?: []);
+            rmdir($tmp_dir);
+        }
+    }
+}

--- a/tests/ExportLibraryLoadTest.php
+++ b/tests/ExportLibraryLoadTest.php
@@ -5,12 +5,8 @@ declare(strict_types=1);
 use PHPUnit\Framework\TestCase;
 
 /**
- * Verifies that packages/reprint-exporter/src/export.php behaves as
- * a library: requiring it does not authenticate requests or terminate
- * the process on its own.
- *
- * Authentication is now the responsibility of the caller (e.g.,
- * reprint-exporter-wp/lib.php runs HMAC before require).
+ * Verifies that requiring export.php does not authenticate requests
+ * or terminate the process — it only registers functions and classes.
  *
  * Tests run in subprocesses because export.php registers shutdown and
  * error handlers at module level.

--- a/tests/FileIndexDedupTest.php
+++ b/tests/FileIndexDedupTest.php
@@ -99,8 +99,6 @@ final class FileIndexDedupTest extends TestCase
                 <<<'PHP'
 <?php
 declare(strict_types=1);
-define('SECRET_KEY', 'test-secret');
-$_GET['SECRET_KEY'] = 'test-secret';
 require_once %s;
 $config = json_decode(file_get_contents(%s), true, 512, JSON_THROW_ON_ERROR);
 $budget = new ResourceBudget(microtime(true), 10, 128 * 1024 * 1024, 0.9);

--- a/tests/e2e/site-registry.json
+++ b/tests/e2e/site-registry.json
@@ -118,6 +118,9 @@
     },
     "siteground-plugins": {
       "port": 8117
+    },
+    "plugin-auth": {
+      "port": 8119
     }
   }
 }

--- a/tests/e2e/tests/import-44-atomic-split-roots.test.js
+++ b/tests/e2e/tests/import-44-atomic-split-roots.test.js
@@ -56,14 +56,14 @@ describe('Import: Atomic-style split roots (__wp__ + document root)', () => {
                 writeFileSync(join(siteDir, 'wp-config.php'), '<?php /* stub config */ ?>');
 
                 // index.php loads the exporter directly, bypassing WordPress.
-                // We define SITE_EXPORT_PLUGIN_DIR and a stub for
-                // plugin_dir_path() since lib.php needs them.
+                // export.php is a library and no longer performs its own
+                // authentication, so we run HMAC verification here using the
+                // shared secret from secret.php before requiring the runtime.
                 writeFileSync(join(siteDir, 'index.php'), `<?php
 define('ABSPATH', __DIR__ . '/__wp__/');
 define('SITE_EXPORT_PLUGIN_DIR', __DIR__ . '/wp-content/plugins/site-export/');
 define('SITE_EXPORT_SECRET_FILE', SITE_EXPORT_PLUGIN_DIR . 'secret.php');
-define('SECRET_KEY', require SITE_EXPORT_SECRET_FILE);
-$_GET['SECRET_KEY'] = SECRET_KEY;
+$shared_secret = require SITE_EXPORT_SECRET_FILE;
 if (!function_exists('plugin_dir_path')) {
     function plugin_dir_path(\$file) { return trailingslashit(dirname(\$file)); }
 }
@@ -74,6 +74,12 @@ require_once SITE_EXPORT_PLUGIN_DIR . 'lib.php';
 $runtime = _site_export_load_exporter_runtime();
 if (!$runtime) { http_response_code(500); echo 'No runtime'; exit; }
 require_once $runtime;
+$auth_error = (new Site_Export_HMAC_Server($shared_secret))->verify_globals();
+if ($auth_error !== null) {
+    http_response_code(403);
+    echo $auth_error;
+    exit;
+}
 $server = new Site_Export_HTTP_Server([
     'default_directory' => __DIR__ . '/__wp__',
 ]);

--- a/tests/e2e/tests/import-44-atomic-split-roots.test.js
+++ b/tests/e2e/tests/import-44-atomic-split-roots.test.js
@@ -56,9 +56,7 @@ describe('Import: Atomic-style split roots (__wp__ + document root)', () => {
                 writeFileSync(join(siteDir, 'wp-config.php'), '<?php /* stub config */ ?>');
 
                 // index.php loads the exporter directly, bypassing WordPress.
-                // export.php is a library and no longer performs its own
-                // authentication, so we run HMAC verification here using the
-                // shared secret from secret.php before requiring the runtime.
+                // HMAC verification runs before the exporter runtime is loaded.
                 writeFileSync(join(siteDir, 'index.php'), `<?php
 define('ABSPATH', __DIR__ . '/__wp__/');
 define('SITE_EXPORT_PLUGIN_DIR', __DIR__ . '/wp-content/plugins/site-export/');

--- a/tests/e2e/tests/import-44-atomic-split-roots.test.js
+++ b/tests/e2e/tests/import-44-atomic-split-roots.test.js
@@ -56,32 +56,18 @@ describe('Import: Atomic-style split roots (__wp__ + document root)', () => {
                 writeFileSync(join(siteDir, 'wp-config.php'), '<?php /* stub config */ ?>');
 
                 // index.php loads the exporter directly, bypassing WordPress.
-                // HMAC verification runs before the exporter runtime is loaded.
+                // lib.php's _site_export_handle_api_request() authenticates
+                // via HMAC and dispatches the request — same path as the
+                // WordPress plugin, just without WP bootstrapped.
                 writeFileSync(join(siteDir, 'index.php'), `<?php
 define('ABSPATH', __DIR__ . '/__wp__/');
 define('SITE_EXPORT_PLUGIN_DIR', __DIR__ . '/wp-content/plugins/site-export/');
 define('SITE_EXPORT_SECRET_FILE', SITE_EXPORT_PLUGIN_DIR . 'secret.php');
-$shared_secret = require SITE_EXPORT_SECRET_FILE;
 if (!function_exists('plugin_dir_path')) {
-    function plugin_dir_path(\$file) { return trailingslashit(dirname(\$file)); }
-}
-if (!function_exists('trailingslashit')) {
-    function trailingslashit(\$s) { return rtrim(\$s, '/') . '/'; }
+    function plugin_dir_path(\$file) { return rtrim(dirname(\$file), '/') . '/'; }
 }
 require_once SITE_EXPORT_PLUGIN_DIR . 'lib.php';
-$runtime = _site_export_load_exporter_runtime();
-if (!$runtime) { http_response_code(500); echo 'No runtime'; exit; }
-require_once $runtime;
-$auth_error = (new Site_Export_HMAC_Server($shared_secret))->verify_globals();
-if ($auth_error !== null) {
-    http_response_code(403);
-    echo $auth_error;
-    exit;
-}
-$server = new Site_Export_HTTP_Server([
-    'default_directory' => __DIR__ . '/__wp__',
-]);
-$server->handle_request();
+_site_export_handle_api_request();
 `);
 
                 // Create site's own wp-content

--- a/tests/e2e/tests/import-47-plugin-auth.test.js
+++ b/tests/e2e/tests/import-47-plugin-auth.test.js
@@ -1,0 +1,66 @@
+/**
+ * Test 47: WordPress plugin authentication
+ *
+ * Installs the site-export plugin in a stock WordPress site — no custom
+ * setup, no afterCreate hooks — and verifies the default authentication
+ * behaviour via HTTP.
+ *
+ * The point is to treat the plugin as a black box: activate it, hit the
+ * endpoint, and confirm that unauthenticated and wrongly-authenticated
+ * requests are rejected while correctly-signed ones succeed.
+ */
+import { describe, it, beforeAll } from 'vitest';
+import assert from 'node:assert/strict';
+import {
+    apiRequest,
+    getSiteUrl, getSiteDir,
+    createHmacClient,
+} from '../lib/test-helpers.js';
+import { ensureSite } from '../lib/site-setup.js';
+
+describe('Import: WordPress plugin authentication', () => {
+    const site = 'plugin-auth';
+
+    beforeAll(async () => {
+        await ensureSite(site);
+    });
+
+    it('rejects requests with no auth headers', async () => {
+        const url = new URL(getSiteUrl(site));
+        url.searchParams.set('endpoint', 'preflight');
+        url.searchParams.set('directory', getSiteDir(site));
+
+        const response = await fetch(url.toString());
+        assert.equal(response.status, 403,
+            'Unauthenticated request must be rejected with 403');
+
+        const body = await response.json();
+        assert.ok(body.error,
+            'Response must include an error message');
+    });
+
+    it('rejects requests signed with the wrong secret', async () => {
+        const url = new URL(getSiteUrl(site));
+        url.searchParams.set('endpoint', 'preflight');
+        url.searchParams.set('directory', getSiteDir(site));
+
+        const wrongClient = createHmacClient('not-the-right-secret');
+        const response = await fetch(url.toString(), {
+            headers: wrongClient.getAuthHeaders(''),
+        });
+        assert.equal(response.status, 403,
+            'Request signed with wrong secret must be rejected with 403');
+
+        const body = await response.json();
+        assert.ok(body.error,
+            'Response must include an error message');
+    });
+
+    it('accepts requests signed with the correct secret', async () => {
+        const response = await apiRequest(site, 'preflight', {
+            directory: getSiteDir(site),
+        });
+        assert.equal(response.status, 200,
+            'Correctly-signed request must be accepted');
+    });
+});


### PR DESCRIPTION
\`export.php\` was designed to be dropped directly into a webroot, so it defended itself with a \`SECRET_KEY\` check at file-include time. Today every consumer wraps it — \`reprint-exporter-wp/index.php\` runs HMAC verification through \`lib.php\` before require, and external integrations like wpcomsh do the same before dispatching the export endpoint. The check became dead weight: each integration was forced to forge \`SECRET_KEY\` just to get past the gate.

This treats \`export.php\` as what it actually is: a library file that exposes endpoint functions and \`Site_Export_HTTP_Server\`. Authentication moves back to the caller where it belongs. The \`secrets.php\` auto-load, which existed only to define \`SECRET_KEY\` for the check we're deleting, goes too.

## Breaking change

Anyone requiring \`packages/reprint-exporter/src/export.php\` directly as an HTTP endpoint without their own auth wrapper will need to add one. Every in-tree consumer is updated, and the package is 0.1.x, so this is the right moment to do it.

## Test plan

- [x] Existing unit tests (ExportHttpServerTest, HmacServerTest, SiteExportSecretTest, FileIndexDedupTest) still pass
- [x] New \`ExportLibraryLoadTest\` verifies that requiring export.php does not reject requests or terminate the process
- [x] reprint-exporter-wp integration path exercised via SiteExportSecretTest's HMAC delegation test