### PR TITLE
db-apply: lex each SQL statement only once during URL rewriting

### DIFF
--- a/packages/reprint-importer/src/lib/url-rewrite/class-base64-value-scanner.php
+++ b/packages/reprint-importer/src/lib/url-rewrite/class-base64-value-scanner.php
@@ -38,10 +38,23 @@ class Base64ValueScanner
 
     private int $cursor = -1;
 
-    public function __construct(string $sql)
+    /**
+     * @param string $sql The SQL statement.
+     * @param WP_MySQL_Token[]|null $tokens Optional pre-lexed token list. When
+     *   provided, the scanner walks these tokens instead of running its own
+     *   WP_MySQL_Lexer pass. Callers that already lex the statement for
+     *   another reason (column-map extraction, etc.) can hand the same token
+     *   stream in to avoid a redundant tokenization. When null, behavior is
+     *   unchanged: the scanner lexes internally.
+     */
+    public function __construct(string $sql, ?array $tokens = null)
     {
         $this->sql = $sql;
-        $this->scan();
+        if ($tokens === null) {
+            $this->scan();
+        } else {
+            $this->scan_tokens($tokens);
+        }
     }
 
     /**
@@ -162,6 +175,73 @@ class Base64ValueScanner
             }
 
             // Shift the two-token window
+            $prev[0] = $prev[1];
+            $prev[1] = $token;
+        }
+    }
+
+    /**
+     * Walk a pre-lexed token list to find FROM_BASE64('…') expressions.
+     *
+     * Equivalent to scan() but reuses tokens already produced by another
+     * pass (typically SqlStatementRewriter, which lexes for the column
+     * map). Avoids re-running WP_MySQL_Lexer on the same statement.
+     *
+     * The buffered token array from WP_MySQL_Lexer::remaining_tokens()
+     * has already been stripped of whitespace and comments, so the
+     * CONVERT + ( + FROM_BASE64 pattern still appears as three
+     * consecutive tokens.
+     *
+     * @param WP_MySQL_Token[] $tokens
+     */
+    private function scan_tokens(array $tokens): void
+    {
+        $token_count = count($tokens);
+        $prev = [null, null];
+
+        for ($i = 0; $i < $token_count; $i++) {
+            $token = $tokens[$i];
+
+            if (
+                $token->id === WP_MySQL_Lexer::IDENTIFIER
+                && strtoupper($token->get_value()) === 'FROM_BASE64'
+            ) {
+                $expr_start = $token->start;
+
+                if (
+                    $prev[1] !== null
+                    && $prev[1]->id === WP_MySQL_Lexer::OPEN_PAR_SYMBOL
+                    && $prev[0] !== null
+                    && $prev[0]->id === WP_MySQL_Lexer::CONVERT_SYMBOL
+                ) {
+                    $expr_start = $prev[0]->start;
+                }
+
+                // Walk forward to find the quoted base64 payload, mirroring
+                // scan(): step past the opening parenthesis, accept either
+                // SINGLE_ or DOUBLE_QUOTED_TEXT, abort on anything else.
+                for ($j = $i + 1; $j < $token_count; $j++) {
+                    $inner = $tokens[$j];
+                    if (
+                        $inner->id === WP_MySQL_Lexer::SINGLE_QUOTED_TEXT
+                        || $inner->id === WP_MySQL_Lexer::DOUBLE_QUOTED_TEXT
+                    ) {
+                        $decoded = base64_decode($inner->get_value(), true);
+                        $this->entries[] = [
+                            'expr_start' => $expr_start,
+                            'quote_start' => $inner->start,
+                            'quote_length' => $inner->length,
+                            'value' => $decoded !== false ? $decoded : '',
+                            'new_value' => null,
+                        ];
+                        break;
+                    }
+                    if ($inner->id !== WP_MySQL_Lexer::OPEN_PAR_SYMBOL) {
+                        break;
+                    }
+                }
+            }
+
             $prev[0] = $prev[1];
             $prev[1] = $token;
         }

--- a/packages/reprint-importer/src/lib/url-rewrite/class-sql-statement-rewriter.php
+++ b/packages/reprint-importer/src/lib/url-rewrite/class-sql-statement-rewriter.php
@@ -97,13 +97,20 @@ class SqlStatementRewriter
             return $sql;
         }
 
+        // Lex the statement once. Both the column-map walker and
+        // Base64ValueScanner used to lex the SQL independently; the
+        // WP_MySQL_Lexer pass dominated the rewriter's CPU time on
+        // bench-shaped dumps. Sharing a single token array between the
+        // two consumers cuts that to a single pass.
+        $tokens = self::significant_tokens($sql);
+
         // Recover the table name and a byte-offset→column map from the
         // INSERT/UPDATE shape so we can hand each FROM_BASE64() value the
         // right content-type hint downstream.
-        $value_to_column_map = $this->map_values_to_columns($sql);
+        $value_to_column_map = $this->map_values_to_columns_from_tokens($tokens);
 
         // Iterate over all FROM_BASE64() values using the cursor-based scanner
-        $scanner = new Base64ValueScanner($sql);
+        $scanner = new Base64ValueScanner($sql, $tokens);
         while ($scanner->next_value()) {
             $value = $scanner->get_value();
 
@@ -179,7 +186,19 @@ class SqlStatementRewriter
      */
     private function map_values_to_columns(string $sql): ?array
     {
-        $tokens = self::significant_tokens($sql);
+        return $this->map_values_to_columns_from_tokens(self::significant_tokens($sql));
+    }
+
+    /**
+     * Same contract as map_values_to_columns(), but consumes a pre-lexed
+     * token array. Lets callers that already lexed the statement avoid a
+     * second WP_MySQL_Lexer pass.
+     *
+     * @param WP_MySQL_Token[] $tokens
+     * @return array{table: string, column_map: list<array{int, int, string}>}|null
+     */
+    private function map_values_to_columns_from_tokens(array $tokens): ?array
+    {
         $token_count = count($tokens);
         if ($token_count < 4) {
             return null;


### PR DESCRIPTION
Rebased onto trunk (no longer stacked on the profiler PR). The change is now self-contained: a behaviour-preserving refactor of the URL rewriter that performs one `WP_MySQL_Lexer` pass per statement instead of two.

## What

`Base64ValueScanner` and `SqlStatementRewriter::map_values_to_columns()` each lexed the same statement independently. Both produce the same token stream — one looks for `FROM_BASE64()` literals, the other walks the column list — so they can share a single token array.

This PR:
- Lexes the statement once in `SqlStatementRewriter::rewrite()` via the existing `significant_tokens()` helper.
- Adds an optional `?array $tokens` parameter to `Base64ValueScanner::__construct()` — when provided, the scanner walks those tokens via a new `scan_tokens()` private method instead of running its own lexer.
- Refactors `map_values_to_columns()` to delegate to a new `map_values_to_columns_from_tokens()` that accepts the same pre-lexed token array.

Standalone callers of `Base64ValueScanner` (tests, anyone who only has the SQL string) keep their existing behaviour: pass just `$sql`, the scanner lexes internally.

## Test plan

- [x] `php -l` clean across both modified files
- [x] PHPUnit `UrlRewriting` suite green (170 tests, 7 pre-existing skipped)
- [ ] CI green