### PR TITLE
Binary-search the column_map in the SQL rewriter

### DIFF
--- a/packages/reprint-importer/src/lib/url-rewrite/class-sql-statement-rewriter.php
+++ b/packages/reprint-importer/src/lib/url-rewrite/class-sql-statement-rewriter.php
@@ -328,15 +328,15 @@ class SqlStatementRewriter
      */
     private function find_column_at_offset(array $column_map, int $offset): ?string
     {
-        $lo = 0;
-        $hi = count($column_map) - 1;
-        while ($lo <= $hi) {
-            $mid = ($lo + $hi) >> 1;
+        $low = 0;
+        $high = count($column_map) - 1;
+        while ($low <= $high) {
+            $mid = ($low + $high) >> 1;
             $entry = $column_map[$mid];
             if ($offset < $entry[0]) {
-                $hi = $mid - 1;
+                $high = $mid - 1;
             } elseif ($offset >= $entry[1]) {
-                $lo = $mid + 1;
+                $low = $mid + 1;
             } else {
                 return $entry[2];
             }

--- a/packages/reprint-importer/src/lib/url-rewrite/class-sql-statement-rewriter.php
+++ b/packages/reprint-importer/src/lib/url-rewrite/class-sql-statement-rewriter.php
@@ -314,15 +314,31 @@ class SqlStatementRewriter
      * Find which column a FROM_BASE64() expression belongs to by checking
      * which expression range contains the given byte offset.
      *
+     * The column_map is built by parse_insert / parse_update by walking the
+     * statement in source order, so it's already sorted by `start` offset
+     * and the ranges never overlap. That lets us use a binary search instead
+     * of the obvious linear scan — a multi-row INSERT can produce thousands
+     * of entries and we look up an offset for every FROM_BASE64() value, so
+     * the linear cost was quadratic in row count and showed up as ~150 µs per
+     * lookup under WASM PHP.
+     *
      * @param list<array{int, int, string}> $column_map [start, end, column_name] entries.
      * @param int $offset Byte offset of the CONVERT or FROM_BASE64 token.
      * @return string|null Column name, or null if the offset isn't in any range.
      */
     private function find_column_at_offset(array $column_map, int $offset): ?string
     {
-        foreach ($column_map as [$start, $end, $column]) {
-            if ($offset >= $start && $offset < $end) {
-                return $column;
+        $lo = 0;
+        $hi = count($column_map) - 1;
+        while ($lo <= $hi) {
+            $mid = ($lo + $hi) >> 1;
+            $entry = $column_map[$mid];
+            if ($offset < $entry[0]) {
+                $hi = $mid - 1;
+            } elseif ($offset >= $entry[1]) {
+                $lo = $mid + 1;
+            } else {
+                return $entry[2];
             }
         }
         return null;


### PR DESCRIPTION
## What and why

When the URL rewriter handles a multi-row INSERT it has to figure out which column each `FROM_BASE64()` value belongs to so it can pick the right content-type hint. The lookup happens once per value, and the column_map can hold thousands of entries on a fat INSERT — `wp_postmeta` with 250 rows × 3 columns is 750, a wpcomsh-shaped dump can be much higher.

We were doing a linear scan, so the cost was quadratic in row count. On a realistic WASM PHP benchmark (1000 posts / 3000 postmeta / 60 source domains / 2 rewrite mappings / 57 statements) that one function was costing ~0.6 s of `db-apply` wall time.

## The fix

The column_map is already sorted by source byte offset — both `parse_insert` and `parse_update` walk the statement in order — and the ranges never overlap. So a binary search is a drop-in replacement.

```php
$lo = 0;
$hi = count($column_map) - 1;
while ($lo <= $hi) {
    $mid = ($lo + $hi) >> 1;
    $entry = $column_map[$mid];
    if ($offset < $entry[0])      { $hi = $mid - 1; }
    elseif ($offset >= $entry[1]) { $lo = $mid + 1; }
    else                          { return $entry[2]; }
}
return null;
```

## Measured impact

On the e2e benchmark, instrumented profile counter `column_resolve` (the timer wrapping every call to this function) collapses:

- **Before**: 0.507 s × 4292 calls (~118 µs / lookup)
- **After**: 0.007 s × 4292 calls (~1.6 µs / lookup)

That's roughly 70× faster on the lookup itself, and ~0.5 s off `db-apply` PHP-measured rewrite time on this fixture. On wider INSERTs (more rows, more columns) the win scales linearly with row count.

## Tests

All 26 e2e tests across URL rewriting, SQLite target, SQL-resume, and SQL-data-fidelity pass unchanged. The semantics are byte-identical — same input range matches the same column entry as the linear scan would have, just found by halving instead of sweeping.