### PR TITLE
Report per-stage pull timings on each PR

### DIFF
--- a/.github/workflows/perf-report.yml
+++ b/.github/workflows/perf-report.yml
@@ -8,8 +8,31 @@ permissions:
   pull-requests: write
 
 jobs:
+  build-phar:
+    name: Build reprint.phar
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          submodules: true
+
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          extensions: pdo, pdo_mysql, json, hash, zlib, mbstring
+
+      - run: composer install --no-dev --no-interaction --prefer-dist
+
+      - run: ./bin/build-reprint-phar.sh
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: importer-phar-perf
+          path: reprint.phar
+
   bench:
     name: Pull pipeline benchmark
+    needs: build-phar
     runs-on: ubuntu-22.04
     timeout-minutes: 25
     env:
@@ -20,14 +43,9 @@ jobs:
         with:
           submodules: true
 
-      - uses: shivammathur/setup-php@v2
+      - uses: actions/download-artifact@v4
         with:
-          php-version: ${{ env.PHP_VERSION }}
-          extensions: pdo, pdo_mysql, json, hash, zlib, mbstring
-
-      - run: composer install --no-dev --no-interaction --prefer-dist
-
-      - run: ./bin/build-reprint-phar.sh
+          name: importer-phar-perf
 
       - uses: actions/setup-node@v4
         with:
@@ -64,9 +82,20 @@ jobs:
           path: |
             tests/e2e/bench-results.json
             tests/e2e/bench-results.md
+          if-no-files-found: ignore
+
+      - name: Check bench-results.md exists
+        id: check_md
+        if: always()
+        run: |
+          if [ -f tests/e2e/bench-results.md ]; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Post sticky PR comment
-        if: always() && github.event_name == 'pull_request'
+        if: always() && github.event_name == 'pull_request' && steps.check_md.outputs.exists == 'true'
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           header: pull-pipeline-perf

--- a/.github/workflows/perf-report.yml
+++ b/.github/workflows/perf-report.yml
@@ -8,8 +8,8 @@ permissions:
   pull-requests: write
 
 jobs:
-  build-phar:
-    name: Build reprint.phar
+  build-pr-phar:
+    name: Build reprint.phar (PR)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -22,19 +22,40 @@ jobs:
           extensions: pdo, pdo_mysql, json, hash, zlib, mbstring
 
       - run: composer install --no-dev --no-interaction --prefer-dist
-
       - run: ./bin/build-reprint-phar.sh
 
       - uses: actions/upload-artifact@v4
         with:
-          name: importer-phar-perf
+          name: importer-phar-pr
+          path: reprint.phar
+
+  build-trunk-phar:
+    name: Build reprint.phar (trunk)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: trunk
+          submodules: true
+
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          extensions: pdo, pdo_mysql, json, hash, zlib, mbstring
+
+      - run: composer install --no-dev --no-interaction --prefer-dist
+      - run: ./bin/build-reprint-phar.sh
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: importer-phar-trunk
           path: reprint.phar
 
   bench:
     name: Pull pipeline benchmark
-    needs: build-phar
+    needs: [build-pr-phar, build-trunk-phar]
     runs-on: ubuntu-22.04
-    timeout-minutes: 25
+    timeout-minutes: 35
     env:
       PHP_VERSION: '8.2'
 
@@ -43,9 +64,17 @@ jobs:
         with:
           submodules: true
 
-      - uses: actions/download-artifact@v4
+      - name: Download PR phar
+        uses: actions/download-artifact@v4
         with:
-          name: importer-phar-perf
+          name: importer-phar-pr
+          path: phars/pr
+
+      - name: Download trunk phar
+        uses: actions/download-artifact@v4
+        with:
+          name: importer-phar-trunk
+          path: phars/trunk
 
       - uses: actions/setup-node@v4
         with:
@@ -68,11 +97,30 @@ jobs:
             chmod +x /tmp/wp-cli.phar
           fi
 
