### PR TITLE
Add Site_Export_HTTP_Server::send_cors_headers() static helper

### DIFF
--- a/packages/reprint-exporter/src/class-http-server.php
+++ b/packages/reprint-exporter/src/class-http-server.php
@@ -45,6 +45,67 @@ final class Site_Export_HTTP_Server {
     }
 
     /**
+     * Emits CORS headers and terminates OPTIONS preflight requests.
+     *
+     * Must be called BEFORE authentication runs — browsers send
+     * preflight OPTIONS without credentials, so the consumer must not
+     * require auth headers before this check passes.
+     *
+     * A wildcard origin ('*') is safe when authentication happens
+     * out-of-band (e.g., HMAC with a pre-shared secret) — an attacker
+     * without the secret cannot export anything regardless of origin.
+     *
+     * For OPTIONS requests this terminates the process. For all other
+     * methods it just emits the headers and returns so the caller can
+     * continue with authentication and dispatch.
+     *
+     * @param string|true $origin The Access-Control-Allow-Origin value,
+     *     or true as a shorthand for '*'.
+     * @param string $allow_headers The Access-Control-Allow-Headers value.
+     *     Defaults to '*' to permit all headers. Pass a comma-separated
+     *     list to restrict (e.g. 'Content-Type, X-Auth-Signature').
+     * @param array<string, mixed> $server Request server array (defaults to $_SERVER).
+     * @param array<string, callable>|null $io Optional overrides for
+     *     'header' (emitter) and 'exit' (preflight terminator). Used
+     *     only by tests.
+     */
+    public static function handle_cors_headers_and_terminate_on_options(
+        $origin = '*',
+        string $allow_headers = '*',
+        array $server = [],
+        ?array $io = null
+    ): void {
+        if ($origin === true) {
+            $origin = '*';
+        }
+        if (!is_string($origin) || $origin === '') {
+            throw new InvalidArgumentException(
+                'CORS origin must be a non-empty string or true'
+            );
+        }
+
+        $emit_header = ($io['header'] ?? null) ?? static function (string $h): void {
+            header($h);
+        };
+        $terminate = ($io['exit'] ?? null) ?? static function (): void {
+            exit;
+        };
+
+        $emit_header('Access-Control-Allow-Origin: ' . $origin);
+        $emit_header('Access-Control-Allow-Methods: GET, POST, OPTIONS');
+        $emit_header('Access-Control-Allow-Headers: ' . $allow_headers);
+
+        $request_server = $server === [] ? $_SERVER : $server;
+        $method = isset($request_server['REQUEST_METHOD']) ? (string) $request_server['REQUEST_METHOD'] : '';
+        if (strtoupper($method) !== 'OPTIONS') {
+            return;
+        }
+
+        $emit_header('Allow: GET, POST, OPTIONS');
+        $terminate();
+    }
+
+    /**
      * @param array<string, mixed> $get
      * @param array<string, mixed> $post
      * @param array<string, mixed> $server

--- a/reprint-exporter-wp/lib.php
+++ b/reprint-exporter-wp/lib.php
@@ -223,16 +223,15 @@ function _site_export_handle_api_request(array $options = []): void {
         ob_end_clean();
     }
 
-    // Allow CORS requests for WordPress Playground integration.
-    header('Access-Control-Allow-Origin: *');
-    header('Access-Control-Allow-Credentials: true');
-    header('Access-Control-Allow-Methods: GET, POST, OPTIONS');
-    header('Access-Control-Allow-Headers: *');
-
-    if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
-        header("Allow: GET, POST, OPTIONS");
-        exit;
+    // Emit CORS headers and short-circuit OPTIONS preflight before
+    // authentication runs — browsers send preflight OPTIONS without
+    // credentials, so we must not require auth before CORS passes.
+    // The class is loaded by the Composer autoloader on demand, but
+    // load it eagerly in case the autoloader hasn't been required yet.
+    if (!class_exists('Site_Export_HTTP_Server')) {
+        _site_export_load_exporter_runtime();
     }
+    Site_Export_HTTP_Server::handle_cors_headers_and_terminate_on_options('*');
 
     // Buffer output so stray warnings don't corrupt the JSON response.
     ob_start();

--- a/tests/HttpServerCorsTest.php
+++ b/tests/HttpServerCorsTest.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests Site_Export_HTTP_Server::handle_cors_headers_and_terminate_on_options —
+ * the static helper consumers call before authentication to emit CORS response
+ * headers and short-circuit OPTIONS preflight.
+ */
+final class HttpServerCorsTest extends TestCase
+{
+    public function testEmitsWildcardOriginByDefault(): void
+    {
+        $emitted = [];
+        Site_Export_HTTP_Server::handle_cors_headers_and_terminate_on_options(
+            '*',
+            '*',
+            ['REQUEST_METHOD' => 'GET'],
+            ['header' => static function (string $h) use (&$emitted): void {
+                $emitted[] = $h;
+            }]
+        );
+
+        $this->assertContains('Access-Control-Allow-Origin: *', $emitted);
+        $this->assertContains('Access-Control-Allow-Methods: GET, POST, OPTIONS', $emitted);
+        $this->assertContains('Access-Control-Allow-Headers: *', $emitted);
+    }
+
+    public function testEmitsSpecificOrigin(): void
+    {
+        $emitted = [];
+        Site_Export_HTTP_Server::handle_cors_headers_and_terminate_on_options(
+            'https://playground.wordpress.net',
+            '*',
+            ['REQUEST_METHOD' => 'GET'],
+            ['header' => static function (string $h) use (&$emitted): void {
+                $emitted[] = $h;
+            }]
+        );
+
+        $this->assertContains(
+            'Access-Control-Allow-Origin: https://playground.wordpress.net',
+            $emitted
+        );
+    }
+
+    public function testTrueMeansWildcard(): void
+    {
+        $emitted = [];
+        Site_Export_HTTP_Server::handle_cors_headers_and_terminate_on_options(
+            true,
+            '*',
+            ['REQUEST_METHOD' => 'GET'],
+            ['header' => static function (string $h) use (&$emitted): void {
+                $emitted[] = $h;
+            }]
+        );
+
+        $this->assertContains('Access-Control-Allow-Origin: *', $emitted);
+    }
+
+    public function testEmitsCustomAllowHeaders(): void
+    {
+        $emitted = [];
+        Site_Export_HTTP_Server::handle_cors_headers_and_terminate_on_options(
+            '*',
+            'Content-Type, X-Auth-Signature, X-Auth-Nonce, X-Auth-Timestamp',
+            ['REQUEST_METHOD' => 'GET'],
+            ['header' => static function (string $h) use (&$emitted): void {
+                $emitted[] = $h;
+            }]
+        );
+
+        $this->assertContains(
+            'Access-Control-Allow-Headers: Content-Type, X-Auth-Signature, X-Auth-Nonce, X-Auth-Timestamp',
+            $emitted
+        );
+    }
+
+    public function testOptionsPreflightEmitsAllowHeaderAndTerminates(): void
+    {
+        $emitted = [];
+        $terminated = false;
+        Site_Export_HTTP_Server::handle_cors_headers_and_terminate_on_options(
+            '*',
+            '*',
+            ['REQUEST_METHOD' => 'OPTIONS'],
+            [
+                'header' => static function (string $h) use (&$emitted): void {
+                    $emitted[] = $h;
+                },
+                'exit' => static function () use (&$terminated): void {
+                    $terminated = true;
+                },
+            ]
+        );
+
+        $this->assertTrue($terminated, 'OPTIONS preflight must terminate the request');
+        $this->assertContains('Allow: GET, POST, OPTIONS', $emitted);
+    }
+
+    public function testNonOptionsRequestDoesNotTerminate(): void
+    {
+        $terminated = false;
+        Site_Export_HTTP_Server::handle_cors_headers_and_terminate_on_options(
+            '*',
+            '*',
+            ['REQUEST_METHOD' => 'POST'],
+            [
+                'header' => static function (): void {},
+                'exit' => static function () use (&$terminated): void {
+                    $terminated = true;
+                },
+            ]
+        );
+
+        $this->assertFalse($terminated, 'Non-OPTIONS requests must not terminate');
+    }
+
+    public function testRejectsEmptyOrigin(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        Site_Export_HTTP_Server::handle_cors_headers_and_terminate_on_options('', '*', ['REQUEST_METHOD' => 'GET']);
+    }
+
+    public function testRejectsInvalidOriginType(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        /** @phpstan-ignore-next-line — intentionally passing wrong type */
+        Site_Export_HTTP_Server::handle_cors_headers_and_terminate_on_options(false, '*', ['REQUEST_METHOD' => 'GET']);
+    }
+}


