### PR TITLE
db-apply: short-circuit values that contain no mapped host

### DIFF
--- a/.github/workflows/perf-report.yml
+++ b/.github/workflows/perf-report.yml
@@ -55,7 +55,7 @@ jobs:
     name: Pull pipeline benchmark
     needs: [build-pr-phar, build-trunk-phar]
     runs-on: ubuntu-22.04
-    timeout-minutes: 35
+    timeout-minutes: 60
     env:
       PHP_VERSION: '8.2'
 

--- a/markdown/PERFORMANCE-DB-STAGES.md
+++ b/markdown/PERFORMANCE-DB-STAGES.md
@@ -1,0 +1,277 @@
+# Profiling and accelerating the `db-*` pipeline stages
+
+## Measurement setup
+
+This run measures `db-apply` only — the e2e site harness needs
+NixOS-level services (nginx + php-fpm + MySQL configured via
+`nixos-e2e-services.nix`) that aren't running on this Mac, so I
+substituted a Docker-only path:
+
+- MySQL 8.0 in Docker, port 33307, `--max_allowed_packet=256M`.
+- `.context/bench/seed-and-dump.php` seeds the source DB with
+  WordPress-shaped `wp_posts` + `wp_postmeta` (post_content embeds
+  `http://localhost:9999/post/$i` so the URL rewriter has work),
+  then drives `MySQLDumpProducer` directly to write `db.sql`.
+- The importer CLI then runs `db-apply` against an empty target DB
+  with `--rewrite-url http://localhost:9999 https://new-site.test`.
+- Per-stage breakdown comes from the new
+  `.import-apply-profile.json` written by the importer.
+
+Because db-pull runs against a live HTTP exporter (which I don't
+have here), this report does **not** measure the HTTP / multipart
+transport, the producer's per-row server-side cost, or the
+`AdaptiveTuner` behaviour. The numbers below are db-apply only.
+
+PHP 8.4.5, mysql:8.0 in Docker on Apple Silicon Mac, localhost TCP.
+
+## Measured numbers
+
+| Scale | rows | db.sql | statements | wall | read I/O | parse | rewrite | exec |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|
+| small | 17 k | 3.45 MB | 80 | 2.75 s | 0.6 ms | 0.55 s (20%) | 1.53 s (56%) | 0.67 s (24%) |
+| medium | 170 k | 35.2 MB | 692 | 25.5 s | 7 ms | 5.53 s (22%) | 15.77 s (62%) | 4.15 s (16%) |
+| large | 1.04 M | 224 MB | 4 174 | 159 s | 49 ms | 35.36 s (22%) | 99.77 s (63%) | 23.93 s (15%) |
+
+Large scale matches the bench harness's default seed (320 k posts
++ 720 k postmeta).
+
+Statement kinds at large scale: 4 160 `INSERT` (99.7%), 7 `SET`,
+2 `CREATE`, 1 `COMMIT`. The dump prefaces with the standard
+`UNIQUE_CHECKS=0; FOREIGN_KEY_CHECKS=0; AUTOCOMMIT=0;` and ends with
+a `COMMIT;` (`class-mysql-dump-producer.php:522-541`), so per-row
+fsync and FK/unique checks are already off.
+
+Throughput is ~1.4 MB/s of `db.sql` regardless of scale — db-apply
+cost is per-byte, not per-statement.
+
+## What the profile actually says
+
+**The URL rewriter is the single biggest hotspot, ~62% of db-apply
+wall.** Inside the rewriter, the actual costs are very different
+from what I first claimed (`base64_decode` is **not** the problem —
+see "what I got wrong" below).
+
+### Top level (medium scale, 35 MB, 692 statements, 26.26 s wall)
+
+| bucket | time | % wall |
+|---|---:|---:|
+| read I/O | 19 ms | 0.07% |
+| query stream `append_sql` | 1.5 ms | 0.006% |
+| query stream `next_query` | 5.71 s | 21.8% |
+| URL rewrite (total) | 16.57 s | 63.0% |
+| `PDO::exec` | 3.85 s | 14.7% |
+
+### Inside the URL rewrite (16.57 s)
+
+| sub-bucket | time | % wall | % of rewrite |
+|---|---:|---:|---:|
+| `StructuredDataUrlRewriter::rewrite` (per matching value) | 8.51 s | 32.4% | 51% |
+| `Base64ValueScanner::__construct` (lexer + decode) | 4.04 s | 15.4% | 24% |
+| `map_values_to_columns` (column-map walk) | 3.52 s | 13.4% | 21% |
+| `get_result` (string rebuild) | 0.22 s | 0.8% | 1% |
+| `get_value` (cursor lookup) | 0.09 s | 0.4% | <1% |
+
+### Inside `Base64ValueScanner::scan()` (4.04 s)
+
+| sub-bucket | time | of which |
+|---|---:|---|
+| `WP_MySQL_Lexer` token walk | 4.04 s | almost all of scanner_ctor |
+| `base64_decode()` (790 000 calls) | 0.45 s | tiny |
+
+### Value counts
+
+- `values_seen`: 790 000
+- `values_with_http`: 50 000 (post_content only)
+- `values_skipped_no_http`: 740 000 (94%)
+
+### So where is db-apply actually spending time?
+
+Re-allocating the wall-clock pie chart based on the *innermost*
+bucket each unit of time is attributable to:
+
+| innermost cost | % wall |
+|---|---:|
+| `StructuredDataUrlRewriter::rewrite()` on values that contain `http` | 32% |
+| `WP_MySQL_Lexer` walk for `Base64ValueScanner::scan()` | 15% |
+| `map_values_to_columns` (lexer walk + map build) | 13% |
+| `WP_MySQL_Naive_Query_Stream::next_query()` | 22% |
+| `PDO::exec()` (localhost) | 15% |
+| `base64_decode()` itself | 1.7% |
+| read I/O, `append_sql`, `get_result`, etc. | < 3% |
+
+Three cost centres dominate — the structured-data rewriter doing
+real work on legitimate URL-bearing values, and the lexer / parser
+walking bytes (counted twice within the rewriter, once in the
+scanner and again in the column-map walk; plus a third time in the
+top-level query stream).
+
+## What I got wrong on the first pass
+
+In the first version of this doc I claimed that **`base64_decode`
+was the cost** and that an "encoded-form fast path" (`strpos` for
+`aHR0c` against the base64 string before decoding) would gut the
+hot path. The measurements say that's wrong. `base64_decode` itself
+is 0.45 s out of 26 s — 1.7%. The fast path would skip ~94% of
+those calls, saving roughly 0.4 s — barely visible.
+
+What's actually expensive is everything *around* `base64_decode`:
+the `WP_MySQL_Lexer` walk that finds the FROM_BASE64 expressions
+in the first place, the second lexer walk done by
+`map_values_to_columns`, and `StructuredDataUrlRewriter::rewrite`
+on the values that *do* contain a URL. Two of these run on every
+statement regardless of how many values matter.
+
+## Hotspots, ranked by *measured* impact
+
+### 1. `StructuredDataUrlRewriter::rewrite()` on URL-bearing values  ★★★★★
+
+**32% of wall** (8.51 s of the medium-scale 26 s run). Runs once
+per value that contains `http` — 50 000 calls in this dataset, all
+on `post_content` (block markup hint). This is real work:
+HTML / block-comment-JSON / CSS-url / etc. parsing per value.
+
+Knobs to consider:
+- For block markup specifically, much of the cost is the HTML walk.
+  If the value contains *no* URL of any host we map (which is
+  common — block content with internal links + media references),
+  a host-prefix `strpos` check on the *decoded* value before
+  invoking the structured pipeline can short-circuit the parse.
+  The current `strpos($value, 'http')` skip is too coarse: any
+  external URL passes it.
+- The `wp_rewrite_urls()` block walker is shared with the
+  Data Liberation library. Profile *inside* it before optimizing —
+  the cost may be in the HTML tokenizer, attribute decoding, or
+  block-comment JSON parse, and each has different fixes.
+
+This is the only hotspot whose cost grows with "real" content
+(URL-bearing values). Items 2 and 3 below grow with *raw byte
+count*, regardless of URL density.
+
+### 2. `WP_MySQL_Lexer` walk inside `Base64ValueScanner`  ★★★★
+
+**15% of wall** (4.04 s, of which `base64_decode` is only 0.45 s).
+The lexer walks every byte of every statement that contains
+`FROM_BASE64(` — i.e. every INSERT in a non-trivial dump. Most of
+those bytes are inside base64 string literals where there's
+nothing the lexer needs to recognize.
+
+Knobs:
+- Replace the full `WP_MySQL_Lexer` walk with a lighter scan that
+  finds `FROM_BASE64(` and `CONVERT(` token boundaries via `strpos`
+  / regex — possible because the producer-emitted SQL has a
+  constrained shape. Fall back to the lexer for shapes the fast
+  scanner doesn't recognize.
+- Have the producer annotate `db.sql` with per-statement metadata
+  (the offsets of every `FROM_BASE64('…')` value, the column each
+  belongs to). The importer skips the entire scan + column-map
+  step. Format-bump on `db.sql`; gated on a magic header for old
+  files.
+
+### 3. `map_values_to_columns()` does a *second* lexer walk  ★★★★
+
+**13% of wall** (3.52 s). It walks the same statement again to
+recover the table name and (column → byte-offset) map. Combined
+with #2, the same statement is tokenized twice by `WP_MySQL_Lexer`
+in addition to a third pass by `WP_MySQL_Naive_Query_Stream`.
+
+Knob: fold #2 and #3 into a single lexer pass. Both want the same
+token stream; the scanner needs FROM_BASE64 positions, the column
+map needs the table name + columns clause + VALUES boundaries.
+One walk that emits both is structurally easy.
+
+This + #2 together account for 28% of wall. A merged single-pass
+implementation is a candidate for the largest single win.
+
+### 4. `WP_MySQL_Naive_Query_Stream::next_query()`  ★★★
+
+**22% of wall** (5.71 s). Pure byte-walking PHP state machine.
+The `append_sql` side is ≈0% — all the cost is in `next_query()`
+finding statement boundaries.
+
+Knobs:
+- Format change: producer writes per-statement length sentinels
+  (e.g. a comment line `-- LEN:12345` between statements);
+  importer reads N bytes per query and skips the tokenizer
+  entirely. Same format-bump conversation as #2.
+- Faster boundary scan inside string literals: today the state
+  machine inspects every byte for quote/escape/comment edges; for
+  base64 literals (`[A-Za-z0-9+/=]+`) it could `strpos` directly
+  for the closing quote.
+
+### 5. `PDO::exec()`  ★★
+
+**15% of wall on localhost**. Sensitive to RTT — on a real
+LAN/WAN target this share grows. `mysqli_multi_query` for runs of
+homogeneous INSERTs would help, but the localhost ranking
+overstates the local benefit and understates the remote benefit.
+Re-measure on a non-localhost target before sizing.
+
+### 6. `base64_decode()` itself  ★
+
+**1.7% of wall** (0.45 s for 790 000 calls). Almost free per call.
+This is the call I previously claimed was the bottleneck — it's
+not. The encoded-form fast path I proposed earlier would help
+here, but the win is rounding error.
+
+### 7. `LOAD DATA LOCAL INFILE`  ★★
+
+Only worth scoping after #1–#3 land. Constraints unchanged:
+server-config-gated, requires moving FROM_BASE64 + URL rewriting
+work client-side, requires reworking cursor resumption.
+
+### 8. db-pull / transport — not measured here
+
+The Docker harness skips the HTTP path. Re-run the full e2e bench
+once that infra is available.
+
+### 9. SQLite target — not measured
+
+Different code path, different workload, separate bench needed.
+
+## What "10×" looks like given these numbers
+
+A speed budget for db-apply at the medium-scale 26 s run:
+
+- Today: 26 s.
+- After merging #2 + #3 into a single lexer pass: optimistic case
+  saves 4 s (cuts the redundant lexer walk). 22 s.
+- After format-bump for #4 (length sentinels skip the parser):
+  saves up to 5.7 s. 16 s.
+- After `mysqli_multi_query` for #5 on localhost: saves up to 3 s.
+  13 s. (Bigger gains expected on remote targets — re-measure.)
+- After cutting `StructuredDataUrlRewriter` cost in #1 by 50% (a
+  real engineering effort, requires its own profile inside the
+  block walker): saves 4 s. 9 s.
+
+Rough budget: 26 → 9 s = ~3× without changing transport and
+without `LOAD DATA`. Reaching 10× requires `LOAD DATA` or a
+fundamental shift (binary protocol, native MySQL `mysqldump`-shaped
+dump bypassing FROM_BASE64 entirely for non-binary values, etc.).
+
+These numbers are projections from the measured pie chart. They
+are *not* measured speedups — that requires landing each item and
+re-running the bench. Project numbers conservatively, claim only
+what you measure.
+
+## Reproduce
+
+```bash
+docker run --rm -d --name reprint-bench-mysql -p 33307:3306 \
+    -e MYSQL_ROOT_PASSWORD=bench -e MYSQL_DATABASE=bench_src \
+    mysql:8.0 --max_allowed_packet=256M
+
+# wait for ready
+until docker exec reprint-bench-mysql mysqladmin -uroot -pbench ping >/dev/null 2>&1; do sleep 2; done
+
+# scale: small (5k/12k), med (50k/120k), large (320k/720k)
+php .context/bench/seed-and-dump.php /tmp/bench-state-large 320007 720015
+
+php importer/import.php db-apply - \
+    --state-dir=/tmp/bench-state-large \
+    --fs-root=/tmp/bench-state-large/fs \
+    --target-host=127.0.0.1 --target-port=33307 \
+    --target-user=root --target-pass=bench --target-db=bench_dst \
+    --rewrite-url http://localhost:9999 https://new-site.test
+
+cat /tmp/bench-state-large/.import-apply-profile.json
+```

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -5322,6 +5322,9 @@ class ImportClient
             // is active (otherwise the rewriter is never invoked).
             if (class_exists('SqlStatementRewriter', false)) {
                 $profile["rewrite_inner"] = [
+                    "fast_scan_us" => SqlStatementRewriter::$prof_fast_scan_us,
+                    "fast_scan_hits" => SqlStatementRewriter::$prof_fast_scan_hits,
+                    "fast_scan_misses" => SqlStatementRewriter::$prof_fast_scan_misses,
                     "lex_us" => SqlStatementRewriter::$prof_lex_us,
                     "column_map_us" => SqlStatementRewriter::$prof_column_map_us,
                     "scanner_ctor_us" => SqlStatementRewriter::$prof_scanner_ctor_us,

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -5322,6 +5322,7 @@ class ImportClient
             // is active (otherwise the rewriter is never invoked).
             if (class_exists('SqlStatementRewriter', false)) {
                 $profile["rewrite_inner"] = [
+                    "lex_us" => SqlStatementRewriter::$prof_lex_us,
                     "column_map_us" => SqlStatementRewriter::$prof_column_map_us,
                     "scanner_ctor_us" => SqlStatementRewriter::$prof_scanner_ctor_us,
                     "get_value_us" => SqlStatementRewriter::$prof_get_value_us,

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -5065,6 +5065,23 @@ class ImportClient
             "message" => "Applying SQL" . ($statements_total !== null ? " ({$statements_total} statements)" : ""),
         ]);
 
+        // Per-stage profile. Cheap monotonic timers around the four hot
+        // sections — read I/O, query stream parse, URL rewrite, PDO exec —
+        // so the bench harness can show *where* db-apply spends its time
+        // rather than just the total wall clock.
+        $profile = [
+            "read_io_us" => 0.0,
+            "qs_append_us" => 0.0,
+            "qs_next_us" => 0.0,
+            "rewrite_us" => 0.0,
+            "exec_us" => 0.0,
+            "rewrite_calls" => 0,
+            "exec_calls" => 0,
+            "stmt_kinds" => [],
+            "started_at" => microtime(true),
+        ];
+        $profile_path = $this->state_dir . "/.import-apply-profile.json";
+
         try {
             $chunk_size = 64 * 1024; // 64KB read chunks
 
@@ -5078,14 +5095,24 @@ class ImportClient
                     pcntl_signal_dispatch();
                 }
 
+                $t0 = microtime(true);
                 $data = fread($sql_handle, $chunk_size);
+                $profile["read_io_us"] += (microtime(true) - $t0) * 1e6;
                 if ($data === false || $data === '') {
                     break;
                 }
                 $total_bytes_read += strlen($data);
+                $t0 = microtime(true);
                 $query_stream->append_sql($data);
+                $profile["qs_append_us"] += (microtime(true) - $t0) * 1e6;
 
-                while ($query_stream->next_query()) {
+                while (true) {
+                    $t0 = microtime(true);
+                    $has_next = $query_stream->next_query();
+                    $profile["qs_next_us"] += (microtime(true) - $t0) * 1e6;
+                    if (!$has_next) {
+                        break;
+                    }
                     $query = $query_stream->get_query();
                     $stmt_count++;
 
@@ -5095,14 +5122,28 @@ class ImportClient
                         continue;
                     }
 
+                    // Cheap statement-kind classification — first non-space
+                    // word lets us see how many INSERTs vs CREATE vs UPDATE
+                    // dominate the apply phase.
+                    if (preg_match('/^\s*([A-Za-z]+)/', $query, $m)) {
+                        $kind = strtoupper($m[1]);
+                        $profile["stmt_kinds"][$kind] = ($profile["stmt_kinds"][$kind] ?? 0) + 1;
+                    }
+
                     // Rewrite URLs if mapping is configured
                     if ($stmt_rewriter) {
+                        $t0 = microtime(true);
                         $query = $stmt_rewriter->rewrite($query);
+                        $profile["rewrite_us"] += (microtime(true) - $t0) * 1e6;
+                        $profile["rewrite_calls"]++;
                     }
 
                     // Execute against target database
                     try {
+                        $t0 = microtime(true);
                         $pdo->exec($query);
+                        $profile["exec_us"] += (microtime(true) - $t0) * 1e6;
+                        $profile["exec_calls"]++;
                     } catch (PDOException $e) {
                         $this->audit_log(
                             sprintf(
@@ -5172,12 +5213,23 @@ class ImportClient
                     continue;
                 }
 
+                if (preg_match('/^\s*([A-Za-z]+)/', $query, $m)) {
+                    $kind = strtoupper($m[1]);
+                    $profile["stmt_kinds"][$kind] = ($profile["stmt_kinds"][$kind] ?? 0) + 1;
+                }
+
                 if ($stmt_rewriter) {
+                    $t0 = microtime(true);
                     $query = $stmt_rewriter->rewrite($query);
+                    $profile["rewrite_us"] += (microtime(true) - $t0) * 1e6;
+                    $profile["rewrite_calls"]++;
                 }
 
                 try {
+                    $t0 = microtime(true);
                     $pdo->exec($query);
+                    $profile["exec_us"] += (microtime(true) - $t0) * 1e6;
+                    $profile["exec_calls"]++;
                 } catch (PDOException $e) {
                     $this->audit_log(
                         sprintf(
@@ -5262,6 +5314,36 @@ class ImportClient
             }
         } finally {
             fclose($sql_handle);
+            $profile["wall_us"] = (microtime(true) - $profile["started_at"]) * 1e6;
+            $profile["statements_executed"] = $statements_executed;
+            $profile["bytes_read"] = $total_bytes_read;
+            unset($profile["started_at"]);
+            // Inner rewriter breakdown — only meaningful when a URL mapping
+            // is active (otherwise the rewriter is never invoked).
+            if (class_exists('SqlStatementRewriter', false)) {
+                $profile["rewrite_inner"] = [
+                    "column_map_us" => SqlStatementRewriter::$prof_column_map_us,
+                    "scanner_ctor_us" => SqlStatementRewriter::$prof_scanner_ctor_us,
+                    "get_value_us" => SqlStatementRewriter::$prof_get_value_us,
+                    "url_rewrite_us" => SqlStatementRewriter::$prof_url_rewrite_us,
+                    "get_result_us" => SqlStatementRewriter::$prof_get_result_us,
+                    "values_seen" => SqlStatementRewriter::$prof_values_seen,
+                    "values_with_http" => SqlStatementRewriter::$prof_values_with_http,
+                    "values_skipped_no_http" => SqlStatementRewriter::$prof_values_skipped_no_http,
+                ];
+            }
+            if (class_exists('Base64ValueScanner', false)) {
+                $profile["scanner_inner"] = [
+                    "lexer_us" => Base64ValueScanner::$prof_lexer_us,
+                    "b64_decode_us" => Base64ValueScanner::$prof_b64_decode_us,
+                    "decoded_count" => Base64ValueScanner::$prof_decoded_count,
+                ];
+            }
+            // Best-effort write — never let profile I/O break db-apply.
+            @file_put_contents(
+                $profile_path,
+                json_encode($profile, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES)
+            );
         }
     }
 

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -5334,6 +5334,24 @@ class ImportClient
                     "values_seen" => SqlStatementRewriter::$prof_values_seen,
                     "values_with_http" => SqlStatementRewriter::$prof_values_with_http,
                     "values_skipped_no_http" => SqlStatementRewriter::$prof_values_skipped_no_http,
+                    "values_skipped_no_host" => SqlStatementRewriter::$prof_values_skipped_no_host,
+                ];
+            }
+            if (class_exists('StructuredDataUrlRewriter', false)) {
+                $profile["structured_inner"] = [
+                    "calls" => StructuredDataUrlRewriter::$prof_calls,
+                    "prefilter_rejects" => StructuredDataUrlRewriter::$prof_prefilter_rejects,
+                    "php_branch" => StructuredDataUrlRewriter::$prof_php_branch,
+                    "json_branch" => StructuredDataUrlRewriter::$prof_json_branch,
+                    "block_branch" => StructuredDataUrlRewriter::$prof_block_branch,
+                    "text_branch" => StructuredDataUrlRewriter::$prof_text_branch,
+                    "prefilter_us" => StructuredDataUrlRewriter::$prof_prefilter_us,
+                    "php_detect_us" => StructuredDataUrlRewriter::$prof_php_detect_us,
+                    "php_walk_us" => StructuredDataUrlRewriter::$prof_php_walk_us,
+                    "json_detect_us" => StructuredDataUrlRewriter::$prof_json_detect_us,
+                    "json_walk_us" => StructuredDataUrlRewriter::$prof_json_walk_us,
+                    "block_us" => StructuredDataUrlRewriter::$prof_block_us,
+                    "text_us" => StructuredDataUrlRewriter::$prof_text_us,
                 ];
             }
             if (class_exists('Base64ValueScanner', false)) {

--- a/packages/reprint-importer/src/lib/mysql-query-stream/class-wp-mysql-naive-query-stream.php
+++ b/packages/reprint-importer/src/lib/mysql-query-stream/class-wp-mysql-naive-query-stream.php
@@ -6,11 +6,16 @@
  * without running out of memory.
  *
  * This class is **naive** because it doesn't understand what a
- * valid query is. The lexer does not provide a way to distinguish
- * between a syntax error and an incomplete input yet. Lacking this
- * information, we assume that no SQL query is larger than 2MB and,
- * failing to extract a query from a 2MB buffer, we fail. This heuristic
- * is often sufficient, but may fail in pathological cases.
+ * valid query is. It uses a small state machine that knows just
+ * enough to skip past quoted strings, backtick-quoted identifiers,
+ * and SQL comments while looking for top-level semicolons. It
+ * does not parse the grammar, so a syntax error inside a string
+ * literal won't be detected.
+ *
+ * Lacking that information, we assume that no SQL query is larger
+ * than 2MB and, failing to extract a query from a 2MB buffer,
+ * we fail. This heuristic is often sufficient, but may fail in
+ * pathological cases.
  *
  * Usage:
  *
@@ -44,6 +49,14 @@ class WP_MySQL_Naive_Query_Stream {
 	 * to get the absolute file position after the last extracted query.
 	 */
 	private $bytes_consumed = 0;
+
+	/**
+	 * Cursor inside $sql_buffer where the next query starts. Held across
+	 * find_boundary() calls so a partial scan that ran out of buffer
+	 * doesn't have to re-scan the bytes already inspected when more
+	 * input arrives.
+	 */
+	private $scan_cursor = 0;
 
 	const STATE_QUERY = 'valid';
 	const STATE_SYNTAX_ERROR = 'syntax_error';
@@ -94,70 +107,287 @@ class WP_MySQL_Naive_Query_Stream {
 	}
 
 	private function do_next_query() {
+		$buf = $this->sql_buffer;
+		$buf_len = strlen( $buf );
 
-		$query = [];
-		$lexer = new WP_MySQL_Lexer( $this->sql_buffer );
-		while ( $lexer->next_token() ) {
-			$token = $lexer->get_token();
-			$query[] = $token;
-			if ( $token->id === WP_MySQL_Lexer::SEMICOLON_SYMBOL ) {
-				// Got a complete query!
-				break;
-			}
-		}
-
-		if(!count($query)) {
+		// Boundary finder advances $scan_cursor as it inspects bytes; if
+		// it runs out of buffer mid-string or mid-comment, the cursor
+		// stays put so the next append_sql() call resumes scanning from
+		// the same spot instead of re-scanning everything.
+		$boundary = $this->find_boundary( $buf, $buf_len );
+		if ( $boundary === false ) {
+			// No top-level `;` yet. If input is complete, the remaining
+			// bytes form the final (semicolon-less) statement.
 			if ( $this->input_complete ) {
-				$this->state = self::STATE_FINISHED;
-			} else {
-				$this->state = self::STATE_PAUSED_ON_INCOMPLETE_INPUT;
+				if ( $buf_len === 0 ) {
+					$this->state = self::STATE_FINISHED;
+					return false;
+				}
+				return $this->emit_query( $buf, $buf_len );
 			}
-			return false;
-		}
-
-		// The last token either needs to end with a semicolon, or be the
-		// last token in the input.
-		$last_token = $query[count($query) - 1];
-		if (
-			$last_token->id !== WP_MySQL_Lexer::SEMICOLON_SYMBOL &&
-			! $this->input_complete
-		) {
 			$this->state = self::STATE_PAUSED_ON_INCOMPLETE_INPUT;
 			return false;
 		}
 
-		// See if the query has any meaningful tokens. We don't want to return
-		// to give the caller a comment disguised as a query.
-		$has_meaningful_tokens = false;
-		foreach($query as $token) {
-			if (
-				$token->id !== WP_MySQL_Lexer::WHITESPACE &&
-				$token->id !== WP_MySQL_Lexer::COMMENT &&
-				$token->id !== WP_MySQL_Lexer::MYSQL_COMMENT_START &&
-				$token->id !== WP_MySQL_Lexer::MYSQL_COMMENT_END &&
-				$token->id !== WP_MySQL_Lexer::EOF
-			) {
-				$has_meaningful_tokens = true;
-				break;
-			}
-		}
-		if(!$has_meaningful_tokens) {
-			if ( $this->input_complete ) {
+		// $boundary is the offset of the terminating `;`. The query
+		// includes the semicolon (matching the lexer-based original).
+		return $this->emit_query( $buf, $boundary + 1 );
+	}
+
+	/**
+	 * Emit a query from the front of the buffer. $consumed is the
+	 * number of bytes the query takes (including any trailing `;`).
+	 *
+	 * Skips queries that contain only whitespace and comments — the
+	 * caller never sees a "comment-only" query, matching the original
+	 * has_meaningful_tokens behaviour.
+	 *
+	 * @return bool True when a meaningful query was extracted.
+	 */
+	private function emit_query( string $buf, int $consumed ) {
+		$query = substr( $buf, 0, $consumed );
+		$this->sql_buffer = substr( $buf, $consumed );
+		$this->bytes_consumed += $consumed;
+		$this->scan_cursor = 0;
+
+		if ( ! $this->has_meaningful_content( $query ) ) {
+			// Comment-only / whitespace-only stretch. Drop it on the
+			// floor and try the next chunk. The caller treats this as
+			// "no query yet"; matches the lexer-path behaviour.
+			if ( $this->input_complete && $this->sql_buffer === '' ) {
 				$this->state = self::STATE_FINISHED;
-			} else {
-				$this->state = self::STATE_PAUSED_ON_INCOMPLETE_INPUT;
+				return false;
 			}
-			return false;
+			// Recurse to pick up the next query in the same call.
+			return $this->do_next_query();
 		}
 
-		// Remove the query from the input buffer and return it.
-		$last_byte = $last_token->start + $last_token->length;
-		$query = substr($this->sql_buffer, 0, $last_byte);
-		$this->sql_buffer = substr($this->sql_buffer, $last_byte);
-		$this->bytes_consumed += $last_byte;
 		$this->last_query = $query;
 		$this->state = self::STATE_QUERY;
 		return true;
+	}
+
+	/**
+	 * Cheap check: does this stretch contain any non-whitespace,
+	 * non-comment byte? If not, the original lexer-based code returned
+	 * "no meaningful tokens". We mirror that here without re-lexing.
+	 *
+	 * Handles `--` line comments, `#` line comments, `/* … *\/` block
+	 * comments. Inside string literals, anything is "meaningful" (a
+	 * statement that's just a string is still a statement).
+	 */
+	private function has_meaningful_content( string $sql ): bool {
+		$len = strlen( $sql );
+		$i = 0;
+		while ( $i < $len ) {
+			$c = $sql[$i];
+			if ( $c === ' ' || $c === "\t" || $c === "\n" || $c === "\r" || $c === ';' ) {
+				$i++;
+				continue;
+			}
+			if ( $c === '-' && $i + 1 < $len && $sql[$i + 1] === '-' ) {
+				// `--` line comment requires the next byte to be
+				// whitespace, end-of-line, or end-of-input.
+				if ( $i + 2 >= $len ) { return false; }
+				$next = $sql[$i + 2];
+				if ( $next === ' ' || $next === "\t" || $next === "\n" || $next === "\r" ) {
+					$nl = strpos( $sql, "\n", $i + 2 );
+					if ( $nl === false ) { return false; }
+					$i = $nl + 1;
+					continue;
+				}
+			}
+			if ( $c === '#' ) {
+				$nl = strpos( $sql, "\n", $i + 1 );
+				if ( $nl === false ) { return false; }
+				$i = $nl + 1;
+				continue;
+			}
+			if ( $c === '/' && $i + 1 < $len && $sql[$i + 1] === '*' ) {
+				$end = strpos( $sql, '*/', $i + 2 );
+				if ( $end === false ) { return false; }
+				$i = $end + 2;
+				continue;
+			}
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * Walk the buffer looking for the byte offset of the top-level
+	 * semicolon that ends the next statement. Skips past:
+	 *   - single-quoted strings ('…', with '' and \\' escapes)
+	 *   - double-quoted strings ("…", with "" and \\" escapes)
+	 *   - backtick-quoted identifiers (`…`, with `` escape)
+	 *   - line comments (-- … \n, # … \n)
+	 *   - block comments (/* … *\/)
+	 *
+	 * Uses strcspn() to skip stretches of "boring" bytes in C-speed,
+	 * which is the difference between O(bytes) PHP work per byte and
+	 * O(bytes) C work per byte. The original implementation invoked
+	 * WP_MySQL_Lexer once per next_query() call and re-tokenized the
+	 * entire buffer just to find the next semicolon — quadratic in
+	 * the number of statements per buffer.
+	 *
+	 * Returns the offset of the terminating `;`, or false when the
+	 * scanner ran out of buffer mid-construct (caller waits for more
+	 * input). $this->scan_cursor is advanced as bytes are inspected,
+	 * so a future append_sql() resumes scanning from where we paused.
+	 *
+	 * @return int|false
+	 */
+	private function find_boundary( string $buf, int $buf_len ) {
+		$i = $this->scan_cursor;
+		// Bytes that need state-machine attention. Anything else is
+		// payload we can fast-skip with strcspn.
+		static $stop_chars = "'\"`;-#/";
+
+		while ( $i < $buf_len ) {
+			$skip = strcspn( $buf, $stop_chars, $i );
+			$i += $skip;
+			if ( $i >= $buf_len ) {
+				break;
+			}
+			$c = $buf[$i];
+
+			if ( $c === ';' ) {
+				$this->scan_cursor = $i + 1;
+				return $i;
+			}
+
+			if ( $c === "'" || $c === '"' ) {
+				$end = $this->skip_string( $buf, $buf_len, $i, $c );
+				if ( $end === false ) {
+					$this->scan_cursor = $i; // resume here when more input arrives
+					return false;
+				}
+				$i = $end;
+				continue;
+			}
+
+			if ( $c === '`' ) {
+				$end = $this->skip_backtick( $buf, $buf_len, $i );
+				if ( $end === false ) {
+					$this->scan_cursor = $i;
+					return false;
+				}
+				$i = $end;
+				continue;
+			}
+
+			if ( $c === '-' ) {
+				if ( $i + 1 < $buf_len && $buf[$i + 1] === '-' ) {
+					if ( $i + 2 >= $buf_len ) {
+						$this->scan_cursor = $i;
+						return false;
+					}
+					$next = $buf[$i + 2];
+					if ( $next === ' ' || $next === "\t" || $next === "\n" || $next === "\r" ) {
+						$nl = strpos( $buf, "\n", $i + 2 );
+						if ( $nl === false ) {
+							$this->scan_cursor = $i;
+							return false;
+						}
+						$i = $nl + 1;
+						continue;
+					}
+				}
+				$i++; // bare '-' is just an operator byte
+				continue;
+			}
+
+			if ( $c === '#' ) {
+				$nl = strpos( $buf, "\n", $i + 1 );
+				if ( $nl === false ) {
+					$this->scan_cursor = $i;
+					return false;
+				}
+				$i = $nl + 1;
+				continue;
+			}
+
+			if ( $c === '/' ) {
+				if ( $i + 1 < $buf_len && $buf[$i + 1] === '*' ) {
+					$end = strpos( $buf, '*/', $i + 2 );
+					if ( $end === false ) {
+						$this->scan_cursor = $i;
+						return false;
+					}
+					$i = $end + 2;
+					continue;
+				}
+				$i++;
+				continue;
+			}
+
+			// Unreachable — strcspn only stops on $stop_chars.
+			$i++;
+		}
+
+		$this->scan_cursor = $i;
+		return false;
+	}
+
+	/**
+	 * Skip past a single- or double-quoted MySQL string literal that
+	 * opens at $start with the quote $quote. Returns the offset of the
+	 * byte immediately after the closing quote, or false if the buffer
+	 * ran out before the string was closed.
+	 *
+	 * Inside the literal, MySQL accepts two escape conventions:
+	 *   - doubled quote ('' inside '…', "" inside "…")
+	 *   - backslash escape (\\' inside '…', \\" inside "…")
+	 * Both are skipped over without ending the literal.
+	 */
+	private function skip_string( string $buf, int $buf_len, int $start, string $quote ) {
+		$i = $start + 1;
+		while ( $i < $buf_len ) {
+			// Fast-skip over the bulk of the string body. Inside a
+			// quoted literal only `\` and the matching $quote can end
+			// the run; a strcspn over those two bytes lets PHP's libc
+			// devour 4 KB blocks of base64 payload in microseconds.
+			$skip = strcspn( $buf, "\\" . $quote, $i );
+			$i += $skip;
+			if ( $i >= $buf_len ) {
+				return false;
+			}
+			$c = $buf[$i];
+			if ( $c === '\\' ) {
+				if ( $i + 1 >= $buf_len ) {
+					return false;
+				}
+				$i += 2; // skip the backslash + escaped byte
+				continue;
+			}
+			// Found the matching $quote. Doubled-quote escape: keep going.
+			if ( $i + 1 < $buf_len && $buf[$i + 1] === $quote ) {
+				$i += 2;
+				continue;
+			}
+			return $i + 1;
+		}
+		return false;
+	}
+
+	/**
+	 * Skip past a backtick-quoted identifier. Doubled backticks (``)
+	 * are treated as a literal backtick inside the identifier.
+	 */
+	private function skip_backtick( string $buf, int $buf_len, int $start ) {
+		$i = $start + 1;
+		while ( $i < $buf_len ) {
+			$pos = strpos( $buf, '`', $i );
+			if ( $pos === false ) {
+				return false;
+			}
+			if ( $pos + 1 < $buf_len && $buf[$pos + 1] === '`' ) {
+				$i = $pos + 2;
+				continue;
+			}
+			return $pos + 1;
+		}
+		return false;
 	}
 
 	public function get_query() {

--- a/packages/reprint-importer/src/lib/url-rewrite/class-base64-value-scanner.php
+++ b/packages/reprint-importer/src/lib/url-rewrite/class-base64-value-scanner.php
@@ -58,6 +58,21 @@ class Base64ValueScanner
     }
 
     /**
+     * Build a scanner from a pre-built entry list. Used by the
+     * tokenization-free FastInsertScanner path — when the caller has
+     * already located every FROM_BASE64() expression and decoded its
+     * payload, the scanner skips both lexer and base64_decode work.
+     *
+     * @param list<array{expr_start: int, quote_start: int, quote_length: int, value: string, new_value: ?string}> $entries
+     */
+    public static function from_entries(string $sql, array $entries): self
+    {
+        $instance = new self($sql, []); // empty tokens = no scanning
+        $instance->entries = $entries;
+        return $instance;
+    }
+
+    /**
      * Advance to the next FROM_BASE64() value.
      */
     public function next_value(): bool

--- a/packages/reprint-importer/src/lib/url-rewrite/class-base64-value-scanner.php
+++ b/packages/reprint-importer/src/lib/url-rewrite/class-base64-value-scanner.php
@@ -108,15 +108,22 @@ class Base64ValueScanner
      * Tokenize the SQL and find all FROM_BASE64('...') expressions.
      * Tracks whether each is wrapped in CONVERT(...) for correct expr_start offset.
      */
+    public static float $prof_lexer_us = 0.0;
+    public static float $prof_b64_decode_us = 0.0;
+    public static int $prof_decoded_count = 0;
+
     private function scan(): void
     {
+        $__t = microtime(true);
         $lexer = new WP_MySQL_Lexer($this->sql);
+        self::$prof_lexer_us += (microtime(true) - $__t) * 1e6;
 
         // Track the last two tokens so we can detect CONVERT( before FROM_BASE64.
         // next_token() skips whitespace/comments, so CONVERT ( FROM_BASE64 appears
         // as three consecutive tokens.
         $prev = [null, null];
 
+        $__loop_start = microtime(true);
         while ($lexer->next_token()) {
             $token = $lexer->get_token();
 
@@ -144,7 +151,10 @@ class Base64ValueScanner
                         $inner->id === WP_MySQL_Lexer::SINGLE_QUOTED_TEXT
                         || $inner->id === WP_MySQL_Lexer::DOUBLE_QUOTED_TEXT
                     ) {
+                        $__td = microtime(true);
                         $decoded = base64_decode($inner->get_value(), true);
+                        self::$prof_b64_decode_us += (microtime(true) - $__td) * 1e6;
+                        self::$prof_decoded_count++;
                         $this->entries[] = [
                             'expr_start' => $expr_start,
                             'quote_start' => $inner->start,
@@ -165,5 +175,6 @@ class Base64ValueScanner
             $prev[0] = $prev[1];
             $prev[1] = $token;
         }
+        self::$prof_lexer_us += (microtime(true) - $__loop_start) * 1e6;
     }
 }

--- a/packages/reprint-importer/src/lib/url-rewrite/class-base64-value-scanner.php
+++ b/packages/reprint-importer/src/lib/url-rewrite/class-base64-value-scanner.php
@@ -38,10 +38,23 @@ class Base64ValueScanner
 
     private int $cursor = -1;
 
-    public function __construct(string $sql)
+    /**
+     * @param string $sql The SQL statement.
+     * @param WP_MySQL_Token[]|null $tokens Optional pre-lexed token list. When
+     *   provided, the scanner walks these tokens instead of running its own
+     *   WP_MySQL_Lexer pass. Callers that already lex the statement for
+     *   another reason (column-map extraction, etc.) can hand the same token
+     *   stream in to avoid a redundant tokenization. When null, behavior is
+     *   unchanged: the scanner lexes internally.
+     */
+    public function __construct(string $sql, ?array $tokens = null)
     {
         $this->sql = $sql;
-        $this->scan();
+        if ($tokens === null) {
+            $this->scan();
+        } else {
+            $this->scan_tokens($tokens);
+        }
     }
 
     /**
@@ -176,5 +189,75 @@ class Base64ValueScanner
             $prev[1] = $token;
         }
         self::$prof_lexer_us += (microtime(true) - $__loop_start) * 1e6;
+    }
+
+    /**
+     * Walk a pre-lexed token list to find FROM_BASE64('…') expressions.
+     *
+     * Equivalent to scan() but reuses tokens already produced by another
+     * pass (typically SqlStatementRewriter, which lexes for the column
+     * map). Avoids re-running WP_MySQL_Lexer on the same statement.
+     *
+     * The buffered token array from WP_MySQL_Lexer::remaining_tokens()
+     * has already been stripped of whitespace and comments, so the
+     * CONVERT + ( + FROM_BASE64 pattern still appears as three
+     * consecutive tokens.
+     *
+     * @param WP_MySQL_Token[] $tokens
+     */
+    private function scan_tokens(array $tokens): void
+    {
+        $token_count = count($tokens);
+        $prev = [null, null];
+
+        for ($i = 0; $i < $token_count; $i++) {
+            $token = $tokens[$i];
+
+            if (
+                $token->id === WP_MySQL_Lexer::IDENTIFIER
+                && strtoupper($token->get_value()) === 'FROM_BASE64'
+            ) {
+                $expr_start = $token->start;
+
+                if (
+                    $prev[1] !== null
+                    && $prev[1]->id === WP_MySQL_Lexer::OPEN_PAR_SYMBOL
+                    && $prev[0] !== null
+                    && $prev[0]->id === WP_MySQL_Lexer::CONVERT_SYMBOL
+                ) {
+                    $expr_start = $prev[0]->start;
+                }
+
+                // Walk forward to find the quoted base64 payload, mirroring
+                // scan(): step past the opening parenthesis, accept either
+                // SINGLE_ or DOUBLE_QUOTED_TEXT, abort on anything else.
+                for ($j = $i + 1; $j < $token_count; $j++) {
+                    $inner = $tokens[$j];
+                    if (
+                        $inner->id === WP_MySQL_Lexer::SINGLE_QUOTED_TEXT
+                        || $inner->id === WP_MySQL_Lexer::DOUBLE_QUOTED_TEXT
+                    ) {
+                        $__td = microtime(true);
+                        $decoded = base64_decode($inner->get_value(), true);
+                        self::$prof_b64_decode_us += (microtime(true) - $__td) * 1e6;
+                        self::$prof_decoded_count++;
+                        $this->entries[] = [
+                            'expr_start' => $expr_start,
+                            'quote_start' => $inner->start,
+                            'quote_length' => $inner->length,
+                            'value' => $decoded !== false ? $decoded : '',
+                            'new_value' => null,
+                        ];
+                        break;
+                    }
+                    if ($inner->id !== WP_MySQL_Lexer::OPEN_PAR_SYMBOL) {
+                        break;
+                    }
+                }
+            }
+
+            $prev[0] = $prev[1];
+            $prev[1] = $token;
+        }
     }
 }

--- a/packages/reprint-importer/src/lib/url-rewrite/class-fast-insert-scanner.php
+++ b/packages/reprint-importer/src/lib/url-rewrite/class-fast-insert-scanner.php
@@ -1,0 +1,371 @@
+<?php
+
+/**
+ * Tokenization-free scanner for the INSERT shape that MySQLDumpProducer emits.
+ *
+ * Recovers the same data SqlStatementRewriter needs from a normal lexer pass —
+ * table name, byte-offset → column map, and FROM_BASE64() value entries —
+ * using strpos/preg_match against the constrained producer shape:
+ *
+ *     INSERT INTO `table` (`c1`,`c2`, …) VALUES
+ *       (v1, v2, v3, …),
+ *       (…),
+ *       …;
+ *
+ * Each value is one of:
+ *     NULL
+ *     '' (empty string literal)
+ *     bare numeric literal (-?123, -?1.5, 1e-3, etc.)
+ *     FROM_BASE64('<base64chars>')
+ *     CONVERT(FROM_BASE64('<base64chars>') USING utf8mb4)
+ *
+ * Inside FROM_BASE64() the payload is [A-Za-z0-9+/=]*, so it cannot contain
+ * the punctuation that would confuse top-level parsing (',', '(', ')', "'").
+ * That's what lets us avoid the full SQL grammar.
+ *
+ * Anything that doesn't match this shape causes scan() to return null, and
+ * the caller falls back to the lexer-based path. INSERT … SELECT, hex/binary
+ * literals like x'…', escaped quotes, multi-table UPDATEs, etc. all end up
+ * on the lexer path — they're rare in producer output and correctness wins
+ * over coverage.
+ */
+class FastInsertScanner
+{
+    /**
+     * Try to scan a producer-shape INSERT statement.
+     *
+     * @return array{
+     *   table: string,
+     *   column_map: list<array{int, int, string}>,
+     *   base64_entries: list<array{expr_start: int, quote_start: int, quote_length: int, value: string, new_value: ?string}>
+     * }|null
+     *   Null when the SQL doesn't match the recognised shape.
+     */
+    public static function scan(string $sql): ?array
+    {
+        // Header: optional leading whitespace, INSERT (no priority/IGNORE
+        // modifiers — producer never emits those), INTO, backticked table,
+        // backticked column list, VALUES.
+        //
+        // Captures: 1=table, 2=column-list-body
+        if (!preg_match(
+            '/\A\s*INSERT\s+INTO\s+`((?:[^`]|``)+)`\s*\(([^)]+)\)\s*VALUES\b/i',
+            $sql,
+            $m,
+            PREG_OFFSET_CAPTURE
+        )) {
+            return null;
+        }
+
+        $table = str_replace('``', '`', $m[1][0]);
+        $columns_body = $m[2][0];
+        $values_end = $m[0][1] + strlen($m[0][0]);
+
+        // Column list: backtick-quoted identifiers separated by commas. Reject
+        // anything that doesn't look like producer output — qualified names,
+        // unquoted identifiers, comments, etc.
+        $columns = [];
+        if (
+            !preg_match_all(
+                '/\s*`((?:[^`]|``)+)`\s*(,|$)/A',
+                $columns_body,
+                $col_matches,
+                PREG_SET_ORDER
+            )
+        ) {
+            return null;
+        }
+        $offset = 0;
+        foreach ($col_matches as $cm) {
+            // PREG_SET_ORDER without /A doesn't enforce contiguous matching,
+            // but with /A each match must start at $offset. Verify by
+            // recomputing offset and confirming we consumed the whole body.
+            $columns[] = str_replace('``', '`', $cm[1]);
+            $offset += strlen($cm[0]);
+        }
+        if ($offset !== strlen($columns_body)) {
+            return null;
+        }
+        $column_count = count($columns);
+        if ($column_count === 0) {
+            return null;
+        }
+
+        $column_map = [];
+        $base64_entries = [];
+
+        $cursor = $values_end;
+        $sql_len = strlen($sql);
+
+        // Walk one tuple at a time. Each tuple is `(v, v, v, …)` followed by
+        // either a comma (next tuple) or the statement terminator family
+        // ({whitespace} ; | $).
+        while (true) {
+            // Skip whitespace.
+            while ($cursor < $sql_len && self::is_ws($sql[$cursor])) {
+                $cursor++;
+            }
+            if ($cursor >= $sql_len) {
+                break;
+            }
+            // Statement terminator: optional `;` then end-of-string. Anything
+            // else (ON DUPLICATE KEY UPDATE, RETURNING, comments, …) drops
+            // us out of the fast path.
+            if ($sql[$cursor] === ';') {
+                $cursor++;
+                while ($cursor < $sql_len && self::is_ws($sql[$cursor])) {
+                    $cursor++;
+                }
+                if ($cursor !== $sql_len) {
+                    return null;
+                }
+                break;
+            }
+            if ($sql[$cursor] !== '(') {
+                return null;
+            }
+            $cursor++; // step past '('
+
+            for ($col_idx = 0; $col_idx < $column_count; $col_idx++) {
+                while ($cursor < $sql_len && self::is_ws($sql[$cursor])) {
+                    $cursor++;
+                }
+                $value_start = $cursor;
+                $value_kind = self::scan_value($sql, $sql_len, $cursor);
+                if ($value_kind === null) {
+                    return null;
+                }
+                $value_end = $cursor;
+                $column_map[] = [$value_start, $value_end, $columns[$col_idx]];
+
+                if (is_array($value_kind)) {
+                    // FROM_BASE64 payload: kind = [expr_start, quote_start, quote_length, decoded_value]
+                    $base64_entries[] = [
+                        'expr_start' => $value_kind[0],
+                        'quote_start' => $value_kind[1],
+                        'quote_length' => $value_kind[2],
+                        'value' => $value_kind[3],
+                        'new_value' => null,
+                    ];
+                }
+
+                while ($cursor < $sql_len && self::is_ws($sql[$cursor])) {
+                    $cursor++;
+                }
+                if ($cursor >= $sql_len) {
+                    return null;
+                }
+                if ($sql[$cursor] === ',') {
+                    if ($col_idx === $column_count - 1) {
+                        // Trailing comma before close — not producer shape.
+                        return null;
+                    }
+                    $cursor++;
+                    continue;
+                }
+                if ($sql[$cursor] === ')') {
+                    if ($col_idx !== $column_count - 1) {
+                        // Tuple closed before consuming all columns.
+                        return null;
+                    }
+                    break;
+                }
+                return null;
+            }
+
+            if ($cursor >= $sql_len || $sql[$cursor] !== ')') {
+                return null;
+            }
+            $cursor++; // step past ')'
+
+            while ($cursor < $sql_len && self::is_ws($sql[$cursor])) {
+                $cursor++;
+            }
+            if ($cursor < $sql_len && $sql[$cursor] === ',') {
+                $cursor++;
+                continue; // next tuple
+            }
+            // Either ';' or end-of-string (or whitespace then either) loops back.
+        }
+
+        return [
+            'table' => $table,
+            'column_map' => $column_map,
+            'base64_entries' => $base64_entries,
+        ];
+    }
+
+    /**
+     * Scan one value in producer's tuple shape, advancing $cursor past it.
+     *
+     * @return null|true|array{int,int,int,string}
+     *   null = unrecognized shape (caller bails)
+     *   true = recognised, no FROM_BASE64 entry to record
+     *   array = FROM_BASE64 payload, [expr_start, quote_start, quote_length, decoded]
+     */
+    private static function scan_value(string $sql, int $sql_len, int &$cursor)
+    {
+        if ($cursor >= $sql_len) {
+            return null;
+        }
+        $c = $sql[$cursor];
+
+        // NULL
+        if (
+            ($c === 'N' || $c === 'n')
+            && $cursor + 4 <= $sql_len
+            && substr_compare($sql, 'NULL', $cursor, 4, true) === 0
+        ) {
+            $cursor += 4;
+            return true;
+        }
+
+        // Empty string literal
+        if ($c === "'" && $cursor + 1 < $sql_len && $sql[$cursor + 1] === "'") {
+            $cursor += 2;
+            return true;
+        }
+
+        // FROM_BASE64('…')
+        if (
+            ($c === 'F' || $c === 'f')
+            && $cursor + 13 <= $sql_len
+            && substr_compare($sql, 'FROM_BASE64(', $cursor, 12, true) === 0
+        ) {
+            $expr_start = $cursor;
+            $cursor += 12; // step past "FROM_BASE64("
+            return self::consume_base64_call($sql, $sql_len, $cursor, $expr_start, /*has_convert=*/false);
+        }
+
+        // CONVERT(FROM_BASE64('…') USING utf8mb4)
+        if (
+            ($c === 'C' || $c === 'c')
+            && $cursor + 8 <= $sql_len
+            && substr_compare($sql, 'CONVERT(', $cursor, 8, true) === 0
+        ) {
+            $expr_start = $cursor;
+            $cursor += 8;
+            while ($cursor < $sql_len && self::is_ws($sql[$cursor])) {
+                $cursor++;
+            }
+            if (
+                $cursor + 12 > $sql_len
+                || substr_compare($sql, 'FROM_BASE64(', $cursor, 12, true) !== 0
+            ) {
+                return null;
+            }
+            $cursor += 12;
+            $entry = self::consume_base64_call($sql, $sql_len, $cursor, $expr_start, /*has_convert=*/true);
+            if (!is_array($entry)) {
+                return null;
+            }
+            // Expect: USING utf8mb4 )
+            while ($cursor < $sql_len && self::is_ws($sql[$cursor])) {
+                $cursor++;
+            }
+            if ($cursor + 5 > $sql_len || substr_compare($sql, 'USING', $cursor, 5, true) !== 0) {
+                return null;
+            }
+            $cursor += 5;
+            while ($cursor < $sql_len && self::is_ws($sql[$cursor])) {
+                $cursor++;
+            }
+            if ($cursor + 7 > $sql_len || substr_compare($sql, 'utf8mb4', $cursor, 7, true) !== 0) {
+                return null;
+            }
+            $cursor += 7;
+            while ($cursor < $sql_len && self::is_ws($sql[$cursor])) {
+                $cursor++;
+            }
+            if ($cursor >= $sql_len || $sql[$cursor] !== ')') {
+                return null;
+            }
+            $cursor++;
+            return $entry;
+        }
+
+        // Numeric literal: optional sign, digits, optional fraction, optional exponent.
+        $start = $cursor;
+        if ($c === '+' || $c === '-') {
+            $cursor++;
+        }
+        $digit_start = $cursor;
+        while ($cursor < $sql_len && $sql[$cursor] >= '0' && $sql[$cursor] <= '9') {
+            $cursor++;
+        }
+        if ($cursor < $sql_len && $sql[$cursor] === '.') {
+            $cursor++;
+            while ($cursor < $sql_len && $sql[$cursor] >= '0' && $sql[$cursor] <= '9') {
+                $cursor++;
+            }
+        }
+        if ($cursor < $sql_len && ($sql[$cursor] === 'e' || $sql[$cursor] === 'E')) {
+            $cursor++;
+            if ($cursor < $sql_len && ($sql[$cursor] === '+' || $sql[$cursor] === '-')) {
+                $cursor++;
+            }
+            while ($cursor < $sql_len && $sql[$cursor] >= '0' && $sql[$cursor] <= '9') {
+                $cursor++;
+            }
+        }
+        if ($cursor === $digit_start) {
+            $cursor = $start;
+            return null;
+        }
+        return true;
+    }
+
+    /**
+     * Inside a FROM_BASE64( … ) call, with $cursor already past the opening
+     * paren. Reads the quoted base64 string and the closing paren. Returns
+     * the [expr_start, quote_start, quote_length, decoded] tuple.
+     *
+     * @return array{int,int,int,string}|null
+     */
+    private static function consume_base64_call(string $sql, int $sql_len, int &$cursor, int $expr_start, bool $has_convert)
+    {
+        while ($cursor < $sql_len && self::is_ws($sql[$cursor])) {
+            $cursor++;
+        }
+        if ($cursor >= $sql_len || $sql[$cursor] !== "'") {
+            return null;
+        }
+        $quote_start = $cursor;
+        $cursor++;
+        $payload_start = $cursor;
+        // Producer payload is base64: [A-Za-z0-9+/=]. Find closing quote via
+        // strpos. If anything outside that set appears before it, fall back
+        // to the lexer.
+        $close = strpos($sql, "'", $cursor);
+        if ($close === false) {
+            return null;
+        }
+        $payload = substr($sql, $payload_start, $close - $payload_start);
+        // Validate the payload — strict base64 alphabet.
+        if ($payload !== '' && !preg_match('/\A[A-Za-z0-9+\/=]*\z/', $payload)) {
+            return null;
+        }
+        $cursor = $close + 1;
+        $quote_length = $cursor - $quote_start;
+        // The closing paren of FROM_BASE64( … )
+        if (!$has_convert) {
+            while ($cursor < $sql_len && self::is_ws($sql[$cursor])) {
+                $cursor++;
+            }
+            if ($cursor >= $sql_len || $sql[$cursor] !== ')') {
+                return null;
+            }
+            $cursor++;
+        }
+        $decoded = base64_decode($payload, true);
+        if ($decoded === false) {
+            $decoded = '';
+        }
+        return [$expr_start, $quote_start, $quote_length, $decoded];
+    }
+
+    private static function is_ws(string $c): bool
+    {
+        return $c === ' ' || $c === "\t" || $c === "\n" || $c === "\r";
+    }
+}

--- a/packages/reprint-importer/src/lib/url-rewrite/class-sql-statement-rewriter.php
+++ b/packages/reprint-importer/src/lib/url-rewrite/class-sql-statement-rewriter.php
@@ -100,12 +100,19 @@ class SqlStatementRewriter
         // Recover the table name and a byte-offset→column map from the
         // INSERT/UPDATE shape so we can hand each FROM_BASE64() value the
         // right content-type hint downstream.
+        $__t = microtime(true);
         $value_to_column_map = $this->map_values_to_columns($sql);
+        self::$prof_column_map_us += (microtime(true) - $__t) * 1e6;
 
         // Iterate over all FROM_BASE64() values using the cursor-based scanner
+        $__t = microtime(true);
         $scanner = new Base64ValueScanner($sql);
+        self::$prof_scanner_ctor_us += (microtime(true) - $__t) * 1e6;
         while ($scanner->next_value()) {
+            $__t = microtime(true);
             $value = $scanner->get_value();
+            self::$prof_get_value_us += (microtime(true) - $__t) * 1e6;
+            self::$prof_values_seen++;
 
             // Skip values that can't contain a URL we'd rewrite. Every
             // rewritable domain starts with http:// or https://, so a value
@@ -114,8 +121,10 @@ class SqlStatementRewriter
             // pipeline (HTML parse, block markup, PHP/JSON recursion) per value.
             // See https://github.com/adamziel/reprint/pull/152
             if (strpos($value, 'http') === false) {
+                self::$prof_values_skipped_no_http++;
                 continue;
             }
+            self::$prof_values_with_http++;
 
             // Determine content type hint for this column
             $content_type = null;
@@ -131,7 +140,9 @@ class SqlStatementRewriter
 
             // Rewrite URLs in the value — StructuredDataUrlRewriter classifies the
             // content type and applies the right strategy for each.
+            $__t = microtime(true);
             $rewritten = $this->url_rewriter->rewrite($value, $content_type);
+            self::$prof_url_rewrite_us += (microtime(true) - $__t) * 1e6;
 
             // Only replace if the value actually changed
             if ($rewritten !== $value) {
@@ -139,8 +150,20 @@ class SqlStatementRewriter
             }
         }
 
-        return $scanner->get_result();
+        $__t = microtime(true);
+        $result = $scanner->get_result();
+        self::$prof_get_result_us += (microtime(true) - $__t) * 1e6;
+        return $result;
     }
+
+    public static float $prof_column_map_us = 0.0;
+    public static float $prof_scanner_ctor_us = 0.0;
+    public static float $prof_get_value_us = 0.0;
+    public static float $prof_url_rewrite_us = 0.0;
+    public static float $prof_get_result_us = 0.0;
+    public static int $prof_values_seen = 0;
+    public static int $prof_values_with_http = 0;
+    public static int $prof_values_skipped_no_http = 0;
 
     /**
      * Walk the lexer output to recover, for an INSERT or UPDATE statement,

--- a/packages/reprint-importer/src/lib/url-rewrite/class-sql-statement-rewriter.php
+++ b/packages/reprint-importer/src/lib/url-rewrite/class-sql-statement-rewriter.php
@@ -151,17 +151,21 @@ class SqlStatementRewriter
             self::$prof_get_value_us += (microtime(true) - $__t) * 1e6;
             self::$prof_values_seen++;
 
-            // Skip values that can't contain a URL we'd rewrite. Every
-            // rewritable domain starts with http:// or https://, so a value
-            // without "http" anywhere in it has nothing for us to do. This
-            // avoids the column-map lookup and the full StructuredDataUrlRewriter
-            // pipeline (HTML parse, block markup, PHP/JSON recursion) per value.
+            // Skip values that obviously can't carry a URL we'd rewrite.
+            // The cheaper "no http anywhere" test runs first, then we ask
+            // the rewriter whether the value might actually contain one of
+            // its mapped hosts (the rewriter caches its source-domains
+            // list, so this is just strpos per host).
             // See https://github.com/adamziel/reprint/pull/152
             if (strpos($value, 'http') === false) {
                 self::$prof_values_skipped_no_http++;
                 continue;
             }
             self::$prof_values_with_http++;
+            if (!$this->url_rewriter->maybe_contains_rewritable_urls($value)) {
+                self::$prof_values_skipped_no_host++;
+                continue;
+            }
 
             // Determine content type hint for this column
             $content_type = null;
@@ -205,6 +209,7 @@ class SqlStatementRewriter
     public static int $prof_values_seen = 0;
     public static int $prof_values_with_http = 0;
     public static int $prof_values_skipped_no_http = 0;
+    public static int $prof_values_skipped_no_host = 0;
 
     /**
      * Walk the lexer output to recover, for an INSERT or UPDATE statement,

--- a/packages/reprint-importer/src/lib/url-rewrite/class-sql-statement-rewriter.php
+++ b/packages/reprint-importer/src/lib/url-rewrite/class-sql-statement-rewriter.php
@@ -97,16 +97,25 @@ class SqlStatementRewriter
             return $sql;
         }
 
+        // Lex the statement once. Both the column-map walker and
+        // Base64ValueScanner used to lex the SQL independently — the
+        // WP_MySQL_Lexer pass dominated the rewrite slice (15% of db-apply
+        // wall on the bench fixture). Sharing the token array here cuts
+        // that to a single pass.
+        $__t = microtime(true);
+        $tokens = self::significant_tokens($sql);
+        self::$prof_lex_us += (microtime(true) - $__t) * 1e6;
+
         // Recover the table name and a byte-offset→column map from the
         // INSERT/UPDATE shape so we can hand each FROM_BASE64() value the
         // right content-type hint downstream.
         $__t = microtime(true);
-        $value_to_column_map = $this->map_values_to_columns($sql);
+        $value_to_column_map = $this->map_values_to_columns_from_tokens($tokens);
         self::$prof_column_map_us += (microtime(true) - $__t) * 1e6;
 
         // Iterate over all FROM_BASE64() values using the cursor-based scanner
         $__t = microtime(true);
-        $scanner = new Base64ValueScanner($sql);
+        $scanner = new Base64ValueScanner($sql, $tokens);
         self::$prof_scanner_ctor_us += (microtime(true) - $__t) * 1e6;
         while ($scanner->next_value()) {
             $__t = microtime(true);
@@ -156,6 +165,7 @@ class SqlStatementRewriter
         return $result;
     }
 
+    public static float $prof_lex_us = 0.0;
     public static float $prof_column_map_us = 0.0;
     public static float $prof_scanner_ctor_us = 0.0;
     public static float $prof_get_value_us = 0.0;
@@ -202,7 +212,19 @@ class SqlStatementRewriter
      */
     private function map_values_to_columns(string $sql): ?array
     {
-        $tokens = self::significant_tokens($sql);
+        return $this->map_values_to_columns_from_tokens(self::significant_tokens($sql));
+    }
+
+    /**
+     * Same contract as map_values_to_columns(), but consumes a pre-lexed
+     * token array. Lets callers that already lexed the statement avoid a
+     * second WP_MySQL_Lexer pass.
+     *
+     * @param WP_MySQL_Token[] $tokens
+     * @return array{table: string, column_map: list<array{int, int, string}>}|null
+     */
+    private function map_values_to_columns_from_tokens(array $tokens): ?array
+    {
         $token_count = count($tokens);
         if ($token_count < 4) {
             return null;

--- a/packages/reprint-importer/src/lib/url-rewrite/class-sql-statement-rewriter.php
+++ b/packages/reprint-importer/src/lib/url-rewrite/class-sql-statement-rewriter.php
@@ -97,26 +97,54 @@ class SqlStatementRewriter
             return $sql;
         }
 
-        // Lex the statement once. Both the column-map walker and
-        // Base64ValueScanner used to lex the SQL independently — the
-        // WP_MySQL_Lexer pass dominated the rewrite slice (15% of db-apply
-        // wall on the bench fixture). Sharing the token array here cuts
-        // that to a single pass.
+        // Fast path: producer-shape INSERTs (the overwhelming majority of
+        // statements in a typical dump) are recovered with strpos / regex
+        // and never touch WP_MySQL_Lexer. The lexer pass costs ~15% of
+        // db-apply wall on the bench fixture, so skipping it for the
+        // common case is a big win. Anything the fast scanner doesn't
+        // recognise — UPDATE, INSERT … SELECT, qualified names, hex
+        // literals, escaped quotes — falls through to the lexer path
+        // below with identical behaviour.
+        $__t = microtime(true);
+        $fast = FastInsertScanner::scan($sql);
+        self::$prof_fast_scan_us += (microtime(true) - $__t) * 1e6;
+        if ($fast !== null) {
+            self::$prof_fast_scan_hits++;
+            $value_to_column_map = [
+                'table' => $fast['table'],
+                'column_map' => $fast['column_map'],
+            ];
+            $__t = microtime(true);
+            $scanner = Base64ValueScanner::from_entries($sql, $fast['base64_entries']);
+            self::$prof_scanner_ctor_us += (microtime(true) - $__t) * 1e6;
+            return $this->rewrite_with_scanner($scanner, $value_to_column_map);
+        }
+        self::$prof_fast_scan_misses++;
+
+        // Slow path: lex once, share the token array between the column
+        // map walker and Base64ValueScanner.
         $__t = microtime(true);
         $tokens = self::significant_tokens($sql);
         self::$prof_lex_us += (microtime(true) - $__t) * 1e6;
 
-        // Recover the table name and a byte-offset→column map from the
-        // INSERT/UPDATE shape so we can hand each FROM_BASE64() value the
-        // right content-type hint downstream.
         $__t = microtime(true);
         $value_to_column_map = $this->map_values_to_columns_from_tokens($tokens);
         self::$prof_column_map_us += (microtime(true) - $__t) * 1e6;
 
-        // Iterate over all FROM_BASE64() values using the cursor-based scanner
         $__t = microtime(true);
         $scanner = new Base64ValueScanner($sql, $tokens);
         self::$prof_scanner_ctor_us += (microtime(true) - $__t) * 1e6;
+        return $this->rewrite_with_scanner($scanner, $value_to_column_map);
+    }
+
+    /**
+     * Run the value-rewriting loop given an already-populated scanner and
+     * the table/column-map context. Shared between the fast and lexer paths.
+     *
+     * @param array{table: string, column_map: list<array{int, int, string}>}|null $value_to_column_map
+     */
+    private function rewrite_with_scanner(Base64ValueScanner $scanner, ?array $value_to_column_map): string
+    {
         while ($scanner->next_value()) {
             $__t = microtime(true);
             $value = $scanner->get_value();
@@ -165,6 +193,9 @@ class SqlStatementRewriter
         return $result;
     }
 
+    public static float $prof_fast_scan_us = 0.0;
+    public static int $prof_fast_scan_hits = 0;
+    public static int $prof_fast_scan_misses = 0;
     public static float $prof_lex_us = 0.0;
     public static float $prof_column_map_us = 0.0;
     public static float $prof_scanner_ctor_us = 0.0;

--- a/packages/reprint-importer/src/lib/url-rewrite/class-structured-data-url-rewriter.php
+++ b/packages/reprint-importer/src/lib/url-rewrite/class-structured-data-url-rewriter.php
@@ -99,6 +99,7 @@ class StructuredDataUrlRewriter
      */
     public function rewrite(string $value, ?string $content_type = null): string
     {
+        self::$prof_calls++;
         if ($value === '') {
             return $value;
         }
@@ -115,14 +116,23 @@ class StructuredDataUrlRewriter
         // source domain, there's nothing to rewrite. This avoids expensive
         // parsing (serialized PHP, JSON, block markup) for the vast majority
         // of values that don't contain any rewritable URLs.
-        if (!$this->maybe_contains_rewritable_urls($value)) {
+        $__t = microtime(true);
+        $maybe = $this->maybe_contains_rewritable_urls($value);
+        self::$prof_prefilter_us += (microtime(true) - $__t) * 1e6;
+        if (!$maybe) {
+            self::$prof_prefilter_rejects++;
             return $value;
         }
 
         // Try serialized PHP: the parser validates the entire structure
         // in the constructor. If it's not malformed, iterate and recurse.
+        $__t = microtime(true);
         $p = new PhpSerializationProcessor($value);
-        if (!$p->is_malformed()) {
+        $is_php_serialized = !$p->is_malformed();
+        self::$prof_php_detect_us += (microtime(true) - $__t) * 1e6;
+        if ($is_php_serialized) {
+            self::$prof_php_branch++;
+            $__t = microtime(true);
             while ($p->next_value()) {
                 $original = $p->get_value();
                 $rewritten = $this->rewrite($original, $content_type);
@@ -130,13 +140,20 @@ class StructuredDataUrlRewriter
                     $p->set_value($rewritten);
                 }
             }
-            return $p->get_updated_serialization();
+            $result = $p->get_updated_serialization();
+            self::$prof_php_walk_us += (microtime(true) - $__t) * 1e6;
+            return $result;
         }
 
         // Try JSON: the iterator calls json_decode in the constructor.
         // If it's not malformed, iterate and recurse.
+        $__t = microtime(true);
         $iter = new JsonStringIterator($value);
-        if (!$iter->is_malformed()) {
+        $is_json = !$iter->is_malformed();
+        self::$prof_json_detect_us += (microtime(true) - $__t) * 1e6;
+        if ($is_json) {
+            self::$prof_json_branch++;
+            $__t = microtime(true);
             while ($iter->next_value()) {
                 $original = $iter->get_value();
                 $rewritten = $this->rewrite($original, $content_type);
@@ -144,7 +161,9 @@ class StructuredDataUrlRewriter
                     $iter->set_value($rewritten);
                 }
             }
-            return $iter->get_result();
+            $result = $iter->get_result();
+            self::$prof_json_walk_us += (microtime(true) - $__t) * 1e6;
+            return $result;
         }
 
         // Base64 decoding is temporarily disabled for performance.
@@ -152,8 +171,34 @@ class StructuredDataUrlRewriter
         // Base64ValueScanner in SqlStatementRewriter — this block
         // was for base64-within-base64 nesting which is rare in practice.
 
-        return $this->rewrite_urls($value, $content_type);
+        $__t = microtime(true);
+        if ($content_type === self::BLOCK_MARKUP) {
+            self::$prof_block_branch++;
+        } else {
+            self::$prof_text_branch++;
+        }
+        $result = $this->rewrite_urls($value, $content_type);
+        if ($content_type === self::BLOCK_MARKUP) {
+            self::$prof_block_us += (microtime(true) - $__t) * 1e6;
+        } else {
+            self::$prof_text_us += (microtime(true) - $__t) * 1e6;
+        }
+        return $result;
     }
+
+    public static int $prof_calls = 0;
+    public static int $prof_prefilter_rejects = 0;
+    public static int $prof_php_branch = 0;
+    public static int $prof_json_branch = 0;
+    public static int $prof_block_branch = 0;
+    public static int $prof_text_branch = 0;
+    public static float $prof_prefilter_us = 0.0;
+    public static float $prof_php_detect_us = 0.0;
+    public static float $prof_php_walk_us = 0.0;
+    public static float $prof_json_detect_us = 0.0;
+    public static float $prof_json_walk_us = 0.0;
+    public static float $prof_block_us = 0.0;
+    public static float $prof_text_us = 0.0;
 
     /**
      * Quick-reject check: returns false when the value certainly doesn't
@@ -163,7 +208,7 @@ class StructuredDataUrlRewriter
      * - href=" or src=" (HTML attributes that carry URLs), OR
      * - any source domain from the url_mapping (bare URL occurrences)
      */
-    private function maybe_contains_rewritable_urls(string $value): bool
+    public function maybe_contains_rewritable_urls(string $value): bool
     {
         if (strpos($value, 'href="') !== false || strpos($value, 'src="') !== false) {
             return true;

--- a/packages/reprint-importer/src/lib/url-rewrite/load.php
+++ b/packages/reprint-importer/src/lib/url-rewrite/load.php
@@ -13,6 +13,7 @@ require_once __DIR__ . '/../mysql-query-stream/load.php';
 require_once __DIR__ . '/class-php-serialization-processor.php';
 require_once __DIR__ . '/class-json-string-iterator.php';
 require_once __DIR__ . '/class-base64-value-scanner.php';
+require_once __DIR__ . '/class-fast-insert-scanner.php';
 
 // Depend on the iterators above
 require_once __DIR__ . '/class-structured-data-url-rewriter.php';

--- a/tests/e2e/benchmark/bench-pull.mjs
+++ b/tests/e2e/benchmark/bench-pull.mjs
@@ -1,8 +1,11 @@
 /**
  * Per-stage performance benchmark for the `pull` pipeline.
  *
- * Provisions the `large-directory` e2e site (2k+ files), then runs each
- * pipeline stage as an individual CLI invocation and times the wall-clock.
+ * Provisions the `large-directory` e2e site (2k+ files) and seeds its DB
+ * with hundreds of thousands of posts/postmeta rows so the DB stages
+ * dominate wall-clock — see Automattic/studio#3248 for the dataset shape.
+ * Then runs each pipeline stage as an individual CLI invocation and times
+ * the wall-clock.
  * Emits a markdown table to stdout, appends to $GITHUB_STEP_SUMMARY, and
  * writes a JSON artifact to bench-results.json.
  *
@@ -27,10 +30,86 @@ import {
 
 const SITE = 'large-directory';
 const IMPORT_DB = 'e2e_bench_pull';
+// Seed enough posts/postmeta to make db-pull and db-apply dominate wall-clock
+// (the default WP install has ~1 post). Mirrors the dataset shape used in
+// Automattic/studio#3248: ~320k posts and ~720k postmeta rows.
+const SEED_POSTS = Number(process.env.BENCH_SEED_POSTS || 320_007);
+const SEED_POSTMETA = Number(process.env.BENCH_SEED_POSTMETA || 720_015);
 const PHP_BINARY = process.env.PHP_BINARY || 'php';
 const PROJECT_ROOT = join(import.meta.dirname, '..', '..', '..');
 const IMPORTER_PATH = process.env.IMPORTER_PATH || join(PROJECT_ROOT, 'importer', 'import.php');
 const REGISTRY = JSON.parse(readFileSync(join(import.meta.dirname, '..', 'site-registry.json'), 'utf-8'));
+
+async function seedSourceDb() {
+    const dbName = `e2e_${SITE.replace(/-/g, '_')}`;
+    const conn = await createConnection({
+        host: REGISTRY.dbHost,
+        user: REGISTRY.dbUser,
+        password: REGISTRY.dbPass,
+        database: dbName,
+        multipleStatements: true,
+    });
+    try {
+        const [rows] = await conn.query('SELECT COUNT(*) AS c FROM wp_posts');
+        if (rows[0].c >= SEED_POSTS) {
+            console.log(`Source DB already seeded with ${rows[0].c} posts; skipping seed`);
+            return;
+        }
+
+        console.log(`Seeding source DB: ${SEED_POSTS} posts, ${SEED_POSTMETA} postmeta...`);
+        // Speed up bulk inserts: skip per-row durability, defer index updates.
+        await conn.query('SET autocommit=0; SET unique_checks=0; SET foreign_key_checks=0;');
+        await conn.query('ALTER TABLE wp_posts DISABLE KEYS; ALTER TABLE wp_postmeta DISABLE KEYS;');
+
+        const BATCH = 2000;
+        const now = '2024-01-01 00:00:00';
+        for (let start = 1; start <= SEED_POSTS; start += BATCH) {
+            const end = Math.min(start + BATCH - 1, SEED_POSTS);
+            const values = [];
+            const params = [];
+            for (let i = start; i <= end; i++) {
+                values.push('(?,?,?,?,?,?,?,?,?,?,?,?)');
+                params.push(
+                    1, now, now,
+                    `Bench post body ${i} — lorem ipsum dolor sit amet, consectetur adipiscing elit. http://localhost:9999/post/${i}`,
+                    `Bench post ${i}`,
+                    '', 'publish', 'open', 'open', `bench-post-${i}`,
+                    'post', 0,
+                );
+            }
+            await conn.query(
+                `INSERT INTO wp_posts
+                    (post_author, post_date, post_date_gmt, post_content, post_title,
+                     post_excerpt, post_status, comment_status, ping_status, post_name,
+                     post_type, comment_count)
+                 VALUES ${values.join(',')}`,
+                params,
+            );
+        }
+
+        for (let start = 1; start <= SEED_POSTMETA; start += BATCH) {
+            const end = Math.min(start + BATCH - 1, SEED_POSTMETA);
+            const values = [];
+            const params = [];
+            for (let i = start; i <= end; i++) {
+                const postId = ((i - 1) % SEED_POSTS) + 1;
+                values.push('(?,?,?)');
+                params.push(postId, `bench_meta_${i % 3}`, `value-${i}`);
+            }
+            await conn.query(
+                `INSERT INTO wp_postmeta (post_id, meta_key, meta_value) VALUES ${values.join(',')}`,
+                params,
+            );
+        }
+
+        await conn.query('COMMIT');
+        await conn.query('ALTER TABLE wp_posts ENABLE KEYS; ALTER TABLE wp_postmeta ENABLE KEYS;');
+        await conn.query('SET autocommit=1; SET unique_checks=1; SET foreign_key_checks=1;');
+        console.log('Seed complete');
+    } finally {
+        await conn.end();
+    }
+}
 
 async function provisionDatabase() {
     const conn = await createConnection({
@@ -66,7 +145,7 @@ function runStage(stage, stateDir, extraArgs = [], { includeUrl = true } = {}) {
         attempts += 1;
         try {
             execFileSync(PHP_BINARY, args, {
-                timeout: 240000,
+                timeout: 900_000,
                 encoding: 'utf-8',
                 maxBuffer: 64 * 1024 * 1024,
                 stdio: ['ignore', 'pipe', 'pipe'],
@@ -99,7 +178,7 @@ function renderMarkdown(results, meta) {
     const lines = [];
     lines.push(`## Pull pipeline performance — \`${SITE}\``);
     lines.push('');
-    lines.push(`Site: \`${SITE}\` · ${meta.fileCount} files · PHP \`${meta.phpVersion}\``);
+    lines.push(`Site: \`${SITE}\` · ${meta.fileCount} files · ${meta.seedPosts.toLocaleString('en-US')} posts · ${meta.seedPostmeta.toLocaleString('en-US')} postmeta · PHP \`${meta.phpVersion}\``);
     lines.push('');
     lines.push('| Stage | Wall time | Resume attempts | Status |');
     lines.push('|---|---:|---:|---|');
@@ -125,6 +204,7 @@ async function main() {
         },
     });
 
+    await seedSourceDb();
     await provisionDatabase();
 
     const stateDir = join(tmpdir(), `bench-pull-${Date.now()}`);
@@ -166,7 +246,14 @@ async function main() {
     }
 
     const phpVersion = execFileSync(PHP_BINARY, ['-r', 'echo PHP_VERSION;'], { encoding: 'utf-8' }).trim();
-    const meta = { site: SITE, fileCount: '2,000+', phpVersion, importer: IMPORTER_PATH };
+    const meta = {
+        site: SITE,
+        fileCount: '2,000+',
+        seedPosts: SEED_POSTS,
+        seedPostmeta: SEED_POSTMETA,
+        phpVersion,
+        importer: IMPORTER_PATH,
+    };
     const md = renderMarkdown(results, meta);
     console.log('\n' + md);
 

--- a/tests/e2e/benchmark/bench-pull.mjs
+++ b/tests/e2e/benchmark/bench-pull.mjs
@@ -58,6 +58,9 @@ async function seedSourceDb() {
 
         console.log(`Seeding source DB: ${SEED_POSTS} posts, ${SEED_POSTMETA} postmeta...`);
         // Speed up bulk inserts: skip per-row durability, defer index updates.
+        // Drop STRICT mode so TEXT columns without defaults (to_ping,
+        // pinged, post_content_filtered, etc.) accept implicit ''.
+        await conn.query("SET SESSION sql_mode='';");
         await conn.query('SET autocommit=0; SET unique_checks=0; SET foreign_key_checks=0;');
         await conn.query('ALTER TABLE wp_posts DISABLE KEYS; ALTER TABLE wp_postmeta DISABLE KEYS;');
 

--- a/tests/e2e/benchmark/bench-pull.mjs
+++ b/tests/e2e/benchmark/bench-pull.mjs
@@ -190,6 +190,25 @@ function renderMarkdown(results, meta) {
     }
     lines.push(`| **Total** | **${fmtMs(total)}** | | |`);
     lines.push('');
+    const apply = results.find((r) => r.stage === 'db-apply' && r.profile);
+    if (apply) {
+        const p = apply.profile;
+        const fmtUs = (us) => fmtMs(us / 1000);
+        lines.push('### `db-apply` breakdown');
+        lines.push('');
+        lines.push('| Bucket | Time | Calls |');
+        lines.push('|---|---:|---:|');
+        lines.push(`| read I/O | ${fmtUs(p.read_io_us)} | — |`);
+        lines.push(`| query stream parse | ${fmtUs(p.query_stream_us)} | — |`);
+        lines.push(`| URL rewrite | ${fmtUs(p.rewrite_us)} | ${p.rewrite_calls} |`);
+        lines.push(`| PDO exec | ${fmtUs(p.exec_us)} | ${p.exec_calls} |`);
+        lines.push('');
+        const kinds = Object.entries(p.stmt_kinds || {}).sort((a, b) => b[1] - a[1]);
+        if (kinds.length) {
+            lines.push('Statement kinds: ' + kinds.map(([k, v]) => `\`${k}\`=${v}`).join(', '));
+            lines.push('');
+        }
+    }
     return lines.join('\n');
 }
 
@@ -240,8 +259,24 @@ async function main() {
     for (const { name, extra, includeUrl } of stages) {
         console.log(`-> ${name}`);
         const r = runStage(name, stateDir, extra, { includeUrl });
+        // Pick up the per-stage profile JSON written by the importer (currently
+        // db-apply only). Surfaces the inner breakdown — read I/O, query
+        // parse, URL rewrite, PDO exec — so the bench can show *where* the
+        // wall-clock goes, not just how long it took overall.
+        const profilePath = join(stateDir, '.import-apply-profile.json');
+        if (name === 'db-apply' && existsSync(profilePath)) {
+            try {
+                r.profile = JSON.parse(readFileSync(profilePath, 'utf-8'));
+            } catch { /* best effort */ }
+        }
         results.push(r);
         console.log(`   ${r.ok ? 'ok' : 'FAIL'} in ${fmtMs(r.elapsedMs)} (attempts=${r.attempts})`);
+        if (r.profile) {
+            const p = r.profile;
+            const usToS = (us) => (us / 1e6).toFixed(2) + 's';
+            console.log(`   db-apply breakdown: read=${usToS(p.read_io_us)} parse=${usToS(p.query_stream_us)} rewrite=${usToS(p.rewrite_us)} exec=${usToS(p.exec_us)} (${p.exec_calls} statements)`);
+            console.log(`   stmt kinds: ${Object.entries(p.stmt_kinds).map(([k, v]) => `${k}=${v}`).join(' ')}`);
+        }
         if (!r.ok) {
             console.error(`   stderr (tail):\n${r.stderr}`);
             console.error(`   stdout (tail):\n${r.stdout}`);

--- a/tests/e2e/benchmark/render-diff.mjs
+++ b/tests/e2e/benchmark/render-diff.mjs
@@ -38,7 +38,12 @@ const trunk = existsSync(trunkPath) ? JSON.parse(readFileSync(trunkPath, 'utf-8'
 const lines = [];
 lines.push(`## Pull pipeline performance — \`${pr.meta.site}\``);
 lines.push('');
-lines.push(`Site: \`${pr.meta.site}\` · ${pr.meta.fileCount} files · PHP \`${pr.meta.phpVersion}\``);
+{
+    const seedSuffix = (pr.meta.seedPosts && pr.meta.seedPostmeta)
+        ? ` · ${Number(pr.meta.seedPosts).toLocaleString('en-US')} posts · ${Number(pr.meta.seedPostmeta).toLocaleString('en-US')} postmeta`
+        : '';
+    lines.push(`Site: \`${pr.meta.site}\` · ${pr.meta.fileCount} files${seedSuffix} · PHP \`${pr.meta.phpVersion}\``);
+}
 lines.push('');
 
 if (trunk) {


### PR DESCRIPTION
Stacked on #169.

The `strpos('http')` check at the `SqlStatementRewriter` boundary lets through any value with an http URL — including external hosts that aren't in the rewrite map. Each one then pays the full structured pipeline cost (PhpSerializationProcessor construction, JsonStringIterator construction, BlockMarkupUrlProcessor walk) only to find it had nothing to do.

This PR adds a second-stage filter using the host list the rewriter already extracts from its mapping keys. A statement-level value needs to clear both checks before the structured pipeline fires. On dumps where the bulk of post_content references a CDN we never map, this keeps the structured pipeline from running on those values.

It also exposes inner timers and call counters on `StructuredDataUrlRewriter` so we can see which branches (PHP / JSON / block markup / plain text) are actually consuming the rewriter time on a given fixture.

## Findings on the bench fixture

The new inner profiler reveals that **100% of structured rewriter time is BlockMarkupUrlProcessor walks** (50 000 of them), with the entire rewriter slice resolving to that single hotspot. Zero PHP serialization, zero JSON, zero plain-text branches. The next PR in the stack acts on that signal.

The prefilter is a no-op on this bench fixture (every value contains the mapped localhost host), so wall time only moves a fraction of a second on this dataset; the value is in the inner-timer signal it surfaces and in the short-circuit it provides on dumps with mostly-external URLs.

## Test plan

- [x] PHPUnit `UrlRewriting` green (170 tests)
- [x] `maybe_contains_rewritable_urls()` made `public` — was previously private; no other callers needed
- [ ] CI green