### PR TITLE
Re-enable native PHP e2e tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -7,7 +7,6 @@ on:
 
 jobs:
   build-phar:
-    if: false  # Temporarily disabled while testing Playground CLI e2e
     name: Build reprint.phar
     runs-on: ubuntu-latest
     steps:
@@ -30,7 +29,6 @@ jobs:
           path: reprint.phar
 
   e2e:
-    if: false  # Temporarily disabled while testing Playground CLI e2e
     name: E2E (PHP ${{ matrix.php }})
     needs: build-phar
     runs-on: ubuntu-22.04


### PR DESCRIPTION
## Summary

PR #119 temporarily disabled the native PHP e2e test matrix (`if: false` on both jobs) while iterating on the Playground CLI WASM workflow. Now that the Playground CLI workflow is stable, this restores the original test matrix so every push and PR runs e2e tests across PHP 7.4–8.5 with native PHP, alongside the Playground CLI tests.

## Test plan

- [ ] The "E2E Tests" workflow runs on this PR and passes across all PHP versions
- [ ] The "E2E (Playground CLI PHP)" workflow continues to pass