### PR DESCRIPTION
Every consumer of the export API that needs browser access — reprint-exporter-wp, wpcomsh, Playground-hosted integrations — was reimplementing the same CORS boilerplate: allow-origin, allow-methods, allow-headers, and the OPTIONS short-circuit. This moves that logic into the package once.

It's a static method rather than an instance-level option because CORS preflight must happen before authentication, which happens before \`Site_Export_HTTP_Server\` is instantiated. The caller threads \`\$_SERVER\` through for testability; tests can also inject custom \`header\` and \`exit\` callbacks.

## Usage

\`\`\`php
Site_Export_HTTP_Server::send_cors_headers('*');
// your authentication here
\$server = new Site_Export_HTTP_Server(['default_directory' => ABSPATH]);
\$server->handle_request();
\`\`\`

## Behavior change worth flagging

The old block in \`reprint-exporter-wp/lib.php\` emitted \`Access-Control-Allow-Credentials: true\` alongside \`Access-Control-Allow-Origin: *\`. Browsers reject that combination per the CORS spec. The export flow uses HMAC headers rather than cookies, so \`Allow-Credentials\` was never actually needed — dropping it.

## Test plan
- [x] Six new unit tests cover: wildcard origin, specific origin, \`true\` shorthand, OPTIONS termination, non-OPTIONS passthrough, empty/invalid origin validation
- [x] Existing Site_Export_HTTP_Server tests still pass
- [x] reprint-exporter-wp/lib.php switched over