### PR TITLE
pull: add start-runtime option

### DIFF
--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -10893,6 +10893,15 @@ if (
             'commands' => ['pull', 'apply-runtime'],
         ],
         [
+            'name' => 'start',
+            'type' => 'value',
+            'target' => 'start',
+            'placeholder' => 'MODE',
+            'valid_values' => ['auto', 'manual'],
+            'help' => 'Whether pull should launch the generated runtime (auto|manual)',
+            'commands' => ['pull'],
+        ],
+        [
             'name' => 'output-dir',
             'type' => 'value',
             'target' => 'output_dir',
@@ -11337,7 +11346,7 @@ if (
                 "  4. Import    — apply SQL to a local database (if --target-db)\n" .
                 "  5. Flatten   — reassemble into standard WP layout (if --flatten-to)\n" .
                 "  6. Runtime   — generate server config (default: php-builtin)\n" .
-                "  7. Start     — launch the local server (php-builtin only)\n" .
+                "  7. Start     — launch the local server when supported (unless --start=manual)\n" .
                 "\n" .
                 "Each step retries automatically on server timeouts. If the process is\n" .
                 "interrupted, re-run the same command to resume from where it left off.\n" .
@@ -11362,7 +11371,12 @@ if (
                 "    --secret=TOKEN --state-dir=./state --fs-root=./files \\\n" .
                 "    --target-engine=sqlite \\\n" .
                 "    --new-site-url=http://localhost:8881 \\\n" .
-                "    --flatten-to=./site --runtime=php-builtin --output-dir=./runtime\n",
+                "    --flatten-to=./site --runtime=php-builtin --output-dir=./runtime\n" .
+                "\n" .
+                "  # Prepare a Playground runtime but let another process start it:\n" .
+                "  reprint pull https://example.com \\\n" .
+                "    --secret=TOKEN --state-dir=./state --fs-root=./files \\\n" .
+                "    --runtime=playground-cli --start=manual --output-dir=./runtime\n",
         ],
         "install-exporter" => [
             "level" => "high",

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -3722,7 +3722,7 @@ class ImportClient
         $runtime = $options["runtime"] ?? null;
         if (empty($runtime)) {
             throw new InvalidArgumentException(
-                "apply-runtime requires --runtime=RUNTIME. Valid runtimes: nginx-fpm, php-builtin, playground-cli"
+                "apply-runtime requires --runtime=RUNTIME."
             );
         }
 
@@ -10889,6 +10889,7 @@ if (
             'type' => 'value',
             'target' => 'runtime',
             'placeholder' => 'RUNTIME',
+            'valid_values' => VALID_TARGET_RUNTIMES,
             'help' => 'Target server runtime: php-builtin, playground-cli, nginx-fpm, or none',
             'commands' => ['pull', 'apply-runtime'],
         ],
@@ -10897,7 +10898,7 @@ if (
             'type' => 'value',
             'target' => 'start_runtime',
             'placeholder' => 'RUNTIME',
-            'valid_values' => ['nginx-fpm', 'php-builtin', 'playground-cli', 'none'],
+            'valid_values' => VALID_TARGET_RUNTIMES,
             'help' => 'Runtime to launch after pull (php-builtin|playground-cli|nginx-fpm|none)',
             'commands' => ['pull'],
         ],

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -10893,12 +10893,12 @@ if (
             'commands' => ['pull', 'apply-runtime'],
         ],
         [
-            'name' => 'start',
+            'name' => 'start-runtime',
             'type' => 'value',
-            'target' => 'start',
-            'placeholder' => 'MODE',
-            'valid_values' => ['auto', 'manual'],
-            'help' => 'Whether pull should launch the generated runtime (auto|manual)',
+            'target' => 'start_runtime',
+            'placeholder' => 'RUNTIME',
+            'valid_values' => ['nginx-fpm', 'php-builtin', 'playground-cli', 'none'],
+            'help' => 'Runtime to launch after pull (php-builtin|playground-cli|nginx-fpm|none)',
             'commands' => ['pull'],
         ],
         [
@@ -11346,7 +11346,7 @@ if (
                 "  4. Import    — apply SQL to a local database (if --target-db)\n" .
                 "  5. Flatten   — reassemble into standard WP layout (if --flatten-to)\n" .
                 "  6. Runtime   — generate server config (default: php-builtin)\n" .
-                "  7. Start     — launch the local server when supported (unless --start=manual)\n" .
+                "  7. Start     — launch the selected runtime when supported\n" .
                 "\n" .
                 "Each step retries automatically on server timeouts. If the process is\n" .
                 "interrupted, re-run the same command to resume from where it left off.\n" .
@@ -11376,7 +11376,7 @@ if (
                 "  # Prepare a Playground runtime but let another process start it:\n" .
                 "  reprint pull https://example.com \\\n" .
                 "    --secret=TOKEN --state-dir=./state --fs-root=./files \\\n" .
-                "    --runtime=playground-cli --start=manual --output-dir=./runtime\n",
+                "    --runtime=playground-cli --start-runtime=none --output-dir=./runtime\n",
         ],
         "install-exporter" => [
             "level" => "high",

--- a/packages/reprint-importer/src/lib/pull/class-pull.php
+++ b/packages/reprint-importer/src/lib/pull/class-pull.php
@@ -237,29 +237,30 @@ class Pull
      */
     private function validate_and_default_options(array $options): array
     {
+        // --runtime and --start-runtime values are validated at CLI parse
+        // time from VALID_TARGET_RUNTIMES. Re-check here for programmatic
+        // callers (e.g. ImportClient::run invoked directly) that bypass
+        // the CLI parser.
+        foreach (['runtime', 'start_runtime'] as $key) {
+            if (!empty($options[$key]) && !in_array($options[$key], VALID_TARGET_RUNTIMES, true)) {
+                $flag = str_replace('_', '-', $key);
+                throw new InvalidArgumentException(
+                    "Invalid --{$flag} value: {$options[$key]}. " .
+                    "Valid runtimes: " . implode(', ', VALID_TARGET_RUNTIMES)
+                );
+            }
+        }
+
         // Default --runtime to php-builtin so pull always ends with a
         // running local server. Users can override with --runtime=nginx-fpm,
         // --runtime=playground-cli, or --runtime=none to skip runtime
         // generation entirely.
-        $valid_runtimes = ['nginx-fpm', 'php-builtin', 'playground-cli', 'none'];
-        if (!empty($options['start_runtime']) && !in_array($options['start_runtime'], $valid_runtimes, true)) {
-            throw new InvalidArgumentException(
-                "Invalid --start-runtime value: {$options['start_runtime']}. " .
-                "Valid start runtimes: " . implode(', ', $valid_runtimes)
-            );
-        }
         if (empty($options['runtime'])) {
             if (!empty($options['start_runtime']) && $options['start_runtime'] !== 'none') {
                 $options['runtime'] = $options['start_runtime'];
             } else {
                 $options['runtime'] = 'php-builtin';
             }
-        }
-        if (!in_array($options['runtime'], $valid_runtimes, true)) {
-            throw new InvalidArgumentException(
-                "Invalid --runtime value: {$options['runtime']}. " .
-                "Valid runtimes: " . implode(', ', $valid_runtimes)
-            );
         }
 
         if (empty($options['start_runtime'])) {

--- a/packages/reprint-importer/src/lib/pull/class-pull.php
+++ b/packages/reprint-importer/src/lib/pull/class-pull.php
@@ -31,7 +31,8 @@ class Pull
      * Always: preflight → files-pull → db-pull.
      * Adds db-apply when a database target is configured, flat-docroot
      * when --flatten-to is set, apply-runtime when --runtime is set,
-     * and start when the runtime can be launched in-process.
+     * and start when the runtime can be launched in-process and
+     * --start=manual was not requested.
      */
     public function stages(array $options): array
     {
@@ -51,7 +52,10 @@ class Pull
             $stages[] = 'apply-runtime';
             // php-builtin and playground-cli both generate a start.sh
             // that can be launched directly from the CLI.
-            if (in_array($options['runtime'], ['php-builtin', 'playground-cli'], true)) {
+            if (
+                ($options['start'] ?? 'auto') !== 'manual' &&
+                in_array($options['runtime'], ['php-builtin', 'playground-cli'], true)
+            ) {
                 $stages[] = 'start';
             }
         }
@@ -248,6 +252,17 @@ class Pull
         }
         if ($options['runtime'] === 'none') {
             unset($options['runtime']);
+        }
+
+        if (empty($options['start'])) {
+            $options['start'] = 'auto';
+        }
+        $valid_start_modes = ['auto', 'manual'];
+        if (!in_array($options['start'], $valid_start_modes, true)) {
+            throw new InvalidArgumentException(
+                "Invalid --start value: {$options['start']}. " .
+                "Valid start modes: " . implode(', ', $valid_start_modes)
+            );
         }
 
         // Default --target-engine to sqlite for php-builtin and

--- a/packages/reprint-importer/src/lib/pull/class-pull.php
+++ b/packages/reprint-importer/src/lib/pull/class-pull.php
@@ -31,8 +31,8 @@ class Pull
      * Always: preflight → files-pull → db-pull.
      * Adds db-apply when a database target is configured, flat-docroot
      * when --flatten-to is set, apply-runtime when --runtime is set,
-     * and start when the runtime can be launched in-process and
-     * --start=manual was not requested.
+     * and start when the selected start runtime can be launched
+     * in-process.
      */
     public function stages(array $options): array
     {
@@ -48,13 +48,14 @@ class Pull
         if (!empty($options['flatten_to'])) {
             $stages[] = 'flat-docroot';
         }
-        if (!empty($options['runtime'])) {
+        $runtime = $this->resolve_runtime($options);
+        $start_runtime = $this->resolve_start_runtime($options, $runtime);
+        if ($runtime !== null && $runtime !== 'none') {
             $stages[] = 'apply-runtime';
-            // php-builtin and playground-cli both generate a start.sh
-            // that can be launched directly from the CLI.
             if (
-                ($options['start'] ?? 'auto') !== 'manual' &&
-                in_array($options['runtime'], ['php-builtin', 'playground-cli'], true)
+                $start_runtime !== 'none' &&
+                $start_runtime === $runtime &&
+                $this->can_start_runtime($start_runtime)
             ) {
                 $stages[] = 'start';
             }
@@ -240,29 +241,47 @@ class Pull
         // running local server. Users can override with --runtime=nginx-fpm,
         // --runtime=playground-cli, or --runtime=none to skip runtime
         // generation entirely.
-        if (empty($options['runtime'])) {
-            $options['runtime'] = 'php-builtin';
-        }
         $valid_runtimes = ['nginx-fpm', 'php-builtin', 'playground-cli', 'none'];
+        if (!empty($options['start_runtime']) && !in_array($options['start_runtime'], $valid_runtimes, true)) {
+            throw new InvalidArgumentException(
+                "Invalid --start-runtime value: {$options['start_runtime']}. " .
+                "Valid start runtimes: " . implode(', ', $valid_runtimes)
+            );
+        }
+        if (empty($options['runtime'])) {
+            if (!empty($options['start_runtime']) && $options['start_runtime'] !== 'none') {
+                $options['runtime'] = $options['start_runtime'];
+            } else {
+                $options['runtime'] = 'php-builtin';
+            }
+        }
         if (!in_array($options['runtime'], $valid_runtimes, true)) {
             throw new InvalidArgumentException(
                 "Invalid --runtime value: {$options['runtime']}. " .
                 "Valid runtimes: " . implode(', ', $valid_runtimes)
             );
         }
-        if ($options['runtime'] === 'none') {
-            unset($options['runtime']);
+
+        if (empty($options['start_runtime'])) {
+            $options['start_runtime'] = $this->default_start_runtime($options['runtime']);
+        }
+        if ($options['start_runtime'] !== 'none') {
+            if (!$this->can_start_runtime($options['start_runtime'])) {
+                throw new InvalidArgumentException(
+                    "Starting runtime {$options['start_runtime']} is not supported yet. " .
+                    "Supported start runtimes: php-builtin, playground-cli, none"
+                );
+            }
+            if ($options['start_runtime'] !== $options['runtime']) {
+                throw new InvalidArgumentException(
+                    "--start-runtime={$options['start_runtime']} requires matching --runtime={$options['start_runtime']}, " .
+                    "or omit --runtime to use {$options['start_runtime']} for both."
+                );
+            }
         }
 
-        if (empty($options['start'])) {
-            $options['start'] = 'auto';
-        }
-        $valid_start_modes = ['auto', 'manual'];
-        if (!in_array($options['start'], $valid_start_modes, true)) {
-            throw new InvalidArgumentException(
-                "Invalid --start value: {$options['start']}. " .
-                "Valid start modes: " . implode(', ', $valid_start_modes)
-            );
+        if ($options['runtime'] === 'none') {
+            unset($options['runtime']);
         }
 
         // Default --target-engine to sqlite for php-builtin and
@@ -303,6 +322,35 @@ class Pull
         }
 
         return $options;
+    }
+
+    private function resolve_runtime(array $options): ?string
+    {
+        if (!empty($options['runtime'])) {
+            return $options['runtime'];
+        }
+        if (!empty($options['start_runtime']) && $options['start_runtime'] !== 'none') {
+            return $options['start_runtime'];
+        }
+        return null;
+    }
+
+    private function resolve_start_runtime(array $options, ?string $runtime): string
+    {
+        if (!empty($options['start_runtime'])) {
+            return $options['start_runtime'];
+        }
+        return $this->default_start_runtime($runtime);
+    }
+
+    private function default_start_runtime(?string $runtime): string
+    {
+        return $this->can_start_runtime($runtime) ? $runtime : 'none';
+    }
+
+    private function can_start_runtime(?string $runtime): bool
+    {
+        return in_array($runtime, ['php-builtin', 'playground-cli'], true);
     }
 
     /**

--- a/packages/reprint-importer/src/lib/target-runtime/functions.php
+++ b/packages/reprint-importer/src/lib/target-runtime/functions.php
@@ -6,6 +6,16 @@
  */
 
 /**
+ * Valid values for --runtime and --start-runtime. Single source of
+ * truth consumed by the CLI option definitions (enforced at parse
+ * time), the Pull orchestrator, and runtime_applier_for().
+ *
+ * 'none' is a pull-time sentinel meaning "skip runtime generation";
+ * it has no applier and runtime_applier_for() rejects it.
+ */
+const VALID_TARGET_RUNTIMES = ['nginx-fpm', 'php-builtin', 'playground-cli', 'none'];
+
+/**
  * Instantiate the right applier for a runtime name.
  */
 function runtime_applier_for(string $runtime): RuntimeApplier
@@ -18,8 +28,9 @@ function runtime_applier_for(string $runtime): RuntimeApplier
         case 'playground-cli':
             return new PlaygroundCliApplier();
         default:
+            $appliable = array_values(array_diff(VALID_TARGET_RUNTIMES, ['none']));
             throw new InvalidArgumentException(
-                "Unknown runtime: {$runtime}. Valid runtimes: nginx-fpm, php-builtin, playground-cli"
+                "Unknown runtime: {$runtime}. Valid runtimes: " . implode(', ', $appliable)
             );
     }
 }

--- a/tests/Import/PullStartModeTest.php
+++ b/tests/Import/PullStartModeTest.php
@@ -118,7 +118,7 @@ class PullStartModeTest extends TestCase
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage(
-            'Invalid --start-runtime value: later. Valid start runtimes: nginx-fpm, php-builtin, playground-cli, none'
+            'Invalid --start-runtime value: later. Valid runtimes: nginx-fpm, php-builtin, playground-cli, none'
         );
 
         $client = new \ImportClient('http://example.invalid', $this->stateDir, $this->fsRoot);

--- a/tests/Import/PullStartModeTest.php
+++ b/tests/Import/PullStartModeTest.php
@@ -58,7 +58,7 @@ class PullStartModeTest extends TestCase
     /**
      * @dataProvider stageProvider
      */
-    public function testStagesHonorStartMode(array $options, bool $expectsStart): void
+    public function testStagesHonorStartRuntimeSelection(array $options, bool $expectsStart): void
     {
         $stages = $this->makePull()->stages($options);
 
@@ -80,13 +80,17 @@ class PullStartModeTest extends TestCase
                 ['runtime' => 'playground-cli'],
                 true,
             ],
-            'manual start skips php-builtin start stage' => [
-                ['runtime' => 'php-builtin', 'start' => 'manual'],
+            'start-runtime=none skips php-builtin start stage' => [
+                ['runtime' => 'php-builtin', 'start_runtime' => 'none'],
                 false,
             ],
-            'manual start skips playground-cli start stage' => [
-                ['runtime' => 'playground-cli', 'start' => 'manual'],
+            'start-runtime=none skips playground-cli start stage' => [
+                ['runtime' => 'playground-cli', 'start_runtime' => 'none'],
                 false,
+            ],
+            'explicit playground-cli start is supported' => [
+                ['runtime' => 'playground-cli', 'start_runtime' => 'playground-cli'],
+                true,
             ],
             'nginx-fpm never adds start stage' => [
                 ['runtime' => 'nginx-fpm'],
@@ -95,15 +99,62 @@ class PullStartModeTest extends TestCase
         ];
     }
 
-    public function testInvalidStartModeIsRejectedBeforeNetworkIO(): void
+    public function testStartRuntimeCanSelectRuntimeWhenRuntimeIsOmitted(): void
+    {
+        $pull = $this->makePull();
+        $reflection = new \ReflectionClass($pull);
+        $method = $reflection->getMethod('validate_and_default_options');
+        $method->setAccessible(true);
+
+        $options = $method->invoke($pull, [
+            'start_runtime' => 'playground-cli',
+        ]);
+
+        $this->assertSame('playground-cli', $options['runtime']);
+        $this->assertSame('playground-cli', $options['start_runtime']);
+    }
+
+    public function testInvalidStartRuntimeValueIsRejectedBeforeNetworkIO(): void
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Invalid --start value: later. Valid start modes: auto, manual');
+        $this->expectExceptionMessage(
+            'Invalid --start-runtime value: later. Valid start runtimes: nginx-fpm, php-builtin, playground-cli, none'
+        );
 
         $client = new \ImportClient('http://example.invalid', $this->stateDir, $this->fsRoot);
         $client->run([
             'command' => 'pull',
-            'start' => 'later',
+            'start_runtime' => 'later',
+        ]);
+    }
+
+    public function testUnsupportedStartRuntimeIsRejected(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            'Starting runtime nginx-fpm is not supported yet. Supported start runtimes: php-builtin, playground-cli, none'
+        );
+
+        $client = new \ImportClient('http://example.invalid', $this->stateDir, $this->fsRoot);
+        $client->run([
+            'command' => 'pull',
+            'runtime' => 'nginx-fpm',
+            'start_runtime' => 'nginx-fpm',
+        ]);
+    }
+
+    public function testMismatchedStartRuntimeIsRejected(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            '--start-runtime=playground-cli requires matching --runtime=playground-cli, or omit --runtime to use playground-cli for both.'
+        );
+
+        $client = new \ImportClient('http://example.invalid', $this->stateDir, $this->fsRoot);
+        $client->run([
+            'command' => 'pull',
+            'runtime' => 'php-builtin',
+            'start_runtime' => 'playground-cli',
         ]);
     }
 }

--- a/tests/Import/PullStartModeTest.php
+++ b/tests/Import/PullStartModeTest.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace ImportTests;
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../packages/reprint-importer/src/import.php';
+
+class PullStartModeTest extends TestCase
+{
+    private string $tempDir;
+    private string $stateDir;
+    private string $fsRoot;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->tempDir = sys_get_temp_dir() . '/reprint-pull-start-' . uniqid('', true);
+        $this->stateDir = $this->tempDir . '/state';
+        $this->fsRoot = $this->tempDir . '/fs-root';
+        mkdir($this->stateDir, 0755, true);
+        mkdir($this->fsRoot, 0755, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->recursiveDelete($this->tempDir);
+        parent::tearDown();
+    }
+
+    private function recursiveDelete(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        foreach (scandir($dir) as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $path = $dir . '/' . $item;
+            if (is_link($path)) {
+                unlink($path);
+            } elseif (is_dir($path)) {
+                $this->recursiveDelete($path);
+            } else {
+                unlink($path);
+            }
+        }
+        rmdir($dir);
+    }
+
+    private function makePull(): \Pull
+    {
+        $client = new \ImportClient('http://example.invalid', $this->stateDir, $this->fsRoot);
+        return new \Pull($client, new \TerminalProgress(false, STDOUT));
+    }
+
+    /**
+     * @dataProvider stageProvider
+     */
+    public function testStagesHonorStartMode(array $options, bool $expectsStart): void
+    {
+        $stages = $this->makePull()->stages($options);
+
+        if ($expectsStart) {
+            $this->assertContains('start', $stages);
+        } else {
+            $this->assertNotContains('start', $stages);
+        }
+    }
+
+    public static function stageProvider(): array
+    {
+        return [
+            'php-builtin defaults to auto start' => [
+                ['runtime' => 'php-builtin'],
+                true,
+            ],
+            'playground-cli defaults to auto start' => [
+                ['runtime' => 'playground-cli'],
+                true,
+            ],
+            'manual start skips php-builtin start stage' => [
+                ['runtime' => 'php-builtin', 'start' => 'manual'],
+                false,
+            ],
+            'manual start skips playground-cli start stage' => [
+                ['runtime' => 'playground-cli', 'start' => 'manual'],
+                false,
+            ],
+            'nginx-fpm never adds start stage' => [
+                ['runtime' => 'nginx-fpm'],
+                false,
+            ],
+        ];
+    }
+
+    public function testInvalidStartModeIsRejectedBeforeNetworkIO(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid --start value: later. Valid start modes: auto, manual');
+
+        $client = new \ImportClient('http://example.invalid', $this->stateDir, $this->fsRoot);
+        $client->run([
+            'command' => 'pull',
+            'start' => 'later',
+        ]);
+    }
+}

--- a/tests/e2e/tests/import-50-pull-manual-start.test.js
+++ b/tests/e2e/tests/import-50-pull-manual-start.test.js
@@ -1,7 +1,7 @@
 /**
- * Test 50: Pull manual start mode
+ * Test 50: Pull start-runtime none
  *
- * Verifies that `pull --runtime=playground-cli --start=manual` completes
+ * Verifies that `pull --runtime=playground-cli --start-runtime=none` completes
  * the full clone and runtime generation without entering the blocking
  * server startup stage.
  */
@@ -15,7 +15,7 @@ import {
 } from '../lib/test-helpers.js';
 import { ensureSite } from '../lib/site-setup.js';
 
-describe('Import: Pull manual start mode', { timeout: 180000 }, () => {
+describe('Import: Pull start-runtime none', { timeout: 180000 }, () => {
     const site = 'basic';
     const runtimePort = 9490;
     let tempDir;
@@ -35,7 +35,7 @@ describe('Import: Pull manual start mode', { timeout: 180000 }, () => {
         return `${getSiteUrl(site)}&directory=${getSiteDir(site)}`;
     }
 
-    it('pull exits after runtime generation when start is manual', () => {
+    it('pull exits after runtime generation when start-runtime is none', () => {
         const result = runImporter(importUrl(), tempDir, 'pull', {
             secret: getSiteSecret(site),
             skipPreflight: true,
@@ -43,7 +43,7 @@ describe('Import: Pull manual start mode', { timeout: 180000 }, () => {
             wallTimeout: 180000,
             extraArgs: [
                 '--runtime=playground-cli',
-                '--start=manual',
+                '--start-runtime=none',
                 '--target-engine=sqlite',
                 '--new-site-url',
                 `http://127.0.0.1:${runtimePort}`,
@@ -54,9 +54,9 @@ describe('Import: Pull manual start mode', { timeout: 180000 }, () => {
         assert.equal(result.exitCode, 0,
             `Expected exit 0, got ${result.exitCode}\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);
         assert.ok(!result.stdout.includes('Press Ctrl-C to stop.'),
-            'pull should not enter the blocking start stage in manual mode');
+            'pull should not enter the blocking start stage when start-runtime is none');
         assert.ok(!result.stdout.includes('Ready at http://'),
-            'pull should not print the server-ready banner in manual mode');
+            'pull should not print the server-ready banner when start-runtime is none');
     });
 
     it('marks the pull complete and generates playground runtime files', () => {

--- a/tests/e2e/tests/import-50-pull-manual-start.test.js
+++ b/tests/e2e/tests/import-50-pull-manual-start.test.js
@@ -1,0 +1,71 @@
+/**
+ * Test 50: Pull manual start mode
+ *
+ * Verifies that `pull --runtime=playground-cli --start=manual` completes
+ * the full clone and runtime generation without entering the blocking
+ * server startup stage.
+ */
+import { describe, it, beforeAll, afterAll } from 'vitest';
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+    runImporter, createTempDir, cleanupTempDir,
+    getSiteUrl, getSiteSecret, getSiteDir,
+} from '../lib/test-helpers.js';
+import { ensureSite } from '../lib/site-setup.js';
+
+describe('Import: Pull manual start mode', { timeout: 180000 }, () => {
+    const site = 'basic';
+    const runtimePort = 9490;
+    let tempDir;
+    let runtimeDir;
+
+    beforeAll(async () => {
+        await ensureSite(site);
+        tempDir = createTempDir('e2e-pull-manual-start');
+        runtimeDir = join(tempDir, 'runtime');
+    });
+
+    afterAll(() => {
+        cleanupTempDir(tempDir);
+    });
+
+    function importUrl() {
+        return `${getSiteUrl(site)}&directory=${getSiteDir(site)}`;
+    }
+
+    it('pull exits after runtime generation when start is manual', () => {
+        const result = runImporter(importUrl(), tempDir, 'pull', {
+            secret: getSiteSecret(site),
+            skipPreflight: true,
+            timeout: 120000,
+            wallTimeout: 180000,
+            extraArgs: [
+                '--runtime=playground-cli',
+                '--start=manual',
+                '--target-engine=sqlite',
+                '--new-site-url',
+                `http://127.0.0.1:${runtimePort}`,
+                `--output-dir=${runtimeDir}`,
+            ],
+        });
+
+        assert.equal(result.exitCode, 0,
+            `Expected exit 0, got ${result.exitCode}\nstderr: ${result.stderr}\nstdout: ${result.stdout}`);
+        assert.ok(!result.stdout.includes('Press Ctrl-C to stop.'),
+            'pull should not enter the blocking start stage in manual mode');
+        assert.ok(!result.stdout.includes('Ready at http://'),
+            'pull should not print the server-ready banner in manual mode');
+    });
+
+    it('marks the pull complete and generates playground runtime files', () => {
+        const state = JSON.parse(readFileSync(join(tempDir, '.import-state.json'), 'utf-8'));
+        assert.equal(state.pull.stage, 'complete');
+        assert.equal(state.status, 'complete');
+
+        assert.ok(existsSync(join(runtimeDir, 'runtime.php')), 'runtime.php should exist');
+        assert.ok(existsSync(join(runtimeDir, 'blueprint.json')), 'blueprint.json should exist');
+        assert.ok(existsSync(join(runtimeDir, 'start.sh')), 'start.sh should exist');
+    });
+});


### PR DESCRIPTION
## What it does

Replaces the pull-specific `--start=manual` switch with `--start-runtime=RUNTIME|none`.

`pull` still defaults to the current behavior: when the generated runtime is directly startable, it starts that runtime after finishing the clone. Callers that only want the runtime files can now use `--start-runtime=none`.

## Rationale

`manual|auto` was too narrow. The real decision is not just "start or don't start", but **which runtime pull should launch** after it generates runtime files. `--start-runtime` makes that explicit and gives Studio the `--start-runtime=none` flow it needs without hard-coding a boolean-only interface.

## Implementation

- renames the pull-only option from `--start` to `--start-runtime`
- accepts runtime-shaped values: `php-builtin`, `playground-cli`, `nginx-fpm`, `none`
- keeps the default aligned with current behavior by starting the runtime `pull` would already start today
- lets `--start-runtime=playground-cli` imply `--runtime=playground-cli` when `--runtime` is omitted
- rejects unsupported or mismatched combinations with actionable errors
- updates the pull help text and example from `--start=manual` to `--start-runtime=none`
- expands PHPUnit coverage for defaulting, explicit runtime selection, unsupported start runtimes, and mismatch validation

## Testing instructions

- `php -l packages/reprint-importer/src/lib/pull/class-pull.php`
- `php -l packages/reprint-importer/src/import.php`
- `php -l tests/Import/PullStartModeTest.php`
- `phpunit --colors=never tests/Import/PullStartModeTest.php`
- `phpunit --colors=never tests/Import/LegacyCommandAliasTest.php`
- `node --check tests/e2e/tests/import-50-pull-manual-start.test.js`
- `cd tests/e2e && npm test -- --run tests/import-50-pull-manual-start.test.js`
  - blocked in this workspace because `ensureSite()` requires passwordless `sudo` to create `/srv/e2e-sites/*`
