### PR TITLE
pull: support deferred file filtering

### DIFF
--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -1258,6 +1258,22 @@ class ImportClient
         $this->save_state($this->state);
     }
 
+    /** Record the pull's file filter and whether deferred files remain. */
+    public function set_pull_files_state(string $filter, bool $skipped_pending): void
+    {
+        $this->state['pull']['files_filter'] = $filter;
+        $this->state['pull']['skipped_pending'] = $skipped_pending;
+        $this->save_state($this->state);
+    }
+
+    /** True when the skipped-download list exists and still has entries. */
+    public function has_skipped_files_pending(): bool
+    {
+        return
+            file_exists($this->skipped_download_list_file) &&
+            filesize($this->skipped_download_list_file) > 0;
+    }
+
     /**
      * Log the executed command and full argv to the audit log.
      * Called from the CLI entry point before run() so the invocation
@@ -1485,8 +1501,17 @@ class ImportClient
         // start fresh (--abort) or finish the current sync before switching.
         // The one valid transition is: essential-files (complete) → skipped-earlier.
         if (isset($options["filter"])) {
-            $prev = $this->state["filter"] ?? null;
             $next = $options["filter"];
+            if (
+                $command === "pull" &&
+                !in_array($next, ["none", "essential-files"], true)
+            ) {
+                throw new InvalidArgumentException(
+                    "Invalid --filter value for pull: {$next}. " .
+                        "Valid values: none, essential-files",
+                );
+            }
+            $prev = $this->state["filter"] ?? null;
             $status = $this->state["status"] ?? null;
             $is_mid_flight = $prev !== null && $prev !== $next && $status !== null && $status !== "complete";
             if ($is_mid_flight) {
@@ -9929,6 +9954,8 @@ class ImportClient
             // "stage" is the last completed stage name, or "complete".
             "pull" => [
                 "stage" => null,
+                "files_filter" => null,
+                "skipped_pending" => false,
             ],
         ];
     }
@@ -10720,8 +10747,8 @@ if (
             'target' => 'filter',
             'placeholder' => 'MODE',
             'valid_values' => ['none', 'essential-files', 'skipped-earlier'],
-            'help' => 'Filter which files to download (none|essential-files|skipped-earlier)',
-            'commands' => ['files-pull'],
+            'help' => 'Filter which files to download (pull: none|essential-files; files-pull also supports skipped-earlier)',
+            'commands' => ['pull', 'files-pull'],
         ],
         [
             'name' => 'extra-directory',
@@ -11343,6 +11370,9 @@ if (
                 "interrupted, re-run the same command to resume from where it left off.\n" .
                 "Running pull again after completion performs a delta sync.\n" .
                 "\n" .
+                "Use --filter=essential-files to defer uploads and other large wp-content\n" .
+                "entries while still completing the rest of the pull.\n" .
+                "\n" .
                 "The ?site-export-api query parameter is added automatically if missing,\n" .
                 "so you can pass just the site URL.\n",
             "extra" =>
@@ -11356,6 +11386,11 @@ if (
                 "    --secret=TOKEN --state-dir=./state --fs-root=./files \\\n" .
                 "    --target-user=root --target-db=wp_local \\\n" .
                 "    --new-site-url=http://localhost:8881\n" .
+                "\n" .
+                "  # Complete the main pull now, defer the heavier file tail:\n" .
+                "  reprint pull https://example.com \\\n" .
+                "    --secret=TOKEN --state-dir=./state --fs-root=./files \\\n" .
+                "    --filter=essential-files --target-engine=sqlite --runtime=none\n" .
                 "\n" .
                 "  # Full clone with SQLite, flattened layout, and PHP built-in server:\n" .
                 "  reprint pull https://example.com \\\n" .

--- a/packages/reprint-importer/src/lib/pull/class-pull.php
+++ b/packages/reprint-importer/src/lib/pull/class-pull.php
@@ -189,8 +189,18 @@ class Pull
                 $this->run_until_complete(function () {
                     $this->client->run_files_sync();
                 });
+                $skipped_pending =
+                    $options['filter'] === 'essential-files' &&
+                    $this->client->has_skipped_files_pending();
+                $this->client->set_pull_files_state($options['filter'], $skipped_pending);
                 $count = $this->client->index_count();
-                $this->print_done($stage, $count > 0 ? number_format($count) . " files" : null);
+                $summary = $count > 0 ? number_format($count) . " files" : null;
+                if ($skipped_pending) {
+                    $summary = $summary !== null
+                        ? $summary . ", deferred files pending"
+                        : "deferred files pending";
+                }
+                $this->print_done($stage, $summary);
                 break;
 
             case 'db-pull':
@@ -287,6 +297,16 @@ class Pull
             $options['output_dir'] = $this->client->state_dir . '/runtime';
         }
 
+        if (!isset($options['filter'])) {
+            $options['filter'] = $this->client->state['filter'] ?? 'none';
+        }
+        if (!in_array($options['filter'], ['none', 'essential-files'], true)) {
+            throw new InvalidArgumentException(
+                "Invalid --filter value for pull: {$options['filter']}. " .
+                "Valid values: none, essential-files"
+            );
+        }
+
         return $options;
     }
 
@@ -316,6 +336,8 @@ class Pull
         $defaults = $this->client->default_state();
         $this->client->mutate_state(function (array $state) use ($defaults) {
             $state['pull']['stage'] = null;
+            $state['pull']['files_filter'] = null;
+            $state['pull']['skipped_pending'] = false;
             $state['command'] = null;
             $state['status'] = null;
             $state['cursor'] = null;
@@ -537,6 +559,11 @@ class Pull
         $this->progress->print_line(
             "\n{$green}{$bold}Done.{$r} {$dim}Files in {$fs_root}{$r}\n"
         );
+        if (!empty($this->client->state['pull']['skipped_pending'])) {
+            $this->progress->print_line(
+                "{$dim}Deferred files remain. The skipped download list was preserved on disk for a follow-up sync.{$r}\n"
+            );
+        }
     }
 
     private function report_failure(string $stage, array $stages, int $i, \Exception $e): void

--- a/tests/Import/PullFilterOptionTest.php
+++ b/tests/Import/PullFilterOptionTest.php
@@ -1,0 +1,221 @@
+<?php
+
+namespace ImportTests;
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../importer/import.php';
+
+class PullFilterFakeClient extends \ImportClient
+{
+    private bool $create_skipped_list;
+
+    public function __construct(string $state_dir, string $fs_root, bool $create_skipped_list)
+    {
+        $this->create_skipped_list = $create_skipped_list;
+        parent::__construct('http://fake.invalid', $state_dir, $fs_root);
+    }
+
+    public function audit_log(string $message, bool $to_console = true): void
+    {
+    }
+
+    public function output_progress(array $data, bool $force = false): void
+    {
+    }
+
+    public function write_status_file(?string $error = null): void
+    {
+    }
+
+    public function index_count(): int
+    {
+        return 12;
+    }
+
+    public function run_preflight(): void
+    {
+        $this->mutate_state(function (array $state) {
+            $state["preflight"] = [
+                "http_code" => 200,
+                "data" => [
+                    "ok" => true,
+                    "database" => [
+                        "wp" => [
+                            "wp_version" => "6.8",
+                        ],
+                    ],
+                    "runtime" => [
+                        "phpversion" => "8.2",
+                    ],
+                ],
+            ];
+            $state["status"] = "complete";
+            return $state;
+        });
+    }
+
+    public function run_files_sync(): void
+    {
+        if ($this->create_skipped_list) {
+            file_put_contents(
+                $this->state_dir . '/.import-download-list-skipped.jsonl',
+                "{\"path\":\"" . base64_encode('/wp-content/uploads/2024/01/photo.jpg') . "\"}\n",
+            );
+        } else {
+            @unlink($this->state_dir . '/.import-download-list-skipped.jsonl');
+        }
+
+        $this->mutate_state(function (array $state) {
+            $state["command"] = "files-pull";
+            $state["status"] = "complete";
+            $state["stage"] = null;
+            return $state;
+        });
+    }
+
+    public function run_db_sync(): void
+    {
+        file_put_contents($this->state_dir . '/db.sql', "SELECT 1;\n");
+        $this->mutate_state(function (array $state) {
+            $state["command"] = "db-pull";
+            $state["status"] = "complete";
+            $state["stage"] = null;
+            return $state;
+        });
+    }
+
+    public function run_db_apply(array $options): void
+    {
+        $this->mutate_state(function (array $state) {
+            $state["command"] = "db-apply";
+            $state["status"] = "complete";
+            $state["stage"] = null;
+            $state["apply"]["statements_executed"] = 42;
+            return $state;
+        });
+    }
+}
+
+/**
+ * Tests for pull-level file filtering.
+ */
+class PullFilterOptionTest extends TestCase
+{
+    private $tempDir;
+    private $stateDir;
+    private $fs_root;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->tempDir = sys_get_temp_dir() . '/pull-filter-test-' . uniqid();
+        $this->stateDir = $this->tempDir . '/state';
+        $this->fs_root = $this->tempDir . '/fs-root';
+        mkdir($this->stateDir, 0755, true);
+        mkdir($this->fs_root, 0755, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->recursiveDelete($this->tempDir);
+        parent::tearDown();
+    }
+
+    private function recursiveDelete(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        foreach (scandir($dir) as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $path = $dir . '/' . $item;
+            if (is_link($path)) {
+                unlink($path);
+            } elseif (is_dir($path)) {
+                $this->recursiveDelete($path);
+            } else {
+                unlink($path);
+            }
+        }
+        rmdir($dir);
+    }
+
+    private function makeClient(bool $create_skipped_list): PullFilterFakeClient
+    {
+        return new PullFilterFakeClient($this->stateDir, $this->fs_root, $create_skipped_list);
+    }
+
+    private function readState(): array
+    {
+        return json_decode(
+            file_get_contents($this->stateDir . '/.import-state.json'),
+            true,
+        );
+    }
+
+    public function testPullRejectsSkippedEarlierFilterBeforePersistingIt(): void
+    {
+        $client = $this->makeClient(false);
+
+        try {
+            ob_start();
+            $client->run([
+                "command" => "pull",
+                "filter" => "skipped-earlier",
+                "runtime" => "none",
+            ]);
+            $this->fail('Expected pull --filter=skipped-earlier to be rejected');
+        } catch (\InvalidArgumentException $e) {
+            $this->assertStringContainsString(
+                'Invalid --filter value for pull',
+                $e->getMessage(),
+            );
+        } finally {
+            ob_end_clean();
+        }
+
+        $this->assertFileDoesNotExist($this->stateDir . '/.import-state.json');
+    }
+
+    public function testPullWithEssentialFilesPersistsDeferredFilesState(): void
+    {
+        $client = $this->makeClient(true);
+
+        ob_start();
+        $client->run([
+            "command" => "pull",
+            "filter" => "essential-files",
+            "runtime" => "none",
+        ]);
+        ob_end_clean();
+
+        $state = $this->readState();
+        $this->assertSame('complete', $state["pull"]["stage"]);
+        $this->assertSame('essential-files', $state["pull"]["files_filter"]);
+        $this->assertTrue($state["pull"]["skipped_pending"]);
+        $this->assertSame('essential-files', $state["filter"]);
+        $this->assertFileExists($this->stateDir . '/.import-download-list-skipped.jsonl');
+    }
+
+    public function testPullWithoutFilterRecordsFullDownloadMode(): void
+    {
+        $client = $this->makeClient(false);
+
+        ob_start();
+        $client->run([
+            "command" => "pull",
+            "runtime" => "none",
+        ]);
+        ob_end_clean();
+
+        $state = $this->readState();
+        $this->assertSame('complete', $state["pull"]["stage"]);
+        $this->assertSame('none', $state["pull"]["files_filter"]);
+        $this->assertFalse($state["pull"]["skipped_pending"]);
+        $this->assertSame('none', $state["filter"]);
+        $this->assertFileDoesNotExist($this->stateDir . '/.import-download-list-skipped.jsonl');
+    }
+}

