### PR TITLE
Namespace exporter utils so parse_size() stops fataling third-party plugins

### DIFF
--- a/packages/reprint-exporter/src/class-http-server.php
+++ b/packages/reprint-exporter/src/class-http-server.php
@@ -1,5 +1,7 @@
 <?php
 
+use function WordPress\Reprint\Exporter\parse_size;
+
 /**
  * HTTP dispatcher for the Site Export API.
  */

--- a/packages/reprint-exporter/src/export.php
+++ b/packages/reprint-exporter/src/export.php
@@ -3,6 +3,11 @@
  * Unified export API for SQL and file operations.
  */
 
+use function WordPress\Reprint\Exporter\assert_valid_path;
+use function WordPress\Reprint\Exporter\build_pdo_dsn;
+use function WordPress\Reprint\Exporter\json_encode_or_throw;
+use function WordPress\Reprint\Exporter\parse_size;
+
 // Capture any accidental output before headers are set so we can discard it
 // when switching to streaming mode later.
 if (!ob_get_level()) {
@@ -381,7 +386,7 @@ function create_sqlite_pdo_adapter()
 // require_once does not resolve symlinks, so the same physical file can
 // be loaded twice through different paths, causing "Cannot redeclare"
 // fatal errors.
-if (!function_exists('build_pdo_dsn')) {
+if (!function_exists('WordPress\\Reprint\\Exporter\\build_pdo_dsn')) {
     require_once __DIR__ . "/utils.php";
 }
 if (!class_exists('Site_Export_HTTP_Server', false)) {

--- a/packages/reprint-exporter/src/utils.php
+++ b/packages/reprint-exporter/src/utils.php
@@ -40,10 +40,9 @@ use RuntimeException;
 // path. In a monorepo where the same package is mirrored into vendor/
 // (e.g. tests/ pulls in vendor/wp-php-toolkit/reprint-exporter/src/utils.php
 // AND packages/reprint-exporter/src/utils.php), both copies are loaded.
-// Guard against redeclaration so only the first wins.
-if (function_exists(__NAMESPACE__ . '\\build_pdo_dsn')) {
-    return;
-}
+// `return` from inside a bracketed namespace block does not abort the
+// whole file, so guard the declarations themselves.
+if (!function_exists(__NAMESPACE__ . '\\build_pdo_dsn')) {
 
 /**
  * Builds a PDO DSN string from a WordPress DB_HOST value.
@@ -224,5 +223,7 @@ function assert_valid_path(string $path, string $label = "path"): void
         }
     }
 }
+
+} // !function_exists guard
 
 }

--- a/packages/reprint-exporter/src/utils.php
+++ b/packages/reprint-exporter/src/utils.php
@@ -1,21 +1,40 @@
 <?php
 /**
  * Shared utility functions used by both export.php and import.php.
+ *
+ * These helpers live in a namespace so they don't collide with global
+ * functions of the same name declared by third-party plugins or
+ * WordPress drop-ins. The package is loaded via Composer's "files"
+ * autoload, which means every host that pulls in this library (e.g.
+ * wpcomsh on WordPress.com) gets these symbols on every request —
+ * generic names like parse_size() or normalize_path() are guaranteed
+ * to clash sooner or later if they sit in the global namespace.
+ *
+ * The two str_* polyfills at the top stay global on purpose: they
+ * backfill PHP 7.4 built-ins, so callers expect to reach them via
+ * the global namespace without a use-statement.
  */
 
 // Polyfill for PHP 7.4 which lacks str_starts_with().
-if (!function_exists('str_starts_with')) {
-    function str_starts_with(string $haystack, string $needle): bool {
-        return $needle === '' || strncmp($haystack, $needle, strlen($needle)) === 0;
+namespace {
+    if (!function_exists('str_starts_with')) {
+        function str_starts_with(string $haystack, string $needle): bool {
+            return $needle === '' || strncmp($haystack, $needle, strlen($needle)) === 0;
+        }
+    }
+
+    // Polyfill for PHP 7.4 which lacks str_contains().
+    if (!function_exists('str_contains')) {
+        function str_contains(string $haystack, string $needle): bool {
+            return $needle === '' || strpos($haystack, $needle) !== false;
+        }
     }
 }
 
-// Polyfill for PHP 7.4 which lacks str_contains().
-if (!function_exists('str_contains')) {
-    function str_contains(string $haystack, string $needle): bool {
-        return $needle === '' || strpos($haystack, $needle) !== false;
-    }
-}
+namespace WordPress\Reprint\Exporter {
+
+use InvalidArgumentException;
+use RuntimeException;
 
 /**
  * Builds a PDO DSN string from a WordPress DB_HOST value.
@@ -195,4 +214,6 @@ function assert_valid_path(string $path, string $label = "path"): void
             );
         }
     }
+}
+
 }

--- a/packages/reprint-exporter/src/utils.php
+++ b/packages/reprint-exporter/src/utils.php
@@ -36,6 +36,15 @@ namespace WordPress\Reprint\Exporter {
 use InvalidArgumentException;
 use RuntimeException;
 
+// Composer's "files" autoload includes this file once per registered
+// path. In a monorepo where the same package is mirrored into vendor/
+// (e.g. tests/ pulls in vendor/wp-php-toolkit/reprint-exporter/src/utils.php
+// AND packages/reprint-exporter/src/utils.php), both copies are loaded.
+// Guard against redeclaration so only the first wins.
+if (function_exists(__NAMESPACE__ . '\\build_pdo_dsn')) {
+    return;
+}
+
 /**
  * Builds a PDO DSN string from a WordPress DB_HOST value.
  *

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -9,6 +9,12 @@
  * - Progress reporting via JSON lines to stdout
  * - Three-phase import: files, SQL, then file deltas
  */
+
+use function WordPress\Reprint\Exporter\assert_valid_path;
+use function WordPress\Reprint\Exporter\normalize_path;
+use function WordPress\Reprint\Exporter\parse_size;
+use function WordPress\Reprint\Exporter\path_is_within_root;
+
 error_reporting(E_ALL);
 ini_set("display_errors", "stderr");
 ini_set("display_startup_errors", 1);

--- a/tests/BuildPdoDsnTest.php
+++ b/tests/BuildPdoDsnTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
+use function WordPress\Reprint\Exporter\build_pdo_dsn;
 
 class BuildPdoDsnTest extends TestCase
 {


### PR DESCRIPTION
## What's broken

`packages/reprint-exporter/src/utils.php` declares eight unguarded global functions, and Composer autoloads it as a `"files"` entry — so the moment wpcomsh boots on a WordPress.com Atomic site, every one of those names is taken.

One of them, `parse_size()`, is a name third-party plugins commonly copy from Drupal. When a plugin like ebook-store also defines `parse_size()`, PHP fatals with `Cannot redeclare parse_size()` and the site goes down on activation.

Reported on educatorsresource.in, tracked in [TSCODE-365](https://linear.app/a8c/issue/TSCODE-365). HEs spent multiple chat sessions on this before the root cause surfaced.

## The fix

Move the helpers into a `WordPress\Reprint\Exporter` namespace. Namespaced functions don't occupy global symbols, so a third-party global `parse_size()` (or `normalize_path()`, etc.) can't collide with them.

Updated call sites in `export.php`, `class-http-server.php`, `import.php`, and `tests/BuildPdoDsnTest.php` pull the helpers in via `use function`. The `str_starts_with` / `str_contains` polyfills at the top of `utils.php` deliberately stay global — they backfill PHP 7.4 built-ins and callers reach them as plain functions.

### Double-load guard

In CI (and any monorepo layout where the package is reachable through both `packages/...` and `vendor/wp-php-toolkit/reprint-exporter/...`), Composer's `"files"` autoload includes `utils.php` once per registered path — so the same file gets loaded twice with different paths. `return` from inside a bracketed `namespace { ... }` block does not abort the file, so to make the second include a no-op the function declarations are wrapped in a single `if (!function_exists(__NAMESPACE__ . '\\build_pdo_dsn')) { ... }` block. Verified locally that requiring the file twice in a row works.

## Other risky names in the package

While auditing the file I checked every other generic global function the package declares. The eight helpers in `utils.php` were the dangerous ones because that file is autoloaded on every request — `parse_size`, `normalize_path`, `build_pdo_dsn`, `path_is_within_root`, `assert_valid_path`, `json_encode_or_throw` all get a namespace in this PR.

`export.php` and `import.php` declare more global functions (`emit_error_chunk`, `parse_http_config`, `to_absolute_path`, `is_sqlite_site`, `resolve_directories`, `create_db_connection`, etc.), but those files are **not** autoloaded — they only execute when the export endpoint or import CLI runs. The collision blast radius is much smaller, so leaving them as-is keeps the diff focused. If we want to namespace them too, that's a follow-up worth doing for hygiene but it isn't fixing an active production fatal.

## CI status

- All 4 PHPUnit jobs (PHP 8.1 – 8.4) green.
- All 6 E2E jobs (PHP 7.4 – 8.5) green.
- PHPStan failure (`SqlStatementRewriter::map_values_to_columns() is unused`) is pre-existing on `trunk` and unrelated to this PR.

## Rollout for the customer fix

Cut a patch release of `wp-php-toolkit/reprint-exporter`, bump the constraint in wpcomsh, ship a wpcomsh point release. That unblocks educatorsresource.in without waiting on the third-party plugin to ship its own fix.