### PR TITLE
Accept ?reprint-api alongside the legacy ?site-export-api

### DIFF
--- a/.github/workflows/e2e-playground.yml
+++ b/.github/workflows/e2e-playground.yml
@@ -94,7 +94,7 @@ jobs:
 
           # Quick smoke test: use the Playground CLI PHP to run the importer
           SECRET="test-secret-basic"
-          BASE="http://127.0.0.1:8081/?site-export-api"
+          BASE="http://127.0.0.1:8081/?reprint-api"
           DIR="/srv/e2e-sites/basic"
 
           echo "=== Playground CLI importer preflight ==="

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -81,7 +81,7 @@ jobs:
 
           # Quick smoke test: use the importer CLI to hit the export API.
           SECRET="test-secret-basic"
-          BASE="http://127.0.0.1:8081/?site-export-api"
+          BASE="http://127.0.0.1:8081/?reprint-api"
           DIR="/srv/e2e-sites/basic"
 
           echo "=== Importer preflight ==="

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -170,7 +170,7 @@ During the file fetch phase, progress and heartbeat records include `files_done`
   - src/lib/url-rewrite/: URL rewriting for db-apply
   - src/lib/mysql-query-stream/: MySQL query stream parser for direct streaming
 - reprint-exporter-wp/: Self-contained WordPress plugin distribution directory
-  - index.php: WordPress plugin entry point — intercepts `?site-export-api` requests during plugin load, requires lib.php
+  - index.php: WordPress plugin entry point — intercepts `?reprint-api` requests (and the legacy `?site-export-api` alias) during plugin load, requires lib.php
   - lib.php: Standalone library — constants, auth functions, and request handler. Can be required without index.php by projects that want to embed the export engine with their own URL routing and authentication (pass a custom `authenticate` callable in the `$options` array to `_site_export_handle_api_request()`)
   - wordpress/: WordPress admin UI (site-export.php)
 - importer/: Thin compatibility wrapper that loads the importer package entry point

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ The migration process has a few steps:
 All commands below use the same base invocation. We'll use `$URL` and `$DIR` as shorthand:
 
 ```bash
-URL="https://example.com/?site-export-api"
+URL="https://example.com/?reprint-api"
 STATE_DIR="./local-directory-where-the-migration-state-will-be-tracked"
 FS_ROOT="./local-directory-where-the-remote-site-files-will-be-recreated"
 SECRET="your-shared-secret"

--- a/packages/reprint-exporter/src/class-hmac-client.php
+++ b/packages/reprint-exporter/src/class-hmac-client.php
@@ -24,14 +24,14 @@
  * $client = new Site_Export_HMAC_Client($secret);
  *
  * // For GET requests:
- * $ch = curl_init('https://example.com/site-export-api/?endpoint=file_index&directory=/var/www/html');
+ * $ch = curl_init('https://example.com/?reprint-api&endpoint=file_index&directory=/var/www/html');
  * $client->sign_curl_request($ch, '');
  * curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
  * $response = curl_exec($ch);
  *
  * // For POST requests with JSON body:
  * $body = json_encode(['paths' => ['/wp-content/uploads/image.jpg']]);
- * $ch = curl_init('https://example.com/site-export-api/?endpoint=file_fetch');
+ * $ch = curl_init('https://example.com/?reprint-api&endpoint=file_fetch');
  * $client->sign_curl_request($ch, $body);
  * curl_setopt($ch, CURLOPT_POST, true);
  * curl_setopt($ch, CURLOPT_POSTFIELDS, $body);

--- a/reprint-exporter-wp/README.md
+++ b/reprint-exporter-wp/README.md
@@ -12,9 +12,9 @@ Many shared hosts (SiteGround, GoDaddy, etc.) block direct PHP execution inside 
 
 The plugin file (`index.php`) is `include`'d by WordPress during its plugin loading loop — this happens *before* the `plugins_loaded` hook fires, making it the earliest interception point available to a regular plugin.
 
-When a request arrives at `https://example.com/?site-export-api`, the plugin:
+When a request arrives at `https://example.com/?reprint-api` (or the legacy `?site-export-api` alias, kept for backwards compatibility), the plugin:
 
-1. Detects `$_GET['site-export-api']` during plugin file load
+1. Detects `$_GET['reprint-api']` or `$_GET['site-export-api']` during plugin file load
 2. Reverts WordPress error display settings (`display_errors`, `html_errors`) that `wp_debug_mode()` may have turned on
 3. Clears any output buffering WordPress started
 4. Sets up error handlers, HMAC auth, and runs the export endpoint

--- a/reprint-exporter-wp/index.php
+++ b/reprint-exporter-wp/index.php
@@ -14,7 +14,11 @@ require_once __DIR__ . '/lib.php';
 // Intercept export API requests as early as possible.
 // WordPress loads plugin files before firing `plugins_loaded`,
 // so this runs before almost anything else in the WordPress stack.
