### PR TITLE
db-apply: profile inner buckets to drive the optimization plan

### DIFF
--- a/.github/workflows/perf-report.yml
+++ b/.github/workflows/perf-report.yml
@@ -55,7 +55,7 @@ jobs:
     name: Pull pipeline benchmark
     needs: [build-pr-phar, build-trunk-phar]
     runs-on: ubuntu-22.04
-    timeout-minutes: 35
+    timeout-minutes: 60
     env:
       PHP_VERSION: '8.2'
 

--- a/markdown/PERFORMANCE-DB-STAGES.md
+++ b/markdown/PERFORMANCE-DB-STAGES.md
@@ -1,0 +1,277 @@
+# Profiling and accelerating the `db-*` pipeline stages
+
+## Measurement setup
+
+This run measures `db-apply` only — the e2e site harness needs
+NixOS-level services (nginx + php-fpm + MySQL configured via
+`nixos-e2e-services.nix`) that aren't running on this Mac, so I
+substituted a Docker-only path:
+
+- MySQL 8.0 in Docker, port 33307, `--max_allowed_packet=256M`.
+- `.context/bench/seed-and-dump.php` seeds the source DB with
+  WordPress-shaped `wp_posts` + `wp_postmeta` (post_content embeds
+  `http://localhost:9999/post/$i` so the URL rewriter has work),
+  then drives `MySQLDumpProducer` directly to write `db.sql`.
+- The importer CLI then runs `db-apply` against an empty target DB
+  with `--rewrite-url http://localhost:9999 https://new-site.test`.
+- Per-stage breakdown comes from the new
+  `.import-apply-profile.json` written by the importer.
+
+Because db-pull runs against a live HTTP exporter (which I don't
+have here), this report does **not** measure the HTTP / multipart
+transport, the producer's per-row server-side cost, or the
+`AdaptiveTuner` behaviour. The numbers below are db-apply only.
+
+PHP 8.4.5, mysql:8.0 in Docker on Apple Silicon Mac, localhost TCP.
+
+## Measured numbers
+
+| Scale | rows | db.sql | statements | wall | read I/O | parse | rewrite | exec |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|
+| small | 17 k | 3.45 MB | 80 | 2.75 s | 0.6 ms | 0.55 s (20%) | 1.53 s (56%) | 0.67 s (24%) |
+| medium | 170 k | 35.2 MB | 692 | 25.5 s | 7 ms | 5.53 s (22%) | 15.77 s (62%) | 4.15 s (16%) |
+| large | 1.04 M | 224 MB | 4 174 | 159 s | 49 ms | 35.36 s (22%) | 99.77 s (63%) | 23.93 s (15%) |
+
+Large scale matches the bench harness's default seed (320 k posts
++ 720 k postmeta).
+
+Statement kinds at large scale: 4 160 `INSERT` (99.7%), 7 `SET`,
+2 `CREATE`, 1 `COMMIT`. The dump prefaces with the standard
+`UNIQUE_CHECKS=0; FOREIGN_KEY_CHECKS=0; AUTOCOMMIT=0;` and ends with
+a `COMMIT;` (`class-mysql-dump-producer.php:522-541`), so per-row
+fsync and FK/unique checks are already off.
+
+Throughput is ~1.4 MB/s of `db.sql` regardless of scale — db-apply
+cost is per-byte, not per-statement.
+
+## What the profile actually says
+
+**The URL rewriter is the single biggest hotspot, ~62% of db-apply
+wall.** Inside the rewriter, the actual costs are very different
+from what I first claimed (`base64_decode` is **not** the problem —
+see "what I got wrong" below).
+
+### Top level (medium scale, 35 MB, 692 statements, 26.26 s wall)
+
+| bucket | time | % wall |
+|---|---:|---:|
+| read I/O | 19 ms | 0.07% |
+| query stream `append_sql` | 1.5 ms | 0.006% |
+| query stream `next_query` | 5.71 s | 21.8% |
+| URL rewrite (total) | 16.57 s | 63.0% |
+| `PDO::exec` | 3.85 s | 14.7% |
+
+### Inside the URL rewrite (16.57 s)
+
+| sub-bucket | time | % wall | % of rewrite |
+|---|---:|---:|---:|
+| `StructuredDataUrlRewriter::rewrite` (per matching value) | 8.51 s | 32.4% | 51% |
+| `Base64ValueScanner::__construct` (lexer + decode) | 4.04 s | 15.4% | 24% |
+| `map_values_to_columns` (column-map walk) | 3.52 s | 13.4% | 21% |
+| `get_result` (string rebuild) | 0.22 s | 0.8% | 1% |
+| `get_value` (cursor lookup) | 0.09 s | 0.4% | <1% |
+
+### Inside `Base64ValueScanner::scan()` (4.04 s)
+
+| sub-bucket | time | of which |
+|---|---:|---|
+| `WP_MySQL_Lexer` token walk | 4.04 s | almost all of scanner_ctor |
+| `base64_decode()` (790 000 calls) | 0.45 s | tiny |
+
+### Value counts
+
+- `values_seen`: 790 000
+- `values_with_http`: 50 000 (post_content only)
+- `values_skipped_no_http`: 740 000 (94%)
+
+### So where is db-apply actually spending time?
+
+Re-allocating the wall-clock pie chart based on the *innermost*
+bucket each unit of time is attributable to:
+
+| innermost cost | % wall |
+|---|---:|
+| `StructuredDataUrlRewriter::rewrite()` on values that contain `http` | 32% |
+| `WP_MySQL_Lexer` walk for `Base64ValueScanner::scan()` | 15% |
+| `map_values_to_columns` (lexer walk + map build) | 13% |
+| `WP_MySQL_Naive_Query_Stream::next_query()` | 22% |
+| `PDO::exec()` (localhost) | 15% |
+| `base64_decode()` itself | 1.7% |
+| read I/O, `append_sql`, `get_result`, etc. | < 3% |
+
+Three cost centres dominate — the structured-data rewriter doing
+real work on legitimate URL-bearing values, and the lexer / parser
+walking bytes (counted twice within the rewriter, once in the
+scanner and again in the column-map walk; plus a third time in the
+top-level query stream).
+
+## What I got wrong on the first pass
+
+In the first version of this doc I claimed that **`base64_decode`
+was the cost** and that an "encoded-form fast path" (`strpos` for
+`aHR0c` against the base64 string before decoding) would gut the
+hot path. The measurements say that's wrong. `base64_decode` itself
+is 0.45 s out of 26 s — 1.7%. The fast path would skip ~94% of
+those calls, saving roughly 0.4 s — barely visible.
+
+What's actually expensive is everything *around* `base64_decode`:
+the `WP_MySQL_Lexer` walk that finds the FROM_BASE64 expressions
+in the first place, the second lexer walk done by
+`map_values_to_columns`, and `StructuredDataUrlRewriter::rewrite`
+on the values that *do* contain a URL. Two of these run on every
+statement regardless of how many values matter.
+
+## Hotspots, ranked by *measured* impact
+
+### 1. `StructuredDataUrlRewriter::rewrite()` on URL-bearing values  ★★★★★
+
+**32% of wall** (8.51 s of the medium-scale 26 s run). Runs once
+per value that contains `http` — 50 000 calls in this dataset, all
+on `post_content` (block markup hint). This is real work:
+HTML / block-comment-JSON / CSS-url / etc. parsing per value.
+
+Knobs to consider:
+- For block markup specifically, much of the cost is the HTML walk.
+  If the value contains *no* URL of any host we map (which is
+  common — block content with internal links + media references),
+  a host-prefix `strpos` check on the *decoded* value before
+  invoking the structured pipeline can short-circuit the parse.
+  The current `strpos($value, 'http')` skip is too coarse: any
+  external URL passes it.
+- The `wp_rewrite_urls()` block walker is shared with the
+  Data Liberation library. Profile *inside* it before optimizing —
+  the cost may be in the HTML tokenizer, attribute decoding, or
+  block-comment JSON parse, and each has different fixes.
+
+This is the only hotspot whose cost grows with "real" content
+(URL-bearing values). Items 2 and 3 below grow with *raw byte
+count*, regardless of URL density.
+
+### 2. `WP_MySQL_Lexer` walk inside `Base64ValueScanner`  ★★★★
+
+**15% of wall** (4.04 s, of which `base64_decode` is only 0.45 s).
+The lexer walks every byte of every statement that contains
+`FROM_BASE64(` — i.e. every INSERT in a non-trivial dump. Most of
+those bytes are inside base64 string literals where there's
+nothing the lexer needs to recognize.
+
+Knobs:
+- Replace the full `WP_MySQL_Lexer` walk with a lighter scan that
+  finds `FROM_BASE64(` and `CONVERT(` token boundaries via `strpos`
+  / regex — possible because the producer-emitted SQL has a
+  constrained shape. Fall back to the lexer for shapes the fast
+  scanner doesn't recognize.
+- Have the producer annotate `db.sql` with per-statement metadata
+  (the offsets of every `FROM_BASE64('…')` value, the column each
+  belongs to). The importer skips the entire scan + column-map
+  step. Format-bump on `db.sql`; gated on a magic header for old
+  files.
+
+### 3. `map_values_to_columns()` does a *second* lexer walk  ★★★★
+
+**13% of wall** (3.52 s). It walks the same statement again to
+recover the table name and (column → byte-offset) map. Combined
+with #2, the same statement is tokenized twice by `WP_MySQL_Lexer`
+in addition to a third pass by `WP_MySQL_Naive_Query_Stream`.
+
+Knob: fold #2 and #3 into a single lexer pass. Both want the same
+token stream; the scanner needs FROM_BASE64 positions, the column
+map needs the table name + columns clause + VALUES boundaries.
+One walk that emits both is structurally easy.
+
+This + #2 together account for 28% of wall. A merged single-pass
+implementation is a candidate for the largest single win.
+
+### 4. `WP_MySQL_Naive_Query_Stream::next_query()`  ★★★
+
+**22% of wall** (5.71 s). Pure byte-walking PHP state machine.
+The `append_sql` side is ≈0% — all the cost is in `next_query()`
+finding statement boundaries.
+
+Knobs:
+- Format change: producer writes per-statement length sentinels
+  (e.g. a comment line `-- LEN:12345` between statements);
+  importer reads N bytes per query and skips the tokenizer
+  entirely. Same format-bump conversation as #2.
+- Faster boundary scan inside string literals: today the state
+  machine inspects every byte for quote/escape/comment edges; for
+  base64 literals (`[A-Za-z0-9+/=]+`) it could `strpos` directly
+  for the closing quote.
+
+### 5. `PDO::exec()`  ★★
+
+**15% of wall on localhost**. Sensitive to RTT — on a real
+LAN/WAN target this share grows. `mysqli_multi_query` for runs of
+homogeneous INSERTs would help, but the localhost ranking
+overstates the local benefit and understates the remote benefit.
+Re-measure on a non-localhost target before sizing.
+
+### 6. `base64_decode()` itself  ★
+
+**1.7% of wall** (0.45 s for 790 000 calls). Almost free per call.
+This is the call I previously claimed was the bottleneck — it's
+not. The encoded-form fast path I proposed earlier would help
+here, but the win is rounding error.
+
+### 7. `LOAD DATA LOCAL INFILE`  ★★
+
+Only worth scoping after #1–#3 land. Constraints unchanged:
+server-config-gated, requires moving FROM_BASE64 + URL rewriting
+work client-side, requires reworking cursor resumption.
+
+### 8. db-pull / transport — not measured here
+
+The Docker harness skips the HTTP path. Re-run the full e2e bench
+once that infra is available.
+
+### 9. SQLite target — not measured
+
+Different code path, different workload, separate bench needed.
+
+## What "10×" looks like given these numbers
+
+A speed budget for db-apply at the medium-scale 26 s run:
+
+- Today: 26 s.
+- After merging #2 + #3 into a single lexer pass: optimistic case
+  saves 4 s (cuts the redundant lexer walk). 22 s.
+- After format-bump for #4 (length sentinels skip the parser):
+  saves up to 5.7 s. 16 s.
+- After `mysqli_multi_query` for #5 on localhost: saves up to 3 s.
+  13 s. (Bigger gains expected on remote targets — re-measure.)
+- After cutting `StructuredDataUrlRewriter` cost in #1 by 50% (a
+  real engineering effort, requires its own profile inside the
+  block walker): saves 4 s. 9 s.
+
+Rough budget: 26 → 9 s = ~3× without changing transport and
+without `LOAD DATA`. Reaching 10× requires `LOAD DATA` or a
+fundamental shift (binary protocol, native MySQL `mysqldump`-shaped
+dump bypassing FROM_BASE64 entirely for non-binary values, etc.).
+
+These numbers are projections from the measured pie chart. They
+are *not* measured speedups — that requires landing each item and
+re-running the bench. Project numbers conservatively, claim only
+what you measure.
+
+## Reproduce
+
+```bash
+docker run --rm -d --name reprint-bench-mysql -p 33307:3306 \
+    -e MYSQL_ROOT_PASSWORD=bench -e MYSQL_DATABASE=bench_src \
+    mysql:8.0 --max_allowed_packet=256M
+
+# wait for ready
+until docker exec reprint-bench-mysql mysqladmin -uroot -pbench ping >/dev/null 2>&1; do sleep 2; done
+
+# scale: small (5k/12k), med (50k/120k), large (320k/720k)
+php .context/bench/seed-and-dump.php /tmp/bench-state-large 320007 720015
+
+php importer/import.php db-apply - \
+    --state-dir=/tmp/bench-state-large \
+    --fs-root=/tmp/bench-state-large/fs \
+    --target-host=127.0.0.1 --target-port=33307 \
+    --target-user=root --target-pass=bench --target-db=bench_dst \
+    --rewrite-url http://localhost:9999 https://new-site.test
+
+cat /tmp/bench-state-large/.import-apply-profile.json
+```

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -5065,6 +5065,23 @@ class ImportClient
             "message" => "Applying SQL" . ($statements_total !== null ? " ({$statements_total} statements)" : ""),
         ]);
 
