### PR TITLE
Bench pull pipeline against a larger seeded DB

### DIFF
--- a/.github/workflows/perf-report.yml
+++ b/.github/workflows/perf-report.yml
@@ -55,7 +55,7 @@ jobs:
     name: Pull pipeline benchmark
     needs: [build-pr-phar, build-trunk-phar]
     runs-on: ubuntu-22.04
-    timeout-minutes: 35
+    timeout-minutes: 60
     env:
       PHP_VERSION: '8.2'
 

--- a/tests/e2e/benchmark/bench-pull.mjs
+++ b/tests/e2e/benchmark/bench-pull.mjs
@@ -1,8 +1,11 @@
 /**
  * Per-stage performance benchmark for the `pull` pipeline.
  *
- * Provisions the `large-directory` e2e site (2k+ files), then runs each
- * pipeline stage as an individual CLI invocation and times the wall-clock.
+ * Provisions the `large-directory` e2e site (2k+ files) and seeds its DB
+ * with hundreds of thousands of posts/postmeta rows so the DB stages
+ * dominate wall-clock — see Automattic/studio#3248 for the dataset shape.
+ * Then runs each pipeline stage as an individual CLI invocation and times
+ * the wall-clock.
  * Emits a markdown table to stdout, appends to $GITHUB_STEP_SUMMARY, and
  * writes a JSON artifact to bench-results.json.
  *
@@ -27,10 +30,86 @@ import {
 
 const SITE = 'large-directory';
 const IMPORT_DB = 'e2e_bench_pull';
+// Seed enough posts/postmeta to make db-pull and db-apply dominate wall-clock
+// (the default WP install has ~1 post). Mirrors the dataset shape used in
+// Automattic/studio#3248: ~320k posts and ~720k postmeta rows.
+const SEED_POSTS = Number(process.env.BENCH_SEED_POSTS || 320_007);
+const SEED_POSTMETA = Number(process.env.BENCH_SEED_POSTMETA || 720_015);
 const PHP_BINARY = process.env.PHP_BINARY || 'php';
 const PROJECT_ROOT = join(import.meta.dirname, '..', '..', '..');
 const IMPORTER_PATH = process.env.IMPORTER_PATH || join(PROJECT_ROOT, 'importer', 'import.php');
 const REGISTRY = JSON.parse(readFileSync(join(import.meta.dirname, '..', 'site-registry.json'), 'utf-8'));
+
+async function seedSourceDb() {
+    const dbName = `e2e_${SITE.replace(/-/g, '_')}`;
+    const conn = await createConnection({
+        host: REGISTRY.dbHost,
+        user: REGISTRY.dbUser,
+        password: REGISTRY.dbPass,
+        database: dbName,
+        multipleStatements: true,
+    });
+    try {
+        const [rows] = await conn.query('SELECT COUNT(*) AS c FROM wp_posts');
+        if (rows[0].c >= SEED_POSTS) {
+            console.log(`Source DB already seeded with ${rows[0].c} posts; skipping seed`);
+            return;
+        }
+
+        console.log(`Seeding source DB: ${SEED_POSTS} posts, ${SEED_POSTMETA} postmeta...`);
+        // Speed up bulk inserts: skip per-row durability, defer index updates.
+        await conn.query('SET autocommit=0; SET unique_checks=0; SET foreign_key_checks=0;');
+        await conn.query('ALTER TABLE wp_posts DISABLE KEYS; ALTER TABLE wp_postmeta DISABLE KEYS;');
+
+        const BATCH = 2000;
+        const now = '2024-01-01 00:00:00';
+        for (let start = 1; start <= SEED_POSTS; start += BATCH) {
+            const end = Math.min(start + BATCH - 1, SEED_POSTS);
+            const values = [];
+            const params = [];
+            for (let i = start; i <= end; i++) {
+                values.push('(?,?,?,?,?,?,?,?,?,?,?,?)');
+                params.push(
+                    1, now, now,
+                    `Bench post body ${i} — lorem ipsum dolor sit amet, consectetur adipiscing elit. http://localhost:9999/post/${i}`,
+                    `Bench post ${i}`,
+                    '', 'publish', 'open', 'open', `bench-post-${i}`,
+                    'post', 0,
+                );
+            }
+            await conn.query(
+                `INSERT INTO wp_posts
+                    (post_author, post_date, post_date_gmt, post_content, post_title,
+                     post_excerpt, post_status, comment_status, ping_status, post_name,
+                     post_type, comment_count)
+                 VALUES ${values.join(',')}`,
+                params,
+            );
+        }
+
+        for (let start = 1; start <= SEED_POSTMETA; start += BATCH) {
+            const end = Math.min(start + BATCH - 1, SEED_POSTMETA);
+            const values = [];
+            const params = [];
+            for (let i = start; i <= end; i++) {
+                const postId = ((i - 1) % SEED_POSTS) + 1;
+                values.push('(?,?,?)');
+                params.push(postId, `bench_meta_${i % 3}`, `value-${i}`);
+            }
+            await conn.query(
+                `INSERT INTO wp_postmeta (post_id, meta_key, meta_value) VALUES ${values.join(',')}`,
+                params,
+            );
+        }
+
+        await conn.query('COMMIT');
+        await conn.query('ALTER TABLE wp_posts ENABLE KEYS; ALTER TABLE wp_postmeta ENABLE KEYS;');
+        await conn.query('SET autocommit=1; SET unique_checks=1; SET foreign_key_checks=1;');
+        console.log('Seed complete');
+    } finally {
+        await conn.end();
+    }
+}
 
 async function provisionDatabase() {
     const conn = await createConnection({
@@ -66,7 +145,7 @@ function runStage(stage, stateDir, extraArgs = [], { includeUrl = true } = {}) {
         attempts += 1;
         try {
             execFileSync(PHP_BINARY, args, {
-                timeout: 240000,
+                timeout: 900_000,
                 encoding: 'utf-8',
                 maxBuffer: 64 * 1024 * 1024,
                 stdio: ['ignore', 'pipe', 'pipe'],
@@ -99,7 +178,7 @@ function renderMarkdown(results, meta) {
     const lines = [];
     lines.push(`## Pull pipeline performance — \`${SITE}\``);
     lines.push('');
-    lines.push(`Site: \`${SITE}\` · ${meta.fileCount} files · PHP \`${meta.phpVersion}\``);
+    lines.push(`Site: \`${SITE}\` · ${meta.fileCount} files · ${meta.seedPosts.toLocaleString('en-US')} posts · ${meta.seedPostmeta.toLocaleString('en-US')} postmeta · PHP \`${meta.phpVersion}\``);
     lines.push('');
     lines.push('| Stage | Wall time | Resume attempts | Status |');
     lines.push('|---|---:|---:|---|');
@@ -125,6 +204,7 @@ async function main() {
         },
     });
 
+    await seedSourceDb();
     await provisionDatabase();
 
     const stateDir = join(tmpdir(), `bench-pull-${Date.now()}`);
@@ -166,7 +246,14 @@ async function main() {
     }
 
     const phpVersion = execFileSync(PHP_BINARY, ['-r', 'echo PHP_VERSION;'], { encoding: 'utf-8' }).trim();
-    const meta = { site: SITE, fileCount: '2,000+', phpVersion, importer: IMPORTER_PATH };
+    const meta = {
+        site: SITE,
+        fileCount: '2,000+',
+        seedPosts: SEED_POSTS,
+        seedPostmeta: SEED_POSTMETA,
+        phpVersion,
+        importer: IMPORTER_PATH,
+    };
     const md = renderMarkdown(results, meta);
     console.log('\n' + md);
 

--- a/tests/e2e/benchmark/bench-pull.mjs
+++ b/tests/e2e/benchmark/bench-pull.mjs
@@ -58,6 +58,9 @@ async function seedSourceDb() {
 
         console.log(`Seeding source DB: ${SEED_POSTS} posts, ${SEED_POSTMETA} postmeta...`);
         // Speed up bulk inserts: skip per-row durability, defer index updates.
+        // Drop STRICT mode so TEXT columns without defaults (to_ping,
+        // pinged, post_content_filtered, etc.) accept implicit ''.
+        await conn.query("SET SESSION sql_mode='';");
         await conn.query('SET autocommit=0; SET unique_checks=0; SET foreign_key_checks=0;');
         await conn.query('ALTER TABLE wp_posts DISABLE KEYS; ALTER TABLE wp_postmeta DISABLE KEYS;');
 

--- a/tests/e2e/benchmark/render-diff.mjs
+++ b/tests/e2e/benchmark/render-diff.mjs
@@ -38,7 +38,12 @@ const trunk = existsSync(trunkPath) ? JSON.parse(readFileSync(trunkPath, 'utf-8'
 const lines = [];
 lines.push(`## Pull pipeline performance — \`${pr.meta.site}\``);
 lines.push('');
-lines.push(`Site: \`${pr.meta.site}\` · ${pr.meta.fileCount} files · PHP \`${pr.meta.phpVersion}\``);
+{
+    const seedSuffix = (pr.meta.seedPosts && pr.meta.seedPostmeta)
+        ? ` · ${Number(pr.meta.seedPosts).toLocaleString('en-US')} posts · ${Number(pr.meta.seedPostmeta).toLocaleString('en-US')} postmeta`
+        : '';
+    lines.push(`Site: \`${pr.meta.site}\` · ${pr.meta.fileCount} files${seedSuffix} · PHP \`${pr.meta.phpVersion}\``);
+}
 lines.push('');
 
 if (trunk) {


### PR DESCRIPTION
The perf-report bench provisions the `large-directory` e2e site, which is a fresh `wp core install` with ~1 post. That means `db-pull` and `db-apply` finished in milliseconds, and SQL-rewriter optimizations (the kind in #158, #161, #163) didn't show up in the PR comment at all — the diff was dominated by noise on `preflight`.

This pads the source DB with ~320k posts and ~720k postmeta rows before timing, matching the dataset shape used in the Automattic/studio#3248 measurement that actually surfaced the SQL-rewriter speedups (db-apply went from 431s to 134s on that dataset). With this in place, the next perf comment on a SQL-rewriter PR should show the real delta instead of single-digit milliseconds of jitter.

Seeding runs once per CI container, is idempotent (skipped if `wp_posts` already has enough rows), and is tunable via `BENCH_SEED_POSTS` / `BENCH_SEED_POSTMETA` if you want a smaller dataset for local iteration. Per-stage timeout bumped to 900s and the workflow job timeout to 60 min so the heavier stages fit on slow runners.