### PR TITLE
Fix symlink-induced double-load crash in WP Cloud E2E test

### DIFF
--- a/packages/reprint-exporter/src/export.php
+++ b/packages/reprint-exporter/src/export.php
@@ -375,8 +375,18 @@ function create_sqlite_pdo_adapter()
     return new SqliteDriverPDO($driver, $raw_pdo);
 }
 
-require_once __DIR__ . "/utils.php";
-require_once __DIR__ . "/class-http-server.php";
+// Guard with existence checks: when loaded via Composer autoloader, both
+// files are already included from a path that may differ from __DIR__
+// (e.g. symlink vs realpath). With opcache.revalidate_path=0 (default),
+// require_once does not resolve symlinks, so the same physical file can
+// be loaded twice through different paths, causing "Cannot redeclare"
+// fatal errors.
+if (!function_exists('build_pdo_dsn')) {
+    require_once __DIR__ . "/utils.php";
+}
+if (!class_exists('Site_Export_HTTP_Server', false)) {
+    require_once __DIR__ . "/class-http-server.php";
+}
 
 /**
  * Emits an error chunk into a gzip multipart stream.


### PR DESCRIPTION
## Summary

The `import-38-flatten-wpcloud` E2E test creates a WP Cloud-like layout where `wp-content` is a symlink to an external directory. When PHP-FPM serves requests through this layout, `utils.php` gets loaded twice — once by Composer's `files` autoload (using the resolved realpath) and once by `export.php`'s `require_once` (using the symlink path). With the default `opcache.revalidate_path=0`, PHP doesn't resolve symlinks for `require_once` deduplication, so the second load triggers `Cannot redeclare build_pdo_dsn()`.

This showed up as a flaky failure on trunk — only PHP 8.1 failed in the latest CI run because the exact symlink resolution behavior varies across PHP versions and opcache states. The same bug would affect any real WP Cloud site where `wp-content` is symlinked away from ABSPATH.

The fix guards the `require_once` calls in `export.php` with `function_exists` / `class_exists` checks, so the redundant include is skipped when the Composer autoloader already loaded the files from a different path.

## Test plan

- [ ] `import-38-flatten-wpcloud` passes on all PHP versions in CI (was failing on PHP 8.1)
- [ ] All other E2E tests remain green