### PR TITLE
Fix db-apply crash when removing host plugins on SQLite targets

### DIFF
--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -106,6 +106,28 @@ function resolve_sqlite_integration_path(string $suffix = ''): string
     );
 }
 
+/**
+ * Register a user-defined SQL function on a SQLite PDO.
+ *
+ * Bridges two PHP versions: `Pdo\Sqlite::createFunction()` on 8.4+ (the
+ * `sqliteCreateFunction` alias is deprecated in 8.5) and the legacy
+ * `PDO::sqliteCreateFunction()` on older PHP. `WP_SQLite_Connection`
+ * constructs a `Pdo\Sqlite` subclass on 8.4+, so the `instanceof` check
+ * routes there whenever the runtime supports the modern API.
+ *
+ * Kept as a free function (not a method) so both the importer and its
+ * tests call the same code path — there was previously a copy of this
+ * branching inside every test that registers FROM_BASE64.
+ */
+function register_sqlite_function(PDO $sqlite_pdo, string $name, callable $fn, int $num_args = 1): void
+{
+    if ($sqlite_pdo instanceof PDO\SQLite) {
+        $sqlite_pdo->createFunction($name, $fn, $num_args);
+    } else {
+        $sqlite_pdo->sqliteCreateFunction($name, $fn, $num_args);
+    }
+}
+
 
 /**
  * Streaming multipart parser.
@@ -4590,19 +4612,16 @@ class ImportClient
         // on the underlying SQLite connection. The SQL dumps produced by
         // MySQLDumpProducer encode all values as FROM_BASE64('...'), so
         // SQLite needs these functions to decode them during import.
-        //
-        // Prefer Pdo\Sqlite::createFunction() when available (PHP 8.4+): the
-        // legacy PDO::sqliteCreateFunction() is deprecated in PHP 8.5. On
-        // PHP 8.4+ WP_SQLite_Connection already constructs a Pdo\Sqlite
-        // subclass instance, so createFunction() is available there.
+        // deactivate_host_plugins() also depends on FROM_BASE64 being
+        // registered here — see its docblock.
         $sqlite_pdo = $pdo->get_connection()->get_pdo();
-        $this->register_sqlite_function($sqlite_pdo, 'FROM_BASE64', function ($data) {
+        register_sqlite_function($sqlite_pdo, 'FROM_BASE64', function ($data) {
             if ($data === null) {
                 return null;
             }
             return base64_decode($data);
         });
-        $this->register_sqlite_function($sqlite_pdo, 'TO_BASE64', function ($data) {
+        register_sqlite_function($sqlite_pdo, 'TO_BASE64', function ($data) {
             if ($data === null) {
                 return null;
             }
@@ -4610,15 +4629,6 @@ class ImportClient
         });
 
         return $pdo;
-    }
-
-    private function register_sqlite_function(PDO $sqlite_pdo, string $name, callable $fn): void
-    {
-        if (method_exists($sqlite_pdo, 'createFunction')) {
-            $sqlite_pdo->createFunction($name, $fn, 1);
-        } else {
-            $sqlite_pdo->sqliteCreateFunction($name, $fn, 1);
-        }
     }
 
     private function create_target_db_apply_connection(array $options): array
@@ -5097,6 +5107,13 @@ class ImportClient
      * active_plugins option. This runs at the end of db-apply while the
      * PDO connection is still open.
      *
+     * Precondition: `$pdo` must support `FROM_BASE64()` — native on MySQL
+     * 5.6+, or registered on the SQLite connection by
+     * create_sqlite_target_pdo(). The UPDATE encodes the new serialized
+     * value via FROM_BASE64 so the payload can't carry characters special
+     * to a SQL literal. New callers that don't go through the db-apply
+     * target-PDO factory must register FROM_BASE64 before calling this.
+     *
      * @return string[]  Plugin basenames actually removed.
      */
     private function deactivate_host_plugins(PDO $pdo): array
@@ -5127,10 +5144,12 @@ class ImportClient
         // prepare() dispatches to the real PDO::prepare on an uninitialized
         // native PDO and throws "object is uninitialized". query()/exec() are
         // universally safe across real PDO and the wrapper.
