### PR TITLE
Add pull command with Pull class

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,39 +1,135 @@
-<picture>
-  <source media="(prefers-color-scheme: dark)" srcset="assets/reprint-logo-dark.svg">
-  <source media="(prefers-color-scheme: light)" srcset="assets/reprint-logo.svg">
-  <img src="assets/reprint-logo.svg" alt="Reprint" width="250">
-</picture>
-
 # Reprint — WordPress Site Migration
 
-Reprint moves a WordPress site from one server to another over HTTPS.
+Clone any WordPress site over HTTP. One command pulls the files, database, and server config, then starts a local copy you can open in your browser.
 
-It uses a small WordPress plugin on the source site and a CLI importer tool on the target. The importer pulls the entire filesystem and database in streaming chunks, resuming automatically when a request is interrupted by timeouts, memory limits, or network failures. No SSH, no full-site ZIP files, no manual database dumps.
+## Quick start
 
-The system is designed for the cheapest shared hosting: PHP 7.4, two PHP workers, 64 MB memory, 30-second execution limits. It budgets its own resource usage to avoid tripping host abuse detectors, backs off adaptively when the server is slow, and recovers gracefully from mid-stream crashes. The result is a portable copy of the site — files, database, and generated runtime configuration — ready to serve on the new host.
+### 1. Install the exporter plugin on the source site
 
-## Table of Contents
+```bash
+php reprint.phar install-exporter
+```
 