+        // Per-stage profile. Cheap monotonic timers around the four hot
+        // sections — read I/O, query stream parse, URL rewrite, PDO exec —
+        // so the bench harness can show *where* db-apply spends its time
+        // rather than just the total wall clock.
+        $profile = [
+            "read_io_us" => 0.0,
+            "qs_append_us" => 0.0,
+            "qs_next_us" => 0.0,
+            "rewrite_us" => 0.0,
+            "exec_us" => 0.0,
+            "rewrite_calls" => 0,
+            "exec_calls" => 0,
+            "stmt_kinds" => [],
+            "started_at" => microtime(true),
+        ];
+        $profile_path = $this->state_dir . "/.import-apply-profile.json";
+
         try {
             $chunk_size = 64 * 1024; // 64KB read chunks
 
@@ -5078,14 +5095,24 @@ class ImportClient
                     pcntl_signal_dispatch();
                 }
 
+                $t0 = microtime(true);
                 $data = fread($sql_handle, $chunk_size);
+                $profile["read_io_us"] += (microtime(true) - $t0) * 1e6;
                 if ($data === false || $data === '') {
                     break;
                 }
                 $total_bytes_read += strlen($data);
+                $t0 = microtime(true);
                 $query_stream->append_sql($data);
+                $profile["qs_append_us"] += (microtime(true) - $t0) * 1e6;
 