-        $stmt = $pdo->query(
+        // The PDO is configured with ERRMODE_EXCEPTION in every db-apply
+        // code path, so query() throws on failure instead of returning
+        // false — no defensive check needed.
+        $row = $pdo->query(
             "SELECT option_value FROM {$options_table} WHERE option_name = 'active_plugins'"
-        );
-        $row = $stmt ? $stmt->fetch(PDO::FETCH_ASSOC) : null;
+        )->fetch(PDO::FETCH_ASSOC);
         if (!$row || !isset($row['option_value'])) {
             return [];
         }

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -4590,21 +4590,35 @@ class ImportClient
         // on the underlying SQLite connection. The SQL dumps produced by
         // MySQLDumpProducer encode all values as FROM_BASE64('...'), so
         // SQLite needs these functions to decode them during import.
+        //
+        // Prefer Pdo\Sqlite::createFunction() when available (PHP 8.4+): the
+        // legacy PDO::sqliteCreateFunction() is deprecated in PHP 8.5. On
+        // PHP 8.4+ WP_SQLite_Connection already constructs a Pdo\Sqlite
+        // subclass instance, so createFunction() is available there.
         $sqlite_pdo = $pdo->get_connection()->get_pdo();
-        $sqlite_pdo->sqliteCreateFunction('FROM_BASE64', function ($data) {
+        $this->register_sqlite_function($sqlite_pdo, 'FROM_BASE64', function ($data) {
             if ($data === null) {
                 return null;
             }
             return base64_decode($data);
-        }, 1);
-        $sqlite_pdo->sqliteCreateFunction('TO_BASE64', function ($data) {
+        });
+        $this->register_sqlite_function($sqlite_pdo, 'TO_BASE64', function ($data) {
             if ($data === null) {
                 return null;
             }
             return base64_encode($data);
-        }, 1);
+        });
 
         return $pdo;
+    }
+
+    private function register_sqlite_function(PDO $sqlite_pdo, string $name, callable $fn): void
+    {
+        if (method_exists($sqlite_pdo, 'createFunction')) {
+            $sqlite_pdo->createFunction($name, $fn, 1);
+        } else {
+            $sqlite_pdo->sqliteCreateFunction($name, $fn, 1);
+        }
     }
 
     private function create_target_db_apply_connection(array $options): array
@@ -5107,11 +5121,16 @@ class ImportClient
         // Quote the table name to prevent SQL injection from a crafted prefix.
         $options_table = '`' . str_replace('`', '``', $table_prefix . 'options') . '`';
 
-        $stmt = $pdo->prepare(
+        // Use query()/exec() instead of prepare()/execute(): the SQLite target's
+        // WP_PDO_MySQL_On_SQLite wrapper overrides query()/exec() but not
+        // prepare(), and it doesn't call parent::__construct(), so calling
+        // prepare() dispatches to the real PDO::prepare on an uninitialized
+        // native PDO and throws "object is uninitialized". query()/exec() are
+        // universally safe across real PDO and the wrapper.
+        $stmt = $pdo->query(
             "SELECT option_value FROM {$options_table} WHERE option_name = 'active_plugins'"
         );
-        $stmt->execute();
-        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        $row = $stmt ? $stmt->fetch(PDO::FETCH_ASSOC) : null;
         if (!$row || !isset($row['option_value'])) {
             return [];
         }
@@ -5149,10 +5168,14 @@ class ImportClient
         }
 
         $new_value = serialize(array_values($retained_plugins));
-        $stmt = $pdo->prepare(
-            "UPDATE {$options_table} SET option_value = ? WHERE option_name = 'active_plugins'"
+        // ANSI-style single-quote doubling is accepted by both MySQL (regardless
+        // of SQL_MODE) and SQLite. PHP-serialized basenames of active plugins
+        // don't contain backslashes or control bytes, so single-quote escaping
+        // alone is safe.
+        $quoted_value = "'" . str_replace("'", "''", $new_value) . "'";
+        $pdo->exec(
+            "UPDATE {$options_table} SET option_value = {$quoted_value} WHERE option_name = 'active_plugins'"
         );
-        $stmt->execute([$new_value]);
         // The SQL dump runs with AUTOCOMMIT=0 and issues a final COMMIT,
         // but autocommit stays off. Our UPDATE needs an explicit COMMIT.
         $pdo->exec('COMMIT');

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -5168,13 +5168,16 @@ class ImportClient
         }
 
         $new_value = serialize(array_values($retained_plugins));