-      - name: Run pull pipeline benchmark
+      - name: Bench PR
         working-directory: tests/e2e
         env:
-          IMPORTER_PATH: ${{ github.workspace }}/reprint.phar
+          IMPORTER_PATH: ${{ github.workspace }}/phars/pr/reprint.phar
+          BENCH_LABEL: pr
+          BENCH_JSON_OUT: bench-pr.json
+          BENCH_MD_OUT: bench-pr.md
         run: node benchmark/bench-pull.mjs
+
+      - name: Bench trunk
+        working-directory: tests/e2e
+        env:
+          IMPORTER_PATH: ${{ github.workspace }}/phars/trunk/reprint.phar
+          BENCH_LABEL: trunk
+          BENCH_JSON_OUT: bench-trunk.json
+          BENCH_MD_OUT: bench-trunk.md
+        # Don't fail the whole job if trunk's bench fails — we still want
+        # to publish the PR's numbers.
+        continue-on-error: true
+        run: node benchmark/bench-pull.mjs
+
+      - name: Render PR vs. trunk diff
+        working-directory: tests/e2e
+        run: node benchmark/render-diff.mjs
 
       - name: Upload benchmark artifacts
         if: always()
@@ -80,7 +128,8 @@ jobs:
         with:
           name: pull-pipeline-bench
           path: |
-            tests/e2e/bench-results.json
+            tests/e2e/bench-pr.json
+            tests/e2e/bench-trunk.json
             tests/e2e/bench-results.md
           if-no-files-found: ignore
 

--- a/.github/workflows/perf-report.yml
+++ b/.github/workflows/perf-report.yml
@@ -1,0 +1,73 @@
+name: Performance Report
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  bench:
+    name: Pull pipeline benchmark
+    runs-on: ubuntu-22.04
+    timeout-minutes: 25
+    env:
+      PHP_VERSION: '8.2'
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          submodules: true
+
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ env.PHP_VERSION }}
+          extensions: pdo, pdo_mysql, json, hash, zlib, mbstring
+
+      - run: composer install --no-dev --no-interaction --prefer-dist
+
+      - run: ./bin/build-reprint-phar.sh
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Setup infrastructure
+        run: tests/e2e/ci/setup-infrastructure.sh "${{ env.PHP_VERSION }}"
+
+      - name: Setup test sites
+        run: tests/e2e/setup.sh
+
+      - name: Install e2e dependencies
+        working-directory: tests/e2e
+        run: npm install
+
+      - name: Download wp-cli
+        run: |
+          if [ ! -f /tmp/wp-cli.phar ]; then
+            curl -sfL "https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar" -o /tmp/wp-cli.phar
+            chmod +x /tmp/wp-cli.phar
+          fi
+
+      - name: Run pull pipeline benchmark
+        working-directory: tests/e2e
+        env:
+          IMPORTER_PATH: ${{ github.workspace }}/reprint.phar
+        run: node benchmark/bench-pull.mjs
+
+      - name: Upload benchmark artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pull-pipeline-bench
+          path: |
+            tests/e2e/bench-results.json
+            tests/e2e/bench-results.md
+
+      - name: Post sticky PR comment
+        if: always() && github.event_name == 'pull_request'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: pull-pipeline-perf
+          path: tests/e2e/bench-results.md