-if (isset($_GET['site-export-api'])) {
+//
+// `?site-export-api` is the legacy query parameter kept for backwards
+// compatibility with clients pinned to earlier plugin versions.
+// New integrations should use `?reprint-api`.
+if (isset($_GET['reprint-api']) || isset($_GET['site-export-api'])) {
     _site_export_handle_api_request();
     exit;
 }

--- a/reprint-exporter-wp/wordpress/site-export.php
+++ b/reprint-exporter-wp/wordpress/site-export.php
@@ -3,7 +3,8 @@
  * Admin interface for Reprint Exporter plugin.
  *
  * This plugin provides a WordPress admin UI for configuring the export API.
- * The export API is triggered via `?site-export-api` during plugin load,
+ * The export API is triggered via `?reprint-api` (or the legacy
+ * `?site-export-api` alias) during plugin load,
  * before WordPress finishes booting. It reads the secret from a site option,
  * with secret.php supported only as an override when present.
  *
@@ -123,7 +124,7 @@ class Site_Export_Plugin {
 
         $stored_secret = _site_export_get_option_secret();
         $effective_secret = _site_export_get_shared_secret() ?? '';
-        $api_url = home_url('?site-export-api');
+        $api_url = home_url('?reprint-api');
         $is_configured = $effective_secret !== '';
         $has_file_override = _site_export_has_secret_file();
 

--- a/tests/Import/NewSiteUrlSqliteTest.php
+++ b/tests/Import/NewSiteUrlSqliteTest.php
@@ -145,7 +145,7 @@ class NewSiteUrlSqliteTest extends TestCase
     {
         $oldUrl = 'https://old-site.example.com';
         $newUrl = 'https://brand-new.example.com';
-        $exportUrl = 'https://old-site.example.com/?site-export-api';
+        $exportUrl = 'https://old-site.example.com/?reprint-api';
         $sqlitePath = $this->tempDir . '/database/wordpress.sqlite';
 
         // Prepare db.sql
@@ -205,7 +205,7 @@ class NewSiteUrlSqliteTest extends TestCase
         $httpsUrl = 'https://old-site.example.com';
         $httpUrl  = 'http://old-site.example.com';
         $newUrl   = 'https://new-site.example.com';
-        $exportUrl = 'http://old-site.example.com/?site-export-api';
+        $exportUrl = 'http://old-site.example.com/?reprint-api';
         $sqlitePath = $this->tempDir . '/database/wordpress.sqlite';
 
         // Build dump with HTTPS siteurl — note that the export URL uses HTTP
@@ -252,7 +252,7 @@ class NewSiteUrlSqliteTest extends TestCase
     {
         $oldUrl = 'https://old-site.example.com';
         $newUrl = 'https://new-site.example.com';
-        $exportUrl = 'https://old-site.example.com/?site-export-api';
+        $exportUrl = 'https://old-site.example.com/?reprint-api';
         $sqlitePath = $this->tempDir . '/database/wordpress.sqlite';
 
         // Build a dump with a post that references the old URL in content

--- a/tests/e2e/lib/test-helpers.js
+++ b/tests/e2e/lib/test-helpers.js
@@ -28,7 +28,7 @@ const DB_PASS = REGISTRY.dbPass;
 export function getSiteUrl(siteName, port = null) {
     const p = port || REGISTRY.sites[siteName]?.port;
     if (!p) throw new Error(`Unknown site: ${siteName}`);
-    return `http://127.0.0.1:${p}/?site-export-api`;
+    return `http://127.0.0.1:${p}/?reprint-api`;
 }
 
 /**

--- a/tests/e2e/tests/import-11-error-messages.test.js
+++ b/tests/e2e/tests/import-11-error-messages.test.js
@@ -43,7 +43,7 @@ describe('Import: Error Messages', () => {
     });
 
     it('unreachable server produces connection error', () => {
-        const url = 'http://127.0.0.1:19999/?site-export-api&directory=/tmp';
+        const url = 'http://127.0.0.1:19999/?reprint-api&directory=/tmp';
         const dir = createTempDir('e2e-import-unreachable');
         try {
             const result = runImporter(url, dir, 'files-sync', {

--- a/tests/e2e/tests/import-34-delta-type-swap-cache-invalidation.test.js
+++ b/tests/e2e/tests/import-34-delta-type-swap-cache-invalidation.test.js
@@ -69,7 +69,7 @@ describe('Import: Delta type swaps cache invalidation', () => {
     }
 
     function importUrl() {
-        return `http://127.0.0.1:${port}/?site-export-api&directory=${getSiteDir(site)}`;
+        return `http://127.0.0.1:${port}/?reprint-api&directory=${getSiteDir(site)}`;
     }
 
     function setupInitialRemoteLayout() {


### PR DESCRIPTION
The plugin's query-parameter entry point is now `?reprint-api`. Requests
arriving at `?site-export-api` keep working as a legacy alias, so clients
pinned to older plugin versions don't break during the transition.

URL builders that used to emit the old name now emit the new one: the admin
UI (`Tools → Reprint Exporter`), the importer e2e test helpers, the two CI
smoke tests, the README example, and the PHPDoc samples in
`Site_Export_HMAC_Client`.

The two hardcoded e2e tests (`import-11-error-messages`,
`import-34-delta-type-swap-cache-invalidation`) and the `NewSiteUrlSqliteTest`
URL fixtures still use the legacy parameter — that's deliberate, so they
double as implicit coverage that the legacy alias still works end to end.

## Test plan

- [ ] CI green (both e2e workflows and PHPUnit)
- [ ] Hit `?reprint-api` against a running WordPress — the API responds as before
- [ ] Hit `?site-export-api` — same response, legacy clients keep working
- [ ] Admin page at Tools → Reprint Exporter shows the new `?reprint-api` URL