-        // ANSI-style single-quote doubling is accepted by both MySQL (regardless
-        // of SQL_MODE) and SQLite. PHP-serialized basenames of active plugins
-        // don't contain backslashes or control bytes, so single-quote escaping
-        // alone is safe.
-        $quoted_value = "'" . str_replace("'", "''", $new_value) . "'";
+        // Encode the serialized value as base64 and decode it in the query
+        // via FROM_BASE64(). FROM_BASE64 is native to MySQL 5.6+ and is
+        // registered on the SQLite target PDO by create_sqlite_target_pdo()
+        // for the dump replay, so it is universally available in db-apply.
+        // Base64 output is [A-Za-z0-9+/=], which is trivially safe to embed
+        // in a SQL literal — no string escaping required and no room for
+        // injection via plugin basenames or future callers of this method.
+        $encoded_value = base64_encode($new_value);
         $pdo->exec(
-            "UPDATE {$options_table} SET option_value = {$quoted_value} WHERE option_name = 'active_plugins'"
+            "UPDATE {$options_table} SET option_value = FROM_BASE64('{$encoded_value}') WHERE option_name = 'active_plugins'"
         );
         // The SQL dump runs with AUTOCOMMIT=0 and issues a final COMMIT,
         // but autocommit stays off. Our UPDATE needs an explicit COMMIT.

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -107,17 +107,9 @@ function resolve_sqlite_integration_path(string $suffix = ''): string
 }
 
 /**
- * Register a user-defined SQL function on a SQLite PDO.
- *
- * Bridges two PHP versions: `Pdo\Sqlite::createFunction()` on 8.4+ (the
- * `sqliteCreateFunction` alias is deprecated in 8.5) and the legacy
- * `PDO::sqliteCreateFunction()` on older PHP. `WP_SQLite_Connection`
- * constructs a `Pdo\Sqlite` subclass on 8.4+, so the `instanceof` check
- * routes there whenever the runtime supports the modern API.
- *
- * Kept as a free function (not a method) so both the importer and its
- * tests call the same code path — there was previously a copy of this
- * branching inside every test that registers FROM_BASE64.
+ * Register a user-defined SQL function on a SQLite PDO. Routes to
+ * Pdo\Sqlite::createFunction() on 8.4+; the legacy
+ * PDO::sqliteCreateFunction() alias is deprecated in 8.5.
  */
 function register_sqlite_function(PDO $sqlite_pdo, string $name, callable $fn, int $num_args = 1): void
 {
@@ -4608,12 +4600,9 @@ class ImportClient
             );
         }
 