--- a/tests/e2e/tests/import-49-pull-essential-files.test.js
+++ b/tests/e2e/tests/import-49-pull-essential-files.test.js
@@ -1,0 +1,116 @@
+/**
+ * Test 49: Pull --filter=essential-files
+ *
+ * Verifies that `reprint pull` accepts `--filter=essential-files`,
+ * completes the main pull pipeline, imports the database, and leaves
+ * the skipped-file tail recorded in pull state for later retrieval.
+ */
+import { describe, it, beforeAll, afterAll } from 'vitest';
+import assert from 'node:assert/strict';
+import { readFileSync, existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { randomBytes } from 'node:crypto';
+import { join } from 'node:path';
+import {
+    runImporter, createTempDir, cleanupTempDir,
+    getSiteUrl, getSiteSecret, getSiteDir,
+    fsRootDir, compareDatabases, createMysqlConnection, getDbName,
+} from '../lib/test-helpers.js';
+import { ensureSite } from '../lib/site-setup.js';
+
+const UPLOAD_FILES = [
+    'wp-content/uploads/2024/01/photo.jpg',
+    'wp-content/uploads/2024/01/banner.png',
+    'wp-content/uploads/2024/01/document.pdf',
+    'wp-content/uploads/2024/06/summer.jpg',
+];
+
+describe('Import: Pull essential-files', { timeout: 180000 }, () => {
+    const site = 'defer-uploads';
+    const importDb = 'e2e_pull_filter_49';
+    let tempDir;
+    let siteDir;
+
+    beforeAll(async () => {
+        await ensureSite(site, {
+            afterCreate: async (remoteSiteDir) => {
+                const uploadsDir = join(remoteSiteDir, 'wp-content', 'uploads', '2024', '01');
+                mkdirSync(uploadsDir, { recursive: true });
+                writeFileSync(join(uploadsDir, 'photo.jpg'), randomBytes(4096));
+                writeFileSync(join(uploadsDir, 'banner.png'), randomBytes(2048));
+                writeFileSync(join(uploadsDir, 'document.pdf'), randomBytes(1024));
+
+                const uploadsDir2 = join(remoteSiteDir, 'wp-content', 'uploads', '2024', '06');
+                mkdirSync(uploadsDir2, { recursive: true });
+                writeFileSync(join(uploadsDir2, 'summer.jpg'), randomBytes(3072));
+            },
+        });
+        siteDir = getSiteDir(site);
+        tempDir = createTempDir('e2e-pull-filter');
+
+        const conn = await createMysqlConnection();
+        await conn.query(`DROP DATABASE IF EXISTS \`${importDb}\``);
+        await conn.query(`CREATE DATABASE \`${importDb}\``);
+        await conn.end();
+    });
+
+    afterAll(async () => {
+        cleanupTempDir(tempDir);
+        const conn = await createMysqlConnection();
+        await conn.query(`DROP DATABASE IF EXISTS \`${importDb}\``);
+        await conn.end();
+    });
+
+    function importUrl() {
+        return `${getSiteUrl(site)}&directory=${siteDir}`;
+    }
+
+    it('pull completes with --filter=essential-files', () => {
+        const result = runImporter(importUrl(), tempDir, 'pull', {
+            secret: getSiteSecret(site),
+            skipPreflight: true,
+            timeout: 120000,
+            wallTimeout: 180000,
+            extraArgs: [
+                '--filter=essential-files',
+                '--target-user=e2e_admin',
+                '--target-pass=e2e_password',
+                `--target-db=${importDb}`,
+                '--new-site-url=http://localhost:9999',
+                '--runtime=none',
+            ],
+        });
+        assert.equal(result.exitCode, 0,
+            `Expected exit 0, got ${result.exitCode}\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);
+    });
+
+    it('state records deferred files in the pull metadata', () => {
+        const stateFile = join(tempDir, '.import-state.json');
+        assert.ok(existsSync(stateFile), 'Expected .import-state.json to exist');
+        const state = JSON.parse(readFileSync(stateFile, 'utf-8'));
+        assert.equal(state.pull.stage, 'complete');
+        assert.equal(state.pull.files_filter, 'essential-files');
+        assert.equal(state.pull.skipped_pending, true);
+    });
+
+    it('skipped download list remains on disk', () => {
+        const skippedList = join(tempDir, '.import-download-list-skipped.jsonl');
+        assert.ok(existsSync(skippedList), 'Expected skipped download list to exist');
+        assert.ok(readFileSync(skippedList, 'utf-8').trim().length > 0,
+            'Expected skipped download list to be non-empty');
+    });
+
+    it('uploads were deferred from the fs-root', () => {
+        const importedRoot = join(fsRootDir(tempDir), siteDir);
+        for (const file of UPLOAD_FILES) {
+            assert.ok(!existsSync(join(importedRoot, file)),
+                `Expected deferred upload to be absent: ${file}`);
+        }
+    });
+
+    it('database still matches the source site', async () => {
+        const comparison = await compareDatabases(getDbName(site), importDb);
+        assert.ok(comparison.match,
+            `Database mismatch: missing=${JSON.stringify(comparison.missingTables)}, ` +
+            `counts=${JSON.stringify(comparison.rowCounts)}`);
+    });
+});


### PR DESCRIPTION
## What it does

Adds `--filter=none|essential-files` to `reprint pull` and records deferred-file state on the top-level pull metadata.

When you run `pull --filter=essential-files`, the `files-pull` stage now leaves the skipped tail on disk, marks `pull.files_filter=essential-files`, and sets `pull.skipped_pending=true` before the rest of the pull continues.

## Rationale

Studio wants to get a runnable local site sooner by deferring uploads and other heavy `wp-content` entries without reimplementing the rest of the pull pipeline.

Before this change, `pull` always ran an unfiltered `files-pull`, so callers that wanted a two-phase import had to orchestrate the lower-level commands themselves.

## Implementation

- Accept `--filter` on `pull`, but only allow `none` and `essential-files`
- Reject `pull --filter=skipped-earlier` before the invalid value can be persisted into state
- Persist `pull.files_filter` and `pull.skipped_pending` alongside `pull.stage`
- Surface deferred-file state in the files stage summary and in the final pull summary
- Add a focused PHPUnit test plus an E2E test that exercises `pull --filter=essential-files`

## Testing instructions

- `phpunit --colors=never tests/Import/PullFilterOptionTest.php`
- Added `tests/e2e/tests/import-49-pull-essential-files.test.js`

Local notes:
- The new PHPUnit test passes locally.
- The new E2E file could not be executed in this workspace because `tests/e2e/lib/site-setup.js` requires passwordless `sudo`, and the local MySQL test service on `127.0.0.1:3306` is not running here.