-                while ($query_stream->next_query()) {
+                while (true) {
+                    $t0 = microtime(true);
+                    $has_next = $query_stream->next_query();
+                    $profile["qs_next_us"] += (microtime(true) - $t0) * 1e6;
+                    if (!$has_next) {
+                        break;
+                    }
                     $query = $query_stream->get_query();
                     $stmt_count++;
 
@@ -5095,14 +5122,28 @@ class ImportClient
                         continue;
                     }
 
+                    // Cheap statement-kind classification — first non-space
+                    // word lets us see how many INSERTs vs CREATE vs UPDATE
+                    // dominate the apply phase.
+                    if (preg_match('/^\s*([A-Za-z]+)/', $query, $m)) {
+                        $kind = strtoupper($m[1]);
+                        $profile["stmt_kinds"][$kind] = ($profile["stmt_kinds"][$kind] ?? 0) + 1;
+                    }
+
                     // Rewrite URLs if mapping is configured
                     if ($stmt_rewriter) {
+                        $t0 = microtime(true);
                         $query = $stmt_rewriter->rewrite($query);
+                        $profile["rewrite_us"] += (microtime(true) - $t0) * 1e6;
+                        $profile["rewrite_calls"]++;
                     }
 
                     // Execute against target database
                     try {
+                        $t0 = microtime(true);
                         $pdo->exec($query);
+                        $profile["exec_us"] += (microtime(true) - $t0) * 1e6;
+                        $profile["exec_calls"]++;
                     } catch (PDOException $e) {
                         $this->audit_log(
                             sprintf(
@@ -5172,12 +5213,23 @@ class ImportClient
                     continue;
                 }
 
+                if (preg_match('/^\s*([A-Za-z]+)/', $query, $m)) {
+                    $kind = strtoupper($m[1]);
+                    $profile["stmt_kinds"][$kind] = ($profile["stmt_kinds"][$kind] ?? 0) + 1;
+                }
+
                 if ($stmt_rewriter) {
+                    $t0 = microtime(true);
                     $query = $stmt_rewriter->rewrite($query);
+                    $profile["rewrite_us"] += (microtime(true) - $t0) * 1e6;
+                    $profile["rewrite_calls"]++;
                 }
 
                 try {
+                    $t0 = microtime(true);
                     $pdo->exec($query);
+                    $profile["exec_us"] += (microtime(true) - $t0) * 1e6;
+                    $profile["exec_calls"]++;
                 } catch (PDOException $e) {
                     $this->audit_log(
                         sprintf(
@@ -5262,6 +5314,36 @@ class ImportClient
             }
         } finally {
             fclose($sql_handle);
+            $profile["wall_us"] = (microtime(true) - $profile["started_at"]) * 1e6;
+            $profile["statements_executed"] = $statements_executed;
+            $profile["bytes_read"] = $total_bytes_read;
+            unset($profile["started_at"]);
+            // Inner rewriter breakdown — only meaningful when a URL mapping
+            // is active (otherwise the rewriter is never invoked).
+            if (class_exists('SqlStatementRewriter', false)) {
+                $profile["rewrite_inner"] = [
+                    "column_map_us" => SqlStatementRewriter::$prof_column_map_us,
+                    "scanner_ctor_us" => SqlStatementRewriter::$prof_scanner_ctor_us,
+                    "get_value_us" => SqlStatementRewriter::$prof_get_value_us,
+                    "url_rewrite_us" => SqlStatementRewriter::$prof_url_rewrite_us,
+                    "get_result_us" => SqlStatementRewriter::$prof_get_result_us,
+                    "values_seen" => SqlStatementRewriter::$prof_values_seen,
+                    "values_with_http" => SqlStatementRewriter::$prof_values_with_http,
+                    "values_skipped_no_http" => SqlStatementRewriter::$prof_values_skipped_no_http,
+                ];
+            }
+            if (class_exists('Base64ValueScanner', false)) {
+                $profile["scanner_inner"] = [
+                    "lexer_us" => Base64ValueScanner::$prof_lexer_us,
+                    "b64_decode_us" => Base64ValueScanner::$prof_b64_decode_us,
+                    "decoded_count" => Base64ValueScanner::$prof_decoded_count,
+                ];
+            }
+            // Best-effort write — never let profile I/O break db-apply.
+            @file_put_contents(
+                $profile_path,
+                json_encode($profile, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES)
+            );
         }
     }
 

--- a/packages/reprint-importer/src/lib/url-rewrite/class-base64-value-scanner.php
+++ b/packages/reprint-importer/src/lib/url-rewrite/class-base64-value-scanner.php
@@ -108,15 +108,22 @@ class Base64ValueScanner
      * Tokenize the SQL and find all FROM_BASE64('...') expressions.
      * Tracks whether each is wrapped in CONVERT(...) for correct expr_start offset.
      */
+    public static float $prof_lexer_us = 0.0;
+    public static float $prof_b64_decode_us = 0.0;
+    public static int $prof_decoded_count = 0;
+
     private function scan(): void
     {
+        $__t = microtime(true);
         $lexer = new WP_MySQL_Lexer($this->sql);
+        self::$prof_lexer_us += (microtime(true) - $__t) * 1e6;
 
         // Track the last two tokens so we can detect CONVERT( before FROM_BASE64.
         // next_token() skips whitespace/comments, so CONVERT ( FROM_BASE64 appears
         // as three consecutive tokens.
         $prev = [null, null];
 
+        $__loop_start = microtime(true);
         while ($lexer->next_token()) {
             $token = $lexer->get_token();
 
@@ -144,7 +151,10 @@ class Base64ValueScanner
                         $inner->id === WP_MySQL_Lexer::SINGLE_QUOTED_TEXT
                         || $inner->id === WP_MySQL_Lexer::DOUBLE_QUOTED_TEXT
                     ) {
+                        $__td = microtime(true);
                         $decoded = base64_decode($inner->get_value(), true);
+                        self::$prof_b64_decode_us += (microtime(true) - $__td) * 1e6;
+                        self::$prof_decoded_count++;
                         $this->entries[] = [
                             'expr_start' => $expr_start,
                             'quote_start' => $inner->start,
@@ -165,5 +175,6 @@ class Base64ValueScanner
             $prev[0] = $prev[1];
             $prev[1] = $token;
         }
+        self::$prof_lexer_us += (microtime(true) - $__loop_start) * 1e6;
     }
 }

--- a/packages/reprint-importer/src/lib/url-rewrite/class-sql-statement-rewriter.php
+++ b/packages/reprint-importer/src/lib/url-rewrite/class-sql-statement-rewriter.php
@@ -100,12 +100,19 @@ class SqlStatementRewriter
         // Recover the table name and a byte-offset→column map from the
         // INSERT/UPDATE shape so we can hand each FROM_BASE64() value the
         // right content-type hint downstream.
+        $__t = microtime(true);
         $value_to_column_map = $this->map_values_to_columns($sql);
+        self::$prof_column_map_us += (microtime(true) - $__t) * 1e6;
 
         // Iterate over all FROM_BASE64() values using the cursor-based scanner
+        $__t = microtime(true);
         $scanner = new Base64ValueScanner($sql);
+        self::$prof_scanner_ctor_us += (microtime(true) - $__t) * 1e6;
         while ($scanner->next_value()) {
+            $__t = microtime(true);
             $value = $scanner->get_value();
+            self::$prof_get_value_us += (microtime(true) - $__t) * 1e6;
+            self::$prof_values_seen++;
 
             // Skip values that can't contain a URL we'd rewrite. Every
             // rewritable domain starts with http:// or https://, so a value
@@ -114,8 +121,10 @@ class SqlStatementRewriter
             // pipeline (HTML parse, block markup, PHP/JSON recursion) per value.
             // See https://github.com/adamziel/reprint/pull/152
             if (strpos($value, 'http') === false) {
+                self::$prof_values_skipped_no_http++;
                 continue;
             }
+            self::$prof_values_with_http++;
 
             // Determine content type hint for this column
             $content_type = null;
@@ -131,7 +140,9 @@ class SqlStatementRewriter
 
             // Rewrite URLs in the value — StructuredDataUrlRewriter classifies the
             // content type and applies the right strategy for each.
+            $__t = microtime(true);
             $rewritten = $this->url_rewriter->rewrite($value, $content_type);
+            self::$prof_url_rewrite_us += (microtime(true) - $__t) * 1e6;
 
             // Only replace if the value actually changed
             if ($rewritten !== $value) {
@@ -139,8 +150,20 @@ class SqlStatementRewriter
             }
         }
 
-        return $scanner->get_result();
+        $__t = microtime(true);
+        $result = $scanner->get_result();
+        self::$prof_get_result_us += (microtime(true) - $__t) * 1e6;
+        return $result;
     }
+
+    public static float $prof_column_map_us = 0.0;
+    public static float $prof_scanner_ctor_us = 0.0;
+    public static float $prof_get_value_us = 0.0;
+    public static float $prof_url_rewrite_us = 0.0;
+    public static float $prof_get_result_us = 0.0;
+    public static int $prof_values_seen = 0;
+    public static int $prof_values_with_http = 0;
+    public static int $prof_values_skipped_no_http = 0;
 
     /**
      * Walk the lexer output to recover, for an INSERT or UPDATE statement,

--- a/tests/e2e/benchmark/bench-pull.mjs
+++ b/tests/e2e/benchmark/bench-pull.mjs
@@ -1,8 +1,11 @@
 /**
  * Per-stage performance benchmark for the `pull` pipeline.
  *
- * Provisions the `large-directory` e2e site (2k+ files), then runs each
- * pipeline stage as an individual CLI invocation and times the wall-clock.
+ * Provisions the `large-directory` e2e site (2k+ files) and seeds its DB
+ * with hundreds of thousands of posts/postmeta rows so the DB stages
+ * dominate wall-clock — see Automattic/studio#3248 for the dataset shape.
+ * Then runs each pipeline stage as an individual CLI invocation and times
+ * the wall-clock.
  * Emits a markdown table to stdout, appends to $GITHUB_STEP_SUMMARY, and
  * writes a JSON artifact to bench-results.json.
  *
@@ -27,10 +30,86 @@ import {
 
 const SITE = 'large-directory';
 const IMPORT_DB = 'e2e_bench_pull';
+// Seed enough posts/postmeta to make db-pull and db-apply dominate wall-clock
+// (the default WP install has ~1 post). Mirrors the dataset shape used in
+// Automattic/studio#3248: ~320k posts and ~720k postmeta rows.
+const SEED_POSTS = Number(process.env.BENCH_SEED_POSTS || 320_007);
+const SEED_POSTMETA = Number(process.env.BENCH_SEED_POSTMETA || 720_015);
 const PHP_BINARY = process.env.PHP_BINARY || 'php';
 const PROJECT_ROOT = join(import.meta.dirname, '..', '..', '..');
 const IMPORTER_PATH = process.env.IMPORTER_PATH || join(PROJECT_ROOT, 'importer', 'import.php');
 const REGISTRY = JSON.parse(readFileSync(join(import.meta.dirname, '..', 'site-registry.json'), 'utf-8'));
+
+async function seedSourceDb() {
+    const dbName = `e2e_${SITE.replace(/-/g, '_')}`;
+    const conn = await createConnection({
+        host: REGISTRY.dbHost,
+        user: REGISTRY.dbUser,
+        password: REGISTRY.dbPass,
+        database: dbName,
+        multipleStatements: true,
+    });
+    try {
+        const [rows] = await conn.query('SELECT COUNT(*) AS c FROM wp_posts');
+        if (rows[0].c >= SEED_POSTS) {
+            console.log(`Source DB already seeded with ${rows[0].c} posts; skipping seed`);
+            return;
+        }
+
+        console.log(`Seeding source DB: ${SEED_POSTS} posts, ${SEED_POSTMETA} postmeta...`);
+        // Speed up bulk inserts: skip per-row durability, defer index updates.
+        await conn.query('SET autocommit=0; SET unique_checks=0; SET foreign_key_checks=0;');
+        await conn.query('ALTER TABLE wp_posts DISABLE KEYS; ALTER TABLE wp_postmeta DISABLE KEYS;');
+
+        const BATCH = 2000;
+        const now = '2024-01-01 00:00:00';
+        for (let start = 1; start <= SEED_POSTS; start += BATCH) {
+            const end = Math.min(start + BATCH - 1, SEED_POSTS);
+            const values = [];
+            const params = [];
+            for (let i = start; i <= end; i++) {
+                values.push('(?,?,?,?,?,?,?,?,?,?,?,?)');
+                params.push(
+                    1, now, now,
+                    `Bench post body ${i} — lorem ipsum dolor sit amet, consectetur adipiscing elit. http://localhost:9999/post/${i}`,
+                    `Bench post ${i}`,
+                    '', 'publish', 'open', 'open', `bench-post-${i}`,
+                    'post', 0,
+                );
+            }
+            await conn.query(
+                `INSERT INTO wp_posts
+                    (post_author, post_date, post_date_gmt, post_content, post_title,
+                     post_excerpt, post_status, comment_status, ping_status, post_name,
+                     post_type, comment_count)
+                 VALUES ${values.join(',')}`,
+                params,
+            );
+        }
+
+        for (let start = 1; start <= SEED_POSTMETA; start += BATCH) {
+            const end = Math.min(start + BATCH - 1, SEED_POSTMETA);
+            const values = [];
+            const params = [];
+            for (let i = start; i <= end; i++) {
+                const postId = ((i - 1) % SEED_POSTS) + 1;
+                values.push('(?,?,?)');
+                params.push(postId, `bench_meta_${i % 3}`, `value-${i}`);
+            }
+            await conn.query(
+                `INSERT INTO wp_postmeta (post_id, meta_key, meta_value) VALUES ${values.join(',')}`,
+                params,
+            );
+        }
+
+        await conn.query('COMMIT');
+        await conn.query('ALTER TABLE wp_posts ENABLE KEYS; ALTER TABLE wp_postmeta ENABLE KEYS;');
+        await conn.query('SET autocommit=1; SET unique_checks=1; SET foreign_key_checks=1;');
+        console.log('Seed complete');
+    } finally {
+        await conn.end();
+    }
+}
 
 async function provisionDatabase() {
     const conn = await createConnection({
@@ -66,7 +145,7 @@ function runStage(stage, stateDir, extraArgs = [], { includeUrl = true } = {}) {
         attempts += 1;
         try {
             execFileSync(PHP_BINARY, args, {
-                timeout: 240000,
+                timeout: 900_000,
                 encoding: 'utf-8',
                 maxBuffer: 64 * 1024 * 1024,
                 stdio: ['ignore', 'pipe', 'pipe'],
@@ -99,7 +178,7 @@ function renderMarkdown(results, meta) {
     const lines = [];
     lines.push(`## Pull pipeline performance — \`${SITE}\``);
     lines.push('');
-    lines.push(`Site: \`${SITE}\` · ${meta.fileCount} files · PHP \`${meta.phpVersion}\``);
+    lines.push(`Site: \`${SITE}\` · ${meta.fileCount} files · ${meta.seedPosts.toLocaleString('en-US')} posts · ${meta.seedPostmeta.toLocaleString('en-US')} postmeta · PHP \`${meta.phpVersion}\``);
     lines.push('');
     lines.push('| Stage | Wall time | Resume attempts | Status |');
     lines.push('|---|---:|---:|---|');
@@ -125,6 +204,7 @@ async function main() {
         },
     });
 
+    await seedSourceDb();
     await provisionDatabase();
 
     const stateDir = join(tmpdir(), `bench-pull-${Date.now()}`);
@@ -166,7 +246,14 @@ async function main() {
     }
 
     const phpVersion = execFileSync(PHP_BINARY, ['-r', 'echo PHP_VERSION;'], { encoding: 'utf-8' }).trim();
-    const meta = { site: SITE, fileCount: '2,000+', phpVersion, importer: IMPORTER_PATH };
+    const meta = {
+        site: SITE,
+        fileCount: '2,000+',
+        seedPosts: SEED_POSTS,
+        seedPostmeta: SEED_POSTMETA,
+        phpVersion,
+        importer: IMPORTER_PATH,
+    };
     const md = renderMarkdown(results, meta);
     console.log('\n' + md);
 

--- a/tests/e2e/benchmark/bench-pull.mjs
+++ b/tests/e2e/benchmark/bench-pull.mjs
@@ -58,6 +58,9 @@ async function seedSourceDb() {
 
         console.log(`Seeding source DB: ${SEED_POSTS} posts, ${SEED_POSTMETA} postmeta...`);
         // Speed up bulk inserts: skip per-row durability, defer index updates.
+        // Drop STRICT mode so TEXT columns without defaults (to_ping,
+        // pinged, post_content_filtered, etc.) accept implicit ''.
+        await conn.query("SET SESSION sql_mode='';");
         await conn.query('SET autocommit=0; SET unique_checks=0; SET foreign_key_checks=0;');
         await conn.query('ALTER TABLE wp_posts DISABLE KEYS; ALTER TABLE wp_postmeta DISABLE KEYS;');
 

--- a/tests/e2e/benchmark/bench-pull.mjs
+++ b/tests/e2e/benchmark/bench-pull.mjs
@@ -190,6 +190,25 @@ function renderMarkdown(results, meta) {
     }
     lines.push(`| **Total** | **${fmtMs(total)}** | | |`);
     lines.push('');
+    const apply = results.find((r) => r.stage === 'db-apply' && r.profile);
+    if (apply) {
+        const p = apply.profile;
+        const fmtUs = (us) => fmtMs(us / 1000);
+        lines.push('### `db-apply` breakdown');
+        lines.push('');
+        lines.push('| Bucket | Time | Calls |');
+        lines.push('|---|---:|---:|');
+        lines.push(`| read I/O | ${fmtUs(p.read_io_us)} | — |`);
+        lines.push(`| query stream parse | ${fmtUs(p.query_stream_us)} | — |`);
+        lines.push(`| URL rewrite | ${fmtUs(p.rewrite_us)} | ${p.rewrite_calls} |`);
+        lines.push(`| PDO exec | ${fmtUs(p.exec_us)} | ${p.exec_calls} |`);
+        lines.push('');
+        const kinds = Object.entries(p.stmt_kinds || {}).sort((a, b) => b[1] - a[1]);
+        if (kinds.length) {
+            lines.push('Statement kinds: ' + kinds.map(([k, v]) => `\`${k}\`=${v}`).join(', '));
+            lines.push('');
+        }
+    }
     return lines.join('\n');
 }
 
@@ -240,8 +259,24 @@ async function main() {
     for (const { name, extra, includeUrl } of stages) {
         console.log(`-> ${name}`);
         const r = runStage(name, stateDir, extra, { includeUrl });
+        // Pick up the per-stage profile JSON written by the importer (currently
+        // db-apply only). Surfaces the inner breakdown — read I/O, query
+        // parse, URL rewrite, PDO exec — so the bench can show *where* the
+        // wall-clock goes, not just how long it took overall.
+        const profilePath = join(stateDir, '.import-apply-profile.json');
+        if (name === 'db-apply' && existsSync(profilePath)) {
+            try {
+                r.profile = JSON.parse(readFileSync(profilePath, 'utf-8'));
+            } catch { /* best effort */ }
+        }
         results.push(r);
         console.log(`   ${r.ok ? 'ok' : 'FAIL'} in ${fmtMs(r.elapsedMs)} (attempts=${r.attempts})`);
