### PR TITLE
db-apply: skip the HTML tokeniser for tag-free block_markup values

### DIFF
--- a/packages/reprint-importer/src/lib/url-rewrite/class-structured-data-url-rewriter.php
+++ b/packages/reprint-importer/src/lib/url-rewrite/class-structured-data-url-rewriter.php
@@ -152,8 +152,31 @@ class StructuredDataUrlRewriter
         // Base64ValueScanner in SqlStatementRewriter — this block
         // was for base64-within-base64 nesting which is rare in practice.
 
+        // Fast path: content tagged block_markup but containing no HTML
+        // structure (no `<` for tags / block comments, no `&` for entities)
+        // is plain text by every observable measure. BlockMarkupUrlProcessor
+        // would tokenise it as a single text node and forward it to
+        // URLInTextProcessor anyway — the wrapping HTML tokenisation is
+        // pure overhead. URLs in attributes (where block markup escapes
+        // differently) can't appear without `<`, so the output stays
+        // byte-identical to the slow path.
+        //
+        // Why this matters: posts written in the Classic Editor (and most
+        // posts in long migration tails) carry no block delimiters; they
+        // still flow through the block_markup column hint and pay the
+        // HTML tokeniser anyway. On the bench fixture this fast path
+        // catches 100% of post_content values.
+        if (
+            $content_type === self::BLOCK_MARKUP
+            && strpos($value, '<') === false
+            && strpos($value, '&') === false
+        ) {
+            return $this->rewrite_urls($value, self::PLAIN_TEXT);
+        }
+
         return $this->rewrite_urls($value, $content_type);
     }
+
 
     /**
      * Quick-reject check: returns false when the value certainly doesn't


### PR DESCRIPTION
Stacked on #170.

#170's inner profiler showed that the entire 7.6 s structured rewriter slice on the bench fixture is `BlockMarkupUrlProcessor` walks on values that don't actually contain any block markup. The block_markup hint says "treat this column like post_content" — but most post_content in real databases (Classic Editor users, drafts, comment content, term descriptions) carries no block delimiters and often no HTML at all. The block-aware processor still tokenises those values as HTML, finds exactly one text node spanning the whole value, then forwards to `URLInTextProcessor` anyway. The HTML tokenisation is pure overhead for that shape.

This PR adds a guard at `StructuredDataUrlRewriter::rewrite()`: if the value is tagged `block_markup` but contains neither `<` (any tag / block comment opener) nor `&` (any HTML entity to decode), use the plain_text path instead. Output is byte-identical: the slow path would have funneled the value through `URLInTextProcessor` too. URLs in HTML attributes (where block markup escapes differently) can't appear without `<`, so the fast path is safe.

## Measured impact (final stack head vs PR0 baseline)

| scale | rows | db.sql | baseline | this PR | speedup |
|---|---:|---:|---:|---:|---:|
| small | 17 k | 3.45 MB | 2.75 s | **1.45 s** | 1.90× |
| medium | 170 k | 35.2 MB | 25.46 s | **11.36 s** | 2.24× |
| large | 1.04 M | 224 MB | 159.17 s | **75.42 s** | 2.11× |

Stack-end remaining cost on medium: rewrite 6.69 s (still URLInTextProcessor on legitimately URL-bearing values), exec 2.55 s, qs_next 0.20 s.

## Test plan

- [x] PHPUnit `UrlRewriting` green (170 tests)
- [x] Spot-checked output: `http://localhost:9999/post/1` rewrote to `https://new.test/post/1` correctly
- [x] Bench at all three scales runs to completion
- [ ] CI green