### PR TITLE
pull: reuse skipped-earlier continuation

### DIFF
--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -1274,6 +1274,20 @@ class ImportClient
             filesize($this->skipped_download_list_file) > 0;
     }
 
+    /** Override the active filter without persisting it to state. */
+    public function set_filter_mode(string $filter): void
+    {
+        $this->filter = $filter;
+    }
+
+    /** True when a completed pull still has deferred files pending. */
+    public function pull_has_skipped_files_pending(): bool
+    {
+        return
+            !empty($this->state['pull']['skipped_pending']) &&
+            ($this->state['pull']['files_filter'] ?? null) === 'essential-files';
+    }
+
     /**
      * Log the executed command and full argv to the audit log.
      * Called from the CLI entry point before run() so the invocation
@@ -2504,22 +2518,9 @@ class ImportClient
                             "Run files-pull with --filter=essential-files first.",
                     );
                 }
-                $this->audit_log(
+                $this->resume_skipped_file_downloads(
                     "FETCH SKIPPED | files-pull was complete — downloading previously skipped files",
-                    true,
                 );
-                $this->progress->show_lifecycle_line("Downloading previously skipped files\n");
-                $this->output_progress([
-                    "type" => "lifecycle",
-                    "event" => "starting",
-                    "command" => "files-pull",
-                    "stage" => "fetch-skipped",
-                    "message" => "Downloading previously skipped files",
-                ], true);
-                $this->state["status"] = "in_progress";
-                $this->state["stage"] = "fetch-skipped";
-                $this->save_state($this->state);
-                $this->run_files_sync_pipeline();
                 return;
             }
 
@@ -2548,6 +2549,22 @@ class ImportClient
                 "has_skipped" => $has_skipped,
                 "message" => "files-pull already complete: {$index_size} files indexed",
             ], true);
+            return;
+        }
+
+        if (
+            $this->filter === "skipped-earlier" &&
+            $this->pull_has_skipped_files_pending()
+        ) {
+            if (!$this->has_skipped_files_pending()) {
+                throw new RuntimeException(
+                    "--filter=skipped-earlier was requested but the skipped file list is missing. " .
+                        "Run pull --filter=essential-files again or use --abort to start over.",
+                );
+            }
+            $this->resume_skipped_file_downloads(
+                "FETCH SKIPPED | pull completed with deferred files — downloading them now",
+            );
             return;
         }
 
@@ -2879,6 +2896,24 @@ class ImportClient
         if ($this->follow_symlinks) {
             $this->recreate_intermediate_symlinks();
         }
+    }
+
+    private function resume_skipped_file_downloads(string $audit_message): void
+    {
+        $this->audit_log($audit_message, true);
+        $this->progress->show_lifecycle_line("Downloading previously skipped files\n");
+        $this->output_progress([
+            "type" => "lifecycle",
+            "event" => "starting",
+            "command" => "files-pull",
+            "stage" => "fetch-skipped",
+            "message" => "Downloading previously skipped files",
+        ], true);
+        $this->state["command"] = "files-pull";
+        $this->state["status"] = "in_progress";
+        $this->state["stage"] = "fetch-skipped";
+        $this->save_state($this->state);
+        $this->run_files_sync_pipeline();
     }
 
     /**
@@ -10751,6 +10786,13 @@ if (
             'commands' => ['pull', 'files-pull'],
         ],
         [
+            'name' => 'fetch-skipped',
+            'type' => 'flag',
+            'target' => 'fetch_skipped',
+            'help' => 'Download only files deferred by a prior pull --filter=essential-files',
+            'commands' => ['pull'],
+        ],
+        [
             'name' => 'extra-directory',
             'type' => 'value',
             'target' => 'extra_directory',
@@ -11391,6 +11433,11 @@ if (
                 "  reprint pull https://example.com \\\n" .
                 "    --secret=TOKEN --state-dir=./state --fs-root=./files \\\n" .
                 "    --filter=essential-files --target-engine=sqlite --runtime=none\n" .
+                "\n" .
+                "  # Later, download the deferred file tail into the same mirror:\n" .
+                "  reprint pull https://example.com \\\n" .
+                "    --secret=TOKEN --state-dir=./state --fs-root=./files \\\n" .
+                "    --fetch-skipped\n" .
                 "\n" .
                 "  # Full clone with SQLite, flattened layout, and PHP built-in server:\n" .
                 "  reprint pull https://example.com \\\n" .

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -1518,11 +1518,11 @@ class ImportClient
             $next = $options["filter"];
             if (
                 $command === "pull" &&
-                !in_array($next, ["none", "essential-files"], true)
+                !in_array($next, ["none", "essential-files", "skipped-earlier"], true)
             ) {
                 throw new InvalidArgumentException(
                     "Invalid --filter value for pull: {$next}. " .
-                        "Valid values: none, essential-files",
+                        "Valid values: none, essential-files, skipped-earlier",
                 );
             }
             $prev = $this->state["filter"] ?? null;
@@ -1535,8 +1535,11 @@ class ImportClient
                 );
             }
             $this->filter = $next;
-            $this->state["filter"] = $this->filter;
-            $this->save_state($this->state);
+            $persist_filter = !($command === "pull" && $next === "skipped-earlier");
+            if ($persist_filter) {
+                $this->state["filter"] = $this->filter;
+                $this->save_state($this->state);
+            }
         } elseif (isset($this->state["filter"])) {
             $this->filter = $this->state["filter"];
         }
@@ -10782,15 +10785,8 @@ if (
             'target' => 'filter',
             'placeholder' => 'MODE',
             'valid_values' => ['none', 'essential-files', 'skipped-earlier'],
-            'help' => 'Filter which files to download (pull: none|essential-files; files-pull also supports skipped-earlier)',
+            'help' => 'Filter which files to download (none|essential-files|skipped-earlier)',
             'commands' => ['pull', 'files-pull'],
-        ],
-        [
-            'name' => 'fetch-skipped',
-            'type' => 'flag',
-            'target' => 'fetch_skipped',
-            'help' => 'Download only files deferred by a prior pull --filter=essential-files',
-            'commands' => ['pull'],
         ],
         [
             'name' => 'extra-directory',
@@ -11413,7 +11409,8 @@ if (
                 "Running pull again after completion performs a delta sync.\n" .
                 "\n" .
                 "Use --filter=essential-files to defer uploads and other large wp-content\n" .
-                "entries while still completing the rest of the pull.\n" .
+                "entries while still completing the rest of the pull. Later, use\n" .
+                "--filter=skipped-earlier to download only that deferred file tail.\n" .
                 "\n" .
                 "The ?site-export-api query parameter is added automatically if missing,\n" .
                 "so you can pass just the site URL.\n",
@@ -11437,7 +11434,7 @@ if (
                 "  # Later, download the deferred file tail into the same mirror:\n" .
                 "  reprint pull https://example.com \\\n" .
                 "    --secret=TOKEN --state-dir=./state --fs-root=./files \\\n" .
-                "    --fetch-skipped\n" .
+                "    --filter=skipped-earlier\n" .
                 "\n" .
                 "  # Full clone with SQLite, flattened layout, and PHP built-in server:\n" .
                 "  reprint pull https://example.com \\\n" .

--- a/packages/reprint-importer/src/lib/pull/class-pull.php
+++ b/packages/reprint-importer/src/lib/pull/class-pull.php
@@ -35,6 +35,10 @@ class Pull
      */
     public function stages(array $options): array
     {
+        if (!empty($options['fetch_skipped'])) {
+            return ['files-pull'];
+        }
+
         $stages = ['preflight', 'files-pull', 'db-pull'];
         $has_db_target =
             !empty($options['target_db']) ||
@@ -82,6 +86,9 @@ class Pull
         $this->progress->enable_quiet_lifecycle();
 
         $options = $this->validate_and_default_options($options);
+        if (!empty($options['fetch_skipped'])) {
+            $this->client->set_filter_mode('skipped-earlier');
+        }
 
         $stages = $this->stages($options);
         $total = count($stages);
@@ -89,7 +96,7 @@ class Pull
         $completed_stage = $state['pull']['stage'] ?? null;
 
         // If the prior pull completed, prepare for a delta re-pull.
-        if ($completed_stage === 'complete') {
+        if ($completed_stage === 'complete' && empty($options['fetch_skipped'])) {
             $this->prepare_repull();
             $completed_stage = null;
         }
@@ -189,10 +196,14 @@ class Pull
                 $this->run_until_complete(function () {
                     $this->client->run_files_sync();
                 });
+                $pull_filter = $options['filter'];
+                if (!empty($options['fetch_skipped'])) {
+                    $pull_filter = $this->client->state['pull']['files_filter'] ?? 'essential-files';
+                }
                 $skipped_pending =
-                    $options['filter'] === 'essential-files' &&
+                    $pull_filter === 'essential-files' &&
                     $this->client->has_skipped_files_pending();
-                $this->client->set_pull_files_state($options['filter'], $skipped_pending);
+                $this->client->set_pull_files_state($pull_filter, $skipped_pending);
                 $count = $this->client->index_count();
                 $summary = $count > 0 ? number_format($count) . " files" : null;
                 if ($skipped_pending) {
@@ -297,13 +308,48 @@ class Pull
             $options['output_dir'] = $this->client->state_dir . '/runtime';
         }
 
-        if (!isset($options['filter'])) {
+        if (!empty($options['fetch_skipped'])) {
+            if (isset($options['filter'])) {
+                throw new InvalidArgumentException(
+                    "--fetch-skipped cannot be combined with --filter. " .
+                    "Run either pull --filter=essential-files or pull --fetch-skipped."
+                );
+            }
+            if (!$this->client->pull_has_skipped_files_pending()) {
+                throw new RuntimeException(
+                    "--fetch-skipped was requested but there are no deferred files pending. " .
+                    "Run pull --filter=essential-files first.",
+                );
+            }
+
+            $command = $this->client->state['command'] ?? null;
+            $stage = $this->client->state['stage'] ?? null;
+            $status = $this->client->state['status'] ?? null;
+            $is_fetch_skipped_resume =
+                $command === 'files-pull' &&
+                $stage === 'fetch-skipped' &&
+                $status !== 'complete';
+            if (
+                !$is_fetch_skipped_resume &&
+                ($this->client->state['pull']['stage'] ?? null) !== 'complete'
+            ) {
+                throw new RuntimeException(
+                    "--fetch-skipped was requested before the prior pull finished. " .
+                    "Re-run the original pull command to complete the main sync first.",
+                );
+            }
+
+            $options['filter'] = 'skipped-earlier';
+        } elseif (!isset($options['filter'])) {
             $options['filter'] = $this->client->state['filter'] ?? 'none';
         }
-        if (!in_array($options['filter'], ['none', 'essential-files'], true)) {
+        $valid_pull_filters = !empty($options['fetch_skipped'])
+            ? ['skipped-earlier']
+            : ['none', 'essential-files'];
+        if (!in_array($options['filter'], $valid_pull_filters, true)) {
             throw new InvalidArgumentException(
                 "Invalid --filter value for pull: {$options['filter']}. " .
-                "Valid values: none, essential-files"
+                "Valid values: " . implode(', ', $valid_pull_filters)
             );
         }
 

--- a/packages/reprint-importer/src/lib/pull/class-pull.php
+++ b/packages/reprint-importer/src/lib/pull/class-pull.php
@@ -35,7 +35,7 @@ class Pull
      */
     public function stages(array $options): array
     {
-        if (!empty($options['fetch_skipped'])) {
+        if ($this->is_skipped_earlier_pull($options)) {
             return ['files-pull'];
         }
 
@@ -86,9 +86,6 @@ class Pull
         $this->progress->enable_quiet_lifecycle();
 
         $options = $this->validate_and_default_options($options);
-        if (!empty($options['fetch_skipped'])) {
-            $this->client->set_filter_mode('skipped-earlier');
-        }
 
         $stages = $this->stages($options);
         $total = count($stages);
@@ -96,7 +93,7 @@ class Pull
         $completed_stage = $state['pull']['stage'] ?? null;
 
         // If the prior pull completed, prepare for a delta re-pull.
-        if ($completed_stage === 'complete' && empty($options['fetch_skipped'])) {
+        if ($completed_stage === 'complete' && !$this->is_skipped_earlier_pull($options)) {
             $this->prepare_repull();
             $completed_stage = null;
         }
@@ -197,7 +194,7 @@ class Pull
                     $this->client->run_files_sync();
                 });
                 $pull_filter = $options['filter'];
-                if (!empty($options['fetch_skipped'])) {
+                if ($this->is_skipped_earlier_pull($options)) {
                     $pull_filter = $this->client->state['pull']['files_filter'] ?? 'essential-files';
                 }
                 $skipped_pending =
@@ -308,16 +305,20 @@ class Pull
             $options['output_dir'] = $this->client->state_dir . '/runtime';
         }
 
-        if (!empty($options['fetch_skipped'])) {
-            if (isset($options['filter'])) {
-                throw new InvalidArgumentException(
-                    "--fetch-skipped cannot be combined with --filter. " .
-                    "Run either pull --filter=essential-files or pull --fetch-skipped."
-                );
-            }
+        if (!isset($options['filter'])) {
+            $options['filter'] = $this->client->state['filter'] ?? 'none';
+        }
+        $valid_pull_filters = ['none', 'essential-files', 'skipped-earlier'];
+        if (!in_array($options['filter'], $valid_pull_filters, true)) {
+            throw new InvalidArgumentException(
+                "Invalid --filter value for pull: {$options['filter']}. " .
+                "Valid values: " . implode(', ', $valid_pull_filters)
+            );
+        }
+        if ($this->is_skipped_earlier_pull($options)) {
             if (!$this->client->pull_has_skipped_files_pending()) {
                 throw new RuntimeException(
-                    "--fetch-skipped was requested but there are no deferred files pending. " .
+                    "pull --filter=skipped-earlier was requested but there are no deferred files pending. " .
                     "Run pull --filter=essential-files first.",
                 );
             }
@@ -334,26 +335,18 @@ class Pull
                 ($this->client->state['pull']['stage'] ?? null) !== 'complete'
             ) {
                 throw new RuntimeException(
-                    "--fetch-skipped was requested before the prior pull finished. " .
+                    "pull --filter=skipped-earlier was requested before the prior pull finished. " .
                     "Re-run the original pull command to complete the main sync first.",
                 );
             }
-
-            $options['filter'] = 'skipped-earlier';
-        } elseif (!isset($options['filter'])) {
-            $options['filter'] = $this->client->state['filter'] ?? 'none';
-        }
-        $valid_pull_filters = !empty($options['fetch_skipped'])
-            ? ['skipped-earlier']
-            : ['none', 'essential-files'];
-        if (!in_array($options['filter'], $valid_pull_filters, true)) {
-            throw new InvalidArgumentException(
-                "Invalid --filter value for pull: {$options['filter']}. " .
-                "Valid values: " . implode(', ', $valid_pull_filters)
-            );
         }
 
         return $options;
+    }
+
+    private function is_skipped_earlier_pull(array $options): bool
+    {
+        return ($options['filter'] ?? null) === 'skipped-earlier';
     }
 
     /**

--- a/tests/Import/PullFetchSkippedStateTest.php
+++ b/tests/Import/PullFetchSkippedStateTest.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace ImportTests;
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../packages/reprint-importer/src/import.php';
+
+class PullFetchSkippedStateTest extends TestCase
+{
+    private string $tempDir;
+    private string $stateDir;
+    private string $fsRoot;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->tempDir = sys_get_temp_dir() . '/reprint-pull-fetch-' . uniqid('', true);
+        $this->stateDir = $this->tempDir . '/state';
+        $this->fsRoot = $this->tempDir . '/fs-root';
+        mkdir($this->stateDir, 0755, true);
+        mkdir($this->fsRoot, 0755, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->recursiveDelete($this->tempDir);
+        parent::tearDown();
+    }
+
+    private function recursiveDelete(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        foreach (scandir($dir) as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $path = $dir . '/' . $item;
+            if (is_link($path)) {
+                unlink($path);
+            } elseif (is_dir($path)) {
+                $this->recursiveDelete($path);
+            } else {
+                unlink($path);
+            }
+        }
+        rmdir($dir);
+    }
+
+    private function writeState(array $state): void
+    {
+        file_put_contents(
+            $this->stateDir . '/.import-state.json',
+            json_encode($state),
+        );
+    }
+
+    private function makePull(): \Pull
+    {
+        $client = new \ImportClient('http://example.invalid', $this->stateDir, $this->fsRoot);
+        return new \Pull($client, new \TerminalProgress(false, STDOUT));
+    }
+
+    public function testFetchSkippedOnlyRunsFilesPullStage(): void
+    {
+        $this->assertSame(
+            ['files-pull'],
+            $this->makePull()->stages(['fetch_skipped' => true]),
+        );
+    }
+
+    public function testFetchSkippedRequiresDeferredFilesState(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage(
+            '--fetch-skipped was requested but there are no deferred files pending. ' .
+            'Run pull --filter=essential-files first.'
+        );
+
+        $client = new \ImportClient('http://example.invalid', $this->stateDir, $this->fsRoot);
+        $client->run([
+            'command' => 'pull',
+            'fetch_skipped' => true,
+        ]);
+    }
+
+    public function testFetchSkippedRejectsIncompletePrimaryPull(): void
+    {
+        $this->writeState([
+            'pull' => [
+                'stage' => 'db-pull',
+                'files_filter' => 'essential-files',
+                'skipped_pending' => true,
+            ],
+        ]);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage(
+            '--fetch-skipped was requested before the prior pull finished. ' .
+            'Re-run the original pull command to complete the main sync first.'
+        );
+
+        $client = new \ImportClient('http://example.invalid', $this->stateDir, $this->fsRoot);
+        $client->run([
+            'command' => 'pull',
+            'fetch_skipped' => true,
+        ]);
+    }
+
+    public function testFetchSkippedRejectsExplicitFilterCombination(): void
+    {
+        $this->writeState([
+            'pull' => [
+                'stage' => 'complete',
+                'files_filter' => 'essential-files',
+                'skipped_pending' => true,
+            ],
+        ]);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            '--fetch-skipped cannot be combined with --filter. ' .
+            'Run either pull --filter=essential-files or pull --fetch-skipped.'
+        );
+
+        $client = new \ImportClient('http://example.invalid', $this->stateDir, $this->fsRoot);
+        $client->run([
+            'command' => 'pull',
+            'fetch_skipped' => true,
+            'filter' => 'essential-files',
+        ]);
+    }
+}

--- a/tests/Import/PullFetchSkippedStateTest.php
+++ b/tests/Import/PullFetchSkippedStateTest.php
@@ -63,30 +63,30 @@ class PullFetchSkippedStateTest extends TestCase
         return new \Pull($client, new \TerminalProgress(false, STDOUT));
     }
 
-    public function testFetchSkippedOnlyRunsFilesPullStage(): void
+    public function testSkippedEarlierOnlyRunsFilesPullStage(): void
     {
         $this->assertSame(
             ['files-pull'],
-            $this->makePull()->stages(['fetch_skipped' => true]),
+            $this->makePull()->stages(['filter' => 'skipped-earlier']),
         );
     }
 
-    public function testFetchSkippedRequiresDeferredFilesState(): void
+    public function testSkippedEarlierRequiresDeferredFilesState(): void
     {
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage(
-            '--fetch-skipped was requested but there are no deferred files pending. ' .
+            'pull --filter=skipped-earlier was requested but there are no deferred files pending. ' .
             'Run pull --filter=essential-files first.'
         );
 
         $client = new \ImportClient('http://example.invalid', $this->stateDir, $this->fsRoot);
         $client->run([
             'command' => 'pull',
-            'fetch_skipped' => true,
+            'filter' => 'skipped-earlier',
         ]);
     }
 
-    public function testFetchSkippedRejectsIncompletePrimaryPull(): void
+    public function testSkippedEarlierRejectsIncompletePrimaryPull(): void
     {
         $this->writeState([
             'pull' => [
@@ -98,20 +98,21 @@ class PullFetchSkippedStateTest extends TestCase
 
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage(
-            '--fetch-skipped was requested before the prior pull finished. ' .
+            'pull --filter=skipped-earlier was requested before the prior pull finished. ' .
             'Re-run the original pull command to complete the main sync first.'
         );
 
         $client = new \ImportClient('http://example.invalid', $this->stateDir, $this->fsRoot);
         $client->run([
             'command' => 'pull',
-            'fetch_skipped' => true,
+            'filter' => 'skipped-earlier',
         ]);
     }
 
-    public function testFetchSkippedRejectsExplicitFilterCombination(): void
+    public function testPullDoesNotPersistSkippedEarlierAsDefaultFilter(): void
     {
         $this->writeState([
+            'filter' => 'essential-files',
             'pull' => [
                 'stage' => 'complete',
                 'files_filter' => 'essential-files',
@@ -119,17 +120,22 @@ class PullFetchSkippedStateTest extends TestCase
             ],
         ]);
 
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage(
-            '--fetch-skipped cannot be combined with --filter. ' .
-            'Run either pull --filter=essential-files or pull --fetch-skipped.'
+        $client = new \ImportClient('http://example.invalid', $this->stateDir, $this->fsRoot);
+        try {
+            $client->run([
+                'command' => 'pull',
+                'filter' => 'skipped-earlier',
+            ]);
+        } catch (\Exception $e) {
+            // Expected: fake host, missing skipped list, etc. The key
+            // assertion is that the persisted default filter stays intact.
+        }
+
+        $state = json_decode(
+            file_get_contents($this->stateDir . '/.import-state.json'),
+            true,
         );
 
-        $client = new \ImportClient('http://example.invalid', $this->stateDir, $this->fsRoot);
-        $client->run([
-            'command' => 'pull',
-            'fetch_skipped' => true,
-            'filter' => 'essential-files',
-        ]);
+        $this->assertSame('essential-files', $state['filter']);
     }
 }

--- a/tests/Import/PullFilterOptionTest.php
+++ b/tests/Import/PullFilterOptionTest.php
@@ -156,7 +156,7 @@ class PullFilterOptionTest extends TestCase
         );
     }
 
-    public function testPullRejectsSkippedEarlierFilterBeforePersistingIt(): void
+    public function testPullSkippedEarlierRequiresDeferredStateWithoutPersistingIt(): void
     {
         $client = $this->makeClient(false);
 
@@ -167,17 +167,20 @@ class PullFilterOptionTest extends TestCase
                 "filter" => "skipped-earlier",
                 "runtime" => "none",
             ]);
-            $this->fail('Expected pull --filter=skipped-earlier to be rejected');
-        } catch (\InvalidArgumentException $e) {
+            $this->fail('Expected pull --filter=skipped-earlier to require deferred pull state');
+        } catch (\RuntimeException $e) {
             $this->assertStringContainsString(
-                'Invalid --filter value for pull',
+                'pull --filter=skipped-earlier was requested but there are no deferred files pending',
                 $e->getMessage(),
             );
         } finally {
             ob_end_clean();
         }
 
-        $this->assertFileDoesNotExist($this->stateDir . '/.import-state.json');
+        if (file_exists($this->stateDir . '/.import-state.json')) {
+            $state = $this->readState();
+            $this->assertNotSame('skipped-earlier', $state["filter"] ?? null);
+        }
     }
 
     public function testPullWithEssentialFilesPersistsDeferredFilesState(): void

--- a/tests/e2e/tests/import-51-pull-fetch-skipped.test.js
+++ b/tests/e2e/tests/import-51-pull-fetch-skipped.test.js
@@ -1,0 +1,87 @@
+/**
+ * Test 51: Pull fetch-skipped continuation
+ *
+ * Verifies that a pull completed with `--filter=essential-files` can later
+ * fetch the deferred file tail with `pull --fetch-skipped`.
+ */
+import { describe, it, beforeAll, afterAll } from 'vitest';
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+    assertTreesMatch,
+    cleanupTempDir,
+    createTempDir,
+    fsRootDir,
+    getSiteDir,
+    getSiteSecret,
+    getSiteUrl,
+    runImporter,
+} from '../lib/test-helpers.js';
+import { ensureSite } from '../lib/site-setup.js';
+
+describe('Import: Pull fetch-skipped continuation', { timeout: 240000 }, () => {
+    const site = 'basic';
+    let tempDir;
+
+    beforeAll(async () => {
+        await ensureSite(site);
+        tempDir = createTempDir('e2e-pull-fetch-skipped');
+    });
+
+    afterAll(() => {
+        cleanupTempDir(tempDir);
+    });
+
+    function importUrl() {
+        return `${getSiteUrl(site)}&directory=${getSiteDir(site)}`;
+    }
+
+    it('pull with essential-files leaves deferred files pending', () => {
+        const result = runImporter(importUrl(), tempDir, 'pull', {
+            secret: getSiteSecret(site),
+            skipPreflight: true,
+            timeout: 120000,
+            wallTimeout: 180000,
+            extraArgs: [
+                '--filter=essential-files',
+                '--target-engine=sqlite',
+                '--runtime=none',
+                '--new-site-url=http://127.0.0.1:9998',
+            ],
+        });
+
+        assert.equal(result.exitCode, 0,
+            `Expected exit 0, got ${result.exitCode}\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);
+
+        const state = JSON.parse(readFileSync(join(tempDir, '.import-state.json'), 'utf-8'));
+        assert.equal(state.pull.stage, 'complete');
+        assert.equal(state.pull.files_filter, 'essential-files');
+        assert.equal(state.pull.skipped_pending, true);
+        assert.ok(existsSync(join(tempDir, '.import-download-list-skipped.jsonl')),
+            'expected the skipped download list to be preserved on disk');
+    });
+
+    it('pull --fetch-skipped downloads the deferred files and clears the pending flag', () => {
+        const result = runImporter(importUrl(), tempDir, 'pull', {
+            secret: getSiteSecret(site),
+            skipPreflight: true,
+            timeout: 120000,
+            wallTimeout: 180000,
+            extraArgs: ['--fetch-skipped'],
+        });
+
+        assert.equal(result.exitCode, 0,
+            `Expected exit 0, got ${result.exitCode}\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);
+
+        const state = JSON.parse(readFileSync(join(tempDir, '.import-state.json'), 'utf-8'));
+        assert.equal(state.pull.stage, 'complete');
+        assert.equal(state.pull.files_filter, 'essential-files');
+        assert.equal(state.pull.skipped_pending, false);
+        assert.ok(!existsSync(join(tempDir, '.import-download-list-skipped.jsonl')),
+            'expected the skipped download list to be cleared after fetch-skipped');
+
+        const importedRoot = join(fsRootDir(tempDir), getSiteDir(site));
+        assertTreesMatch(getSiteDir(site), importedRoot);
+    });
+});

--- a/tests/e2e/tests/import-51-pull-fetch-skipped.test.js
+++ b/tests/e2e/tests/import-51-pull-fetch-skipped.test.js
@@ -1,8 +1,8 @@
 /**
- * Test 51: Pull fetch-skipped continuation
+ * Test 51: Pull skipped-earlier continuation
  *
  * Verifies that a pull completed with `--filter=essential-files` can later
- * fetch the deferred file tail with `pull --fetch-skipped`.
+ * fetch the deferred file tail with `pull --filter=skipped-earlier`.
  */
 import { describe, it, beforeAll, afterAll } from 'vitest';
 import assert from 'node:assert/strict';
@@ -20,13 +20,13 @@ import {
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
-describe('Import: Pull fetch-skipped continuation', { timeout: 240000 }, () => {
+describe('Import: Pull skipped-earlier continuation', { timeout: 240000 }, () => {
     const site = 'basic';
     let tempDir;
 
     beforeAll(async () => {
         await ensureSite(site);
-        tempDir = createTempDir('e2e-pull-fetch-skipped');
+        tempDir = createTempDir('e2e-pull-skipped-earlier');
     });
 
     afterAll(() => {
@@ -62,13 +62,13 @@ describe('Import: Pull fetch-skipped continuation', { timeout: 240000 }, () => {
             'expected the skipped download list to be preserved on disk');
     });
 
-    it('pull --fetch-skipped downloads the deferred files and clears the pending flag', () => {
+    it('pull --filter=skipped-earlier downloads the deferred files and clears the pending flag', () => {
         const result = runImporter(importUrl(), tempDir, 'pull', {
             secret: getSiteSecret(site),
             skipPreflight: true,
             timeout: 120000,
             wallTimeout: 180000,
-            extraArgs: ['--fetch-skipped'],
+            extraArgs: ['--filter=skipped-earlier'],
         });
 
         assert.equal(result.exitCode, 0,
@@ -79,7 +79,7 @@ describe('Import: Pull fetch-skipped continuation', { timeout: 240000 }, () => {
         assert.equal(state.pull.files_filter, 'essential-files');
         assert.equal(state.pull.skipped_pending, false);
         assert.ok(!existsSync(join(tempDir, '.import-download-list-skipped.jsonl')),
-            'expected the skipped download list to be cleared after fetch-skipped');
+            'expected the skipped download list to be cleared after skipped-earlier');
 
         const importedRoot = join(fsRootDir(tempDir), getSiteDir(site));
         assertTreesMatch(getSiteDir(site), importedRoot);

--- a/tests/e2e/tests/import-51-pull-fetch-skipped.test.js
+++ b/tests/e2e/tests/import-51-pull-fetch-skipped.test.js
@@ -82,6 +82,10 @@ describe('Import: Pull skipped-earlier continuation', { timeout: 240000 }, () =>
             'expected the skipped download list to be cleared after skipped-earlier');
 
         const importedRoot = join(fsRootDir(tempDir), getSiteDir(site));
-        assertTreesMatch(getSiteDir(site), importedRoot);
+        assert.ok(existsSync(join(importedRoot, 'wp-content', 'database', '.ht.sqlite')),
+            'expected the local SQLite database file to be preserved');
+        assertTreesMatch(getSiteDir(site), importedRoot, {
+            exclude: ['wp-content/database/.ht.sqlite'],
+        });
     });
 });


### PR DESCRIPTION
## What it does

Stacked on top of #155.

Lets `reprint pull` reuse the existing `--filter=skipped-earlier` continuation mode instead of introducing a separate `--fetch-skipped` flag.

## Rationale

`files-pull` already uses `--filter=skipped-earlier` to download the deferred tail from an earlier `--filter=essential-files` run. Reusing that same filter at the `pull` level keeps the interface consistent and avoids teaching callers two different continuation mechanisms for the same workflow.

## Implementation

- makes `pull --filter=skipped-earlier` collapse to the `files-pull` stage only
- validates that deferred files actually exist and that the main pull has finished, unless this is resuming an already-started skipped-file fetch
- keeps the underlying `files-pull` continuation logic, but allows it to proceed when top-level pull state says deferred files are pending
- avoids persisting `skipped-earlier` as the default pull filter, so a continuation run does not accidentally change later pulls
- removes the pull-only `--fetch-skipped` flag and updates help/examples to use `--filter=skipped-earlier`
- updates PHPUnit and e2e coverage around the unified filter semantics

## Testing instructions

- `php -l packages/reprint-importer/src/import.php`
- `php -l packages/reprint-importer/src/lib/pull/class-pull.php`
- `php -l tests/Import/PullFilterOptionTest.php`
- `php -l tests/Import/PullFetchSkippedStateTest.php`
- `phpunit --colors=never tests/Import/PullFilterOptionTest.php`
- `phpunit --colors=never tests/Import/PullFetchSkippedStateTest.php`
- `node --check tests/e2e/tests/import-51-pull-fetch-skipped.test.js`
- `cd tests/e2e && npm test -- --run tests/import-51-pull-fetch-skipped.test.js`
  - blocked in this workspace because `ensureSite()` requires passwordless `sudo` to create `/srv/e2e-sites/*`
