### PR TITLE
Skip domain scanning for values without http

### DIFF
--- a/packages/reprint-importer/src/lib/url-rewrite/class-domain-collector.php
+++ b/packages/reprint-importer/src/lib/url-rewrite/class-domain-collector.php
@@ -78,6 +78,10 @@ class DomainCollector
             return [];
         }
 
+        if (strpos($value, 'http') === false) {
+            return [];
+        }
+
         $before = count($this->domains);
 
         // Serialized PHP: the parser validates the entire structure in


### PR DESCRIPTION
## What it does

Adds a `strpos($value, 'http')` short-circuit at the top of `DomainCollector::scan()`. Values that don't contain `http` are skipped before any parsing begins. This shortened processing my Blog's database from ~2 minutes to 30 seconds.

**This PR effectively disables URL rewriting in Base64 strings!** We'll need to find a way to keep them enabled without adding a significant overhead to the process.

## Implementation

The guard sits right after the existing empty-string check, before any parser is constructed:

```php
if (strpos($value, 'http') === false) {
    return [];
}
```

This is safe because every URL domain we collect must start with `http://` or `https://`. The `strpos` check is case-sensitive, which matches the URL schemes we care about.

## Testing instructions

```bash
composer test
```

Existing `DomainCollector` tests cover values with and without URLs — nothing changes for values that contain `http`.
