### PR TITLE
Skip URL rewriting for base64 values without http

### DIFF
--- a/packages/reprint-importer/src/lib/url-rewrite/class-sql-statement-rewriter.php
+++ b/packages/reprint-importer/src/lib/url-rewrite/class-sql-statement-rewriter.php
@@ -101,6 +101,15 @@ class SqlStatementRewriter
         while ($scanner->next_value()) {
             $value = $scanner->get_value();
 
+            // Skip values that can't contain a URL we'd rewrite. Every
+            // rewritable domain starts with http:// or https://, so a value
+            // without "http" anywhere in it has nothing for us to do. This
+            // avoids the column-map lookup and the full StructuredDataUrlRewriter
+            // pipeline (HTML parse, block markup, PHP/JSON recursion) per value.
+            if (strpos($value, 'http') === false) {
+                continue;
+            }
+
             // Determine content type hint for this column
             $content_type = null;
             if ($parsed !== null) {

--- a/packages/reprint-importer/src/lib/url-rewrite/class-sql-statement-rewriter.php
+++ b/packages/reprint-importer/src/lib/url-rewrite/class-sql-statement-rewriter.php
@@ -82,6 +82,11 @@ class SqlStatementRewriter
     /**
      * Rewrite URLs in a SQL statement.
      *
+     * NOTE: base64-encoded values that do not contain the string "http" are
+     * skipped entirely — column resolution and the StructuredDataUrlRewriter
+     * pipeline are never run for them. This means URLs stored in base64
+     * without an http/https scheme will not be rewritten.
+     *
      * @param string $sql The SQL statement.
      * @return string The modified SQL statement.
      */

--- a/packages/reprint-importer/src/lib/url-rewrite/class-sql-statement-rewriter.php
+++ b/packages/reprint-importer/src/lib/url-rewrite/class-sql-statement-rewriter.php
@@ -111,6 +111,7 @@ class SqlStatementRewriter
             // without "http" anywhere in it has nothing for us to do. This
             // avoids the column-map lookup and the full StructuredDataUrlRewriter
             // pipeline (HTML parse, block markup, PHP/JSON recursion) per value.
+            // See https://github.com/adamziel/reprint/pull/152
             if (strpos($value, 'http') === false) {
                 continue;
             }


### PR DESCRIPTION
## What it does

Applies the same `strpos($value, 'http') === false` short-circuit from #151 — but one layer deeper, inside `SqlStatementRewriter::rewrite()`, on each decoded base64 value.

**This PR effectively disables URL rewriting in base64 strings**, just like #151 did for domain collection. We will need to find a way to keep them enabled without adding significant overhead.

Before this change, every base64 value in an INSERT/UPDATE went through a column-map lookup and the full `StructuredDataUrlRewriter` pipeline (HTML parse, block markup traversal, PHP/JSON recursion). None of that can produce a rewrite unless the value contains a URL starting with `http://` or `https://`. The new guard bails out before either step when there is no `http` substring at all.

## Implementation

```php
if (strpos($value, 'http') === false) {
    continue;
}
```

Added right after `$scanner->get_value()`, before column-name resolution and the `StructuredDataUrlRewriter::rewrite()` call. The outer `FROM_BASE64(` early-return (which skips the whole statement when there is no base64 at all) already existed and is unchanged.

## Testing

```bash
composer test
```