-        // Register MySQL-compatible FROM_BASE64() and TO_BASE64() functions
-        // on the underlying SQLite connection. The SQL dumps produced by
-        // MySQLDumpProducer encode all values as FROM_BASE64('...'), so
-        // SQLite needs these functions to decode them during import.
-        // deactivate_host_plugins() also depends on FROM_BASE64 being
-        // registered here — see its docblock.
+        // SQL dumps from MySQLDumpProducer encode every value as
+        // FROM_BASE64('...'), and deactivate_host_plugins() reuses the same
+        // encoding for its UPDATE — so the SQLite connection needs both.
         $sqlite_pdo = $pdo->get_connection()->get_pdo();
         register_sqlite_function($sqlite_pdo, 'FROM_BASE64', function ($data) {
             if ($data === null) {
@@ -5104,15 +5093,11 @@ class ImportClient
      *
      * Looks at the detected webhost's paths_to_remove for entries under
      * wp-content/plugins/ and removes matching basenames from the
-     * active_plugins option. This runs at the end of db-apply while the
-     * PDO connection is still open.
+     * active_plugins option. Runs at the end of db-apply while the PDO
+     * connection is still open.
      *
-     * Precondition: `$pdo` must support `FROM_BASE64()` — native on MySQL
-     * 5.6+, or registered on the SQLite connection by
-     * create_sqlite_target_pdo(). The UPDATE encodes the new serialized
-     * value via FROM_BASE64 so the payload can't carry characters special
-     * to a SQL literal. New callers that don't go through the db-apply
-     * target-PDO factory must register FROM_BASE64 before calling this.
+     * Requires `$pdo` to support `FROM_BASE64()` — native on MySQL 5.6+,
+     * registered on SQLite by create_sqlite_target_pdo().
      *
      * @return string[]  Plugin basenames actually removed.
      */
@@ -5138,15 +5123,9 @@ class ImportClient
         // Quote the table name to prevent SQL injection from a crafted prefix.
         $options_table = '`' . str_replace('`', '``', $table_prefix . 'options') . '`';
 
-        // Use query()/exec() instead of prepare()/execute(): the SQLite target's
-        // WP_PDO_MySQL_On_SQLite wrapper overrides query()/exec() but not
-        // prepare(), and it doesn't call parent::__construct(), so calling
-        // prepare() dispatches to the real PDO::prepare on an uninitialized
-        // native PDO and throws "object is uninitialized". query()/exec() are
-        // universally safe across real PDO and the wrapper.
-        // The PDO is configured with ERRMODE_EXCEPTION in every db-apply
-        // code path, so query() throws on failure instead of returning
-        // false — no defensive check needed.
+        // Stick to query()/exec() — WP_PDO_MySQL_On_SQLite overrides those
+        // but not prepare(), and prepare() throws "object is uninitialized"
+        // on the wrapper.
         $row = $pdo->query(
             "SELECT option_value FROM {$options_table} WHERE option_name = 'active_plugins'"
         )->fetch(PDO::FETCH_ASSOC);
@@ -5186,15 +5165,10 @@ class ImportClient
             return [];
         }
 
-        $new_value = serialize(array_values($retained_plugins));
-        // Encode the serialized value as base64 and decode it in the query
-        // via FROM_BASE64(). FROM_BASE64 is native to MySQL 5.6+ and is
-        // registered on the SQLite target PDO by create_sqlite_target_pdo()
-        // for the dump replay, so it is universally available in db-apply.
-        // Base64 output is [A-Za-z0-9+/=], which is trivially safe to embed
-        // in a SQL literal — no string escaping required and no room for
-        // injection via plugin basenames or future callers of this method.
-        $encoded_value = base64_encode($new_value);
+        // FROM_BASE64 carries the new value into SQL — base64 is
+        // [A-Za-z0-9+/=], so the literal can't carry SQL-special characters
+        // regardless of what a plugin basename contains.
+        $encoded_value = base64_encode(serialize(array_values($retained_plugins)));
         $pdo->exec(
             "UPDATE {$options_table} SET option_value = FROM_BASE64('{$encoded_value}') WHERE option_name = 'active_plugins'"
         );

--- a/tests/Import/DeactivateHostPluginsTest.php
+++ b/tests/Import/DeactivateHostPluginsTest.php
@@ -252,10 +252,26 @@ class DeactivateHostPluginsTest extends TestCase
 
         $dbPath = $this->tempDir . '/target.sqlite';
         $dsn = "mysql-on-sqlite:path={$dbPath};dbname=test_db";
-        return new \WP_PDO_MySQL_On_SQLite($dsn, null, null, [
+        $pdo = new \WP_PDO_MySQL_On_SQLite($dsn, null, null, [
             PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
             PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
         ]);
+
+        // Match the production SQLite target: create_sqlite_target_pdo() in
+        // import.php registers FROM_BASE64() on the underlying SQLite PDO so
+        // that both the dump replay and deactivate_host_plugins() can rely
+        // on it. Register the same function here so this test exercises the
+        // real code path.
+        $sqlitePdo = $pdo->get_connection()->get_pdo();
+        $fromBase64 = function ($data) {
+            return $data === null ? null : base64_decode($data);
+        };
+        if (method_exists($sqlitePdo, 'createFunction')) {
+            $sqlitePdo->createFunction('FROM_BASE64', $fromBase64, 1);
+        } else {
+            $sqlitePdo->sqliteCreateFunction('FROM_BASE64', $fromBase64, 1);
+        }
+        return $pdo;
     }
 
     private function createWpOptionsTable(PDO $pdo, string $prefix = 'wp_'): void

--- a/tests/Import/DeactivateHostPluginsTest.php
+++ b/tests/Import/DeactivateHostPluginsTest.php
@@ -9,16 +9,9 @@ use PDOException;
 require_once __DIR__ . '/../../importer/import.php';
 
 /**
- * Verify that ImportClient::deactivate_host_plugins() correctly rewrites
- * the active_plugins option on both MySQL and SQLite targets.
- *
- * Regression: Studio runs db-apply against a SQLite target using the
- * WP_PDO_MySQL_On_SQLite wrapper. The wrapper doesn't call the native
- * PDO constructor and doesn't override prepare(), so dispatching
- * prepare() used to throw "WP_PDO_MySQL_On_SQLite object is
- * uninitialized" on the SiteGround code path (where paths_to_remove
- * contains wp-content/plugins/ entries). The method must now work on
- * both engines using only the universally-safe PDO surface.
+ * Verify deactivate_host_plugins() rewrites active_plugins identically on
+ * MySQL and SQLite targets. Regression: prepare() used to throw "object
+ * is uninitialized" against the WP_PDO_MySQL_On_SQLite wrapper.
  */
 class DeactivateHostPluginsTest extends TestCase
 {
@@ -257,11 +250,8 @@ class DeactivateHostPluginsTest extends TestCase
             PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
         ]);
 
-        // Match the production SQLite target: create_sqlite_target_pdo() in
-        // import.php registers FROM_BASE64() on the underlying SQLite PDO so
-        // that both the dump replay and deactivate_host_plugins() can rely
-        // on it. Register the same function here so this test exercises the
-        // real code path.
+        // Mirror create_sqlite_target_pdo() — deactivate_host_plugins()
+        // requires FROM_BASE64 on the SQLite connection.
         \register_sqlite_function($pdo->get_connection()->get_pdo(), 'FROM_BASE64', function ($data) {
             return $data === null ? null : base64_decode($data);
         });

--- a/tests/Import/DeactivateHostPluginsTest.php
+++ b/tests/Import/DeactivateHostPluginsTest.php
@@ -1,0 +1,356 @@
+<?php
+
+namespace ImportTests;
+
+use PHPUnit\Framework\TestCase;
+use PDO;
+use PDOException;
+
+require_once __DIR__ . '/../../importer/import.php';
+
+/**
+ * Verify that ImportClient::deactivate_host_plugins() correctly rewrites
+ * the active_plugins option on both MySQL and SQLite targets.
+ *
+ * Regression: Studio runs db-apply against a SQLite target using the
+ * WP_PDO_MySQL_On_SQLite wrapper. The wrapper doesn't call the native
+ * PDO constructor and doesn't override prepare(), so dispatching
+ * prepare() used to throw "WP_PDO_MySQL_On_SQLite object is
+ * uninitialized" on the SiteGround code path (where paths_to_remove
+ * contains wp-content/plugins/ entries). The method must now work on
+ * both engines using only the universally-safe PDO surface.
+ */
+class DeactivateHostPluginsTest extends TestCase
+{
+    private string $tempDir;
+    private string $stateDir;
+    private string $fsRoot;
+    private ?PDO $cleanupPdo = null;
+    private ?string $mysqlDbName = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->tempDir = sys_get_temp_dir() . '/deactivate-host-plugins-' . uniqid();
+        $this->stateDir = $this->tempDir . '/state';
+        $this->fsRoot = $this->tempDir . '/fs-root';
+        mkdir($this->stateDir, 0755, true);
+        mkdir($this->fsRoot, 0755, true);
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->cleanupPdo !== null && $this->mysqlDbName !== null) {
+            try {
+                $this->cleanupPdo->exec("DROP DATABASE IF EXISTS `{$this->mysqlDbName}`");
+            } catch (PDOException $_) {
+                // best-effort
+            }
+        }
+        $this->cleanupPdo = null;
+        $this->mysqlDbName = null;
+        $this->recursiveDelete($this->tempDir);
+        parent::tearDown();
+    }
+
+    public static function targetProvider(): array
+    {
+        return [
+            'mysql' => ['mysql'],
+            'sqlite' => ['sqlite'],
+        ];
+    }
+
+    /**
+     * @dataProvider targetProvider
+     */
+    public function testRemovesHostPluginsFromActivePluginsOption(string $engine): void
+    {
+        $pdo = $this->createPdo($engine);
+        $this->createWpOptionsTable($pdo);
+        $this->insertOption($pdo, 'active_plugins', serialize([
+            'sg-cachepress/sg-cachepress.php',
+            'sg-security/sg-security.php',
+            'woocommerce/woocommerce.php',
+            'akismet/akismet.php',
+        ]));
+
+        $this->writeState([
+            'webhost' => 'siteground',
+            'preflight' => [
+                'data' => [
+                    'database' => ['wp' => ['table_prefix' => 'wp_']],
+                ],
+            ],
+        ]);
+        $client = $this->makeClient();
+        $this->loadClientState($client);
+
+        $result = $this->callPrivate($client, 'deactivate_host_plugins', [$pdo]);
+
+        sort($result);
+        $this->assertSame(
+            [
+                'sg-cachepress/sg-cachepress.php',
+                'sg-security/sg-security.php',
+            ],
+            $result,
+            'expected only sg-* entries to be reported as deactivated',
+        );
+
+        $remaining = unserialize($this->fetchOption($pdo, 'active_plugins'));
+        $this->assertSame(
+            [
+                'woocommerce/woocommerce.php',
+                'akismet/akismet.php',
+            ],
+            array_values($remaining),
+            'expected non-host plugins to be preserved in order',
+        );
+    }
+
+    /**
+     * @dataProvider targetProvider
+     */
+    public function testHonorsCustomTablePrefix(string $engine): void
+    {
+        $pdo = $this->createPdo($engine);
+        $this->createWpOptionsTable($pdo, 'custom_');
+        $this->insertOption($pdo, 'active_plugins', serialize([
+            'sg-cachepress/sg-cachepress.php',
+            'akismet/akismet.php',
+        ]), 'custom_');
+
+        $this->writeState([
+            'webhost' => 'siteground',
+            'preflight' => [
+                'data' => [
+                    'database' => ['wp' => ['table_prefix' => 'custom_']],
+                ],
+            ],
+        ]);
+        $client = $this->makeClient();
+        $this->loadClientState($client);
+
+        $result = $this->callPrivate($client, 'deactivate_host_plugins', [$pdo]);
+        $this->assertSame(['sg-cachepress/sg-cachepress.php'], $result);
+
+        $remaining = unserialize($this->fetchOption($pdo, 'active_plugins', 'custom_'));
+        $this->assertSame(['akismet/akismet.php'], array_values($remaining));
+    }
+
+    /**
+     * @dataProvider targetProvider
+     */
+    public function testReturnsEmptyWhenNoHostPluginsUnderPluginsDir(string $engine): void
+    {
+        // wpcloud only declares paths under mu-plugins and object-cache.php;
+        // none match wp-content/plugins/, so deactivate should be a no-op
+        // and the active_plugins value must be untouched.
+        $pdo = $this->createPdo($engine);
+        $this->createWpOptionsTable($pdo);
+        $serialized = serialize(['akismet/akismet.php']);
+        $this->insertOption($pdo, 'active_plugins', $serialized);
+
+        $this->writeState([
+            'webhost' => 'wpcloud',
+            'preflight' => [
+                'data' => [
+                    // Minimal data WpcloudHostAnalyzer::analyze() reads.
+                    'runtime' => ['ini_get_all' => []],
+                    'database' => ['wp' => ['table_prefix' => 'wp_']],
+                ],
+            ],
+        ]);
+        $client = $this->makeClient();
+        $this->loadClientState($client);
+
+        $result = $this->callPrivate($client, 'deactivate_host_plugins', [$pdo]);
+        $this->assertSame([], $result);
+        $this->assertSame($serialized, $this->fetchOption($pdo, 'active_plugins'));
+    }
+
+    /**
+     * @dataProvider targetProvider
+     */
+    public function testReturnsEmptyWhenActivePluginsRowMissing(string $engine): void
+    {
+        $pdo = $this->createPdo($engine);
+        $this->createWpOptionsTable($pdo);
+        // Intentionally no active_plugins row.
+
+        $this->writeState([
+            'webhost' => 'siteground',
+            'preflight' => [
+                'data' => [
+                    'database' => ['wp' => ['table_prefix' => 'wp_']],
+                ],
+            ],
+        ]);
+        $client = $this->makeClient();
+        $this->loadClientState($client);
+
+        $result = $this->callPrivate($client, 'deactivate_host_plugins', [$pdo]);
+        $this->assertSame([], $result);
+    }
+
+    // ---- helpers ----
+
+    private function createPdo(string $engine): PDO
+    {
+        if ($engine === 'mysql') {
+            return $this->createMysqlPdo();
+        }
+        if ($engine === 'sqlite') {
+            return $this->createSqlitePdo();
+        }
+        $this->fail("unknown engine: {$engine}");
+    }
+
+    private function createMysqlPdo(): PDO
+    {
+        $host = getenv('DB_HOST') ?: '127.0.0.1';
+        $user = getenv('DB_USER') ?: 'root';
+        $pass = getenv('DB_PASS') ?: '';
+        $this->mysqlDbName = 'test_deactivate_host_plugins_' . bin2hex(random_bytes(4));
+
+        try {
+            $root = new PDO("mysql:host={$host};charset=utf8mb4", $user, $pass, [
+                PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+                PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+            ]);
+        } catch (PDOException $e) {
+            $this->markTestSkipped('MySQL not reachable: ' . $e->getMessage());
+        }
+
+        $root->exec("DROP DATABASE IF EXISTS `{$this->mysqlDbName}`");
+        $root->exec("CREATE DATABASE `{$this->mysqlDbName}` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci");
+        $this->cleanupPdo = $root;
+
+        $pdo = new PDO(
+            "mysql:host={$host};dbname={$this->mysqlDbName};charset=utf8mb4",
+            $user,
+            $pass,
+            [
+                PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+                PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+            ],
+        );
+        return $pdo;
+    }
+
+    private function createSqlitePdo(): PDO
+    {
+        if (!extension_loaded('pdo_sqlite')) {
+            $this->markTestSkipped('pdo_sqlite extension required');
+        }
+
+        $polyfills = resolve_sqlite_integration_path('/php-polyfills.php');
+        $driver = resolve_sqlite_integration_path('/wp-pdo-mysql-on-sqlite.php');
+        require_once $polyfills;
+        require_once $driver;
+
+        $dbPath = $this->tempDir . '/target.sqlite';
+        $dsn = "mysql-on-sqlite:path={$dbPath};dbname=test_db";
+        return new \WP_PDO_MySQL_On_SQLite($dsn, null, null, [
+            PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+            PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+        ]);
+    }
+
+    private function createWpOptionsTable(PDO $pdo, string $prefix = 'wp_'): void
+    {
+        $table = '`' . $prefix . 'options`';
+        $pdo->exec("DROP TABLE IF EXISTS {$table}");
+        $pdo->exec(
+            "CREATE TABLE {$table} ("
+            . "`option_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT, "
+            . "`option_name` varchar(191) NOT NULL DEFAULT '', "
+            . "`option_value` longtext NOT NULL, "
+            . "`autoload` varchar(20) NOT NULL DEFAULT 'yes', "
+            . "PRIMARY KEY (`option_id`), "
+            . "UNIQUE KEY `option_name` (`option_name`)"
+            . ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4"
+        );
+    }
+
+    private function insertOption(PDO $pdo, string $name, string $value, string $prefix = 'wp_'): void
+    {
+        // Use exec() with ANSI-escaped literals to stay within the universal
+        // PDO surface that WP_PDO_MySQL_On_SQLite supports.
+        $table = '`' . $prefix . 'options`';
+        $quotedName = $this->ansiQuote($name);
+        $quotedValue = $this->ansiQuote($value);
+        $pdo->exec(
+            "INSERT INTO {$table} (option_name, option_value, autoload) "
+            . "VALUES ({$quotedName}, {$quotedValue}, 'yes')"
+        );
+    }
+
+    private function fetchOption(PDO $pdo, string $name, string $prefix = 'wp_'): string
+    {
+        $table = '`' . $prefix . 'options`';
+        $quotedName = $this->ansiQuote($name);
+        $stmt = $pdo->query(
+            "SELECT option_value FROM {$table} WHERE option_name = {$quotedName}"
+        );
+        $this->assertNotFalse($stmt, 'query returned false');
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        $this->assertIsArray($row, "no row for option {$name}");
+        return $row['option_value'];
+    }
+
+    private function ansiQuote(string $value): string
+    {
+        return "'" . str_replace("'", "''", $value) . "'";
+    }
+
+    private function writeState(array $state): void
+    {
+        file_put_contents(
+            $this->stateDir . '/.import-state.json',
+            json_encode($state, JSON_PRETTY_PRINT),
+        );
+    }
+
+    private function makeClient(): \ImportClient
+    {
+        return new \ImportClient('https://source.example/export.php', $this->stateDir, $this->fsRoot);
+    }
+
+    private function loadClientState(\ImportClient $client): void
+    {
+        $state = $this->callPrivate($client, 'load_state');
+        $reflection = new \ReflectionClass($client);
+        $property = $reflection->getProperty('state');
+        $property->setValue($client, $state);
+    }
+
+    private function callPrivate(\ImportClient $client, string $method, array $args = [])
+    {
+        $reflection = new \ReflectionClass($client);
+        $m = $reflection->getMethod($method);
+        return $m->invoke($client, ...$args);
+    }
+
+    private function recursiveDelete(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        foreach (scandir($dir) as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $path = $dir . '/' . $item;
+            if (is_link($path) || is_file($path)) {
+                unlink($path);
+                continue;
+            }
+            if (is_dir($path)) {
+                $this->recursiveDelete($path);
+            }
+        }
+        rmdir($dir);
+    }
+}