+        if (r.profile) {
+            const p = r.profile;
+            const usToS = (us) => (us / 1e6).toFixed(2) + 's';
+            console.log(`   db-apply breakdown: read=${usToS(p.read_io_us)} parse=${usToS(p.query_stream_us)} rewrite=${usToS(p.rewrite_us)} exec=${usToS(p.exec_us)} (${p.exec_calls} statements)`);
+            console.log(`   stmt kinds: ${Object.entries(p.stmt_kinds).map(([k, v]) => `${k}=${v}`).join(' ')}`);
+        }
         if (!r.ok) {
             console.error(`   stderr (tail):\n${r.stderr}`);
             console.error(`   stdout (tail):\n${r.stdout}`);

--- a/tests/e2e/benchmark/render-diff.mjs
+++ b/tests/e2e/benchmark/render-diff.mjs
@@ -38,7 +38,12 @@ const trunk = existsSync(trunkPath) ? JSON.parse(readFileSync(trunkPath, 'utf-8'
 const lines = [];
 lines.push(`## Pull pipeline performance — \`${pr.meta.site}\``);
 lines.push('');
-lines.push(`Site: \`${pr.meta.site}\` · ${pr.meta.fileCount} files · PHP \`${pr.meta.phpVersion}\``);
+{
+    const seedSuffix = (pr.meta.seedPosts && pr.meta.seedPostmeta)
+        ? ` · ${Number(pr.meta.seedPosts).toLocaleString('en-US')} posts · ${Number(pr.meta.seedPostmeta).toLocaleString('en-US')} postmeta`
+        : '';
+    lines.push(`Site: \`${pr.meta.site}\` · ${pr.meta.fileCount} files${seedSuffix} · PHP \`${pr.meta.phpVersion}\``);
+}
 lines.push('');
 
 if (trunk) {


### PR DESCRIPTION
Per-stage wall time alone hides where db-apply spends its time. This adds microtime timers around the four hot sections of the apply loop — read I/O, query stream parse, URL rewrite, PDO exec — and inside the rewriter breaks down the column-map walk, the Base64ValueScanner construction, the URL rewriter call, and the result-string rebuild. Inside Base64ValueScanner, the WP_MySQL_Lexer walk is separated from base64_decode itself.

The profile JSON is written best-effort to `.import-apply-profile.json` in the state directory; the bench harness now surfaces it as an inner breakdown table next to the per-stage wall-time table. A new doc in `markdown/PERFORMANCE-DB-STAGES.md` walks the measured pie chart and ranks the optimization candidates by share of wall.

## Headline finding

At the bench's default scale (1.04M rows, 224MB db.sql, 159s wall):
- URL rewriter: **63%** of wall (most of it is the WP_MySQL_Lexer walking the same statement twice — once in the value scanner, once in the column-map walk)
- Query stream parser: 22%
- PDO exec: 15%
- base64_decode itself: under 2%

This PR is the foundation. The follow-up PRs in this stack act on what the profile says.

## Test plan

- [x] `php -l` clean across modified files
- [x] PHPUnit `UrlRewriting` and `NaiveQueryStreamTest` suites green
- [x] Bench at small / medium / large scales runs to completion and produces `.import-apply-profile.json`
- [ ] CI green