### PR TITLE
Stabilize the runtime file download e2e test

### DIFF
--- a/tests/e2e/ci/setup-infrastructure.sh
+++ b/tests/e2e/ci/setup-infrastructure.sh
@@ -84,6 +84,7 @@ php_admin_value[display_errors] = Off
 php_admin_value[log_errors] = On
 php_admin_value[error_log] = /tmp/php-e2e-errors.log
 php_admin_value[user_ini.cache_ttl] = 0
+php_admin_value[realpath_cache_ttl] = 0
 
 env[SITE_EXPORT_TEST_MODE] = 1
 EOF

--- a/tests/e2e/docker-entrypoint.sh
+++ b/tests/e2e/docker-entrypoint.sh
@@ -48,6 +48,8 @@ php_admin_value[error_reporting] = E_ALL
 php_admin_value[display_errors] = Off
 php_admin_value[log_errors] = On
 php_admin_value[error_log] = /tmp/php-e2e-errors.log
+php_admin_value[user_ini.cache_ttl] = 0
+php_admin_value[realpath_cache_ttl] = 0
 env[SITE_EXPORT_TEST_MODE] = 1
 EOF
 rm -f "/etc/php/${PHP_VERSION}/fpm/pool.d/www.conf"

--- a/tests/e2e/nixos-e2e-services.nix
+++ b/tests/e2e/nixos-e2e-services.nix
@@ -150,6 +150,8 @@ in {
       "php_admin_value[display_errors]" = "Off";
       "php_admin_value[log_errors]" = "On";
       "php_admin_value[error_log]" = "/tmp/php-e2e-errors.log";
+      "php_admin_value[user_ini.cache_ttl]" = "0";
+      "php_admin_value[realpath_cache_ttl]" = "0";
     };
     phpEnv = {
       SITE_EXPORT_TEST_MODE = "1";

--- a/tests/e2e/tests/import-45-runtime-file-download.test.js
+++ b/tests/e2e/tests/import-45-runtime-file-download.test.js
@@ -55,11 +55,37 @@ describe('Import: Runtime file download', () => {
 
         tempDir = createTempDir('e2e-runtime-download');
 
-        preflightResult = runImporter(importUrlWithDirectory(), tempDir, 'preflight', {
-            secret: getSiteSecret(site),
-        });
-        assert.equal(preflightResult.exitCode, 0,
-            `Expected exit 0\nstderr: ${preflightResult.stderr}\nstdout: ${preflightResult.stdout}`);
+        // PHP-FPM can briefly miss a freshly-written .user.ini when a worker
+        // has a stale realpath/stat cache for the site directory (e.g. from
+        // a parent-directory lookup that predates this site's creation).
+        // The pool sets user_ini.cache_ttl=0 and realpath_cache_ttl=0, but
+        // caches survive until the current request ends, so retry preflight
+        // a few times until auto_prepend_file shows up. Each preflight wipes
+        // tempDir state, so retries are safe.
+        const maxAttempts = 5;
+        for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+            preflightResult = runImporter(importUrlWithDirectory(), tempDir, 'preflight', {
+                secret: getSiteSecret(site),
+            });
+            assert.equal(preflightResult.exitCode, 0,
+                `Expected exit 0\nstderr: ${preflightResult.stderr}\nstdout: ${preflightResult.stdout}`);
+
+            const state = JSON.parse(readFileSync(join(tempDir, '.import-state.json'), 'utf-8'));
+            const prepend = state.preflight?.data?.runtime?.ini_get_all?.auto_prepend_file ?? '';
+            if (prepend.includes('scripts/env.php')) {
+                break;
+            }
+            if (attempt === maxAttempts) {
+                break;
+            }
+            // Touch .user.ini so any worker that cached a missing-file stat
+            // re-checks on the next request, then brief pause for FPM workers
+            // to cycle.
+            try {
+                execSync(`sudo touch ${JSON.stringify(join(siteDir, '.user.ini'))}`);
+            } catch {}
+            await new Promise((r) => setTimeout(r, 500));
+        }
     });
 
     afterAll(() => {


### PR DESCRIPTION
## What it does

Stabilizes `tests/e2e/tests/import-45-runtime-file-download.test.js`, which intermittently asserted an empty `auto_prepend_file` in the preflight state even though the test's `beforeAll` wrote a `.user.ini` before running preflight.

## Rationale

PHP-FPM workers cache directory lookups via the realpath cache (default TTL 120s) and `.user.ini` discovery via `user_ini.cache_ttl` (default 300s). When a worker had resolved anything under the site path before the test recreated the site and wrote `.user.ini`, the cached miss persisted across the fresh request — so `ini_get_all` returned `auto_prepend_file=""` and the assertion failed.

CI's FPM pool already had `user_ini.cache_ttl = 0`, but the Docker and NixOS pools did not, and `realpath_cache_ttl` was left at the default everywhere.

## Implementation

Two fixes, belt and suspenders:

1. Zero out both caches in every FPM pool config we run, so each request re-scans `.user.ini`:

   ```ini
   php_admin_value[user_ini.cache_ttl] = 0
   php_admin_value[realpath_cache_ttl] = 0
   ```

   Applied in `tests/e2e/ci/setup-infrastructure.sh`, `tests/e2e/docker-entrypoint.sh`, and `tests/e2e/nixos-e2e-services.nix`.

2. Retry preflight in the test's `beforeAll` until `auto_prepend_file` shows up (max 5 attempts, `sudo touch` on `.user.ini` plus a 500ms sleep between tries). `preflight` wipes its own state dir, so retries are safe.

## Testing instructions

```bash
cd tests/e2e
for i in 1 2 3 4 5; do npm run test -- tests/import-45-runtime-file-download.test.js || break; done
```

Should pass all five runs. Full `./run-all-tests.sh` should stay green.