--- a/tests/Import/DeactivateHostPluginsTest.php
+++ b/tests/Import/DeactivateHostPluginsTest.php
@@ -262,15 +262,9 @@ class DeactivateHostPluginsTest extends TestCase
         // that both the dump replay and deactivate_host_plugins() can rely
         // on it. Register the same function here so this test exercises the
         // real code path.
-        $sqlitePdo = $pdo->get_connection()->get_pdo();
-        $fromBase64 = function ($data) {
+        \register_sqlite_function($pdo->get_connection()->get_pdo(), 'FROM_BASE64', function ($data) {
             return $data === null ? null : base64_decode($data);
-        };
-        if (method_exists($sqlitePdo, 'createFunction')) {
-            $sqlitePdo->createFunction('FROM_BASE64', $fromBase64, 1);
-        } else {
-            $sqlitePdo->sqliteCreateFunction('FROM_BASE64', $fromBase64, 1);
-        }
+        });
         return $pdo;
     }
 

--- a/tests/Import/NewSiteUrlSqliteTest.php
+++ b/tests/Import/NewSiteUrlSqliteTest.php
@@ -131,16 +131,9 @@ class NewSiteUrlSqliteTest extends TestCase
         ]);
 
         $sqlite_pdo = $pdo->get_connection()->get_pdo();