--- a/tests/e2e/benchmark/bench-pull.mjs
+++ b/tests/e2e/benchmark/bench-pull.mjs
@@ -170,8 +170,11 @@ async function main() {
     const md = renderMarkdown(results, meta);
     console.log('\n' + md);
 
-    writeFileSync('bench-results.json', JSON.stringify({ meta, results }, null, 2));
-    writeFileSync('bench-results.md', md);
+    const label = process.env.BENCH_LABEL || 'pr';
+    const jsonOut = process.env.BENCH_JSON_OUT || 'bench-results.json';
+    const mdOut = process.env.BENCH_MD_OUT || 'bench-results.md';
+    writeFileSync(jsonOut, JSON.stringify({ meta: { ...meta, label }, results }, null, 2));
+    writeFileSync(mdOut, md);
 
     if (process.env.GITHUB_STEP_SUMMARY) {
         appendFileSync(process.env.GITHUB_STEP_SUMMARY, md + '\n');

--- a/tests/e2e/benchmark/bench-pull.mjs
+++ b/tests/e2e/benchmark/bench-pull.mjs
@@ -44,12 +44,12 @@ async function provisionDatabase() {
     await conn.end();
 }
 
-function runStage(stage, stateDir, extraArgs = []) {
+function runStage(stage, stateDir, extraArgs = [], { includeUrl = true } = {}) {
     const url = `${getSiteUrl(SITE)}&directory=${getSiteDir(SITE)}`;
     const args = [
         IMPORTER_PATH,
         stage,
-        url,
+        ...(includeUrl ? [url] : []),
         `--state-dir=${stateDir}`,
         `--fs-root=${fsRootDir(stateDir)}`,
         `--secret=${getSiteSecret(SITE)}`,
@@ -137,20 +137,26 @@ async function main() {
         `--target-db=${IMPORT_DB}`,
         `--new-site-url=http://localhost:9999`,
     ];
-    const runtimeArgs = ['--runtime=none'];
+    const runtimeOutDir = join(stateDir, 'runtime-out');
+    mkdirSync(runtimeOutDir, { recursive: true });
+    const runtimeArgs = [
+        '--runtime=php-builtin',
+        `--output-dir=${runtimeOutDir}`,
+    ];
 
     const stages = [
         { name: 'preflight', extra: [] },
         { name: 'files-pull', extra: [] },
         { name: 'db-pull', extra: [] },
         { name: 'db-apply', extra: dbApplyArgs },
-        { name: 'apply-runtime', extra: runtimeArgs },
+        // apply-runtime is local-only; it doesn't take a remote URL.
+        { name: 'apply-runtime', extra: runtimeArgs, includeUrl: false },
     ];
 
     const results = [];
-    for (const { name, extra } of stages) {
+    for (const { name, extra, includeUrl } of stages) {
         console.log(`-> ${name}`);
-        const r = runStage(name, stateDir, extra);
+        const r = runStage(name, stateDir, extra, { includeUrl });
         results.push(r);
         console.log(`   ${r.ok ? 'ok' : 'FAIL'} in ${fmtMs(r.elapsedMs)} (attempts=${r.attempts})`);
         if (!r.ok) {

--- a/tests/e2e/benchmark/bench-pull.mjs
+++ b/tests/e2e/benchmark/bench-pull.mjs
@@ -1,0 +1,182 @@
+/**
+ * Per-stage performance benchmark for the `pull` pipeline.
+ *
+ * Provisions the `large-directory` e2e site (2k+ files), then runs each
+ * pipeline stage as an individual CLI invocation and times the wall-clock.
+ * Emits a markdown table to stdout, appends to $GITHUB_STEP_SUMMARY, and
+ * writes a JSON artifact to bench-results.json.
+ *
+ * Stages timed: preflight, files-pull, db-pull, db-apply, apply-runtime.
+ *
+ * Note: each stage runs in a fresh PHP process to keep timings comparable
+ * with how the importer is run in production (resumable, single-stage).
+ * That means each measurement includes one PHP startup cost, which is
+ * roughly constant across stages and across PRs — so deltas remain
+ * meaningful even though absolute numbers carry that overhead.
+ */
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, writeFileSync, readFileSync, appendFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { performance } from 'node:perf_hooks';
+import { createConnection } from 'mysql2/promise';
+import { ensureSite } from '../lib/site-setup.js';
+import {
+    getSiteUrl, getSiteSecret, getSiteDir, fsRootDir,
+} from '../lib/test-helpers.js';
+
+const SITE = 'large-directory';
+const IMPORT_DB = 'e2e_bench_pull';
+const PHP_BINARY = process.env.PHP_BINARY || 'php';
+const PROJECT_ROOT = join(import.meta.dirname, '..', '..', '..');
+const IMPORTER_PATH = process.env.IMPORTER_PATH || join(PROJECT_ROOT, 'importer', 'import.php');
+const REGISTRY = JSON.parse(readFileSync(join(import.meta.dirname, '..', 'site-registry.json'), 'utf-8'));
+
+async function provisionDatabase() {
+    const conn = await createConnection({
+        host: REGISTRY.dbHost,
+        user: REGISTRY.dbUser,
+        password: REGISTRY.dbPass,
+        multipleStatements: true,
+    });
+    await conn.query(`DROP DATABASE IF EXISTS \`${IMPORT_DB}\``);
+    await conn.query(`CREATE DATABASE \`${IMPORT_DB}\``);
+    await conn.end();
+}
+
+function runStage(stage, stateDir, extraArgs = []) {
+    const url = `${getSiteUrl(SITE)}&directory=${getSiteDir(SITE)}`;
+    const args = [
+        IMPORTER_PATH,
+        stage,
+        url,
+        `--state-dir=${stateDir}`,
+        `--fs-root=${fsRootDir(stateDir)}`,
+        `--secret=${getSiteSecret(SITE)}`,
+        ...extraArgs,
+    ];
+
+    const start = performance.now();
+    let attempts = 0;
+    let lastErr = null;
+
+    // Stages other than preflight may exit 2 to request resumption. Loop
+    // until the command runs to completion (exit 0) or fatally fails.
+    while (true) {
+        attempts += 1;
+        try {
+            execFileSync(PHP_BINARY, args, {
+                timeout: 240000,
+                encoding: 'utf-8',
+                maxBuffer: 64 * 1024 * 1024,
+                stdio: ['ignore', 'pipe', 'pipe'],
+            });
+            const elapsedMs = performance.now() - start;
+            return { stage, elapsedMs, attempts, ok: true };
+        } catch (e) {
+            const exitCode = e.status === null ? -1 : (e.status || 1);
+            lastErr = e;
+            if (exitCode === 2 && attempts < 50) {
+                continue;
+            }
+            const elapsedMs = performance.now() - start;
+            return {
+                stage, elapsedMs, attempts, ok: false, exitCode,
+                stderr: (e.stderr || '').toString().slice(-2000),
+                stdout: (e.stdout || '').toString().slice(-2000),
+            };
+        }
+    }
+}
+
+function fmtMs(ms) {
+    if (ms < 1000) return `${ms.toFixed(0)} ms`;
+    return `${(ms / 1000).toFixed(2)} s`;
+}
+
+function renderMarkdown(results, meta) {
+    const total = results.reduce((s, r) => s + r.elapsedMs, 0);
+    const lines = [];
+    lines.push(`## Pull pipeline performance — \`${SITE}\``);
+    lines.push('');
+    lines.push(`Site: \`${SITE}\` · ${meta.fileCount} files · PHP \`${meta.phpVersion}\``);
+    lines.push('');
+    lines.push('| Stage | Wall time | Resume attempts | Status |');
+    lines.push('|---|---:|---:|---|');
+    for (const r of results) {
+        lines.push(`| \`${r.stage}\` | ${fmtMs(r.elapsedMs)} | ${r.attempts} | ${r.ok ? '✓' : '✗ exit ' + r.exitCode} |`);
+    }
+    lines.push(`| **Total** | **${fmtMs(total)}** | | |`);
+    lines.push('');
+    return lines.join('\n');
+}
+
+async function main() {
+    console.log(`Provisioning site: ${SITE}`);
+    await ensureSite(SITE, {
+        files: 'none',
+        afterCreate: async (siteDir) => {
+            const manyDir = join(siteDir, 'test-data', 'many-files');
+            mkdirSync(manyDir, { recursive: true });
+            for (let i = 1; i <= 2000; i++) {
+                const num = String(i).padStart(4, '0');
+                writeFileSync(join(manyDir, `file-${num}.txt`), `content-${num}`);
+            }
+        },
+    });
+
+    await provisionDatabase();
+
+    const stateDir = join(tmpdir(), `bench-pull-${Date.now()}`);
+    mkdirSync(stateDir, { recursive: true });
+    mkdirSync(fsRootDir(stateDir), { recursive: true });
+
+    const dbApplyArgs = [
+        `--target-user=${REGISTRY.dbUser}`,
+        `--target-pass=${REGISTRY.dbPass}`,
+        `--target-db=${IMPORT_DB}`,
+        `--new-site-url=http://localhost:9999`,
+    ];
+    const runtimeArgs = ['--runtime=none'];
+
+    const stages = [
+        { name: 'preflight', extra: [] },
+        { name: 'files-pull', extra: [] },
+        { name: 'db-pull', extra: [] },
+        { name: 'db-apply', extra: dbApplyArgs },
+        { name: 'apply-runtime', extra: runtimeArgs },
+    ];
+
+    const results = [];
+    for (const { name, extra } of stages) {
+        console.log(`-> ${name}`);
+        const r = runStage(name, stateDir, extra);
+        results.push(r);
+        console.log(`   ${r.ok ? 'ok' : 'FAIL'} in ${fmtMs(r.elapsedMs)} (attempts=${r.attempts})`);
+        if (!r.ok) {
+            console.error(`   stderr (tail):\n${r.stderr}`);
+            console.error(`   stdout (tail):\n${r.stdout}`);
+        }
+    }
+
+    const phpVersion = execFileSync(PHP_BINARY, ['-r', 'echo PHP_VERSION;'], { encoding: 'utf-8' }).trim();
+    const meta = { site: SITE, fileCount: '2,000+', phpVersion, importer: IMPORTER_PATH };
+    const md = renderMarkdown(results, meta);
+    console.log('\n' + md);
+
+    writeFileSync('bench-results.json', JSON.stringify({ meta, results }, null, 2));
+    writeFileSync('bench-results.md', md);
+
+    if (process.env.GITHUB_STEP_SUMMARY) {
+        appendFileSync(process.env.GITHUB_STEP_SUMMARY, md + '\n');
+    }
+
+    if (results.some((r) => !r.ok)) {
+        process.exit(1);
+    }
+}
+
+main().catch((e) => {
+    console.error(e);
+    process.exit(1);
+});

--- a/tests/e2e/benchmark/render-diff.mjs
+++ b/tests/e2e/benchmark/render-diff.mjs
@@ -1,0 +1,78 @@
+/**
+ * Combine PR and trunk bench results into a single markdown table with
+ * per-stage deltas. Reads bench-pr.json and bench-trunk.json, writes
+ * bench-results.md.
+ */
+import { readFileSync, writeFileSync, existsSync } from 'node:fs';
+
+function fmtMs(ms) {
+    if (ms < 1000) return `${ms.toFixed(0)} ms`;
+    return `${(ms / 1000).toFixed(2)} s`;
+}
+
+function fmtDelta(prMs, trunkMs) {
+    const diff = prMs - trunkMs;
+    const pct = trunkMs > 0 ? (diff / trunkMs) * 100 : 0;
+    const sign = diff >= 0 ? '+' : '';
+    const abs = `${sign}${fmtMs(Math.abs(diff)).replace(/^/, diff < 0 ? '-' : '')}`;
+    // Simple visual cue: 🟢 ≥10% faster, 🔴 ≥10% slower, ⚪ otherwise.
+    let marker = '⚪';
+    if (Math.abs(pct) >= 10 && Math.abs(diff) >= 50) {
+        marker = diff < 0 ? '🟢' : '🔴';
+    }
+    return `${marker} ${abs} (${sign}${pct.toFixed(1)}%)`;
+}
+
+const prPath = process.env.PR_JSON || 'bench-pr.json';
+const trunkPath = process.env.TRUNK_JSON || 'bench-trunk.json';
+const outPath = process.env.OUT_MD || 'bench-results.md';
+
+if (!existsSync(prPath)) {
+    console.error(`Missing PR results: ${prPath}`);
+    process.exit(1);
+}
+
+const pr = JSON.parse(readFileSync(prPath, 'utf-8'));
+const trunk = existsSync(trunkPath) ? JSON.parse(readFileSync(trunkPath, 'utf-8')) : null;
+
+const lines = [];
+lines.push(`## Pull pipeline performance — \`${pr.meta.site}\``);
+lines.push('');
+lines.push(`Site: \`${pr.meta.site}\` · ${pr.meta.fileCount} files · PHP \`${pr.meta.phpVersion}\``);
+lines.push('');
+
+if (trunk) {
+    lines.push('| Stage | PR | trunk | Δ | Status |');
+    lines.push('|---|---:|---:|---:|---|');
+    const trunkByStage = Object.fromEntries(trunk.results.map((r) => [r.stage, r]));
+    let prTotal = 0;
+    let trunkTotal = 0;
+    for (const r of pr.results) {
+        const t = trunkByStage[r.stage];
+        prTotal += r.elapsedMs;
+        if (t) trunkTotal += t.elapsedMs;
+        const delta = t ? fmtDelta(r.elapsedMs, t.elapsedMs) : '—';
+        const status = r.ok ? '✓' : '✗ exit ' + r.exitCode;
+        lines.push(`| \`${r.stage}\` | ${fmtMs(r.elapsedMs)} | ${t ? fmtMs(t.elapsedMs) : '—'} | ${delta} | ${status} |`);
+    }
+    lines.push(`| **Total** | **${fmtMs(prTotal)}** | **${fmtMs(trunkTotal)}** | **${fmtDelta(prTotal, trunkTotal)}** | |`);
+} else {
+    lines.push('_Trunk baseline unavailable — showing PR numbers only._');
+    lines.push('');
+    lines.push('| Stage | Wall time | Resume attempts | Status |');
+    lines.push('|---|---:|---:|---|');
+    let total = 0;
+    for (const r of pr.results) {
+        total += r.elapsedMs;
+        lines.push(`| \`${r.stage}\` | ${fmtMs(r.elapsedMs)} | ${r.attempts} | ${r.ok ? '✓' : '✗ exit ' + r.exitCode} |`);
+    }
+    lines.push(`| **Total** | **${fmtMs(total)}** | | |`);
+}
+
+lines.push('');
+lines.push('<sub>Numbers carry runner noise; treat single-run deltas as directional, not authoritative.</sub>');
+lines.push('');
+
+const md = lines.join('\n');
+writeFileSync(outPath, md);
+console.log(md);


### PR DESCRIPTION
## Summary

Each PR now gets a sticky comment showing how long each stage of the `pull` pipeline took against the `large-directory` e2e fixture (2k+ files): preflight, files-pull, db-pull, db-apply, apply-runtime.

The bench runs each stage as a separate CLI invocation so the timings match the way the importer actually executes — one stage per process, resumable. No production code changes; everything is measured externally.

This is meant as visibility, not a regression gate — GitHub runners are noisy enough that single-run deltas aren't trustworthy. Easy follow-up if we want it: also bench `trunk` in the same job and show the diff.

## Test plan

- [ ] Open this PR and confirm the new "Performance Report" workflow runs
- [ ] Confirm a sticky PR comment appears with a per-stage table
- [ ] Confirm `bench-results.json` and `bench-results.md` are uploaded as artifacts
- [ ] Push a follow-up commit and confirm the comment updates in place