### PR TITLE
Add Site_Export_HTTP_Server::serve() one-call entry point

### DIFF
--- a/packages/reprint-exporter/src/class-http-server.php
+++ b/packages/reprint-exporter/src/class-http-server.php
@@ -106,6 +106,34 @@ final class Site_Export_HTTP_Server {
     }
 
     /**
+     * One-call convenience entry point: loads export.php, constructs
+     * the server, and dispatches the current request.
+     *
+     * Equivalent to:
+     *
+     *     require_once __DIR__ . '/export.php';
+     *     $server = new Site_Export_HTTP_Server($options);
+     *     $server->handle_request();
+     *
+     * export.php is only required once. Callers that need to run CORS
+     * or their own authentication must do that before calling this method.
+     *
+     * @param array<string, mixed> $options Forwarded to the constructor.
+     */
+    public static function serve(array $options = []): void {
+        // endpoint_preflight is defined by export.php — use it as a
+        // cheap sentinel to detect whether the runtime is already
+        // loaded. require_once would be safe either way, but this
+        // avoids re-running the stat() on hot paths.
+        if (!function_exists('endpoint_preflight')) {
+            require_once __DIR__ . '/export.php';
+        }
+
+        $server = new self($options);
+        $server->handle_request();
+    }
+
+    /**
      * @param array<string, mixed> $get
      * @param array<string, mixed> $post
      * @param array<string, mixed> $server

--- a/reprint-exporter-wp/lib.php
+++ b/reprint-exporter-wp/lib.php
@@ -275,22 +275,21 @@ function _site_export_handle_api_request(array $options = []): void {
     $authenticate = $options['authenticate'] ?? '_site_export_default_authenticate';
     $authenticate();
 
-    $export_runtime = _site_export_load_exporter_runtime();
-    if ($export_runtime === null) {
+    // Ensure the Composer autoloader is loaded so Site_Export_HTTP_Server
+    // is resolvable. The class itself will require export.php on demand
+    // via serve() below.
+    if (_site_export_load_exporter_runtime() === null) {
         _site_export_error(
             500,
             'Reprint Exporter runtime is incomplete. Run composer install in reprint-exporter-wp or rebuild the release package.'
         );
     }
 
-    require_once $export_runtime;
-
     // -- Dispatch --
     try {
-        $server = new Site_Export_HTTP_Server([
+        Site_Export_HTTP_Server::serve([
             'default_directory' => ABSPATH,
         ]);
-        $server->handle_request();
     } catch (Exception $e) {
         if (!headers_sent()) {
             http_response_code(400);

--- a/tests/HttpServerServeTest.php
+++ b/tests/HttpServerServeTest.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests Site_Export_HTTP_Server::serve() — the one-call convenience
+ * entry point that loads export.php, constructs the server, and
+ * dispatches the current request.
+ *
+ * Tests run in subprocesses because serve() requires export.php, which
+ * registers shutdown and error handlers at module level.
+ */
+final class HttpServerServeTest extends TestCase
+{
+    private const CLASS_PATH = __DIR__ . '/../packages/reprint-exporter/src/class-http-server.php';
+    private const EXPORT_PATH = __DIR__ . '/../packages/reprint-exporter/src/export.php';
+
+    public function testServeLoadsExportPhpWhenNotYetLoaded(): void
+    {
+        $script = <<<PHP
+        \$_GET['endpoint'] = 'preflight';
+        \$_GET['directory'] = sys_get_temp_dir();
+
+        require '{$this->classPath()}';
+
+        // endpoint_preflight is defined by export.php; it must not
+        // exist before serve() is called.
+        if (function_exists('endpoint_preflight')) {
+            echo "FAIL: endpoint_preflight defined before serve()";
+            exit;
+        }
+
+        Site_Export_HTTP_Server::serve();
+
+        // serve() should have required export.php, which defines endpoint_preflight.
+        echo function_exists('endpoint_preflight') ? "OK" : "FAIL: endpoint_preflight not defined";
+        PHP;
+
+        $output = $this->runScript($script);
+
+        $this->assertStringContainsString('OK', $output);
+        $this->assertStringNotContainsString('FAIL', $output);
+    }
+
+    public function testServeDoesNotRedundantlyReloadExportPhp(): void
+    {
+        $script = <<<PHP
+        \$_GET['endpoint'] = 'preflight';
+        \$_GET['directory'] = sys_get_temp_dir();
+
+        require '{$this->classPath()}';
+        require '{$this->exportPath()}';
+
+        // Track require side-effect: if export.php was re-required, endpoint_preflight
+        // would be re-declared which would be a fatal error.
+        Site_Export_HTTP_Server::serve();
+        echo "OK";
+        PHP;
+
+        $output = $this->runScript($script);
+        $this->assertStringContainsString('OK', $output);
+    }
+
+    public function testServeForwardsOptionsToConstructor(): void
+    {
+        $script = <<<PHP
+        \$_GET['endpoint'] = 'preflight';
+
+        require '{$this->classPath()}';
+
+        // Override the default handler for 'preflight' to verify the
+        // options were passed through to the constructor.
+        Site_Export_HTTP_Server::serve([
+            'handlers' => [
+                'preflight' => function (\$config) {
+                    echo "handler-called:" . \$config['endpoint'];
+                },
+            ],
+        ]);
+        PHP;
+
+        $output = $this->runScript($script);
+        $this->assertStringContainsString('handler-called:preflight', $output);
+    }
+
+    private function classPath(): string
+    {
+        $path = realpath(self::CLASS_PATH);
+        $this->assertNotFalse($path);
+        return $path;
+    }
+
+    private function exportPath(): string
+    {
+        $path = realpath(self::EXPORT_PATH);
+        $this->assertNotFalse($path);
+        return $path;
+    }
+
+    private function runScript(string $body): string
+    {
+        $tmp_dir = sys_get_temp_dir() . '/serve-test-' . uniqid();
+        mkdir($tmp_dir, 0755, true);
+
+        try {
+            $php_code = "<?php\n" . $body . "\n";
+            file_put_contents($tmp_dir . '/run.php', $php_code);
+
+            $descriptors = [
+                0 => ['pipe', 'r'],
+                1 => ['pipe', 'w'],
+                2 => ['pipe', 'w'],
+            ];
+
+            $process = proc_open(
+                [PHP_BINARY, $tmp_dir . '/run.php'],
+                $descriptors,
+                $pipes,
+                $tmp_dir
+            );
+
+            if (!is_resource($process)) {
+                $this->fail('Failed to spawn PHP subprocess');
+            }
+
+            fclose($pipes[0]);
+            $stdout = stream_get_contents($pipes[1]);
+            $stderr = stream_get_contents($pipes[2]);
+            fclose($pipes[1]);
+            fclose($pipes[2]);
+            proc_close($process);
+
+            return ($stdout ?: '') . ($stderr ?: '');
+        } finally {
+            array_map('unlink', glob($tmp_dir . '/*') ?: []);
+            rmdir($tmp_dir);
+        }
+    }
+}


### PR DESCRIPTION
Every consumer of the export API repeats the same three-step dance to dispatch a request:

\`\`\`php
require_once __DIR__ . '/vendor/wp-php-toolkit/reprint-exporter/src/export.php';
\$server = new Site_Export_HTTP_Server(\$options);
\$server->handle_request();
\`\`\`

\`serve()\` folds that into one call and loads export.php lazily so integrations that already require it explicitly don't pay the cost twice.

## Usage

\`\`\`php
Site_Export_HTTP_Server::serve([
    'default_directory' => ABSPATH,
]);
\`\`\`

Authentication and CORS still happen before \`serve()\` — those are out-of-band concerns the package doesn't assume responsibility for. reprint-exporter-wp/lib.php switched over.

## Test plan
- [x] Three new subprocess tests verify: export.php is loaded on first call, redundant calls don't re-require, constructor options are forwarded
- [x] Existing Site_Export_HTTP_Server tests still pass