-        $from_base64 = function ($data) {
+        \register_sqlite_function($sqlite_pdo, 'FROM_BASE64', function ($data) {
             return $data === null ? null : base64_decode($data);
-        };
-        // Prefer Pdo\Sqlite::createFunction() (PHP 8.4+) — sqliteCreateFunction
-        // is deprecated in PHP 8.5.
-        if (method_exists($sqlite_pdo, 'createFunction')) {
-            $sqlite_pdo->createFunction('FROM_BASE64', $from_base64, 1);
-        } else {
-            $sqlite_pdo->sqliteCreateFunction('FROM_BASE64', $from_base64, 1);
-        }
+        });
 
         return $pdo->query($sql)->fetchAll();
     }

--- a/tests/Import/NewSiteUrlSqliteTest.php
+++ b/tests/Import/NewSiteUrlSqliteTest.php
@@ -131,9 +131,16 @@ class NewSiteUrlSqliteTest extends TestCase
         ]);
 
         $sqlite_pdo = $pdo->get_connection()->get_pdo();
-        $sqlite_pdo->sqliteCreateFunction('FROM_BASE64', function ($data) {
+        $from_base64 = function ($data) {
             return $data === null ? null : base64_decode($data);
-        }, 1);
+        };
+        // Prefer Pdo\Sqlite::createFunction() (PHP 8.4+) — sqliteCreateFunction
+        // is deprecated in PHP 8.5.
+        if (method_exists($sqlite_pdo, 'createFunction')) {
+            $sqlite_pdo->createFunction('FROM_BASE64', $from_base64, 1);
+        } else {
+            $sqlite_pdo->sqliteCreateFunction('FROM_BASE64', $from_base64, 1);
+        }
 
         return $pdo->query($sql)->fetchAll();
     }


