### PR TITLE
Re-enable PHPUnit and PHPStan CI workflows

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -7,7 +7,6 @@ on:
 
 jobs:
   phpunit:
-    if: false  # Temporarily disabled while testing Playground CLI e2e
     name: PHPUnit (PHP ${{ matrix.php }})
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -7,7 +7,6 @@ on:
 
 jobs:
   phpstan:
-    if: false  # Temporarily disabled while testing Playground CLI e2e
     name: PHPStan
     runs-on: ubuntu-latest
     steps:

--- a/phpstan-stubs.php
+++ b/phpstan-stubs.php
@@ -1,13 +1,17 @@
 <?php
 /**
- * PHPStan stubs for symbols unavailable on the analysis runtime.
+ * PHPStan bootstrap – stub symbols unavailable on the analysis runtime.
  *
  * PDO\SQLite was introduced in PHP 8.4. The sqlite-database-integration
  * submodule references it, but CI runs PHPStan on PHP 8.2.
  */
 
-namespace PDO {
-    class SQLite extends \PDO {
-        public function createFunction(string $function_name, callable $callback, int $num_args = -1, int $flags = 0): bool {}
-    }
+namespace PDO;
+
+if ( ! class_exists( 'PDO\\SQLite', false ) ) {
+	class SQLite extends \PDO {
+		public function createFunction( string $function_name, callable $callback, int $num_args = -1, int $flags = 0 ): bool {
+			return true;
+		}
+	}
 }

--- a/phpstan-stubs.php
+++ b/phpstan-stubs.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * PHPStan stubs for symbols unavailable on the analysis runtime.
+ *
+ * PDO\SQLite was introduced in PHP 8.4. The sqlite-database-integration
+ * submodule references it, but CI runs PHPStan on PHP 8.2.
+ */
+
+namespace PDO {
+    class SQLite extends \PDO {
+        public function createFunction(string $function_name, callable $callback, int $num_args = -1, int $flags = 0): bool {}
+    }
+}

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -4,6 +4,8 @@ includes:
 parameters:
     bootstrapFiles:
         - phpstan-bootstrap.php
+    stubFiles:
+        - phpstan-stubs.php
     phpVersion: 70400
     level: 5
     paths:

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -4,7 +4,6 @@ includes:
 parameters:
     bootstrapFiles:
         - phpstan-bootstrap.php
-    stubFiles:
         - phpstan-stubs.php
     phpVersion: 70400
     level: 5


### PR DESCRIPTION
## Summary

The PHPUnit and PHPStan workflows were disabled on April 11 while the Playground CLI e2e test infrastructure was being built. That work has since landed (#119, #145), so these workflows can run again.

PHPStan passes cleanly on the current codebase. PHPUnit relies on a MySQL service container in CI.

## Test plan

- [ ] PHPStan job passes in this PR's CI run
- [ ] PHPUnit jobs pass across PHP 8.1–8.4