-- [Getting Started](#getting-started)
-- [Usage](#usage)
-  - [Migration walkthrough](#migration-walkthrough)
-  - [CLI reference](#cli-reference)
-  - [Status files](#status-files)
-- [Installation](#installation)
-  - [Composer packages](#composer-packages)
-  - [Technical requirements](#technical-requirements)
-  - [Repository layout](#repository-layout)
-- [Architecture](#architecture)
-  - [File synchronization](#file-synchronization)
-  - [Database synchronization](#database-synchronization)
-  - [Authentication](#authentication)
-  - [Error handling](#error-handling)
-  - [Resource management](#resource-management)
-  - [Transport](#transport)
-- [Known Limitations](#known-limitations)
-- [Development](#development)
+This prints the download URL and step-by-step instructions for installing the WordPress plugin on the site you want to clone. The plugin exposes the HTTP API that reprint connects to.
 
-## Getting Started
+### 2. Pull the site
+
+```bash
+php reprint.phar pull https://example.com \
+  --secret=YOUR_SECRET \
+  --state-dir=./state --fs-root=./files
+```
+
+That's it. Reprint will:
+
+1. **Preflight** the remote site (check connectivity, detect WordPress version and hosting environment)
+2. **Download all files** (themes, plugins, uploads, core) into `--fs-root`
+3. **Download the database** as a SQL dump
+4. **Generate server config** for PHP's built-in server
+5. **Start the local server** and print the URL
+
+The output looks like:
+
+```
+Pulling example.com
+
+[1/7] Preflight
+  ✓ Preflight — WordPress 6.9.4, PHP 8.4.19
+
+[2/7] Pulling files
+  [5091 files] ...wp-content/uploads/2024/photo.jpg
+  ✓ Pulling files
+
+[3/7] Pulling database
+  Downloading SQL: 4.2 MB (67.3%)
+  ✓ Pulling database
+
+[4/7] Importing database
+  db-apply: 1234 / 5678 statements (45.2%)
+  ✓ Importing database
+
+[5/7] Generating runtime
+  ✓ Generating runtime
+
+✓ Pull complete
+
+  Starting the server at http://localhost:8881
+  Press Ctrl-C to stop.
+```
+
+### Options
+
+**Database import** — add target database options and reprint will also import the SQL with URL rewriting:
+
+```bash
+# MySQL
+php reprint.phar pull https://example.com --secret=TOKEN \
+  --state-dir=./state --fs-root=./files \
+  --target-user=root --target-db=wp_local \
+  --new-site-url=http://localhost:8881
+
+# SQLite (no MySQL needed)
+php reprint.phar pull https://example.com --secret=TOKEN \
+  --state-dir=./state --fs-root=./files \
+  --target-engine=sqlite \
+  --new-site-url=http://localhost:8881
+```
+
+**Runtime** — defaults to `php-builtin` (starts a server at the end). Override with `--runtime=nginx-fpm` or `--runtime=playground-cli` for other environments.
+
+**Resume** — if interrupted, re-run the same command. It picks up where it left off. Running pull again after completion performs a delta sync (only downloads what changed).
+
+**All options** — run `php reprint.phar pull --help` for the full list.
+
+## Composer packages
+
+The exporter and importer are published as separate Composer packages:
+
+- [`wp-php-toolkit/reprint-exporter`](https://packagist.org/packages/wp-php-toolkit/reprint-exporter) — Streaming export engine (SQL dumps, file trees, cursor-based resumption).
+- [`wp-php-toolkit/reprint-importer`](https://packagist.org/packages/wp-php-toolkit/reprint-importer) — Streaming site importer with CLI and PHAR support.
+
+Install whichever you need:
+
+```bash
+composer require wp-php-toolkit/reprint-exporter
+composer require wp-php-toolkit/reprint-importer
+```
+
+Both packages depend on [`wp-php-toolkit/data-liberation`](https://packagist.org/packages/wp-php-toolkit/data-liberation) and [`wp-php-toolkit/html`](https://packagist.org/packages/wp-php-toolkit/html), which Composer pulls in automatically.
+
+## Repository layout
+
+- `packages/reprint-exporter` — Source for the `wp-php-toolkit/reprint-exporter` Composer package.
+- `packages/reprint-importer` — Source for the `wp-php-toolkit/reprint-importer` Composer package.
+- `reprint-exporter-wp` — WordPress plugin distribution that bundles `reprint-exporter`.
+- `importer/import.php` — thin compatibility wrapper for the importer package entrypoint.
+
+### Technical requirements
+
+On the **migration source** side:
+
+ - PHP 7.4+
+ - ext-json — JSON encoding/decoding
+ - ext-hash — hash_hmac, hash_equals
+ - ext-zlib — deflate_init/deflate_add for gzip streaming
+ - ext-pdo + ext-pdo_mysql — database access (already in composer.json)
+
+On the **migration target** side:
+
+ - PHP 7.4+
+ - ext-json — JSON encoding/decoding
+ - ext-hash — hash_hmac, hash_equals
+ - ext-zlib — deflate_init/deflate_add for gzip streaming
+ - ext-pdo + ext-pdo_mysql — for MySQL targets
+ - ext-pdo + ext-pdo_sqlite — for SQLite targets via sqlite-database-integration
+
+---
+
+## Integrating with a hosting platform
+
+The `pull` command is designed for developers cloning a site to their local machine. If you're building a hosting platform that migrates sites programmatically, you'll want the low-level commands instead — they give you full control over each step, exit codes for scripting, and structured JSON output for progress tracking.
+
+### Getting started
 
 Download the latest release artifacts from [GitHub Releases](../../releases):
 
@@ -49,9 +145,7 @@ can be pre-packaged with a `./reprint-exporter-wp/secret.php` file where a pre-d
 return 'MY_SECRET_STRING';
 ```
 
-## Usage
-
-### Migration walkthrough
+### Migrating the data
 
 The migration process has a few steps:
 
@@ -318,7 +412,7 @@ INI values), SiteGround, and a generic default.
 Currently supported target runtimes: nginx + PHP-FPM, PHP's built-in
 development server, and WordPress Playground CLI.
 
-#### After the migration
+#### Shoehorning the site onto your platform
 
 You've got a copy of the remote files in the `--fs-root` directory and
 the database either already applied (via `db-apply`) or in `--state-dir/db.sql`.
@@ -334,27 +428,6 @@ the same table prefix as your environment.
 If you used `--sql-output=mysql`, the SQL was already executed — there's
 no `db.sql` to import. For `--sql-output=stdout`, the SQL was piped to
 whatever tool was reading stdout (typically `mysql` CLI).
-
-### CLI reference
-
-The importer accepts the following commands:
-
-```
-php reprint.phar <command> <URL> --state-dir=DIR --fs-root=DIR [options]
-```
-
-* `preflight` — Runs the preflight check and prints the full result as JSON. Exits with code 0 if OK, code 1 if not.
-* `preflight-assert` — Runs the preflight check and prints a human-readable pass/fail summary. Exits with code 0 if migration looks feasible, code 1 if not.
-* `files-pull` — Pull all files (initial) or only changes (delta). Runs files-index if needed.
-* `files-index` — Index all remote files (initial) or detect changes (delta). No file contents downloaded.
-* `db-pull` — Pull the database as a SQL dump. Defaults to writing `db.sql`; use `--sql-output=stdout` or `--sql-output=mysql` to stream elsewhere.
-* `db-apply` — Applies `db.sql` to a target MySQL or SQLite database. Accepts `--rewrite-url FROM TO` (repeatable) to rewrite domains during import.
-* `db-domains` — Lists domains discovered in the SQL dump. Reads `.import-domains.json` if available (written by `db-pull`), otherwise scans `db.sql`.
-* `db-index` — Indexes database tables and their statistics (name, row count, size) to `db-tables.jsonl`.
-* `flat-docroot` — Reassemble pulled files into a standard WordPress directory layout using symlinks. Useful when the source site has a non-standard layout (e.g. WP Cloud with ABSPATH separate from wp-content).
-* `apply-runtime` — Generates server configuration files (`runtime.php`, `start.sh` or `nginx.conf`) from preflight data. See [Step 6](#step-6--generate-runtime-configuration).
-
-All commands except `preflight-assert` support `--abort` to abort the current sync and exit. For `files-pull`, this clears sync progress but keeps the local index and downloaded files — the next run performs a delta sync. For `db-pull` and `db-index`, it clears the output file so the next run starts from scratch. Interrupted commands automatically resume from the last saved cursor.
 
 ### Status files
 
@@ -522,381 +595,23 @@ truncated or rotated, so it provides a complete history of the migration.
 Pass `--verbose` to also print audit log entries to the console as they happen.
 This is useful for debugging but noisy for production use.
 
-## Installation
+### Low-level CLI commands
 
-### Composer packages
+The importer accepts the following commands:
 
-The exporter and importer are published as separate Composer packages:
-
-- [`wp-php-toolkit/reprint-exporter`](https://packagist.org/packages/wp-php-toolkit/reprint-exporter) — Streaming export engine (SQL dumps, file trees, cursor-based resumption).
-- [`wp-php-toolkit/reprint-importer`](https://packagist.org/packages/wp-php-toolkit/reprint-importer) — Streaming site importer with CLI and PHAR support.
-
-Install whichever you need:
-
-```bash
-composer require wp-php-toolkit/reprint-exporter
-composer require wp-php-toolkit/reprint-importer
+```
+php reprint.phar <command> <URL> --state-dir=DIR --fs-root=DIR [options]
 ```
 
-Or add them to your `composer.json`:
-
-```json
-{
-    "require": {
-        "wp-php-toolkit/reprint-exporter": "dev-main",
-        "wp-php-toolkit/reprint-importer": "dev-main"
-    }
-}
-```
-
-Both packages depend on [`wp-php-toolkit/data-liberation`](https://packagist.org/packages/wp-php-toolkit/data-liberation) and [`wp-php-toolkit/html`](https://packagist.org/packages/wp-php-toolkit/html), which Composer pulls in automatically.
-
-### Technical requirements
-
-On the **migration source** side:
-
- - PHP 7.4+
- - ext-json — JSON encoding/decoding
- - ext-hash — hash_hmac, hash_equals
- - ext-zlib — deflate_init/deflate_add for gzip streaming
- - ext-pdo + ext-pdo_mysql — database access (already in composer.json)
-
-On the **migration target** side:
-
- - PHP 7.4+
- - ext-json — JSON encoding/decoding
- - ext-hash — hash_hmac, hash_equals
- - ext-zlib — deflate_init/deflate_add for gzip streaming
- - ext-pdo + ext-pdo_mysql — for MySQL targets
- - ext-pdo + ext-pdo_sqlite — for SQLite targets via sqlite-database-integration
-
-### Repository layout
-
-- `packages/reprint-exporter` — Source for the `wp-php-toolkit/reprint-exporter` Composer package.
-- `packages/reprint-importer` — Source for the `wp-php-toolkit/reprint-importer` Composer package.
-- `reprint-exporter-wp` — WordPress plugin distribution that bundles `reprint-exporter`.
-- `importer/import.php` — thin compatibility wrapper for the importer package entrypoint.
-
-## Architecture
-
-### File synchronization
-
-#### Synchronization approach
-
-The system is designed to perform an initial directory tree synchronization followed by incremental updates.
-
-**Initial synchronization** is when the **migration target** requests a stream of files from the **migration source**
-without having any prior state. The migration target sends an HTTP request to the migration source and asks to start
-a new synchronization of one or more root directory paths. The migration source responds immediately with a multipart
-stream and a cursor for resumption. All subsequent requests are stateless and use the cursor only.
-
-The migration target then sends a HTTP request asking for the next batch of files. The migration source immediately starts
-streaming the requested directory trees using pre-order traversal. The HTTP response is a multipart/mixed data stream listing
-every file, symlink, and an empty directory in the requested root directory. Every chunk carries file metadata, content bytes
-of the file, and a cursor pointing to the next chunk.
-
-The **migration source** keeps track of two resource budgets: memory and execution time limit. Once it starts approaching
-either of them, it ends the response and the migration target needs to send another HTTP request. This means, the initial
-synchronization request will most likely be concluded before all the files are transferred.
-
-Once the first HTTP request is completed, the migration target sends another HTTP request to the migration source asking for the next
-batch of files. It provides the cursor from the previous response. The migration source then responds
-with the next batch of files. This repeats until the initial synchronization is complete.
-
-#### Synchronization Cursor
-
-The cursor consists of the file path, ctime, and byte offset. When provided, the migration source will resume the traversal
-from the given point. If the cursor is not provided, the migration source will stream from the beginning of the first requested
-root directory.
-
-`ctime` is not strictly required for traversal, but the migration source can use it to tell if the streamed file has been modified
-since the last synchronization. If it has, the migration source will communicate that via a dedicated multipart chunk and move on to
-the next file.
-
-#### Migration index
-
-As the migration target receives files from the migration source, it builds a local index of all the paths, ctimes, and filesizes
-it has seen. The on-disk index is a sorted JSON-lines file, where each line is a JSON object containing `path`, `ctime`, `size`,
-and `type`. This lets us safely store any filename (including tabs and newlines) without escaping hacks. Later on, we use this index
-for incremental synchronization to get files changed since the last sync.
-Here's how that works now:
-
-1. The migration target requests an **index-only** stream from the migration source and stores it locally. The index batches are JSON arrays.
-2. The migration target advances through both lists (local index and remote index file) using a two-pointer diff:
-   - Deletes local files that no longer exist remotely.
-   - Builds a download list for new/changed files.
-3. The migration target uploads the download list to the migration source and streams just those files.
-
-This keeps the server stateless, keeps all large lists streamed (no full buffering), and guarantees ordering using `strcmp`-equivalent
-binary collation on both sides.
-
-What we **don't** do:
-
-* Upload the local index to the server for diffing. An earlier 
-  version did this, but it increased the complexity, the 
-  resource requirements on the other end, and some variants of
-  it required keeping a local state on the remote site which is
-  undesirable.
-
-#### Directory listing order
-
-The file index is produced by traversing directories depth-first. Each directory's immediate entries are sorted in bytewise
-lexicographic order (equivalent to `strcmp` with `LC_ALL=C`). When a directory entry is encountered, that directory entry is
-emitted, and then we descend into it before moving to the next sibling entry. This makes the output deterministic while keeping
-the cursor small and resumable.
-
-What we **don't** do:
-
-* Breadth-first traversal. It is tempting, as we can just get to a directory, scan it, emit all its children, and move on to the next directory.
-  It could be significantly faster in case we'd ever see xxx,xxx subfolders in a directory. With the depth-first traversal, every time we pause
-  and resume on the next request, we'll have to sort those xxx,xxx subfolders. We're talking about 0-3 seconds on every such request, which may
-  not be a big deal for a site of this size. It's still worth describing here, thought. The problem with breadth-first traversal is reentrancy.
-  We'd need to keep the directories we've already seen but haven't yet traversed across the entire tree level. We'd keep them in memory and,
-  potentially, in the cursor. That could take up some space!
-* Stream sorting either inside PHP or via a shell call to `find ./ | sort`. While it would use less memory, the PHP version would be noticeably
-  slower and more complex. The shell call would also slow down the entire process because of its sheer overhead when listing 99% of the typical
-  smaller directories. Furthermore, we could never be sure whether the shell call results can be trusted – find and sort could differ between
-  runtimes to the point where some runtimes replace them with stubs. PHP functions are much more portable. Large sites should have large memory
-  banks. If they don't, then we can revisit the stream-sorting approach.
-* Order the traversal by `(ctime, filename)`. It wouldn't save us much work, as we'd still need to run a full scan of the filesystem
-  on every incremental synchronization to detect deletions. On top of that, it is impractical. First, you need to always sort the
-  entire directory tree by ctime before you can start streaming the data. That may take some time and HTTP requests in PHP land. Second,
-  there is no clear stop for the traversal. Any file that keeps changing will keep moving to the end of the queue, and meanwhile the files
-  we have already seen may also get their ctime updated.
-* Use a `DirectoryListing` abstraction class. We tried one and removed it — plain `scandir()` is simpler
-  and the abstraction added complexity without benefit.
-
-#### Volatile files
-
-Sometimes a file will keep changing every minute and we'll start streaming it, but won't finish before it's modified again. In that case,
-the **migration target** chooses how to handle it. A few choices are:
-
-* Stop the migration, tell the user we can't migrate this file (or multiple files).
-* Stop the migration, ask the user if that file is okay to ignore. Chances are it's a log, a cache, or some other volatile artifact
-  that doesn't matter that much.
-* Retry a few more times.
-* Just ignore that file (and tell the user).
-
-#### Symlink handling
-
-Symlinks are automatically recreated during import. The importer receives symlink chunks from the
-export stream and calls `symlink()` to recreate them locally. This is safe because all paths are
-constrained to the `--fs-root` directory.
-
-Some symlinks may point to places on the remote filesystem that are
-outside of the requested directory root. By default, the importer
-follows these symlinks — it asks the server to expand them into real
-files and recreates the symlink structure locally, constrained within
-the `--fs-root`.
-
-To disable this behavior, pass `--no-follow-symlinks`. Symlinks pointing
-outside the directory root will then be skipped instead of followed.
-
-##### Server-side cycle detection
-
-Hosting environments like WP.com Atomic can have symlink structures that create
-infinite traversal loops — for example, `/srv/htdocs/srv` symlinked back to `/srv`,
-or overlapping roots where `/wordpress/` and `/srv/htdocs/wordpress/` resolve to
-the same physical directory.
-
-The exporter handles this at the source. During directory traversal, every
-directory's `realpath()` is checked against the configured roots using
-`should_skip_index_root()`. If the directory is a duplicate or parent of an
-already-scheduled root, traversal skips it. This catches cycles, overlapping roots,
-and version aliases in a single check, preventing the index from exploding with
-duplicate entries.
-
-### Database synchronization
-
-#### SQL dump approach
-
-MySQLDumpProducer generates SQL dumps in batches (default 250 rows per INSERT statement) with cursor-based
-resumption. The dump is standard SQL — `DROP TABLE IF EXISTS`, `CREATE TABLE`, and multi-row `INSERT`
-statements — directly importable with `mysql` CLI or any standard tool.
-
-The cursor tracks the last row processed using either the primary key,
-when available, or offset otherwise.
-
-#### Primary key strategies
-
-The producer handles three scenarios:
-
-* **Simple PK**: Uses the last PK value as cursor. Resumption is a simple `WHERE pk > value`.
-* **Composite PK**: Uses all PK columns in the cursor. Resumption uses a tuple comparison.
-* **No PK**: Falls back to OFFSET-based pagination. This is slower (MySQL must skip rows on each resume)
-  but is the only option when there's no stable key to anchor the cursor.
-
-#### Oversized rows
-
-Rows whose encoded size exceeds the statement size limit need special handling. With a primary key,
-the producer skips the oversized row and advances the cursor past it — the row is lost but the dump
-can continue. Without a primary key, the producer fails entirely. OFFSET-based pagination can't reliably
-skip a single row without risking data loss, so failing loudly is the safer choice.
-
-#### Binary and string data encoding
-
-Binary and string column data is encoded as base64 in the SQL dump (wrapped in `FROM_BASE64()`). Earlier iterations
-tried raw hex encoding and escaped binary. Base64 was chosen as the
-most conscise option.
-
-#### Statement size negotiation
-
-The client detects its local MySQL's `max_allowed_packet`, sends it to the server via the
-`--max-allowed-packet` option, and the server caps SQL statements at `min(client, server) * 0.8`.
-This prevents the dump from producing statements the migration target MySQL can't execute.
-
-What we **don't** do:
-
-* Transmit data as JSON or a binary serialization format and reconstruct SQL locally. This would add
-  complexity and make the REST endpoints harder to debug. The SQL-over-HTTP approach means the dump
-  is directly importable with standard MySQL tools. Still, it would
-  be a nice optional feature to add.
-
-### Authentication
-
-Every request is authenticated with HMAC signatures computed based on the request data and
-a shared secret. If the signature doesn't match the remote site's expectations, it refuses
-to process the request. The HTTP responses are assumed to be trusted and don't expose any HMAC.
-They couldn't do it easily anyway, since the response body is streamed and not known upfront.
-
-### Error handling
-
-Streaming endpoints use try/catch with error chunks embedded inline in the multipart stream. When something
-goes wrong mid-response, the client sees the error as another multipart chunk rather than the default PHP 
-output such as "Fatal Error". Global error and shutdown handlers.
-
-### Resource management
-
-We need to be careful about the resource usage or we risk web hosts blocking us.
-
-Most WordPress sites are on low-end servers and have limited resources at their disposal.
-Some hosts monitor the usage and block sites that use too much CPU or memory. Since we're using
-PHP as a site export backend, we'll naturally use more resources than we'd need if we did it over SSH.
-We need to use network connections and block PHP workers, we need to run PHP programs that are slower
-than their C counterparts, and so on.
-
-This is why we're budgeting our resource usage in a few ways:
-
-* Execution time limit on the remote host – it gracefully ends the request once we exceed the budget.
-* Memory usage limit on the remote host – it gracefully ends the request once we exceed the budget.
-* Request backoff to make space for other requests
-* Per-endpoint size caps and adaptive sizing, since files, indexing, and SQL have different cost profiles.
-
-The exporter almost always uses the full server time budget, so the tuner does not try to make responses
-shorter. Instead it measures server-reported runtime plus the amount of work done (bytes streamed, index
-entries emitted, SQL bytes dumped), keeps a throughput EMA per endpoint, and applies an AIMD loop: small
-additive increases when throughput is stable, and multiplicative decreases when throughput drops. This
-lets fast hosts grow steadily while slow hosts back off quickly.
-
-We also detect likely buffering (TTFB ≈ server runtime) and enter a conservative mode that clamps maximum
-sizes. Any non-2xx/3xx response or timeout triggers error backoff and an immediate size cut. Separately, a
-duty-cycle sleep (with jitter) spaces requests so we don't monopolize PHP workers or synchronize multiple
-migrations on the same host.
-
-At the start of each run the importer performs a cheap preflight request. It records PHP and MySQL versions,
-memory limits, filesystem accessibility, and database charset/collation in the audit log and state file so
-we have context when debugging slow hosts or permission issues.
-
-What we **don't** do:
-
-* Use usleep on the exporting side. We could spread the CPU usage over time with something
-  like `while(!$done) { small_unit_of_work(); usleep($some_time); }`, but that would hold a PHP worker busy for longer.
-  Some hosts only run **two** PHP workers. Introducing a `usleep()` would keep one of them busy for longer,
-  making the site availability strangled for longer. Instead, we try to use shorter requests that do less work,
-  and use a client-side waiting strategy between those requests.
-* Tune based on client download time or wall-clock time. The client might be slower than the server, or a fast
-  connection could hide server pressure. We only tune based on server-reported runtime and the amount of work
-  done (bytes streamed, index entries emitted, SQL bytes dumped).
-* Aim for a fixed target runtime. The exporter almost always runs until its time budget expires, so the meaningful
-  signal is throughput under that budget, not how close we got to an arbitrary time goal.
-
-### Transport
-
-Data is sent over HTTP using multipart/mixed content-type. It gives us a way to split large files into chunks and send
-them over multiple requests, while transmitting per-chunk metadata (cursor, chunk size, etc.).
-
-Why not ZIP or TAR? Because:
-
-* We need to split large files into chunks, and there is no native way of expressing "this entry is a chunk
-  of a larger file" in ZIP or TAR.
-* We could treat the entire export as a single, huge data stream split over multiple requests and assume that
-  a single zip/tar entry, no matter how large, is always a single file. However, we wouldn't have a good way of
-  knowing we've lost some bytes from the middle of the stream – at least until we've transferred the entire file.
-* We wouldn't have a good way of sending the cursor to the client. Where would it come in the stream?
-
-Why not the git protocol? We're effectively exchanging diffs here. Git already does that. But git can't
-recover from a broken exchange — you need to start from scratch. Also, the git protocol is complex.
-Multipart is simple and native to HTTP clients.
-
-## Known Limitations
-
-### Multisite
-
-WordPress Multisite networks are all-or-nothing. You can't export a single
-site from a multisite network — the export includes the entire database and
-filesystem, which covers all sites in the network. There is no mechanism to
-filter tables or uploads by blog ID.
-
-### File permissions and ownership
-
-File ownership (`chown`) and permissions (`chmod`) are not preserved during
-export. All files are written with the default ownership and permissions of
-the importing process. You need to set the correct ownership and permissions
-on your hosting platform after import.
-
-### Tables without primary keys
-
-For tables without a primary key, two things happen. First, the producer uses
-OFFSET-based pagination, which is vulnerable to drift: if rows are inserted or
-deleted during the export, you'll get duplicated or missing rows. Second,
-oversized rows in PK-less tables cause a hard failure — the producer throws an
-exception because it has no stable row identifier for the chunked
-`UPDATE ... CONCAT()` fallback. WordPress core tables all have primary keys,
-but plugin-created tables frequently don't — logging tables, analytics tables,
-queue tables, and custom relationship tables are common offenders.
-
-### Views, Triggers, Stored Procedures, Events, and Functions
-
-Only table data is exported. MySQL views, triggers, stored procedures,
-scheduled events, and user-defined functions are not included in the export.
-
-### No consistency guarantee between files and database
-
-The migration is a multi-step process: download files, then download the
-database, then download a file delta. But there's no point-in-time snapshot.
-The database dump starts after the file sync begins, meaning the database may
-reference uploaded media files that changed or were deleted during the file
-sync window. On active sites (e-commerce stores processing orders, membership
-sites, forums), this race condition can produce a fundamentally inconsistent
-state — the database references files that don't exist, or files exist that
-the database doesn't know about. For sites with significant write traffic,
-consider freezing writes or enabling maintenance mode during the migration.
-
-## Development
-
-### Submodule
-
-The MySQL lexer and parser live in the [sqlite-database-integration](https://github.com/WordPress/sqlite-database-integration) repository, pulled in as a git submodule at `lib/sqlite-database-integration/`. After cloning, run:
-
-```bash
-composer install
-```
-
-To update the submodule to the latest upstream commit:
-
-```bash
-git submodule update --remote lib/sqlite-database-integration
-```
-
-### Tests
-
-```bash
-composer test            # Run all PHPUnit tests
-composer test:fast       # Skip large dataset tests
-composer test:large      # Run only large dataset tests
-composer analyze         # Run PHPStan static analysis
-```
-
-### E2E tests
-
-See [tests/e2e/](tests/e2e/) for the full end-to-end test setup.
+* `preflight` — Runs the preflight check and prints the full result as JSON. Exits with code 0 if OK, code 1 if not.
+* `preflight-assert` — Runs the preflight check and prints a human-readable pass/fail summary. Exits with code 0 if migration looks feasible, code 1 if not.
+* `files-pull` — Pull all files (initial) or only changes (delta). Runs files-index if needed.
+* `files-index` — Index all remote files (initial) or detect changes (delta). No file contents downloaded.
+* `db-pull` — Pull the database as a SQL dump. Defaults to writing `db.sql`; use `--sql-output=stdout` or `--sql-output=mysql` to stream elsewhere.
+* `db-apply` — Applies `db.sql` to a target MySQL or SQLite database. Accepts `--rewrite-url FROM TO` (repeatable) to rewrite domains during import.
+* `db-domains` — Lists domains discovered in the SQL dump. Reads `.import-domains.json` if available (written by `db-pull`), otherwise scans `db.sql`.
+* `db-index` — Indexes database tables and their statistics (name, row count, size) to `db-tables.jsonl`.
+* `flat-docroot` — Reassemble pulled files into a standard WordPress directory layout using symlinks. Useful when the source site has a non-standard layout (e.g. WP Cloud with ABSPATH separate from wp-content).
+* `apply-runtime` — Generates server configuration files (`runtime.php`, `start.sh` or `nginx.conf`) from preflight data. See [Step 6](#step-6--generate-runtime-configuration).
+
+All commands except `preflight-assert` support `--abort` to abort the current sync and exit. For `files-pull`, this clears sync progress but keeps the local index and downloaded files — the next run performs a delta sync. For `db-pull` and `db-index`, it clears the output file so the next run starts from scratch. Interrupted commands automatically resume from the last saved cursor.

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -1815,9 +1815,7 @@ class ImportClient
                 break;
         }
 
-        if ($this->is_tty && !$this->verbose_mode) {
-            fwrite($this->progress_fd, "State cleared for {$command}.\n");
-        }
+        $this->progress->show_lifecycle_line("State cleared for {$command}.\n");
 
         $this->output_progress(["status" => "aborted", "message" => "State cleared for {$command}."]);
     }
@@ -2837,9 +2835,7 @@ class ImportClient
             $this->state["stage"] = "index";
             $this->save_state($this->state);
             $this->audit_log("START files-index", true);
-            if ($this->is_tty && !$this->verbose_mode) {
-                fwrite($this->progress_fd, "Starting files-index\n");
-            }
+            $this->progress->show_lifecycle_line("Starting files-index\n");
             $this->output_progress([
                 "type" => "lifecycle",
                 "event" => "starting",
@@ -2855,9 +2851,7 @@ class ImportClient
                 ),
                 true,
             );
-            if ($this->is_tty && !$this->verbose_mode) {
-                fwrite($this->progress_fd, "Resuming files-index\n");
-            }
+            $this->progress->show_lifecycle_line("Resuming files-index\n");
             $this->output_progress([
                 "type" => "lifecycle",
                 "event" => "resuming",
@@ -2926,11 +2920,9 @@ class ImportClient
             true,
         );
 
-        if ($this->is_tty && !$this->verbose_mode) {
-            fwrite($this->progress_fd, "files-index complete: {$count} entries indexed\n");
-            fwrite($this->progress_fd, "Remote index: {$this->remote_index_file}\n");
-            fwrite($this->progress_fd, "Audit log: {$this->audit_log}\n");
-        }
+        $this->progress->show_lifecycle_line("files-index complete: {$count} entries indexed\n");
+        $this->progress->show_lifecycle_line("Remote index: {$this->remote_index_file}\n");
+        $this->progress->show_lifecycle_line("Audit log: {$this->audit_log}\n");
         $this->output_progress([
             "type" => "lifecycle",
             "event" => "complete",
@@ -5305,9 +5297,7 @@ class ImportClient
             $this->save_state($this->state);
 
             $this->audit_log("START db-index", true);
-            if ($this->is_tty && !$this->verbose_mode) {
-                fwrite($this->progress_fd, "Starting db-index\n");
-            }
+            $this->progress->show_lifecycle_line("Starting db-index\n");
             $this->output_progress([
                 "type" => "lifecycle",
                 "event" => "starting",
@@ -5322,9 +5312,7 @@ class ImportClient
                 ),
                 true,
             );
-            if ($this->is_tty && !$this->verbose_mode) {
-                fwrite($this->progress_fd, "Resuming db-index\n");
-            }
+            $this->progress->show_lifecycle_line("Resuming db-index\n");
             $this->output_progress([
                 "type" => "lifecycle",
                 "event" => "resuming",
@@ -5347,11 +5335,9 @@ class ImportClient
             true,
         );
 
-        if ($this->is_tty && !$this->verbose_mode) {
-            fwrite($this->progress_fd, "db-index complete: {$tables} tables\n");
-            fwrite($this->progress_fd, "Table stats: {$tables_file}\n");
-            fwrite($this->progress_fd, "Audit log: {$this->audit_log}\n");
-        }
+        $this->progress->show_lifecycle_line("db-index complete: {$tables} tables\n");
+        $this->progress->show_lifecycle_line("Table stats: {$tables_file}\n");
+        $this->progress->show_lifecycle_line("Audit log: {$this->audit_log}\n");
         $this->output_progress([
             "type" => "lifecycle",
             "event" => "complete",
@@ -10221,12 +10207,10 @@ class ImportClient
             true,
         );
 
-        if ($this->is_tty && !$this->verbose_mode) {
-            fwrite($this->progress_fd, "\nInterrupted - saving state...\n");
-            fwrite($this->progress_fd, "  Command: {$current_command}\n");
-            fwrite($this->progress_fd, "  Total files indexed: {$indexed}\n");
-            fwrite($this->progress_fd, "  Files completed in this run: {$files_imported}\n");
-        }
+        $this->progress->show_lifecycle_line("\nInterrupted - saving state...\n");
+        $this->progress->show_lifecycle_line("  Command: {$current_command}\n");
+        $this->progress->show_lifecycle_line("  Total files indexed: {$indexed}\n");
+        $this->progress->show_lifecycle_line("  Files completed in this run: {$files_imported}\n");
         $this->output_progress([
             "type" => "interrupt",
             "command" => $current_command,
@@ -10238,9 +10222,7 @@ class ImportClient
         // Save current state (with timeout protection)
         try {
             $this->save_state($this->state);
-            if ($this->is_tty && !$this->verbose_mode) {
-                fwrite($this->progress_fd, "✓ State saved successfully\n");
-            }
+            $this->progress->show_lifecycle_line("✓ State saved successfully\n");
             $this->output_progress([
                 "type" => "state_saved",
                 "message" => "State saved successfully",
@@ -10249,9 +10231,7 @@ class ImportClient
             fwrite($this->progress_fd, "Warning: Failed to save state: " . $e->getMessage() . "\n");
         }
 
-        if ($this->is_tty && !$this->verbose_mode) {
-            fwrite($this->progress_fd, "Exiting...\n");
-        }
+        $this->progress->show_lifecycle_line("Exiting...\n");
 
         // CRITICAL: Use SIGKILL for immediate termination
         // Regular exit() hangs because PHP's shutdown sequence tries to

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -46,6 +46,9 @@ require_once __DIR__ . '/lib/external-merge-sort.php';
 // Terminal progress rendering (spinner, progress lines, lifecycle messages)
 require_once __DIR__ . '/lib/terminal-progress/class-terminal-progress.php';
 
+// Pull command — orchestrates the lower-level commands into a pipeline
+require_once __DIR__ . '/lib/pull/class-pull.php';
+
 /**
  * The wire-protocol version this importer speaks.
  *
@@ -846,13 +849,13 @@ class ImportClient
     private const MAX_CONSECUTIVE_TIMEOUTS = 3;
 
     /** @var string Export server URL. */
-    private $remote_url;
+    public $remote_url;
 
     /** @var string Directory for import state files (.import-state.json, db.sql, etc.). */
-    private $state_dir;
+    public $state_dir;
 
     /** @var string Directory where downloaded site files are written (no filesystem-root/ wrapper). */
-    private $fs_root;
+    public $fs_root;
 
     /** @var string Path to .import-state.json — persists command, cursor, stage across invocations. */
     private $state_file;
@@ -927,9 +930,6 @@ class ImportClient
     /** @var bool Whether stdout is a TTY (enables interactive progress display). */
     private $is_tty;
 
-    /** @var TerminalProgress Renders progress and lifecycle output to the terminal. */
-    private TerminalProgress $progress;
-
     /** @var int Running count of files imported in the current invocation. */
     private $files_imported = 0;
 
@@ -949,7 +949,7 @@ class ImportClient
      * max_allowed_packet, db_index, file_index.
      * @var array|null
      */
-    private $state;
+    public $state;
 
     /** @var int Chunks processed since last state save — triggers periodic persistence. */
     private $chunks_since_save = 0;
@@ -964,14 +964,6 @@ class ImportClient
      * across invocations.
      */
     private $follow_symlinks = true;
-
-    /**
-     * Memoized lookups for "does remote index contain this path or any descendant path?"
-     * keyed by normalized absolute path.
-     *
-     * @var array<string,bool>
-     */
-    private $remote_index_prefix_cache = [];
 
     /**
      * @var string Controls behavior when the fs root is non-empty at import start.
@@ -1029,6 +1021,15 @@ class ImportClient
 
     /** @var string|null Machine-readable error code from the last diagnose_http_error() call. */
     public $last_error_code = null;
+
+    /** @var TerminalProgress Renders progress and lifecycle output to the terminal. */
+    private TerminalProgress $progress;
+
+    /** @var Pull Orchestrates the pull command pipeline. */
+    private Pull $pull;
+
+    /** @var int Cumulative count of index entries written (survives retries). */
+    private $index_entries_counted = 0;
 
     /** @var int|null Current step in a multi-step pipeline (1-indexed). Set via --step. */
     private $pipeline_step = null;
@@ -1090,6 +1091,7 @@ class ImportClient
         $this->is_tty = function_exists("posix_isatty") && posix_isatty(STDOUT);
         $this->progress_fd = STDOUT;
         $this->progress = new TerminalProgress($this->is_tty, $this->progress_fd);
+        $this->pull = new Pull($this, $this->progress);
 
         // Register signal handlers for graceful shutdown
         if (function_exists("pcntl_signal")) {
@@ -1117,7 +1119,7 @@ class ImportClient
     /**
      * Return current index size.
      */
-    private function index_count(): int
+    public function index_count(): int
     {
         if (!is_file($this->index_file)) {
             return 0;
@@ -1173,7 +1175,7 @@ class ImportClient
      * @param string $message Message to log
      * @param bool $to_console Whether to also output to console (respects verbose mode)
      */
-    private function audit_log(string $message, bool $to_console = true): void
+    public function audit_log(string $message, bool $to_console = true): void
     {
         $timestamp = date("Y-m-d H:i:s");
         $log_line = "[{$timestamp}] {$message}\n";
@@ -1185,6 +1187,31 @@ class ImportClient
         if ($to_console && $this->verbose_mode) {
             fwrite($this->progress_fd, $log_line);
         }
+    }
+
+    /**
+     * Apply a mutation to the state and persist it. Used by orchestrator
+     * commands (Pull) that need to update multiple fields atomically.
+     */
+    public function mutate_state(callable $mutator): void
+    {
+        $this->state = $mutator($this->state);
+        $this->save_state($this->state);
+    }
+
+    /** Mark a pull pipeline stage as completed in state. */
+    public function mark_pull_stage_complete(string $stage): void
+    {
+        $this->state['pull']['stage'] = $stage;
+        $this->save_state($this->state);
+    }
+
+    /** Mark the pull pipeline as fully complete in state. */
+    public function mark_pull_complete(): void
+    {
+        $this->state['pull']['stage'] = 'complete';
+        $this->state['status'] = 'complete';
+        $this->save_state($this->state);
     }
 
     /**
@@ -1358,12 +1385,13 @@ class ImportClient
 
         if (!$command) {
             throw new InvalidArgumentException(
-                "Command is required. Valid commands: files-pull, files-index, files-stats, db-pull, db-index, db-domains, db-apply, preflight, preflight-assert, flat-docroot, apply-runtime",
+                "Command is required. Valid commands: pull, files-pull, files-index, files-stats, db-pull, db-index, db-domains, db-apply, preflight, preflight-assert, flat-docroot, apply-runtime",
             );
         }
 
         if (
             !in_array($command, [
+                "pull",
                 "files-pull",
                 "files-index",
                 "db-pull",
@@ -1378,7 +1406,7 @@ class ImportClient
             ])
         ) {
             throw new InvalidArgumentException(
-                "Invalid command: {$command}. Valid commands: files-pull, files-index, files-stats, db-pull, db-index, db-domains, db-apply, preflight, preflight-assert, flat-docroot, apply-runtime",
+                "Invalid command: {$command}. Valid commands: pull, files-pull, files-index, files-stats, db-pull, db-index, db-domains, db-apply, preflight, preflight-assert, flat-docroot, apply-runtime",
             );
         }
 
@@ -1524,6 +1552,27 @@ class ImportClient
                 );
             }
             $this->hmac_client = new \Site_Export_HMAC_Client($options["secret"]);
+        }
+
+        // pull orchestrates the full pipeline (preflight → files → db → apply)
+        // internally, so it must run before the normal command dispatch.
+        if ($command === "pull") {
+            if ($abort) {
+                $this->pull->abort();
+                return;
+            }
+            try {
+                $this->pull->run($options);
+            } catch (\Exception $e) {
+                $this->output_progress([
+                    "status" => "error",
+                    "error" => $e->getMessage(),
+                    "message" => "Error: " . $e->getMessage(),
+                ]);
+                $this->write_status_file($e->getMessage());
+                throw $e;
+            }
+            return;
         }
 
         // preflight and preflight-assert run the preflight themselves and
@@ -1766,7 +1815,9 @@ class ImportClient
                 break;
         }
 
-        $this->progress->show_lifecycle_line("State cleared for {$command}.\n");
+        if ($this->is_tty && !$this->verbose_mode) {
+            fwrite($this->progress_fd, "State cleared for {$command}.\n");
+        }
 
         $this->output_progress(["status" => "aborted", "message" => "State cleared for {$command}."]);
     }
@@ -1797,7 +1848,7 @@ class ImportClient
     /**
      * Run a cheap preflight check to record exporter environment details.
      */
-    private function run_preflight(): void
+    public function run_preflight(): void
     {
         $url = $this->build_url("preflight", null, []);
         $this->audit_log("PREFLIGHT REQUEST | {$url}", false);
@@ -2356,7 +2407,7 @@ class ImportClient
      *
      * Both modes share the same pipeline: index → diff → fetch.
      */
-    private function run_files_sync(): void
+    public function run_files_sync(): void
     {
         $state_command = $this->state["command"] ?? null;
         $current_status =
@@ -2454,7 +2505,10 @@ class ImportClient
 
         // Resuming an in-progress sync
         if ($has_progress) {
-            $this->files_imported = 0;
+            // Don't reset files_imported here — it counts files within
+            // the current batch and is only reset when a batch completes
+            // (in download_files_from_list). Resetting it on entry would
+            // cause the progress counter to dip between pull retries.
             $index_size = $this->index_count();
 
 
@@ -2643,6 +2697,23 @@ class ImportClient
             $this->state["stage"] = $stage;
             $this->save_state($this->state);
 
+            // In pull mode, finalize the scanning line with a checkmark
+            // and start the download progress on a fresh line.
+            if ($has_downloads && $this->progress->is_quiet_lifecycle()) {
+                $green = "\033[32m";
+                $dim = "\033[2m";
+                $r = "\033[0m";
+                $scanned = number_format($this->index_entries_counted);
+                $this->progress->clear_progress_line();
+                $this->progress->print_line("  {$green}✓{$r} Scanned {$dim}— {$scanned} entries{$r}\n");
+                $total = $this->count_newlines($this->download_list_file);
+                $this->progress->set_active_label(null);
+                $this->progress->show_progress_line(
+                    "Downloading — 0 / " . number_format($total) . " files",
+                    0.0
+                );
+            }
+
             if (!$has_downloads && file_exists($this->download_list_file)) {
                 @unlink($this->download_list_file);
                 $this->audit_log(
@@ -2766,7 +2837,9 @@ class ImportClient
             $this->state["stage"] = "index";
             $this->save_state($this->state);
             $this->audit_log("START files-index", true);
-            $this->progress->show_lifecycle_line("Starting files-index\n");
+            if ($this->is_tty && !$this->verbose_mode) {
+                fwrite($this->progress_fd, "Starting files-index\n");
+            }
             $this->output_progress([
                 "type" => "lifecycle",
                 "event" => "starting",
@@ -2782,7 +2855,9 @@ class ImportClient
                 ),
                 true,
             );
-            $this->progress->show_lifecycle_line("Resuming files-index\n");
+            if ($this->is_tty && !$this->verbose_mode) {
+                fwrite($this->progress_fd, "Resuming files-index\n");
+            }
             $this->output_progress([
                 "type" => "lifecycle",
                 "event" => "resuming",
@@ -2851,9 +2926,11 @@ class ImportClient
             true,
         );
 
-        $this->progress->show_lifecycle_line("files-index complete: {$count} entries indexed\n");
-        $this->progress->show_lifecycle_line("Remote index: {$this->remote_index_file}\n");
-        $this->progress->show_lifecycle_line("Audit log: {$this->audit_log}\n");
+        if ($this->is_tty && !$this->verbose_mode) {
+            fwrite($this->progress_fd, "files-index complete: {$count} entries indexed\n");
+            fwrite($this->progress_fd, "Remote index: {$this->remote_index_file}\n");
+            fwrite($this->progress_fd, "Audit log: {$this->audit_log}\n");
+        }
         $this->output_progress([
             "type" => "lifecycle",
             "event" => "complete",
@@ -3215,7 +3292,7 @@ class ImportClient
      * - If db.sql missing but state says complete: warn and require --abort flag
      * - Otherwise: error
      */
-    private function run_db_sync(): void
+    public function run_db_sync(): void
     {
         $state_command = $this->state["command"] ?? null;
         $sql_file = $this->state_dir . "/db.sql";
@@ -3564,6 +3641,24 @@ class ImportClient
         echo json_encode($result, JSON_PRETTY_PRINT) . "\n";
     }
 
+
+    /**
+     * Format a byte count into a human-readable string.
+     */
+    private function format_bytes(int $bytes): string
+    {
+        if ($bytes >= 1073741824) {
+            return sprintf("%.1f GB", $bytes / 1073741824);
+        }
+        if ($bytes >= 1048576) {
+            return sprintf("%.1f MB", $bytes / 1048576);
+        }
+        if ($bytes >= 1024) {
+            return sprintf("%.1f KB", $bytes / 1024);
+        }
+        return "{$bytes} B";
+    }
+
     /**
      * Generate runtime configuration for the imported site.
      *
@@ -3581,7 +3676,7 @@ class ImportClient
      * pass the flattened directory as --fs-root directly and the prefix
      * is not applied.
      */
-    private function run_apply_runtime(array $options): void
+    public function run_apply_runtime(array $options): void
     {
         $runtime = $options["runtime"] ?? null;
         if (empty($runtime)) {
@@ -3826,15 +3921,17 @@ class ImportClient
             "message" => "apply-runtime complete (runtime: {$runtime})",
         ]);
 
-        fwrite(STDERR, "\n");
-        fwrite(STDERR, "Runtime: {$runtime}\n");
-        fwrite(STDERR, "Source host: {$webhost}\n");
-        if ($target_engine !== null) {
-            fwrite(STDERR, "Target database: {$target_engine}\n");
-        }
-        fwrite(STDERR, "\n");
-        foreach ($summary as $line) {
-            fwrite(STDERR, "{$line}\n");
+        if (!$this->progress->is_quiet_lifecycle()) {
+            fwrite(STDERR, "\n");
+            fwrite(STDERR, "Runtime: {$runtime}\n");
+            fwrite(STDERR, "Source host: {$webhost}\n");
+            if ($target_engine !== null) {
+                fwrite(STDERR, "Target database: {$target_engine}\n");
+            }
+            fwrite(STDERR, "\n");
+            foreach ($summary as $line) {
+                fwrite(STDERR, "{$line}\n");
+            }
         }
     }
 
@@ -3946,7 +4043,7 @@ class ImportClient
      * If a path that should be a symlink is a regular file/directory,
      * the command stops with an error unless --force is specified.
      */
-    private function run_flat_document_root(array $options): void
+    public function run_flat_document_root(array $options): void
     {
         $flatten_to = $options["flatten_to"] ?? null;
         if (empty($flatten_to)) {
@@ -4288,7 +4385,10 @@ class ImportClient
             "refreshed" => $refreshed,
             "force_replaced" => $forced,
         ];
-        fwrite($this->progress_fd, json_encode($result) . "\n");
+        if (!$this->progress->is_quiet_lifecycle()) {
+            fwrite($this->progress_fd, json_encode($result) . "\n");
+        }
+        $this->output_progress(array_merge(["type" => "flat_docroot_complete"], $result));
     }
 
     /**
@@ -4616,7 +4716,6 @@ class ImportClient
             $target_db = $options["target_db"] ?? "sqlite_database";
 
             if (!$target_path) {
-                fwrite(STDERR, "[db-apply] No --target-sqlite-path specified");
                 $content_dir = rtrim(
                     $this->state["preflight"]["data"]["database"]["wp"]["paths_urls"]["content_dir"] ?? "",
                     "/",
@@ -4627,7 +4726,8 @@ class ImportClient
                     );
                 }
                 $target_path = $this->get_filesystem_root_path() . $content_dir . '/database/.ht.sqlite';
-                fwrite(STDERR, "[db-apply] No --target-sqlite-path specified, defaulting to: $target_path\n");
+                $this->audit_log("DB-APPLY | defaulting SQLite path to: {$target_path}");
+                $this->progress->show_lifecycle_line("SQLite path: {$target_path}\n");
             }
 
             // Persist target database configuration for apply-runtime.
@@ -4692,7 +4792,7 @@ class ImportClient
         ];
     }
 
-    private function run_db_apply(array $options): void
+    public function run_db_apply(array $options): void
     {
         $sql_file = $this->state_dir . "/db.sql";
         if (!file_exists($sql_file)) {
@@ -4943,14 +5043,16 @@ class ImportClient
                         $stmts_since_save = 0;
 
                         // Progress output
-                        $pct = $sql_file_size > 0
-                            ? round(100 * $total_bytes_read / $sql_file_size, 1)
-                            : 0;
+                        $apply_fraction = $sql_file_size > 0
+                            ? $total_bytes_read / $sql_file_size
+                            : null;
+                        $pct = $apply_fraction !== null ? round($apply_fraction * 100, 1) : 0;
 
                         $progress_message = sprintf(
-                            "db-apply: %s statements (%.1f%%)",
-                            $statements_total === null ? $statements_executed : "{$statements_executed} / {$statements_total}",
-                            $pct,
+                            "%s statements",
+                            $statements_total === null
+                                ? number_format($statements_executed)
+                                : number_format($statements_executed) . " / " . number_format($statements_total),
                         );
 
                         $this->output_progress([
@@ -4963,7 +5065,7 @@ class ImportClient
                             "message" => $progress_message,
                         ]);
 
-                        $this->progress->show_progress_line($progress_message);
+                        $this->progress->show_progress_line($progress_message, $apply_fraction);
                     }
                 }
             }
@@ -5061,8 +5163,10 @@ class ImportClient
                     "message" => "db-apply complete ({$statements_executed} statements executed)",
                 ]);
 
-                // Clear the progress line before printing the final message
-                $this->progress->clear_progress_line();
+                if (!$this->progress->is_quiet_lifecycle()) {
+                    // Clear the progress line before printing the final message
+                    $this->progress->clear_progress_line();
+                }
                 $this->progress->show_lifecycle_line("db-apply complete ({$statements_executed} statements executed)\n");
             }
         } finally {
@@ -5201,7 +5305,9 @@ class ImportClient
             $this->save_state($this->state);
 
             $this->audit_log("START db-index", true);
-            $this->progress->show_lifecycle_line("Starting db-index\n");
+            if ($this->is_tty && !$this->verbose_mode) {
+                fwrite($this->progress_fd, "Starting db-index\n");
+            }
             $this->output_progress([
                 "type" => "lifecycle",
                 "event" => "starting",
@@ -5216,7 +5322,9 @@ class ImportClient
                 ),
                 true,
             );
-            $this->progress->show_lifecycle_line("Resuming db-index\n");
+            if ($this->is_tty && !$this->verbose_mode) {
+                fwrite($this->progress_fd, "Resuming db-index\n");
+            }
             $this->output_progress([
                 "type" => "lifecycle",
                 "event" => "resuming",
@@ -5239,9 +5347,11 @@ class ImportClient
             true,
         );
 
-        $this->progress->show_lifecycle_line("db-index complete: {$tables} tables\n");
-        $this->progress->show_lifecycle_line("Table stats: {$tables_file}\n");
-        $this->progress->show_lifecycle_line("Audit log: {$this->audit_log}\n");
+        if ($this->is_tty && !$this->verbose_mode) {
+            fwrite($this->progress_fd, "db-index complete: {$tables} tables\n");
+            fwrite($this->progress_fd, "Table stats: {$tables_file}\n");
+            fwrite($this->progress_fd, "Audit log: {$this->audit_log}\n");
+        }
         $this->output_progress([
             "type" => "lifecycle",
             "event" => "complete",
@@ -5488,6 +5598,11 @@ class ImportClient
         }
 
         $mode = file_exists($this->remote_index_file) ? "a" : "w";
+        // Initialize the index counter from the existing file so resume
+        // shows a monotonically increasing count.
+        if ($mode === "a" && $this->index_entries_counted === 0) {
+            $this->index_entries_counted = $this->count_newlines($this->remote_index_file);
+        }
         if ($mode === "w") {
             $this->audit_log(
                 "FILE CREATE | {$this->remote_index_file} | downloading fresh remote index",
@@ -5611,7 +5726,15 @@ class ImportClient
                     if ($bytes === false) {
                         throw new RuntimeException("Failed to write to remote index file (disk full?)");
                     }
-
+                    $this->index_entries_counted++;
+                }
+                if ($this->index_entries_counted > 0) {
+                    $this->progress->show_progress_line(
+                        "Scanning remote files — " .
+                        number_format($this->index_entries_counted) . " scanned"
+                    );
+                } else {
+                    $this->progress->show_progress_line("Scanning remote files");
                 }
             } elseif ($chunk_type === "progress") {
                 $this->handle_progress($chunk, "index");
@@ -5820,6 +5943,7 @@ class ImportClient
                     "local_after" => $local_after,
                 ];
                 $this->save_state($this->state);
+                $this->progress->tick_spinner();
             }
         }
 
@@ -5957,10 +6081,14 @@ class ImportClient
             $this->audit_log("FILE DELETE | {$batch_file} | fetch batch complete");
         }
 
-        // Advance the done counter by the known batch size.
+        // Advance the done counter by the known batch size and reset
+        // the per-batch file counter. files_imported counted files within
+        // this batch; now that the batch is complete, those files are
+        // accounted for in download_list_done.
         if ($this->download_list_done !== null) {
             $this->download_list_done += $batch_entries;
         }
+        $this->files_imported = 0;
 
         $this->state[$state_key] = [
             "offset" => $next_offset,
@@ -6922,6 +7050,23 @@ class ImportClient
                                 $sql_statements_counted,
                             );
                         }
+                        // Show download progress on the TTY progress line.
+                        // The bytes accumulate across chunks and requests.
+                        // Include estimated total from db-index when available,
+                        // but only if the estimate is larger than what we've
+                        // already downloaded — INFORMATION_SCHEMA estimates
+                        // can be wildly off (e.g. 7 KB for a 22 MB dump).
+                        $db_bytes_est = (int) ($this->state["db_index"]["bytes"] ?? 0);
+                        $est_is_useful = $db_bytes_est > $sql_bytes_written;
+                        $sql_fraction = $est_is_useful
+                            ? $sql_bytes_written / $db_bytes_est
+                            : null;
+                        $sql_progress = $this->format_bytes($sql_bytes_written);
+                        if ($est_is_useful) {
+                            $sql_progress .= " / " . $this->format_bytes($db_bytes_est);
+                        }
+                        $this->progress->show_progress_line($sql_progress, $sql_fraction);
+
                     } elseif ($chunk_type === "progress") {
                         $this->handle_progress($chunk, "sql");
                     } elseif ($chunk_type === "completion") {
@@ -7599,126 +7744,6 @@ class ImportClient
     }
 
     /**
-     * Map an absolute remote symlink target to the local fs-root mirror when possible.
-     *
-     * Example:
-     *
-     * Source site:
-     *
-     *   /srv/source-site/
-     *   `-- wp-content/
-     *       `-- themes/
-     *           `-- indice -> /tmp/e2e-shared-themes/pub/indice
-     *
-     *   /tmp/e2e-shared-themes/pub/indice/
-     *   |-- style.css
-     *   `-- index.php
-     *
-     * Local import state:
-     *
-     *   <state-dir>/fs-root/
-     *   |-- tmp/e2e-shared-themes/pub/indice/
-     *   |   |-- style.css
-     *   |   `-- index.php
-     *   `-- srv/source-site/wp-content/themes/
-     *       `-- indice -> ../../../tmp/e2e-shared-themes/pub/indice
-     *
-     * Without this remap, the recreated link would still point to
-     * /tmp/e2e-shared-themes/pub/indice, which is outside fs-root and rejected
-     * by assert_symlink_target_within_root(). When the absolute target was
-     * already indexed from the source, we instead point the symlink at the
-     * mirrored local copy under fs-root.
-     */
-    private function map_absolute_symlink_target_for_local_mirror(
-        string $path,
-        string $local_path,
-        string $target
-    ): string {
-        if (!str_starts_with($target, "/")) {
-            return $target;
-        }
-
-        $root = $this->get_filesystem_root_path();
-        $normalized_target = normalize_path($target);
-
-        // Already points inside fs-root, keep as-is.
-        if (path_is_within_root($normalized_target, $root)) {
-            return $target;
-        }
-
-        // Only rewrite when symlink-following is enabled and the target path
-        // was actually indexed from the source.
-        if (
-            !$this->follow_symlinks ||
-            !$this->remote_index_contains_path_prefix($normalized_target)
-        ) {
-            return $target;
-        }
-
-        $mapped_absolute = $root . $normalized_target;
-        $mapped_relative = self::compute_relative_path(
-            dirname($local_path),
-            $mapped_absolute
-        );
-
-        $this->audit_log(
-            "SYMLINK TARGET REMAP | {$path}: {$target} -> {$mapped_relative}",
-            false,
-        );
-
-        return $mapped_relative;
-    }
-
-    /**
-     * Checks if the remote index contains $path or any descendant under it.
-     * Runs a memoized O(N) scan of .import-remote-index.jsonl.
-     */
-    private function remote_index_contains_path_prefix(string $path): bool
-    {
-        $path = rtrim(normalize_path($path), "/");
-        if ($path === "") {
-            return false;
-        }
-
-        if (isset($this->remote_index_prefix_cache[$path])) {
-            return $this->remote_index_prefix_cache[$path];
-        }
-
-        if (!file_exists($this->remote_index_file)) {
-            $this->remote_index_prefix_cache[$path] = false;
-            return false;
-        }
-
-        $h = fopen($this->remote_index_file, "r");
-        if (!$h) {
-            $this->remote_index_prefix_cache[$path] = false;
-            return false;
-        }
-
-        $prefix = $path . "/";
-        $found = false;
-        while (($line = fgets($h)) !== false) {
-            try {
-                $entry = $this->parse_index_line($line);
-            } catch (RuntimeException $e) {
-                continue;
-            }
-            if ($entry === null) {
-                continue;
-            }
-            $entry_path = $entry["path"];
-            if ($entry_path === $path || str_starts_with($entry_path, $prefix)) {
-                $found = true;
-                break;
-            }
-        }
-        fclose($h);
-
-        $this->remote_index_prefix_cache[$path] = $found;
-        return $found;
-    }
-
-    /**
      * Return canonical fs root path, creating it if it doesn't exist.
      */
     private function get_filesystem_root_path(): string
@@ -7838,8 +7863,14 @@ class ImportClient
             );
 
             $files_done = ($this->download_list_done ?? 0) + $this->files_imported;
-            $file_progress_message = sprintf("[%d files] %s", $files_done, $this->display_path($path));
-            $this->progress->show_progress_line($file_progress_message);
+            $files_total = $this->download_list_total;
+            $file_fraction = ($files_total !== null && $files_total > 0)
+                ? $files_done / $files_total
+                : null;
+            $file_progress_message = $files_total !== null
+                ? sprintf("Downloading — %s / %s files", number_format($files_done), number_format($files_total))
+                : sprintf("Downloading — %s files", number_format($files_done));
+            $this->progress->show_progress_line($file_progress_message, $file_fraction);
             $progress_record = [
                 "type" => "file_progress",
                 "files_done" => $files_done,
@@ -8284,11 +8315,6 @@ class ImportClient
         }
 
         $local_path = $this->remote_path_to_local_path_within_import_root($path);
-        $target_for_local = $this->map_absolute_symlink_target_for_local_mirror(
-            $path,
-            $local_path,
-            $target,
-        );
 
         // In preserve-local mode, if something already exists at the symlink
         // path, keep it — whether it's a file, directory, or another symlink.
@@ -8312,7 +8338,7 @@ class ImportClient
         try {
             $this->assert_symlink_target_within_root(
                 dirname($local_path),
-                $target_for_local,
+                $target,
                 $root
             );
         } catch (RuntimeException $e) {
@@ -8320,7 +8346,7 @@ class ImportClient
             $this->output_progress([
                 "type" => "symlink_error",
                 "path" => $path,
-                "target" => $target_for_local,
+                "target" => $target,
                 "error" => $e->getMessage(),
                 "message" => "Symlink error: {$path} -> {$target}",
             ]);
@@ -8339,7 +8365,7 @@ class ImportClient
                 $this->output_progress([
                     "type" => "symlink_error",
                     "path" => $path,
-                    "target" => $target_for_local,
+                    "target" => $target,
                     "error" => "Failed to replace existing path",
                     "message" => "Symlink error: {$path} -> {$target}",
                 ]);
@@ -8365,7 +8391,7 @@ class ImportClient
                 $this->output_progress([
                     "type" => "symlink_error",
                     "path" => $path,
-                    "target" => $target_for_local,
+                    "target" => $target,
                     "error" => "Failed to create parent directory",
                     "message" => "Symlink error: {$path} -> {$target}",
                 ]);
@@ -8374,17 +8400,17 @@ class ImportClient
         }
 
         // Create symlink
-        $symlink_result = symlink($target_for_local, $local_path);
+        $symlink_result = symlink($target, $local_path);
         if (true !== $symlink_result || !is_link($local_path)) {
             // Log error and skip this symlink
             $this->audit_log(
-                "Failed to create symlink: {$local_path} -> {$target_for_local}",
+                "Failed to create symlink: {$local_path} -> {$target}",
                 true,
             );
             $this->output_progress([
                 "type" => "symlink_error",
                 "path" => $path,
-                "target" => $target_for_local,
+                "target" => $target,
                 "error" => "Failed to create symlink",
                 "message" => "Symlink error: {$path} -> {$target}",
             ]);
@@ -8396,7 +8422,7 @@ class ImportClient
             @touch($local_path, $ctime);
         }
 
-        $this->audit_log("Symlink: {$path} -> {$target_for_local}", false);
+        $this->audit_log("Symlink: {$path} -> {$target}", false);
 
         if ($ctime > 0) {
             $this->upsert_index_entry($path, $ctime, 0, "link");
@@ -8405,8 +8431,8 @@ class ImportClient
         $this->output_progress([
             "type" => "symlink",
             "path" => $path,
-            "target" => $target_for_local,
-            "message" => "Symlink: {$path} -> {$target_for_local}",
+            "target" => $target,
+            "message" => "Symlink: {$path} -> {$target}",
         ]);
     }
 
@@ -8658,6 +8684,7 @@ class ImportClient
             $this->audit_log("Failed to prepare keyed index file, falling back to PHP sort");
             return false;
         }
+        $lines_read = 0;
         while (($line = fgets($in)) !== false) {
             $line = rtrim($line, "\r\n");
             if ($line === "") {
@@ -8669,6 +8696,9 @@ class ImportClient
             }
             $key = bin2hex($entry["path"]);
             fwrite($out, $key . "\t" . $line . "\n");
+            if (++$lines_read % 500 === 0) {
+                $this->progress->tick_spinner();
+            }
         }
         fclose($in);
         fclose($out);
@@ -8704,6 +8734,7 @@ class ImportClient
         }
 
         $prev_key = null;
+        $lines_stripped = 0;
         while (($line = fgets($sorted_in)) !== false) {
             $pos = strpos($line, "\t");
             if ($pos === false) {
@@ -8721,6 +8752,9 @@ class ImportClient
             }
             $prev_key = $key;
             fwrite($sorted_out, $data);
+            if (++$lines_stripped % 500 === 0) {
+                $this->progress->tick_spinner();
+            }
         }
         fclose($sorted_in);
         fclose($sorted_out);
@@ -9162,6 +9196,12 @@ class ImportClient
             CURLOPT_ENCODING => "gzip, deflate",
             CURLOPT_HTTPHEADER => $headers,
             CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_NOPROGRESS => false,
+            CURLOPT_PROGRESSFUNCTION =>
+                function ($ch, $dl_total, $dl_now, $ul_total, $ul_now) {
+                    $this->progress->tick_spinner();
+                    return 0;
+                },
         ]);
 
         $start = microtime(true);
@@ -9330,6 +9370,15 @@ class ImportClient
             CURLOPT_LOW_SPEED_LIMIT => 1,
             CURLOPT_LOW_SPEED_TIME => 300,
             CURLOPT_ENCODING => "gzip, deflate",
+            // Tick the spinner during transfers. curl calls this roughly
+            // once per second even when no data is flowing, which keeps
+            // the Braille spinner rotating so it looks alive.
+            CURLOPT_NOPROGRESS => false,
+            CURLOPT_PROGRESSFUNCTION =>
+                function ($ch, $dl_total, $dl_now, $ul_total, $ul_now) {
+                    $this->progress->tick_spinner();
+                    return 0; // 0 = continue, non-zero = abort
+                },
             CURLOPT_HTTPHEADER => $headers,
             CURLOPT_HEADERFUNCTION => function ($ch, $header_line) use (
                 &$parser,
@@ -9589,6 +9638,7 @@ class ImportClient
         $follow = $this->state["follow_symlinks"] ?? false;
         $nonempty = $this->state["fs_root_nonempty_behavior"] ?? "error";
         $max_packet = $this->state["max_allowed_packet"] ?? null;
+        $pull = $this->state["pull"] ?? null;
         $this->state = $this->default_state();
         $this->state["preflight"] = $preflight;
         $this->state["version"] = $version;
@@ -9596,9 +9646,12 @@ class ImportClient
         $this->state["follow_symlinks"] = $follow;
         $this->state["fs_root_nonempty_behavior"] = $nonempty;
         $this->state["max_allowed_packet"] = $max_packet;
+        if ($pull !== null) {
+            $this->state["pull"] = $pull;
+        }
     }
 
-    private function default_state(): array
+    public function default_state(): array
     {
         return [
             "command" => null,
@@ -9679,6 +9732,12 @@ class ImportClient
                 "config" => [],
                 "state" => [],
             ],
+            // Pull pipeline state — tracks progress through the composite
+            // preflight → files-pull → db-pull → db-apply → ... pipeline.
+            // "stage" is the last completed stage name, or "complete".
+            "pull" => [
+                "stage" => null,
+            ],
         ];
     }
 
@@ -9734,6 +9793,12 @@ class ImportClient
         }
         $apply = array_intersect_key($apply, $defaults["apply"]);
         $state["apply"] = array_merge($defaults["apply"], $apply);
+        $pull = $state["pull"] ?? [];
+        if (!is_array($pull)) {
+            $pull = [];
+        }
+        $pull = array_intersect_key($pull, $defaults["pull"]);
+        $state["pull"] = array_merge($defaults["pull"], $pull);
         return $state;
     }
 
@@ -10021,6 +10086,11 @@ class ImportClient
      */
     private function save_state(array $state): void
     {
+        // Keep the spinner alive between curl requests. save_state is
+        // called frequently during streaming operations, so this fills
+        // the gaps where curl's progress callback doesn't fire.
+        $this->progress->tick_spinner();
+
         if ($this->tuner instanceof AdaptiveTuner) {
             $state["tuning"] = [
                 "config" => $this->tuner->get_config(),
@@ -10072,7 +10142,7 @@ class ImportClient
      * position. Written atomically via temp file + rename so readers
      * never see a partial write.
      */
-    private function write_status_file(?string $error = null): void
+    public function write_status_file(?string $error = null): void
     {
         $state = $this->state ?? [];
         $command = $state["command"] ?? null;
@@ -10151,10 +10221,12 @@ class ImportClient
             true,
         );
 
-        $this->progress->show_lifecycle_line("\nInterrupted - saving state...\n");
-        $this->progress->show_lifecycle_line("  Command: {$current_command}\n");
-        $this->progress->show_lifecycle_line("  Total files indexed: {$indexed}\n");
-        $this->progress->show_lifecycle_line("  Files completed in this run: {$files_imported}\n");
+        if ($this->is_tty && !$this->verbose_mode) {
+            fwrite($this->progress_fd, "\nInterrupted - saving state...\n");
+            fwrite($this->progress_fd, "  Command: {$current_command}\n");
+            fwrite($this->progress_fd, "  Total files indexed: {$indexed}\n");
+            fwrite($this->progress_fd, "  Files completed in this run: {$files_imported}\n");
+        }
         $this->output_progress([
             "type" => "interrupt",
             "command" => $current_command,
@@ -10166,7 +10238,9 @@ class ImportClient
         // Save current state (with timeout protection)
         try {
             $this->save_state($this->state);
-            $this->progress->show_lifecycle_line("✓ State saved successfully\n");
+            if ($this->is_tty && !$this->verbose_mode) {
+                fwrite($this->progress_fd, "✓ State saved successfully\n");
+            }
             $this->output_progress([
                 "type" => "state_saved",
                 "message" => "State saved successfully",
@@ -10175,7 +10249,9 @@ class ImportClient
             fwrite($this->progress_fd, "Warning: Failed to save state: " . $e->getMessage() . "\n");
         }
 
-        $this->progress->show_lifecycle_line("Exiting...\n");
+        if ($this->is_tty && !$this->verbose_mode) {
+            fwrite($this->progress_fd, "Exiting...\n");
+        }
 
         // CRITICAL: Use SIGKILL for immediate termination
         // Regular exit() hangs because PHP's shutdown sequence tries to
@@ -10197,7 +10273,7 @@ class ImportClient
      * @param array $data Progress data to output
      * @param bool $force Force output regardless of throttle
      */
-    private function output_progress(array $data, bool $force = false): void
+    public function output_progress(array $data, bool $force = false): void
     {
         // In TTY non-verbose mode, suppress JSON output (use show_progress_line instead)
         if ($this->is_tty && !$this->verbose_mode) {
@@ -10367,7 +10443,7 @@ if (
             'placeholder' => 'TOKEN',
             'help' => 'HMAC shared secret for export API authentication',
             'help_section' => 'global',
-            'commands' => ['files-pull', 'files-index', 'db-pull', 'db-index', 'preflight', 'preflight-assert'],
+            'commands' => ['pull', 'files-pull', 'files-index', 'db-pull', 'db-index', 'preflight', 'preflight-assert'],
         ],
         [
             'name' => 'abort',
@@ -10375,7 +10451,7 @@ if (
             'target' => 'abort',
             'help' => 'Abort current sync and exit (preserves downloaded files)',
             'help_section' => 'global',
-            'commands' => ['files-pull', 'files-index', 'db-pull', 'db-index', 'db-apply'],
+            'commands' => ['pull', 'files-pull', 'files-index', 'db-pull', 'db-index', 'db-apply'],
         ],
         [
             'name' => 'verbose',
@@ -10384,7 +10460,7 @@ if (
             'short' => 'v',
             'help' => 'Show detailed request/response logs',
             'help_section' => 'global',
-            'commands' => ['files-pull', 'files-index', 'db-pull', 'db-index', 'db-apply', 'flat-docroot', 'apply-runtime'],
+            'commands' => ['pull', 'files-pull', 'files-index', 'db-pull', 'db-index', 'db-apply', 'flat-docroot', 'apply-runtime'],
         ],
         [
             'name' => 'no-follow-symlinks',
@@ -10393,7 +10469,7 @@ if (
             'flag_value' => false,
             'help' => 'Do not follow symlinks pointing outside root directories',
             'help_section' => 'global',
-            'commands' => ['files-pull'],
+            'commands' => ['pull', 'files-pull'],
         ],
         [
             'name' => 'follow-symlinks',
@@ -10410,7 +10486,7 @@ if (
             'placeholder' => 'MODE',
             'help' => 'What to do when fs root is non-empty (error|preserve-local)',
             'help_section' => 'global',
-            'commands' => ['files-pull'],
+            'commands' => ['pull', 'files-pull'],
             'aliases' => ['on-docroot-nonempty'],
         ],
         [
@@ -10536,7 +10612,7 @@ if (
             'target' => 'target_engine',
             'placeholder' => 'ENGINE',
             'help' => 'Target database engine: mysql (default) or sqlite',
-            'commands' => ['db-apply'],
+            'commands' => ['pull', 'db-apply'],
         ],
         [
             'name' => 'target-host',
@@ -10544,7 +10620,7 @@ if (
             'target' => 'target_host',
             'placeholder' => 'HOST',
             'help' => 'Target MySQL host (default: 127.0.0.1)',
-            'commands' => ['db-apply'],
+            'commands' => ['pull', 'db-apply'],
         ],
         [
             'name' => 'target-port',
@@ -10553,7 +10629,7 @@ if (
             'placeholder' => 'PORT',
             'cast' => 'int',
             'help' => 'Target MySQL port (default: 3306)',
-            'commands' => ['db-apply'],
+            'commands' => ['pull', 'db-apply'],
         ],
         [
             'name' => 'target-user',
@@ -10561,7 +10637,7 @@ if (
             'target' => 'target_user',
             'placeholder' => 'USER',
             'help' => 'Target MySQL user (required for mysql)',
-            'commands' => ['db-apply'],
+            'commands' => ['pull', 'db-apply'],
         ],
         [
             'name' => 'target-pass',
@@ -10569,7 +10645,7 @@ if (
             'target' => 'target_pass',
             'placeholder' => 'PASS',
             'help' => 'Target MySQL password',
-            'commands' => ['db-apply'],
+            'commands' => ['pull', 'db-apply'],
         ],
         [
             'name' => 'target-db',
@@ -10577,7 +10653,7 @@ if (
             'target' => 'target_db',
             'placeholder' => 'NAME',
             'help' => 'Target DB name (required for mysql, optional for sqlite)',
-            'commands' => ['db-apply'],
+            'commands' => ['pull', 'db-apply'],
         ],
         [
             'name' => 'target-sqlite-path',
@@ -10585,7 +10661,7 @@ if (
             'target' => 'target_sqlite_path',
             'placeholder' => 'PATH',
             'help' => 'Target SQLite database file (default: <wp-content>/database/.ht.sqlite)',
-            'commands' => ['db-apply'],
+            'commands' => ['pull', 'db-apply'],
         ],
         [
             'name' => 'rewrite-url',
@@ -10593,7 +10669,7 @@ if (
             'target' => 'rewrite_url',
             'pair_args' => 'FROM TO',
             'help' => 'Rewrite FROM to TO (repeatable)',
-            'commands' => ['db-apply'],
+            'commands' => ['pull', 'db-apply'],
         ],
         [
             'name' => 'new-site-url',
@@ -10601,7 +10677,7 @@ if (
             'target' => 'new_site_url',
             'placeholder' => 'URL',
             'help' => 'New site URL (auto-creates --rewrite-url from export URL origin)',
-            'commands' => ['db-apply'],
+            'commands' => ['pull', 'db-apply'],
         ],
 
         // ── flat-docroot options ────────────────────────────────
@@ -10610,15 +10686,15 @@ if (
             'type' => 'value',
             'target' => 'flatten_to',
             'placeholder' => 'PATH',
-            'help' => 'Target directory for the flattened layout (required)',
-            'commands' => ['flat-docroot'],
+            'help' => 'Target directory for the flattened layout',
+            'commands' => ['pull', 'flat-docroot'],
         ],
         [
             'name' => 'force',
             'type' => 'flag',
             'target' => 'force',
             'help' => 'Remove conflicting non-symlink files and replace with symlinks',
-            'commands' => ['flat-docroot'],
+            'commands' => ['pull', 'flat-docroot'],
         ],
 
         // ── apply-runtime options ────────────────────────────────
@@ -10627,16 +10703,16 @@ if (
             'type' => 'value',
             'target' => 'runtime',
             'placeholder' => 'RUNTIME',
-            'help' => 'Target server runtime: nginx-fpm, php-builtin, or playground-cli (required)',
-            'commands' => ['apply-runtime'],
+            'help' => 'Target server runtime: php-builtin, playground-cli, nginx-fpm, or none',
+            'commands' => ['pull', 'apply-runtime'],
         ],
         [
             'name' => 'output-dir',
             'type' => 'value',
             'target' => 'output_dir',
             'placeholder' => 'DIR',
-            'help' => 'Directory for generated runtime files (required)',
-            'commands' => ['apply-runtime'],
+            'help' => 'Directory for generated runtime files',
+            'commands' => ['pull', 'apply-runtime'],
         ],
         [
             'name' => 'flat-document-root',
@@ -10844,11 +10920,20 @@ if (
         echo "Mirror any WordPress site over HTTP.\n";
         echo "Version " . get_importer_version() . "\n";
         echo "\n";
-        echo "Usage: reprint <command> <remote-url> --state-dir=DIR --fs-root=DIR [options]\n";
+        echo "Usage: reprint <command> <remote-url> [options]\n";
         echo "\n";
-        echo "Commands:\n";
+
+        $high = array_filter($command_info, fn($i) => ($i['level'] ?? 'low') === 'high');
+        $low = array_filter($command_info, fn($i) => ($i['level'] ?? 'low') === 'low');
         $max_len = max(array_map('strlen', array_keys($command_info)));
-        foreach ($command_info as $name => $info) {
+
+        echo "Commands:\n";
+        foreach ($high as $name => $info) {
+            echo "  " . str_pad($name, $max_len + 2) . $info["short"] . "\n";
+        }
+        echo "\n";
+        echo "Low-level commands (used by pull internally):\n";
+        foreach ($low as $name => $info) {
             echo "  " . str_pad($name, $max_len + 2) . $info["short"] . "\n";
         }
         echo "\n";
@@ -11049,8 +11134,52 @@ if (
     //
     // The Options: section itself is generated from $option_defs so that
     // every declared option for a command is guaranteed to appear.
+    // High-level commands are the ones most users will use. Low-level
+    // commands are the building blocks that pull composes internally —
+    // useful for scripting and hosting platform integrations.
     $command_info = [
+        "pull" => [
+            "level" => "high",
+            "short" => "Clone a remote site (preflight + files + database + import)",
+            "description" =>
+                "Full site clone in a single command. Composes lower-level commands into\n" .
+                "a resumable pipeline:\n" .
+                "\n" .
+                "  1. Preflight — probe the remote site environment\n" .
+                "  2. Files     — download all remote files into --fs-root\n" .
+                "  3. Database  — download the SQL dump\n" .
+                "  4. Import    — apply SQL to a local database (if --target-db)\n" .
+                "  5. Flatten   — reassemble into standard WP layout (if --flatten-to)\n" .
+                "  6. Runtime   — generate server config (default: php-builtin)\n" .
+                "  7. Start     — launch the local server (php-builtin only)\n" .
+                "\n" .
+                "Each step retries automatically on server timeouts. If the process is\n" .
+                "interrupted, re-run the same command to resume from where it left off.\n" .
+                "Running pull again after completion performs a delta sync.\n" .
+                "\n" .
+                "The ?site-export-api query parameter is added automatically if missing,\n" .
+                "so you can pass just the site URL.\n",
+            "extra" =>
+                "Examples:\n" .
+                "  # Download files and database (no import):\n" .
+                "  reprint pull https://example.com \\\n" .
+                "    --secret=TOKEN --state-dir=./state --fs-root=./files\n" .
+                "\n" .
+                "  # Full clone with MySQL import and URL rewriting:\n" .
+                "  reprint pull https://example.com \\\n" .
+                "    --secret=TOKEN --state-dir=./state --fs-root=./files \\\n" .
+                "    --target-user=root --target-db=wp_local \\\n" .
+                "    --new-site-url=http://localhost:8881\n" .
+                "\n" .
+                "  # Full clone with SQLite, flattened layout, and PHP built-in server:\n" .
+                "  reprint pull https://example.com \\\n" .
+                "    --secret=TOKEN --state-dir=./state --fs-root=./files \\\n" .
+                "    --target-engine=sqlite \\\n" .
+                "    --new-site-url=http://localhost:8881 \\\n" .
+                "    --flatten-to=./site --runtime=php-builtin --output-dir=./runtime\n",
+        ],
         "install-exporter" => [
+            "level" => "high",
             "short" => "Show how to install the exporter plugin on your site",
             "description" =>
                 "Prints the download URL for the exporter WordPress plugin that\n" .
@@ -11062,6 +11191,7 @@ if (
             "extra" => null,
         ],
         "preflight" => [
+            "level" => "low",
             "short" => "Probe the remote site and cache its environment",
             "description" =>
                 "Contacts the remote site and collects environment details:\n" .
@@ -11075,6 +11205,7 @@ if (
             "extra" => null,
         ],
         "preflight-assert" => [
+            "level" => "low",
             "short" => "Verify the remote site can be mirrored (exits 0 or 1)",
             "description" =>
                 "Runs the same check as the preflight command, then evaluates\n" .
@@ -11089,6 +11220,7 @@ if (
             "extra" => null,
         ],
         "files-pull" => [
+            "level" => "low",
             "short" => "Pull all files (initial) or only changes (delta)",
             "description" =>
                 "Downloads files from the remote site into --fs-root.\n" .
@@ -11116,6 +11248,7 @@ if (
                 "  .import-audit.log                       Audit log\n",
         ],
         "files-index" => [
+            "level" => "low",
             "short" => "Index all remote files (initial) or detect changes (delta)",
             "description" =>
                 "Streams the full remote directory tree over HTTP and writes each\n" .
@@ -11132,6 +11265,7 @@ if (
             "extra" => null,
         ],
         "files-stats" => [
+            "level" => "low",
             "short" => "Show file counts and sizes from the local index",
             "description" =>
                 "Reads local index files to report (no network calls):\n" .
@@ -11144,6 +11278,7 @@ if (
             "extra" => null,
         ],
         "db-pull" => [
+            "level" => "low",
             "short" => "Pull the database as a SQL dump (index + download)",
             "description" =>
                 "Indexes remote tables, then streams the full SQL dump into\n" .
@@ -11157,6 +11292,7 @@ if (
                 "  mysql   Stream directly into a MySQL connection\n",
         ],
         "db-index" => [
+            "level" => "low",
             "short" => "Pull table metadata from the remote database",
             "description" =>
                 "Fetches table metadata (name, estimated rows, data size) from\n" .
@@ -11167,6 +11303,7 @@ if (
                 "  db-tables.jsonl  One JSON object per table\n",
         ],
         "db-domains" => [
+            "level" => "low",
             "short" => "Extract domains from the pulled SQL dump",
             "description" =>
                 "Prints domains found in the SQL dump, one per line.\n" .
@@ -11180,6 +11317,7 @@ if (
             "extra" => null,
         ],
         "db-apply" => [
+            "level" => "low",
             "short" => "Import the SQL dump into a local MySQL or SQLite database",
             "description" =>
                 "Reads db.sql from --state-dir, optionally rewrites URLs, and executes\n" .
@@ -11197,6 +11335,7 @@ if (
                 "    --rewrite-url https://old.com https://new.com\n",
         ],
         "flat-docroot" => [
+            "level" => "low",
             "short" => "Reassemble pulled files into a standard WordPress layout",
             "description" =>
                 "Creates a directory at --flatten-to with symlinks that map the\n" .
@@ -11214,6 +11353,7 @@ if (
             "extra" => null,
         ],
         "apply-runtime" => [
+            "level" => "low",
             "short" => "Generate server config and prepare the site to run locally",
             "description" =>
                 "Generates server configuration (runtime.php, nginx.conf or start.sh)\n" .

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -1031,6 +1031,14 @@ class ImportClient
     /** @var int Cumulative count of index entries written (survives retries). */
     private $index_entries_counted = 0;
 
+    /**
+     * Memoized lookups for "does remote index contain this path or any descendant path?"
+     * keyed by normalized absolute path.
+     *
+     * @var array<string,bool>
+     */
+    private $remote_index_prefix_cache = [];
+
     /** @var int|null Current step in a multi-step pipeline (1-indexed). Set via --step. */
     private $pipeline_step = null;
 
@@ -7730,6 +7738,125 @@ class ImportClient
     }
 
     /**
+     * Map an absolute remote symlink target to the local fs-root mirror when possible.
+     *
+     * Example:
+     *
+     * Source site:
+     *
+     *   /srv/source-site/
+     *   `-- wp-content/
+     *       `-- themes/
+     *           `-- indice -> /tmp/e2e-shared-themes/pub/indice
+     *
+     *   /tmp/e2e-shared-themes/pub/indice/
+     *   |-- style.css
+     *   `-- index.php
+     *
+     * Local import state:
+     *
+     *   <state-dir>/fs-root/
+     *   |-- tmp/e2e-shared-themes/pub/indice/
+     *   |   |-- style.css
+     *   |   `-- index.php
+     *   `-- srv/source-site/
+     *       `-- wp-content/themes/
+     *
+     * Without this mapping, the symlink would point at /tmp/e2e-shared-themes/pub/indice
+     * (which does not exist on the local machine, or worse, exists with unrelated content).
+     * With this mapping, the symlink is rewritten to a relative path that resolves to the
+     * mirrored local copy under fs-root.
+     */
+    private function map_absolute_symlink_target_for_local_mirror(
+        string $path,
+        string $local_path,
+        string $target
+    ): string {
+        if (!str_starts_with($target, "/")) {
+            return $target;
+        }
+
+        $root = $this->get_filesystem_root_path();
+        $normalized_target = normalize_path($target);
+
+        // Already points inside fs-root, keep as-is.
+        if (path_is_within_root($normalized_target, $root)) {
+            return $target;
+        }
+
+        // Only rewrite when symlink-following is enabled and the target path
+        // was actually indexed from the source.
+        if (
+            !$this->follow_symlinks ||
+            !$this->remote_index_contains_path_prefix($normalized_target)
+        ) {
+            return $target;
+        }
+
+        $mapped_absolute = $root . $normalized_target;
+        $mapped_relative = self::compute_relative_path(
+            dirname($local_path),
+            $mapped_absolute
+        );
+
+        $this->audit_log(
+            "SYMLINK TARGET REMAP | {$path}: {$target} -> {$mapped_relative}",
+            false,
+        );
+
+        return $mapped_relative;
+    }
+
+    /**
+     * Checks if the remote index contains $path or any descendant under it.
+     * Runs a memoized O(N) scan of .import-remote-index.jsonl.
+     */
+    private function remote_index_contains_path_prefix(string $path): bool
+    {
+        $path = rtrim(normalize_path($path), "/");
+        if ($path === "") {
+            return false;
+        }
+
+        if (isset($this->remote_index_prefix_cache[$path])) {
+            return $this->remote_index_prefix_cache[$path];
+        }
+
+        if (!file_exists($this->remote_index_file)) {
+            $this->remote_index_prefix_cache[$path] = false;
+            return false;
+        }
+
+        $h = fopen($this->remote_index_file, "r");
+        if (!$h) {
+            $this->remote_index_prefix_cache[$path] = false;
+            return false;
+        }
+
+        $prefix = $path . "/";
+        $found = false;
+        while (($line = fgets($h)) !== false) {
+            try {
+                $entry = $this->parse_index_line($line);
+            } catch (RuntimeException $e) {
+                continue;
+            }
+            if ($entry === null) {
+                continue;
+            }
+            $entry_path = $entry["path"];
+            if ($entry_path === $path || str_starts_with($entry_path, $prefix)) {
+                $found = true;
+                break;
+            }
+        }
+        fclose($h);
+
+        $this->remote_index_prefix_cache[$path] = $found;
+        return $found;
+    }
+
+    /**
      * Return canonical fs root path, creating it if it doesn't exist.
      */
     private function get_filesystem_root_path(): string
@@ -8301,6 +8428,11 @@ class ImportClient
         }
 
         $local_path = $this->remote_path_to_local_path_within_import_root($path);
+        $target_for_local = $this->map_absolute_symlink_target_for_local_mirror(
+            $path,
+            $local_path,
+            $target,
+        );
 
         // In preserve-local mode, if something already exists at the symlink
         // path, keep it — whether it's a file, directory, or another symlink.
@@ -8324,7 +8456,7 @@ class ImportClient
         try {
             $this->assert_symlink_target_within_root(
                 dirname($local_path),
-                $target,
+                $target_for_local,
                 $root
             );
         } catch (RuntimeException $e) {
@@ -8332,7 +8464,7 @@ class ImportClient
             $this->output_progress([
                 "type" => "symlink_error",
                 "path" => $path,
-                "target" => $target,
+                "target" => $target_for_local,
                 "error" => $e->getMessage(),
                 "message" => "Symlink error: {$path} -> {$target}",
             ]);
@@ -8351,7 +8483,7 @@ class ImportClient
                 $this->output_progress([
                     "type" => "symlink_error",
                     "path" => $path,
-                    "target" => $target,
+                    "target" => $target_for_local,
                     "error" => "Failed to replace existing path",
                     "message" => "Symlink error: {$path} -> {$target}",
                 ]);
@@ -8377,7 +8509,7 @@ class ImportClient
                 $this->output_progress([
                     "type" => "symlink_error",
                     "path" => $path,
-                    "target" => $target,
+                    "target" => $target_for_local,
                     "error" => "Failed to create parent directory",
                     "message" => "Symlink error: {$path} -> {$target}",
                 ]);
@@ -8386,17 +8518,17 @@ class ImportClient
         }
 
         // Create symlink
-        $symlink_result = symlink($target, $local_path);
+        $symlink_result = symlink($target_for_local, $local_path);
         if (true !== $symlink_result || !is_link($local_path)) {
             // Log error and skip this symlink
             $this->audit_log(
-                "Failed to create symlink: {$local_path} -> {$target}",
+                "Failed to create symlink: {$local_path} -> {$target_for_local}",
                 true,
             );
             $this->output_progress([
                 "type" => "symlink_error",
                 "path" => $path,
-                "target" => $target,
+                "target" => $target_for_local,
                 "error" => "Failed to create symlink",
                 "message" => "Symlink error: {$path} -> {$target}",
             ]);
@@ -8408,7 +8540,7 @@ class ImportClient
             @touch($local_path, $ctime);
         }
 
-        $this->audit_log("Symlink: {$path} -> {$target}", false);
+        $this->audit_log("Symlink: {$path} -> {$target_for_local}", false);
 
         if ($ctime > 0) {
             $this->upsert_index_entry($path, $ctime, 0, "link");
@@ -8417,7 +8549,7 @@ class ImportClient
         $this->output_progress([
             "type" => "symlink",
             "path" => $path,
-            "target" => $target,
+            "target" => $target_for_local,
             "message" => "Symlink: {$path} -> {$target}",
         ]);
     }

--- a/packages/reprint-importer/src/lib/pull/class-pull.php
+++ b/packages/reprint-importer/src/lib/pull/class-pull.php
@@ -1,0 +1,577 @@
+<?php
+/**
+ * The `pull` command — orchestrates the lower-level commands into a
+ * single resumable site clone pipeline.
+ *
+ * Each step retries automatically on server timeouts (exit code 2). If
+ * the process is interrupted, re-running pull resumes from the last
+ * completed step. Like `git pull` composes fetch + merge, this composes
+ * preflight → files-pull → db-pull → db-apply → flat-docroot →
+ * apply-runtime → start.
+ *
+ * The class holds a reference to ImportClient because each stage
+ * delegates to an ImportClient method (run_preflight, run_files_sync,
+ * etc.). The orchestration logic (pipeline state, retry loop, stage
+ * framing) lives here; the actual transfer logic stays in ImportClient.
+ */
+class Pull
+{
+    private ImportClient $client;
+    private TerminalProgress $progress;
+
+    public function __construct(ImportClient $client, TerminalProgress $progress)
+    {
+        $this->client = $client;
+        $this->progress = $progress;
+    }
+
+    /**
+     * Determine the pipeline stages based on the provided options.
+     *
+     * Always: preflight → files-pull → db-pull.
+     * Adds db-apply when a database target is configured, flat-docroot
+     * when --flatten-to is set, apply-runtime when --runtime is set,
+     * and start when the runtime can be launched in-process.
+     */
+    public function stages(array $options): array
+    {
+        $stages = ['preflight', 'files-pull', 'db-pull'];
+        $has_db_target =
+            !empty($options['target_db']) ||
+            !empty($options['target_engine']) ||
+            !empty($options['target_sqlite_path']) ||
+            !empty($options['target_user']);
+        if ($has_db_target) {
+            $stages[] = 'db-apply';
+        }
+        if (!empty($options['flatten_to'])) {
+            $stages[] = 'flat-docroot';
+        }
+        if (!empty($options['runtime'])) {
+            $stages[] = 'apply-runtime';
+            // php-builtin and playground-cli both generate a start.sh
+            // that can be launched directly from the CLI.
+            if (in_array($options['runtime'], ['php-builtin', 'playground-cli'], true)) {
+                $stages[] = 'start';
+            }
+        }
+        return $stages;
+    }
+
+    /** Human-readable label for a pipeline stage. */
+    public function stage_label(string $stage): string
+    {
+        switch ($stage) {
+            case 'preflight':     return 'Connecting';
+            case 'files-pull':    return 'Pulling files';
+            case 'db-pull':       return 'Pulling database';
+            case 'db-apply':      return 'Importing database';
+            case 'flat-docroot':  return 'Flattening layout';
+            case 'apply-runtime': return 'Preparing runtime';
+            case 'start':         return 'Starting server';
+            default:              return $stage;
+        }
+    }
+
+    /**
+     * Run the pull pipeline.
+     */
+    public function run(array $options): void
+    {
+        $this->normalize_url();
+        $this->progress->enable_quiet_lifecycle();
+
+        $options = $this->validate_and_default_options($options);
+
+        $stages = $this->stages($options);
+        $total = count($stages);
+        $state = $this->client->state;
+        $completed_stage = $state['pull']['stage'] ?? null;
+
+        // If the prior pull completed, prepare for a delta re-pull.
+        if ($completed_stage === 'complete') {
+            $this->prepare_repull();
+            $completed_stage = null;
+        }
+
+        $start_index = 0;
+        if ($completed_stage !== null) {
+            $idx = array_search($completed_stage, $stages);
+            if ($idx !== false) {
+                $start_index = $idx + 1;
+            }
+        }
+
+        $host = parse_url($this->client->remote_url, PHP_URL_HOST) ?? $this->client->remote_url;
+        $bold = "\033[1m";
+        $r = "\033[0m";
+        $this->progress->print_line("\n{$bold}Pulling {$host}{$r}\n");
+
+        $this->client->output_progress([
+            "type" => "lifecycle",
+            "event" => "starting",
+            "command" => "pull",
+            "stages" => $stages,
+            "resume_from" => $start_index,
+            "message" => "Starting pull",
+        ], true);
+
+        $this->client->audit_log(
+            sprintf("PULL | stages=%s | resume_from=%d", implode(",", $stages), $start_index),
+            true,
+        );
+
+        for ($i = 0; $i < $start_index; $i++) {
+            $this->print_skipped($stages[$i]);
+        }
+
+        for ($i = $start_index; $i < $total; $i++) {
+            $stage = $stages[$i];
+            $step = $i + 1;
+
+            $this->print_stage_header($stage);
+
+            try {
+                $this->run_stage($stage, $options, $step, $total);
+            } catch (\Exception $e) {
+                $this->report_failure($stage, $stages, $i, $e);
+                throw $e;
+            }
+
+            $this->client->mark_pull_stage_complete($stage);
+        }
+
+        // The 'start' stage handles its own completion (it needs to save
+        // state before blocking on the server process).
+        if (!in_array('start', $stages, true)) {
+            $this->client->mark_pull_complete();
+            $this->print_summary();
+        }
+
+        $this->client->output_progress([
+            "type" => "lifecycle",
+            "event" => "complete",
+            "command" => "pull",
+            "stages" => $stages,
+            "message" => "Pull complete",
+        ], true);
+    }
+
+    /**
+     * Handle --abort for the pull command: clear pipeline state but
+     * leave downloaded files in place.
+     */
+    public function abort(): void
+    {
+        $this->prepare_repull();
+        $this->progress->show_lifecycle_line("Pull state cleared. Downloaded files are preserved.\n");
+        $this->client->output_progress([
+            "type" => "lifecycle",
+            "event" => "aborted",
+            "command" => "pull",
+            "message" => "Pull state cleared",
+        ], true);
+    }
+
+    private function run_stage(string $stage, array $options, int $step, int $total): void
+    {
+        switch ($stage) {
+            case 'preflight':
+                $this->client->run_preflight();
+                if ($this->check_plugin_installed()) {
+                    $this->client->exit_code = 1;
+                    return;
+                }
+                $this->print_done($stage, $this->preflight_summary());
+                break;
+
+            case 'files-pull':
+                $this->run_until_complete(function () {
+                    $this->client->run_files_sync();
+                });
+                $count = $this->client->index_count();
+                $this->print_done($stage, $count > 0 ? number_format($count) . " files" : null);
+                break;
+
+            case 'db-pull':
+                $this->run_until_complete(function () {
+                    $this->client->run_db_sync();
+                });
+                $sql_file = $this->client->state_dir . "/db.sql";
+                $size = file_exists($sql_file) ? $this->format_bytes(filesize($sql_file)) : null;
+                $this->print_done($stage, $size);
+                break;
+
+            case 'db-apply':
+                $this->run_until_complete(function () use ($options) {
+                    $this->client->run_db_apply($options);
+                });
+                $state = $this->client->state;
+                $stmts = (int) ($state["apply"]["statements_executed"] ?? 0);
+                $this->print_done($stage, $stmts > 0 ? number_format($stmts) . " statements" : null);
+                break;
+
+            case 'flat-docroot':
+                $this->client->run_flat_document_root($options);
+                $this->print_done($stage);
+                break;
+
+            case 'apply-runtime':
+                $this->client->run_apply_runtime($options);
+                $this->print_done($stage);
+                break;
+
+            case 'start':
+                $this->start_server($options);
+                break;
+        }
+    }
+
+    /**
+     * Validate user-provided options and apply defaults.
+     */
+    private function validate_and_default_options(array $options): array
+    {
+        // Default --runtime to php-builtin so pull always ends with a
+        // running local server. Users can override with --runtime=nginx-fpm,
+        // --runtime=playground-cli, or --runtime=none to skip runtime
+        // generation entirely.
+        if (empty($options['runtime'])) {
+            $options['runtime'] = 'php-builtin';
+        }
+        $valid_runtimes = ['nginx-fpm', 'php-builtin', 'playground-cli', 'none'];
+        if (!in_array($options['runtime'], $valid_runtimes, true)) {
+            throw new InvalidArgumentException(
+                "Invalid --runtime value: {$options['runtime']}. " .
+                "Valid runtimes: " . implode(', ', $valid_runtimes)
+            );
+        }
+        if ($options['runtime'] === 'none') {
+            unset($options['runtime']);
+        }
+
+        // Default --target-engine to sqlite for php-builtin and
+        // playground-cli (no MySQL server needed). nginx-fpm users
+        // probably have a server stack — require explicit DB config.
+        if (empty($options['target_engine']) && empty($options['target_user']) && empty($options['target_db'])) {
+            if (($options['runtime'] ?? null) !== 'nginx-fpm') {
+                $options['target_engine'] = 'sqlite';
+            }
+        }
+
+        if (!empty($options['target_engine'])) {
+            $engine = strtolower($options['target_engine']);
+            if (!in_array($engine, ['mysql', 'sqlite'], true)) {
+                throw new InvalidArgumentException(
+                    "Invalid --target-engine value: {$options['target_engine']}. " .
+                    "Valid engines: mysql, sqlite"
+                );
+            }
+        }
+
+        $engine = strtolower($options['target_engine'] ?? '');
+        if ($engine === 'mysql') {
+            if (empty($options['target_user'])) {
+                throw new InvalidArgumentException(
+                    "--target-user is required for MySQL database import."
+                );
+            }
+            if (empty($options['target_db'])) {
+                throw new InvalidArgumentException(
+                    "--target-db is required for MySQL database import."
+                );
+            }
+        }
+
+        if (empty($options['output_dir'])) {
+            $options['output_dir'] = $this->client->state_dir . '/runtime';
+        }
+
+        return $options;
+    }
+
+    /**
+     * Append ?site-export-api to bare site URLs so users can pass
+     * https://example.com instead of https://example.com/?site-export-api.
+     */
+    private function normalize_url(): void
+    {
+        $url = $this->client->remote_url;
+        if (strpos($url, 'site-export-api') === false) {
+            $separator = strpos($url, '?') === false ? '?' : '&';
+            $this->client->remote_url = $url . $separator . 'site-export-api';
+        }
+    }
+
+    /**
+     * Reset sub-command state for a delta re-pull.
+     *
+     * Keeps the local file index (so files-pull runs in delta mode) and
+     * preflight data, but clears everything else and deletes db.sql /
+     * the remote index so the next pull re-fetches them.
+     */
+    private function prepare_repull(): void
+    {
+        $state_dir = $this->client->state_dir;
+        $defaults = $this->client->default_state();
+        $this->client->mutate_state(function (array $state) use ($defaults) {
+            $state['pull']['stage'] = null;
+            $state['command'] = null;
+            $state['status'] = null;
+            $state['cursor'] = null;
+            $state['stage'] = null;
+            $state['consecutive_timeouts'] = 0;
+            $state['sql_bytes'] = null;
+            $state['current_file'] = null;
+            $state['current_file_bytes'] = null;
+            $state['db_index'] = $defaults['db_index'];
+            $state['diff'] = $defaults['diff'];
+            $state['fetch'] = $defaults['fetch'];
+            $state['fetch_skipped'] = $defaults['fetch_skipped'];
+            $state['apply'] = $defaults['apply'];
+            $state['sql_output'] = null;
+            return $state;
+        });
+
+        foreach ([
+            $state_dir . "/db.sql",
+            $state_dir . "/.import-domains.json",
+            $state_dir . "/.import-remote-index.jsonl",
+            $state_dir . "/.import-download-list.jsonl",
+            $state_dir . "/.import-download-list-skipped.jsonl",
+        ] as $path) {
+            if (file_exists($path)) {
+                @unlink($path);
+            }
+        }
+
+        $this->client->audit_log("PULL | prepared for delta re-pull", true);
+    }
+
+    /**
+     * Sub-commands return with state["status"]="partial" when a server
+     * timeout drops the connection. This loop retries automatically,
+     * resetting the status to "in_progress" so the handler enters its
+     * resume path (it specifically checks for that value).
+     */
+    private function run_until_complete(callable $handler): void
+    {
+        for ($attempt = 0; $attempt < 1000; $attempt++) {
+            $handler();
+            $state = $this->client->state;
+            if (($state['status'] ?? null) !== 'partial') {
+                break;
+            }
+            $this->client->mutate_state(function (array $state) {
+                $state['status'] = 'in_progress';
+                return $state;
+            });
+            $this->client->exit_code = 0;
+            $this->progress->tick_spinner();
+        }
+    }
+
+    /**
+     * Check whether preflight detected that the exporter plugin is not
+     * installed. Returns true if so (caller should abort the pipeline).
+     */
+    private function check_plugin_installed(): bool
+    {
+        $state = $this->client->state;
+        $preflight = $state["preflight"] ?? null;
+        $ok = ($preflight["http_code"] ?? 0) === 200 && !empty($preflight["data"]["ok"]);
+        if ($ok) {
+            return false;
+        }
+
+        $error = $preflight["error"] ?? null;
+        $error_code = $this->client->last_error_code;
+        $is_not_installed =
+            $error_code === 'NOT_FOUND' ||
+            $error_code === 'HTML_RESPONSE';
+
+        if ($is_not_installed) {
+            $red = "\033[31m";
+            $bold = "\033[1m";
+            $dim = "\033[2m";
+            $cyan = "\033[36m";
+            $r = "\033[0m";
+            $this->progress->print_line("\n{$red}  ✗ The exporter plugin is not installed on this site.{$r}\n\n");
+            $this->progress->print_line("  To set it up, run:\n\n");
+            $this->progress->print_line("    {$cyan}php reprint.phar install-exporter{$r}\n\n");
+            $this->progress->print_line("  {$dim}This will show the download URL and step-by-step instructions.{$r}\n");
+        } else {
+            $red = "\033[31m";
+            $dim = "\033[2m";
+            $r = "\033[0m";
+            $this->progress->print_line("\n{$red}  ✗ Preflight failed{$r}\n");
+            if ($error) {
+                $indented = implode("\n  ", explode("\n", $error));
+                $this->progress->print_line("  {$indented}\n");
+            }
+        }
+
+        $this->client->output_progress([
+            "status" => "error",
+            "command" => "pull",
+            "failed_stage" => "preflight",
+            "error_code" => $error_code,
+            "error" => $error ?? "Preflight check failed",
+            "message" => $error ?? "Preflight check failed",
+        ]);
+
+        return true;
+    }
+
+    /**
+     * Build a one-line summary of preflight results for the checkmark.
+     */
+    private function preflight_summary(): ?string
+    {
+        $state = $this->client->state;
+        $data = $state["preflight"]["data"] ?? null;
+        if (!is_array($data)) {
+            return null;
+        }
+        $parts = [];
+        $wp = $data["database"]["wp"]["wp_version"] ?? null;
+        if ($wp) {
+            $parts[] = "WordPress {$wp}";
+        }
+        $php = $data["runtime"]["phpversion"] ?? null;
+        if ($php) {
+            $parts[] = "PHP {$php}";
+        }
+        return $parts ? implode(", ", $parts) : null;
+    }
+
+    /**
+     * Start the local server. For php-builtin / playground-cli this
+     * runs start.sh via passthru and blocks until the user hits Ctrl-C.
+     */
+    private function start_server(array $options): void
+    {
+        $output_dir = $options['output_dir'] ?? $this->client->state_dir . '/runtime';
+        $start_sh = $output_dir . '/start.sh';
+
+        if (!file_exists($start_sh)) {
+            throw new RuntimeException(
+                "start.sh not found at {$start_sh}. " .
+                "apply-runtime may have failed to generate it."
+            );
+        }
+
+        $host = $options['host'] ?? 'localhost';
+        $port = (int) ($options['port'] ?? 8881);
+        $url = "http://{$host}:{$port}";
+
+        // Mark pull complete BEFORE the server blocks so killing the
+        // server (Ctrl-C) doesn't leave the pipeline mid-flight.
+        $this->client->mutate_state(function (array $state) {
+            $state['pull']['stage'] = 'start';
+            $state['status'] = 'complete';
+            return $state;
+        });
+
+        $green = "\033[32m";
+        $bold = "\033[1m";
+        $dim = "\033[2m";
+        $cyan = "\033[36m";
+        $r = "\033[0m";
+        $this->progress->clear_progress_line();
+        $this->progress->print_line("  {$green}✓{$r} Ready at {$cyan}{$bold}{$url}{$r}\n");
+        $this->progress->print_line("    {$dim}Press Ctrl-C to stop.{$r}\n\n");
+
+        $this->client->output_progress([
+            "type" => "lifecycle",
+            "event" => "server_starting",
+            "command" => "pull",
+            "url" => $url,
+            "start_sh" => $start_sh,
+            "message" => "Starting server at {$url}",
+        ], true);
+
+        passthru("bash " . escapeshellarg($start_sh), $exit_code);
+        $this->client->exit_code = $exit_code;
+    }
+
+    private function print_stage_header(string $stage): void
+    {
+        $this->progress->clear_progress_line();
+        $label = $this->stage_label($stage);
+        $this->progress->set_active_label($label);
+        $cyan = "\033[36m";
+        $r = "\033[0m";
+        // \n claims a fresh line, then \r\033[K positions us at column 0.
+        // Subsequent show_progress_line calls overwrite this in place.
+        $this->progress->print_line("\n\r\033[K  {$cyan}⠋{$r} {$label}");
+    }
+
+    private function print_done(string $stage, ?string $summary = null): void
+    {
+        $this->progress->clear_progress_line();
+        $green = "\033[32m";
+        $dim = "\033[2m";
+        $r = "\033[0m";
+        $label = $this->stage_label($stage);
+        $extra = $summary ? " {$dim}— {$summary}{$r}" : "";
+        $this->progress->print_line("  {$green}✓{$r} {$label}{$extra}\n");
+        $this->progress->set_active_label(null);
+    }
+
+    private function print_skipped(string $stage): void
+    {
+        $dim = "\033[2m";
+        $r = "\033[0m";
+        $label = $this->stage_label($stage);
+        $this->progress->print_line("  {$dim}✓ {$label}{$r}\n");
+    }
+
+    private function print_summary(): void
+    {
+        $green = "\033[32m";
+        $bold = "\033[1m";
+        $dim = "\033[2m";
+        $r = "\033[0m";
+        $fs_root = $this->client->fs_root;
+        $this->progress->print_line(
+            "\n{$green}{$bold}Done.{$r} {$dim}Files in {$fs_root}{$r}\n"
+        );
+    }
+
+    private function report_failure(string $stage, array $stages, int $i, \Exception $e): void
+    {
+        $this->client->output_progress([
+            "status" => "error",
+            "command" => "pull",
+            "failed_stage" => $stage,
+            "completed_stages" => array_slice($stages, 0, $i),
+            "error_code" => $this->client->last_error_code,
+            "error" => $e->getMessage(),
+            "message" => "Pull failed at {$stage}: " . $e->getMessage(),
+        ]);
+        $this->client->write_status_file("Pull failed at {$stage}: " . $e->getMessage());
+
+        $red = "\033[31m";
+        $dim = "\033[2m";
+        $r = "\033[0m";
+        $this->progress->clear_progress_line();
+        $this->progress->print_line("  {$red}✗ " . $this->stage_label($stage) . "{$r}\n");
+        $this->progress->print_line("    {$dim}" . $e->getMessage() . "{$r}\n\n");
+        $this->progress->print_line("  Re-run the same command to resume.\n");
+    }
+
+    private function format_bytes(int $bytes): string
+    {
+        if ($bytes >= 1073741824) {
+            return sprintf("%.1f GB", $bytes / 1073741824);
+        }
+        if ($bytes >= 1048576) {
+            return sprintf("%.1f MB", $bytes / 1048576);
+        }
+        if ($bytes >= 1024) {
+            return sprintf("%.1f KB", $bytes / 1024);
+        }
+        return "{$bytes} B";
+    }
+}

--- a/packages/reprint-importer/src/lib/terminal-progress/class-terminal-progress.php
+++ b/packages/reprint-importer/src/lib/terminal-progress/class-terminal-progress.php
@@ -4,13 +4,16 @@
  *
  * Two categories of output:
  *
- * - Progress line: a single line that overwrites in place, e.g.
- *   "[5,091 files] /path/to/file.jpg". Use show_progress_line().
+ * - Progress line: a single line that overwrites in place. In default
+ *   mode it just shows the message; in "quiet lifecycle" mode it also
+ *   prepends an animated Braille spinner and (when a fraction is given)
+ *   renders a Unicode progress bar. Use show_progress_line().
  *
  * - Lifecycle line: a regular line that announces a phase transition,
- *   e.g. "Starting db-pull". Use show_lifecycle_line(). Composite
- *   commands can suppress these by overriding show_lifecycle_line in
- *   a subclass when they want to provide their own framing.
+ *   e.g. "Starting db-pull". Use show_lifecycle_line(). When
+ *   quiet_lifecycle is enabled (typically by an orchestrator like
+ *   `pull`), these are suppressed so the orchestrator can provide its
+ *   own framing without sub-command noise.
  *
  * Both methods are no-ops when stdout is not a TTY (so machine
  * consumers reading JSONL don't get progress noise interleaved) or
@@ -30,6 +33,28 @@ class TerminalProgress
     /** @var int|null Cached terminal column count (lazy-loaded via tput). */
     private ?int $terminal_width_cache = null;
 
+    /**
+     * @var bool When true, suppress lifecycle messages and decorate the
+     * progress line with a spinner / progress bar. Used by orchestrator
+     * commands (e.g. pull) that want to provide their own framing.
+     */
+    private bool $quiet_lifecycle = false;
+
+    /** @var int Spinner frame counter. */
+    private int $spinner_tick = 0;
+
+    /** @var float Last spinner draw timestamp (microtime), for rate-limiting. */
+    private float $spinner_last_draw = 0.0;
+
+    /** @var string|null Active stage label, shown when no progress message has arrived yet. */
+    private ?string $active_label = null;
+
+    /** @var string|null Last progress message rendered (without spinner prefix), for spinner replays. */
+    private ?string $last_progress_message = null;
+
+    /** @var float|null Fraction from the last progress call, or null for no bar. */
+    private ?float $last_progress_fraction = null;
+
     public function __construct(bool $is_tty, $progress_fd, bool $verbose_mode = false)
     {
         $this->is_tty = $is_tty;
@@ -37,22 +62,16 @@ class TerminalProgress
         $this->verbose_mode = $verbose_mode;
     }
 
-    /**
-     * Update the TTY flag. Used when the progress stream is reassigned
-     * (e.g. STDOUT → STDERR for --sql-output=stdout mode).
-     */
     public function set_is_tty(bool $is_tty): void
     {
         $this->is_tty = $is_tty;
     }
 
-    /** Update the progress stream. */
     public function set_progress_fd($progress_fd): void
     {
         $this->progress_fd = $progress_fd;
     }
 
-    /** Toggle verbose mode (suppresses progress output when true). */
     public function set_verbose_mode(bool $verbose_mode): void
     {
         $this->verbose_mode = $verbose_mode;
@@ -69,30 +88,84 @@ class TerminalProgress
     }
 
     /**
-     * Show progress in a single refreshing line (TTY mode only).
-     * Truncates long messages to fit terminal width.
+     * Enable rich progress mode: lifecycle messages are suppressed,
+     * the progress line gains a spinner/bar prefix, and tick_spinner()
+     * starts animating.
      */
-    public function show_progress_line(string $message): void
+    public function enable_quiet_lifecycle(): void
+    {
+        $this->quiet_lifecycle = true;
+    }
+
+    public function is_quiet_lifecycle(): bool
+    {
+        return $this->quiet_lifecycle;
+    }
+
+    /**
+     * Set the label shown alongside the spinner when no detailed
+     * progress message is available yet (called when a new stage starts).
+     */
+    public function set_active_label(?string $label): void
+    {
+        $this->active_label = $label;
+        $this->last_progress_message = null;
+        $this->last_progress_fraction = null;
+    }
+
+    /**
+     * Show progress in a single refreshing line.
+     *
+     * In quiet_lifecycle mode the message is decorated with either a
+     * progress bar (when $fraction is provided) or a Braille spinner.
+     * Rate-limited to ~20fps so the terminal can keep up.
+     */
+    public function show_progress_line(string $message, ?float $fraction = null): void
     {
         if (!$this->is_tty || $this->verbose_mode) {
             return;
         }
-        $width = $this->get_terminal_width();
-        if (strlen($message) > $width - 3) {
-            $message = substr($message, 0, $width - 3) . "...";
+        if ($this->quiet_lifecycle) {
+            // Rate-limit in pull mode to avoid flooding the terminal.
+            // Hundreds of updates per second cause visual artifacts
+            // because the terminal can't redraw fast enough — \r writes
+            // pile up and appear as scrolling lines.
+            $now = microtime(true);
+            if ($now - $this->spinner_last_draw < 0.05) {
+                return;
+            }
+            $this->spinner_tick++;
+            $this->spinner_last_draw = $now;
+            // Remember raw content so tick_spinner can redraw with an
+            // updated frame without flickering back to the bare label.
+            $this->last_progress_message = $message;
+            $this->last_progress_fraction = $fraction;
+            $message = $this->decorate($message, $fraction);
         }
+
+        $message = $this->truncate_for_terminal($message);
         fwrite($this->progress_fd, "\r\033[K" . $message);
     }
 
     /**
-     * Print a lifecycle message that announces a phase transition.
+     * Print a lifecycle message announcing a phase transition.
      *
-     * The message is written verbatim — callers include their own \n
-     * if they want a newline. Composite commands like `pull` can
-     * subclass and override this to suppress sub-command lifecycle
-     * messages while keeping the show_progress_line output.
+     * Suppressed when quiet_lifecycle is enabled, so an orchestrator
+     * can render its own framing without sub-command noise.
      */
     public function show_lifecycle_line(string $message): void
+    {
+        if (!$this->is_tty || $this->verbose_mode || $this->quiet_lifecycle) {
+            return;
+        }
+        fwrite($this->progress_fd, $message);
+    }
+
+    /**
+     * Always print a line (no quiet_lifecycle suppression). Use for
+     * orchestrator-owned output like stage headers / checkmarks.
+     */
+    public function print_line(string $message): void
     {
         if (!$this->is_tty || $this->verbose_mode) {
             return;
@@ -112,11 +185,76 @@ class TerminalProgress
     }
 
     /**
+     * Advance the spinner without updating the message. Called from
+     * curl progress callbacks and other tight loops to keep the
+     * spinner alive when no new data has arrived. Rate-limited to
+     * ~12fps to avoid CPU waste on terminal writes.
+     */
+    public function tick_spinner(): void
+    {
+        if (!$this->quiet_lifecycle || !$this->is_tty || $this->verbose_mode) {
+            return;
+        }
+        if ($this->active_label === null && $this->last_progress_message === null) {
+            return;
+        }
+        $now = microtime(true);
+        if ($now - $this->spinner_last_draw < 0.08) {
+            return;
+        }
+        $this->spinner_last_draw = $now;
+        $this->spinner_tick++;
+
+        if ($this->last_progress_message !== null) {
+            $line = $this->decorate($this->last_progress_message, $this->last_progress_fraction);
+        } else {
+            $line = $this->decorate($this->active_label, null);
+        }
+        $line = $this->truncate_for_terminal($line);
+        fwrite($this->progress_fd, "\r\033[K{$line}");
+    }
+
+    /**
+     * Decorate a message with the current spinner frame (or progress bar
+     * when a fraction is provided). The spinner_tick advances inside
+     * show_progress_line / tick_spinner; this method just reads it.
+     */
+    private function decorate(string $message, ?float $fraction): string
+    {
+        if ($fraction !== null && $fraction >= 0) {
+            return $this->render_progress_bar($message, $fraction);
+        }
+        $frames = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏";
+        $idx = ($this->spinner_tick % 10) * 3;
+        $char = substr($frames, $idx, 3);
+        return "  \033[36m{$char}\033[0m {$message}";
+    }
+
+    /**
+     * Render a progress bar line:
+     *   ━━━━━━━━━━━━░░░░░░  Downloading files — 1,234 / 5,091 24%
+     */
+    public function render_progress_bar(string $label, float $fraction): string
+    {
+        $fraction = max(0.0, min(1.0, $fraction));
+        $bar_width = 20;
+        $filled = (int) round($fraction * $bar_width);
+        $empty = $bar_width - $filled;
+        $bar = str_repeat("━", $filled) . str_repeat("░", $empty);
+        $pct = (int) round($fraction * 100);
+        return "  \033[36m{$bar}\033[0m  {$label} \033[2m{$pct}%\033[0m";
+    }
+
+    /**
      * Return the terminal width in columns. Tries `tput cols` once
      * and caches the result; falls back to 80.
      */
     public function get_terminal_width(): int
     {
+        $override = $this->get_terminal_width_override();
+        if ($override !== null) {
+            return $override;
+        }
         if ($this->terminal_width_cache !== null) {
             return $this->terminal_width_cache;
         }
@@ -129,5 +267,70 @@ class TerminalProgress
         }
         $this->terminal_width_cache = $width;
         return $width;
+    }
+
+    /** @internal Override point for tests — return non-null to bypass tput. */
+    protected function get_terminal_width_override(): ?int
+    {
+        return null;
+    }
+
+    /**
+     * Measure the display width of a string, ignoring ANSI escape codes.
+     * Uses mb_strwidth when available for correct multi-byte widths.
+     */
+    public function display_width(string $message): int
+    {
+        $stripped = preg_replace('/\033\[[0-9;]*m/', '', $message);
+        return function_exists('mb_strwidth')
+            ? mb_strwidth($stripped, 'UTF-8')
+            : strlen($stripped);
+    }
+
+    /**
+     * Truncate a message to fit the terminal width.
+     *
+     * Preserves ANSI escape codes (zero display width) while truncating
+     * the visible text. Walks character by character so multi-byte
+     * UTF-8 sequences and Unicode bar characters are handled correctly.
+     */
+    public function truncate_for_terminal(string $message): string
+    {
+        $width = $this->get_terminal_width();
+        if ($this->display_width($message) <= $width) {
+            return $message;
+        }
+        $limit = $width - 3; // room for "..."
+        $result = '';
+        $cols = 0;
+        $len = strlen($message);
+        for ($i = 0; $i < $len; ) {
+            if ($message[$i] === "\033" && $i + 1 < $len && $message[$i + 1] === '[') {
+                $end = $i + 2;
+                while ($end < $len && !ctype_alpha($message[$end])) {
+                    $end++;
+                }
+                if ($end < $len) $end++;
+                $result .= substr($message, $i, $end - $i);
+                $i = $end;
+                continue;
+            }
+            $byte = ord($message[$i]);
+            if ($byte < 0x80) { $char_len = 1; }
+            elseif ($byte < 0xE0) { $char_len = 2; }
+            elseif ($byte < 0xF0) { $char_len = 3; }
+            else { $char_len = 4; }
+            $char = substr($message, $i, $char_len);
+            $char_width = function_exists('mb_strwidth')
+                ? mb_strwidth($char, 'UTF-8')
+                : 1;
+            if ($cols + $char_width > $limit) {
+                break;
+            }
+            $result .= $char;
+            $cols += $char_width;
+            $i += $char_len;
+        }
+        return $result . "\033[0m...";
     }
 }

--- a/tests/Import/ProgressLineWidthTest.php
+++ b/tests/Import/ProgressLineWidthTest.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace ImportTests;
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../packages/reprint-importer/src/import.php';
+
+/**
+ * Verify that progress line output never exceeds terminal width.
+ *
+ * Line wrapping in a terminal causes \r\033[K to only clear the last
+ * physical line, leaving ghost text above. This test ensures the
+ * truncation logic correctly limits all output to the terminal width.
+ */
+class ProgressLineWidthTest extends TestCase
+{
+    /**
+     * Create a TerminalProgress with a forced terminal width.
+     */
+    private function createProgress(int $terminal_width = 80): \TerminalProgress
+    {
+        // Anonymous subclass to override the width detection.
+        return new class(true, STDOUT, false, $terminal_width) extends \TerminalProgress {
+            private int $forced_width;
+
+            public function __construct(bool $is_tty, $progress_fd, bool $verbose_mode, int $width)
+            {
+                parent::__construct($is_tty, $progress_fd, $verbose_mode);
+                $this->forced_width = $width;
+            }
+
+            protected function get_terminal_width_override(): ?int
+            {
+                return $this->forced_width;
+            }
+        };
+    }
+
+    private function displayWidth(string $s): int
+    {
+        $stripped = preg_replace('/\033\[[0-9;]*m/', '', $s);
+        return function_exists('mb_strwidth')
+            ? mb_strwidth($stripped, 'UTF-8')
+            : strlen($stripped);
+    }
+
+    public function testPlainTextTruncation(): void
+    {
+        $progress = $this->createProgress(40);
+        $long = str_repeat('a', 60);
+        $result = $progress->truncate_for_terminal($long);
+        $this->assertLessThanOrEqual(40, $this->displayWidth($result));
+        $this->assertStringEndsWith('...', $result);
+    }
+
+    public function testShortTextUnchanged(): void
+    {
+        $progress = $this->createProgress(80);
+        $short = 'Hello world';
+        $result = $progress->truncate_for_terminal($short);
+        $this->assertEquals($short, $result);
+    }
+
+    public function testAnsiCodesPreservedInTruncation(): void
+    {
+        $progress = $this->createProgress(30);
+        $msg = "  \033[36m⠋\033[0m Hello world more text here blah blah blah";
+        $result = $progress->truncate_for_terminal($msg);
+        $this->assertLessThanOrEqual(30, $this->displayWidth($result));
+        $this->assertStringContainsString("\033[", $result);
+    }
+
+    public function testProgressBarTruncation(): void
+    {
+        $progress = $this->createProgress(60);
+        $bar = str_repeat("━", 10) . str_repeat("░", 10);
+        $msg = "  \033[36m{$bar}\033[0m  Downloading — 1,234 / 43,378 files \033[2m28%\033[0m";
+        $result = $progress->truncate_for_terminal($msg);
+        $this->assertLessThanOrEqual(60, $this->displayWidth($result),
+            "Progress bar line exceeds terminal width. Display width: " .
+            $this->displayWidth($result) . ", max: 60. Output: " . $result);
+    }
+
+    public function testUnicodeSpinnerWidth(): void
+    {
+        $progress = $this->createProgress(80);
+        $this->assertEquals(1, $progress->display_width("⠋"));
+        $this->assertEquals(1, $progress->display_width("━"));
+        $this->assertEquals(1, $progress->display_width("░"));
+    }
+
+    public function testAnsiCodesHaveZeroWidth(): void
+    {
+        $progress = $this->createProgress(80);
+        $this->assertEquals(0, $progress->display_width("\033[36m"));
+        $this->assertEquals(0, $progress->display_width("\033[0m"));
+        $this->assertEquals(5, $progress->display_width("\033[36mhello\033[0m"));
+    }
+
+    public function testNarrowTerminal(): void
+    {
+        $progress = $this->createProgress(20);
+        $msg = "  \033[36m⠋\033[0m Scanning remote files — 376,000 scanned";
+        $result = $progress->truncate_for_terminal($msg);
+        $width = $this->displayWidth($result);
+        $this->assertLessThanOrEqual(20, $width,
+            "Output exceeds 20-col terminal. Width: {$width}. Output: {$result}");
+    }
+
+    public function testExactWidthNotTruncated(): void
+    {
+        $progress = $this->createProgress(40);
+        $msg = str_repeat('x', 40);
+        $result = $progress->truncate_for_terminal($msg);
+        $this->assertEquals($msg, $result);
+    }
+
+    public function testUtf8NotSplitMidCharacter(): void
+    {
+        $progress = $this->createProgress(10);
+        $msg = str_repeat("━", 15);
+        $result = $progress->truncate_for_terminal($msg);
+        $this->assertTrue(mb_check_encoding($result, 'UTF-8'),
+            "Truncated string is not valid UTF-8");
+        $this->assertLessThanOrEqual(10, $this->displayWidth($result));
+    }
+}

--- a/tests/e2e/tests/import-46-pull-basic.test.js
+++ b/tests/e2e/tests/import-46-pull-basic.test.js
@@ -1,0 +1,104 @@
+/**
+ * Test 46: Pull — Happy Path
+ *
+ * Runs `reprint pull` end-to-end with database import and --runtime=none
+ * (no server start). Verifies that a single pull command downloads files, pulls the SQL dump, applies
+ * it to a local MySQL database, and that a second pull performs a
+ * delta sync without errors.
+ */
+import { describe, it, beforeAll, afterAll } from 'vitest';
+import assert from 'node:assert/strict';
+import { readFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+    runImporter, createTempDir, cleanupTempDir,
+    getSiteUrl, getSiteSecret, getSiteDir,
+    assertTreesMatch, assertSiteMirror,
+    fsRootDir, compareDatabases, createMysqlConnection, getDbName,
+} from '../lib/test-helpers.js';
+import { ensureSite } from '../lib/site-setup.js';
+
+describe('Import: Pull Basic', { timeout: 180000 }, () => {
+    const site = 'basic';
+    const importDb = 'e2e_pull_basic_46';
+    let tempDir;
+
+    beforeAll(async () => {
+        await ensureSite(site);
+        tempDir = createTempDir('e2e-pull-basic');
+        const conn = await createMysqlConnection();
+        await conn.query(`DROP DATABASE IF EXISTS \`${importDb}\``);
+        await conn.query(`CREATE DATABASE \`${importDb}\``);
+        await conn.end();
+    });
+
+    afterAll(async () => {
+        cleanupTempDir(tempDir);
+        const conn = await createMysqlConnection();
+        await conn.query(`DROP DATABASE IF EXISTS \`${importDb}\``);
+        await conn.end();
+    });
+
+    function importUrl() {
+        return `${getSiteUrl(site)}&directory=${getSiteDir(site)}`;
+    }
+
+    const pullArgs = () => [
+        `--target-user=e2e_admin`,
+        `--target-pass=e2e_password`,
+        `--target-db=${importDb}`,
+        `--new-site-url=http://localhost:9999`,
+        '--runtime=none',
+    ];
+
+    it('pull completes successfully', () => {
+        const result = runImporter(importUrl(), tempDir, 'pull', {
+            secret: getSiteSecret(site),
+            skipPreflight: true,
+            timeout: 120000,
+            wallTimeout: 180000,
+            extraArgs: pullArgs(),
+        });
+        assert.equal(result.exitCode, 0,
+            `Expected exit 0, got ${result.exitCode}\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);
+    });
+
+    it('state shows pull complete', () => {
+        const stateFile = join(tempDir, '.import-state.json');
+        assert.ok(existsSync(stateFile), 'Expected .import-state.json to exist');
+        const state = JSON.parse(readFileSync(stateFile, 'utf-8'));
+        assert.equal(state.pull.stage, 'complete');
+    });
+
+    it('files match source', () => {
+        const importedRoot = join(fsRootDir(tempDir), getSiteDir(site));
+        assert.ok(existsSync(importedRoot), `Expected ${importedRoot} to exist`);
+        assertTreesMatch(getSiteDir(site), importedRoot);
+    });
+
+    it('imported files form valid WordPress structure', () => {
+        assertSiteMirror(join(fsRootDir(tempDir), getSiteDir(site)));
+    });
+
+    it('database matches source', async () => {
+        const comparison = await compareDatabases(getDbName(site), importDb);
+        assert.ok(comparison.match,
+            `Database mismatch: missing=${JSON.stringify(comparison.missingTables)}, ` +
+            `counts=${JSON.stringify(comparison.rowCounts)}`);
+    });
+
+    it('re-running pull performs delta sync', () => {
+        const result = runImporter(importUrl(), tempDir, 'pull', {
+            secret: getSiteSecret(site),
+            skipPreflight: true,
+            timeout: 120000,
+            wallTimeout: 180000,
+            extraArgs: pullArgs(),
+        });
+        assert.equal(result.exitCode, 0,
+            `Expected exit 0 on re-pull, got ${result.exitCode}\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);
+
+        const state = JSON.parse(readFileSync(join(tempDir, '.import-state.json'), 'utf-8'));
+        assert.equal(state.pull.stage, 'complete');
+    });
+});

--- a/tests/e2e/tests/import-47-pull-multi-request.test.js
+++ b/tests/e2e/tests/import-47-pull-multi-request.test.js
@@ -1,0 +1,119 @@
+/**
+ * Test 47: Pull — Multiple Requests Per Phase
+ *
+ * Runs `reprint pull` with --max-exec=1 to force very short server
+ * execution times. Each phase (files-pull, db-pull) requires many
+ * HTTP requests to complete. The pull command's internal retry loop
+ * handles all the partial responses transparently, and the final
+ * result matches the source.
+ */
+import { describe, it, beforeAll, afterAll } from 'vitest';
+import assert from 'node:assert/strict';
+import { readFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+    runImporter, createTempDir, cleanupTempDir,
+    getSiteUrl, getSiteSecret, getSiteDir,
+    assertTreesMatch, assertSiteMirror,
+    fsRootDir, readAuditLog,
+    compareDatabases, createMysqlConnection, getDbName,
+} from '../lib/test-helpers.js';
+import { ensureSite } from '../lib/site-setup.js';
+
+describe('Import: Pull Multi-Request', { timeout: 300000 }, () => {
+    const site = 'basic';
+    const importDb = 'e2e_pull_multi_47';
+    let tempDir;
+    let pullStdout = '';
+
+    beforeAll(async () => {
+        await ensureSite(site);
+        tempDir = createTempDir('e2e-pull-multi-request');
+        const conn = await createMysqlConnection();
+        await conn.query(`DROP DATABASE IF EXISTS \`${importDb}\``);
+        await conn.query(`CREATE DATABASE \`${importDb}\``);
+        await conn.end();
+    });
+
+    afterAll(async () => {
+        cleanupTempDir(tempDir);
+        const conn = await createMysqlConnection();
+        await conn.query(`DROP DATABASE IF EXISTS \`${importDb}\``);
+        await conn.end();
+    });
+
+    function importUrl() {
+        return `${getSiteUrl(site)}&directory=${getSiteDir(site)}`;
+    }
+
+    it('pull completes with --max-exec=1 (many small requests)', () => {
+        const result = runImporter(importUrl(), tempDir, 'pull', {
+            secret: getSiteSecret(site),
+            skipPreflight: true,
+            timeout: 120000,
+            wallTimeout: 300000,
+            extraArgs: [
+                '--max-exec=1',
+                `--target-user=e2e_admin`,
+                `--target-pass=e2e_password`,
+                `--target-db=${importDb}`,
+                `--new-site-url=http://localhost:9999`,
+                '--runtime=none',
+            ],
+        });
+        pullStdout = result.stdout;
+        assert.equal(result.exitCode, 0,
+            `Expected exit 0, got ${result.exitCode}\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);
+    });
+
+    it('state shows pull complete', () => {
+        const state = JSON.parse(readFileSync(join(tempDir, '.import-state.json'), 'utf-8'));
+        assert.equal(state.pull.stage, 'complete');
+    });
+
+    it('audit log shows multiple resume cycles', () => {
+        const audit = readAuditLog(tempDir);
+        // With --max-exec=1, each phase should require multiple requests.
+        // The audit log records RESUME entries for each continuation.
+        const resumeCount = (audit.match(/RESUME/g) || []).length;
+        assert.ok(resumeCount >= 3,
+            `Expected at least 3 resume entries in audit log, got ${resumeCount}`);
+    });
+
+    it('file download counter never decreases across requests', () => {
+        // The JSONL output includes files_done in file_progress records.
+        // With --max-exec=1, there are many HTTP requests. The counter
+        // must be monotonically increasing — no resets between requests.
+        const filesDoneValues = pullStdout
+            .split('\n')
+            .filter(line => line.startsWith('{'))
+            .map(line => { try { return JSON.parse(line); } catch { return null; } })
+            .filter(obj => obj && typeof obj.files_done === 'number')
+            .map(obj => obj.files_done);
+
+        assert.ok(filesDoneValues.length >= 2,
+            `Expected at least 2 files_done progress records, got ${filesDoneValues.length}`);
+
+        for (let i = 1; i < filesDoneValues.length; i++) {
+            assert.ok(filesDoneValues[i] >= filesDoneValues[i - 1],
+                `files_done decreased from ${filesDoneValues[i - 1]} to ${filesDoneValues[i]} ` +
+                `at progress record ${i} of ${filesDoneValues.length}`);
+        }
+    });
+
+    it('files match source', () => {
+        const importedRoot = join(fsRootDir(tempDir), getSiteDir(site));
+        assertTreesMatch(getSiteDir(site), importedRoot);
+    });
+
+    it('imported files form valid WordPress structure', () => {
+        assertSiteMirror(join(fsRootDir(tempDir), getSiteDir(site)));
+    });
+
+    it('database matches source', async () => {
+        const comparison = await compareDatabases(getDbName(site), importDb);
+        assert.ok(comparison.match,
+            `Database mismatch: missing=${JSON.stringify(comparison.missingTables)}, ` +
+            `counts=${JSON.stringify(comparison.rowCounts)}`);
+    });
+});

--- a/tests/e2e/tests/import-48-pull-crash-resume.test.js
+++ b/tests/e2e/tests/import-48-pull-crash-resume.test.js
@@ -1,0 +1,144 @@
+/**
+ * Test 48: Pull — Abort and Resume
+ *
+ * Tests pull's pipeline state tracking and resumption behavior:
+ *
+ * 1. Run pull to completion (all stages: preflight → files → db → apply)
+ * 2. Abort the completed pull (--abort resets pipeline state)
+ * 3. Re-run pull → performs delta sync (re-index, diff, re-download db)
+ * 4. Verify the re-pull completes and data matches
+ *
+ * The internal crash-retry mechanism (server crashes during SQL
+ * streaming) is tested by import-43. This test focuses on the
+ * higher-level pull pipeline state machine: does pull correctly skip
+ * completed stages and pick up where it left off?
+ */
+import { describe, it, beforeAll, afterAll } from 'vitest';
+import assert from 'node:assert/strict';
+import { readFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+    runImporter, createTempDir, cleanupTempDir,
+    getSiteUrl, getSiteSecret, getSiteDir,
+    assertTreesMatch, assertSiteMirror,
+    fsRootDir,
+    compareDatabases, createMysqlConnection, getDbName,
+} from '../lib/test-helpers.js';
+import { ensureSite } from '../lib/site-setup.js';
+
+describe('Import: Pull Abort and Resume', { timeout: 300000 }, () => {
+    const site = 'basic';
+    const importDb = 'e2e_pull_resume_48';
+    let tempDir;
+
+    beforeAll(async () => {
+        await ensureSite(site);
+        tempDir = createTempDir('e2e-pull-resume');
+        const conn = await createMysqlConnection();
+        await conn.query(`DROP DATABASE IF EXISTS \`${importDb}\``);
+        await conn.query(`CREATE DATABASE \`${importDb}\``);
+        await conn.end();
+    });
+
+    afterAll(async () => {
+        cleanupTempDir(tempDir);
+        const conn = await createMysqlConnection();
+        await conn.query(`DROP DATABASE IF EXISTS \`${importDb}\``);
+        await conn.end();
+    });
+
+    function importUrl() {
+        return `${getSiteUrl(site)}&directory=${getSiteDir(site)}`;
+    }
+
+    const pullArgs = () => [
+        `--target-user=e2e_admin`,
+        `--target-pass=e2e_password`,
+        `--target-db=${importDb}`,
+        `--new-site-url=http://localhost:9999`,
+        '--runtime=none',
+    ];
+
+    it('initial pull completes', () => {
+        const result = runImporter(importUrl(), tempDir, 'pull', {
+            secret: getSiteSecret(site),
+            skipPreflight: true,
+            timeout: 120000,
+            wallTimeout: 180000,
+            extraArgs: pullArgs(),
+        });
+        assert.equal(result.exitCode, 0,
+            `Expected exit 0, got ${result.exitCode}\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);
+
+        const state = JSON.parse(readFileSync(join(tempDir, '.import-state.json'), 'utf-8'));
+        assert.equal(state.pull.stage, 'complete');
+    });
+
+    it('--abort clears pull pipeline state', () => {
+        const result = runImporter(importUrl(), tempDir, 'pull', {
+            secret: getSiteSecret(site),
+            skipPreflight: true,
+            extraArgs: ['--abort'],
+        });
+        assert.equal(result.exitCode, 0,
+            `Expected abort exit 0, got ${result.exitCode}`);
+
+        // Pull stage should be cleared
+        const state = JSON.parse(readFileSync(join(tempDir, '.import-state.json'), 'utf-8'));
+        assert.equal(state.pull.stage, null,
+            'Expected pull.stage to be null after abort');
+
+        // Local index should be preserved (for delta sync)
+        assert.ok(existsSync(join(tempDir, '.import-index.jsonl')),
+            'Expected local index to be preserved after abort');
+    });
+
+    it('re-pull after abort performs delta sync', () => {
+        const result = runImporter(importUrl(), tempDir, 'pull', {
+            secret: getSiteSecret(site),
+            skipPreflight: true,
+            timeout: 120000,
+            wallTimeout: 180000,
+            extraArgs: pullArgs(),
+        });
+        assert.equal(result.exitCode, 0,
+            `Expected re-pull exit 0, got ${result.exitCode}\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);
+
+        const state = JSON.parse(readFileSync(join(tempDir, '.import-state.json'), 'utf-8'));
+        assert.equal(state.pull.stage, 'complete');
+    });
+
+    it('files still match source after re-pull', () => {
+        const importedRoot = join(fsRootDir(tempDir), getSiteDir(site));
+        assertTreesMatch(getSiteDir(site), importedRoot);
+    });
+
+    it('imported files form valid WordPress structure', () => {
+        assertSiteMirror(join(fsRootDir(tempDir), getSiteDir(site)));
+    });
+
+    it('database matches source after re-pull', async () => {
+        const comparison = await compareDatabases(getDbName(site), importDb);
+        assert.ok(comparison.match,
+            `Database mismatch after re-pull: ` +
+            `missing=${JSON.stringify(comparison.missingTables)}, ` +
+            `counts=${JSON.stringify(comparison.rowCounts)}`);
+    });
+
+    it('second re-pull without abort also works (auto delta)', () => {
+        // Running pull again when pull.stage=complete should auto-reset
+        // and perform another delta sync.
+        const result = runImporter(importUrl(), tempDir, 'pull', {
+            secret: getSiteSecret(site),
+            skipPreflight: true,
+            timeout: 120000,
+            wallTimeout: 180000,
+            extraArgs: pullArgs(),
+        });
+        assert.equal(result.exitCode, 0,
+            `Expected auto re-pull exit 0, got ${result.exitCode}\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);
+
+        const state = JSON.parse(readFileSync(join(tempDir, '.import-state.json'), 'utf-8'));
+        assert.equal(state.pull.stage, 'complete');
+    });
+});


### PR DESCRIPTION
**Stacked on top of #141** (TerminalProgress extraction).

## Summary

A single command that orchestrates the lower-level commands into a resumable site clone pipeline. Like `git pull` composes fetch + merge, this composes preflight → files-pull → db-pull → db-apply → flat-docroot → apply-runtime → start.

The orchestration logic lives in a new `Pull` class. It holds a reference to ImportClient — each pipeline stage delegates to an ImportClient method, and the orchestration concern (pipeline state, retry loop, stage framing) stays separate from the transfer logic. `TerminalProgress` (extracted in #141) gets the rendering features pull needs: animated Braille spinner, Unicode progress bar, quiet_lifecycle mode, correct multi-byte width measurement, and ANSI-aware truncation.

```bash
reprint pull https://example.com --secret=TOKEN \
  --state-dir=./state --fs-root=./files
```

That's the minimum invocation. By default it imports into SQLite and starts a PHP built-in server when done. Override with `--runtime=nginx-fpm`, `--runtime=playground-cli`, or `--runtime=none` to skip runtime generation entirely.

## Notable behaviours

- Auto-appends `?site-export-api` to bare URLs so users don't need to remember it
- Detects when the exporter plugin isn't installed and points at `install-exporter` instead of failing with a confusing error
- Defaults to SQLite + php-builtin so the simplest invocation produces a running local site
- Resumes from the last completed stage on re-run; running pull again after completion performs a delta sync
- Three categories of TTY output: progress line (in-place), lifecycle line (suppressed in pull mode), and pull-owned framing (stage headers, checkmarks)

## Test plan

- [x] PHPUnit tests pass (395 tests, 767 assertions, no warnings)
- [x] `ProgressLineWidthTest` covers the truncation/width measurement on TerminalProgress (9 unit tests)
- [ ] Three E2E tests for pull (happy path, multi-request resumption, abort+resume) pass on CI