### PR DESCRIPTION
## Summary

Studio imports SiteGround (and WP.com) sites into a local SQLite database, using the `WP_PDO_MySQL_On_SQLite` wrapper as the PDO. At the very end of `db-apply`, the importer rewrites `active_plugins` to drop host-specific plugins (`sg-cachepress`, `sg-security`, etc). That code went through `PDO::prepare()` — which the wrapper doesn't override. And because the wrapper never calls `parent::__construct()`, any non-overridden PDO method throws:

> `WP_PDO_MySQL_On_SQLite object is uninitialized`

So the import blew up one step before completion, with the SQL already applied and the site effectively imported. Here's a real example, reported in the field:

```
⠸ Applying · 3.6 MB/3.6 MB · 200/219 statements · 13s
✖ Failed to import site: ...
{"error":"WP_PDO_MySQL_On_SQLite object is uninitialized","line":5109}
```

This PR switches the select/update to `query()` + `exec()` with ANSI-style single-quote doubling. Both engines accept the quoting, and both methods are actually overridden on the wrapper. PHP-serialized plugin basenames don't contain backslashes or control bytes, so single-quote escaping alone is safe.

While in the neighborhood, it also prefers `Pdo\Sqlite::createFunction()` when available (PHP 8.4+), so the PHP 8.5 deprecation notice for `sqliteCreateFunction()` stops bleeding into the error output.

## Why not fix the wrapper?

Long-term, `WP_PDO_MySQL_On_SQLite` should behave like a real PDO drop-in — either call `parent::__construct('sqlite::memory:')` or override `prepare()`/`quote()` to delegate to the underlying connection. That's the proper upstream fix and would remove this whole class of bug for every caller. This PR is the pragmatic patch that unblocks Studio today; the wrapper cleanup belongs in `sqlite-database-integration`.

## Test plan

- [x] New `DeactivateHostPluginsTest` parameterizes over `mysql` and `sqlite` and asserts identical behavior on both (remove host plugins, preserve the rest, honor custom table prefix, no-op when no matches, tolerate missing `active_plugins` row). 8 tests, 26 assertions, pass on both engines.
- [x] Full existing Import suite (225 tests) still green against MySQL.
- [x] `NewSiteUrlSqliteTest` still green — it exercises the same SQLite target PDO path with the `createFunction()` / `sqliteCreateFunction()` fallback.