### PR TITLE
flat-docroot: symlink wp-config.php from ABSPATH parent directory

### DIFF
--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -4204,6 +4204,32 @@ class ImportClient
             );
         }
 
+        // Phase 1c: Symlink wp-config.php from ABSPATH's parent directory.
+        // WordPress allows wp-config.php one directory above ABSPATH —
+        // wp-load.php checks dirname(ABSPATH) as a fallback. On WP Cloud
+        // the typical layout is /srv/htdocs/wp-config.php with ABSPATH at
+        // /srv/htdocs/wordpress/, so Phase 1's ABSPATH scan won't find it.
+        $wp_config_in_flatten = $flatten_to . "/wp-config.php";
+        if (!file_exists($wp_config_in_flatten)) {
+            $parent_of_abspath = dirname($abspath);
+            $local_parent_wp_config = $this->fs_root . $parent_of_abspath . "/wp-config.php";
+            if (file_exists($local_parent_wp_config)) {
+                $this->flatten_place_symlink(
+                    $local_parent_wp_config,
+                    $wp_config_in_flatten,
+                    $force,
+                    $created,
+                    $refreshed,
+                    $forced,
+                );
+                $this->audit_log(
+                    "FLAT-DOCUMENT-ROOT | Symlinked wp-config.php from ABSPATH parent: " .
+                        "{$parent_of_abspath}/wp-config.php",
+                );
+            }
+        }
+
+
         // Phase 2: Handle wp-content when it's outside ABSPATH
         if ($need_exploded_content && $local_content_dir !== null) {
             // wp-content must be a real directory because some sub-components

--- a/tests/Import/FlatDocrootWpConfigTest.php
+++ b/tests/Import/FlatDocrootWpConfigTest.php
@@ -1,0 +1,188 @@
+<?php
+
+namespace ImportTests;
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../importer/import.php';
+
+/**
+ * Verify run_flat_document_root() picks up wp-config.php when it lives
+ * in ABSPATH's parent directory (the WordPress one-directory-up convention).
+ */
+class FlatDocrootWpConfigTest extends TestCase
+{
+    private string $tempDir;
+    private string $stateDir;
+    private string $fsRoot;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->tempDir = sys_get_temp_dir() . '/flat-docroot-wpconfig-' . uniqid();
+        $this->stateDir = $this->tempDir . '/state';
+        $this->fsRoot = $this->tempDir . '/fs-root';
+        mkdir($this->stateDir, 0755, true);
+        mkdir($this->fsRoot, 0755, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->recursiveDelete($this->tempDir);
+        parent::tearDown();
+    }
+
+    /**
+     * WP Cloud layout: wp-config.php in /srv/htdocs/ (parent of ABSPATH),
+     * ABSPATH at /srv/htdocs/wordpress/. Phase 1c should symlink it.
+     */
+    public function testSymlinksWpConfigFromAbspathParent(): void
+    {
+        $abspath = '/srv/htdocs/wordpress/';
+        $parentDir = '/srv/htdocs';
+
+        // Create the filesystem layout under fsRoot
+        $localAbspath = $this->fsRoot . $abspath;
+        $localParent = $this->fsRoot . $parentDir;
+        mkdir($localAbspath, 0755, true);
+
+        // wp-config.php lives in the parent of ABSPATH
+        file_put_contents($localParent . '/wp-config.php', '<?php // wp-config from parent');
+
+        // Put a minimal wp-load.php in ABSPATH so the directory isn't empty
+        file_put_contents($localAbspath . 'wp-load.php', '<?php // wp-load');
+
+        $this->writeState([
+            'preflight' => [
+                'data' => [
+                    'database' => [
+                        'wp' => [
+                            'table_prefix' => 'wp_',
+                            'paths_urls' => [
+                                'abspath' => $abspath,
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $flattenTo = $this->tempDir . '/flat';
+        $client = $this->makeClient();
+        $this->loadClientState($client);
+
+        $this->callPrivate($client, 'run_flat_document_root', [
+            ['flatten_to' => $flattenTo, 'force' => false],
+        ]);
+
+        $wpConfigFlat = $flattenTo . '/wp-config.php';
+        $this->assertFileExists($wpConfigFlat, 'wp-config.php should exist in flattened output');
+        $this->assertTrue(is_link($wpConfigFlat), 'wp-config.php should be a symlink');
+        $this->assertStringContainsString(
+            'wp-config from parent',
+            file_get_contents($wpConfigFlat),
+            'wp-config.php should contain the parent directory content',
+        );
+    }
+
+    /**
+     * When wp-config.php exists in BOTH ABSPATH and its parent, the ABSPATH
+     * version should win (Phase 1 already placed it).
+     */
+    public function testDoesNotOverwriteWpConfigAlreadyInAbspath(): void
+    {
+        $abspath = '/srv/htdocs/wordpress/';
+        $parentDir = '/srv/htdocs';
+
+        $localAbspath = $this->fsRoot . $abspath;
+        $localParent = $this->fsRoot . $parentDir;
+        mkdir($localAbspath, 0755, true);
+
+        // wp-config.php in both locations
+        file_put_contents($localParent . '/wp-config.php', '<?php // wp-config from parent');
+        file_put_contents($localAbspath . 'wp-config.php', '<?php // wp-config from abspath');
+        file_put_contents($localAbspath . 'wp-load.php', '<?php // wp-load');
+
+        $this->writeState([
+            'preflight' => [
+                'data' => [
+                    'database' => [
+                        'wp' => [
+                            'table_prefix' => 'wp_',
+                            'paths_urls' => [
+                                'abspath' => $abspath,
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $flattenTo = $this->tempDir . '/flat';
+        $client = $this->makeClient();
+        $this->loadClientState($client);
+
+        $this->callPrivate($client, 'run_flat_document_root', [
+            ['flatten_to' => $flattenTo, 'force' => false],
+        ]);
+
+        $wpConfigFlat = $flattenTo . '/wp-config.php';
+        $this->assertFileExists($wpConfigFlat);
+        $this->assertStringContainsString(
+            'wp-config from abspath',
+            file_get_contents($wpConfigFlat),
+            'ABSPATH wp-config.php should take precedence over parent',
+        );
+    }
+
+    // ---- helpers ----
+
+    private function writeState(array $state): void
+    {
+        file_put_contents(
+            $this->stateDir . '/.import-state.json',
+            json_encode($state, JSON_PRETTY_PRINT),
+        );
+    }
+
+    private function makeClient(): \ImportClient
+    {
+        return new \ImportClient('https://source.example/export.php', $this->stateDir, $this->fsRoot);
+    }
+
+    private function loadClientState(\ImportClient $client): void
+    {
+        $state = $this->callPrivate($client, 'load_state');
+        $reflection = new \ReflectionClass($client);
+        $property = $reflection->getProperty('state');
+        $property->setValue($client, $state);
+    }
+
+    private function callPrivate(\ImportClient $client, string $method, array $args = [])
+    {
+        $reflection = new \ReflectionClass($client);
+        $m = $reflection->getMethod($method);
+        return $m->invoke($client, ...$args);
+    }
+
+    private function recursiveDelete(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        foreach (scandir($dir) as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $path = $dir . '/' . $item;
+            if (is_link($path) || is_file($path)) {
+                unlink($path);
+                continue;
+            }
+            if (is_dir($path)) {
+                $this->recursiveDelete($path);
+            }
+        }
+        rmdir($dir);
+    }
+}


### PR DESCRIPTION
## Why this is needed

On the remote host, WordPress finds `wp-config.php` via `wp-load.php`'s built-in fallback: it checks `dirname(ABSPATH)`. For example on WP Cloud, `ABSPATH` is `/srv/htdocs/wordpress/` and `wp-config.php` lives at `/srv/htdocs/wp-config.php` — the parent directory lookup works because the two-level directory hierarchy is intact.

`flat-docroot` collapses this hierarchy into a single directory. After flattening, `ABSPATH` becomes the flat output directory. The `dirname(ABSPATH)` fallback now points to some random parent directory, not the original `/srv/htdocs/`. `wp-config.php` is lost.

## The fix

This adds **Phase 1c** to `run_flat_document_root()`: after scanning `ABSPATH` entries (Phase 1) and handling detached `wp-admin`/`wp-includes` (Phase 1b), it checks whether `wp-config.php` ended up in the flattened output. If not, it looks in `ABSPATH`'s parent in the raw tree and symlinks it in. This compensates for the structural change that flattening itself introduces.

## Testing Instructions

- Run the new test: `vendor/bin/phpunit tests/Import/FlatDocrootWpConfigTest.php`
- Verify existing flat-docroot tests still pass

## Pre-merge Checklist

- [x] Changes are covered by tests
- [x] Commit message explains intent