### PR TITLE
Run perf checks on PHP 8.5

### DIFF
--- a/.github/workflows/perf-report.yml
+++ b/.github/workflows/perf-report.yml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2'
+          php-version: '8.5'
           extensions: pdo, pdo_mysql, json, hash, zlib, mbstring
 
       - run: composer install --no-dev --no-interaction --prefer-dist
@@ -40,7 +40,7 @@ jobs:
 
       - uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2'
+          php-version: '8.5'
           extensions: pdo, pdo_mysql, json, hash, zlib, mbstring
 
       - run: composer install --no-dev --no-interaction --prefer-dist
@@ -57,7 +57,7 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 60
     env:
-      PHP_VERSION: '8.2'
+      PHP_VERSION: '8.5'
 
     steps:
       - uses: actions/checkout@v5

--- a/packages/reprint-importer/src/lib/url-rewrite/class-sql-statement-rewriter.php
+++ b/packages/reprint-importer/src/lib/url-rewrite/class-sql-statement-rewriter.php
@@ -200,6 +200,16 @@ class SqlStatementRewriter
      * contain `(`, `)`, `,` etc. arrive as a single token and never affect
      * depth.
      *
+     * @return array{table: string, column_map: list<array{int, int, string}>}|null
+     */
+    // Called via reflection in SqlStatementRewriterLexerWalkerTest.
+    // @phpstan-ignore method.unused
+    private function map_values_to_columns(string $sql): ?array
+    {
+        return $this->map_values_to_columns_from_tokens(self::significant_tokens($sql));
+    }
+
+    /**
      * Consumes a pre-lexed token array. Lets callers that already lexed the
      * statement avoid a second WP_MySQL_Lexer pass.
      *

--- a/packages/reprint-importer/src/lib/url-rewrite/class-sql-statement-rewriter.php
+++ b/packages/reprint-importer/src/lib/url-rewrite/class-sql-statement-rewriter.php
@@ -200,17 +200,8 @@ class SqlStatementRewriter
      * contain `(`, `)`, `,` etc. arrive as a single token and never affect
      * depth.
      *
-     * @return array{table: string, column_map: list<array{int, int, string}>}|null
-     */
-    private function map_values_to_columns(string $sql): ?array
-    {
-        return $this->map_values_to_columns_from_tokens(self::significant_tokens($sql));
-    }
-
-    /**
-     * Same contract as map_values_to_columns(), but consumes a pre-lexed
-     * token array. Lets callers that already lexed the statement avoid a
-     * second WP_MySQL_Lexer pass.
+     * Consumes a pre-lexed token array. Lets callers that already lexed the
+     * statement avoid a second WP_MySQL_Lexer pass.
      *
      * @param WP_MySQL_Token[] $tokens
      * @return array{table: string, column_map: list<array{int, int, string}>}|null

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -49,3 +49,13 @@ parameters:
 			message: "#^Function _doing_it_wrong not found\\.$#"
 			count: 1
 			path: packages/reprint-importer/src/lib/url-rewrite/class-structured-data-url-rewriter.php
+
+		-
+			message: "#^Class PDO\\\\SQLite not found\\.$#"
+			count: 1
+			path: packages/reprint-importer/src/import.php
+
+		-
+			message: "#^Call to method createFunction\\(\\) on an unknown class PDO\\\\SQLite\\.$#"
+			count: 1
+			path: packages/reprint-importer/src/import.php

--- a/phpstan-stubs.php
+++ b/phpstan-stubs.php
@@ -1,17 +1,13 @@
 <?php
 /**
- * PHPStan bootstrap – stub symbols unavailable on the analysis runtime.
- *
- * PDO\SQLite was introduced in PHP 8.4. The sqlite-database-integration
- * submodule references it, but CI runs PHPStan on PHP 8.2.
+ * PHPStan stub – PDO\SQLite was introduced in PHP 8.4. CI runs PHPStan on
+ * PHP 8.2, so we stub the class to avoid "not found" errors.
  */
 
 namespace PDO;
 
-if ( ! class_exists( 'PDO\\SQLite', false ) ) {
-	class SQLite extends \PDO {
-		public function createFunction( string $function_name, callable $callback, int $num_args = -1, int $flags = 0 ): bool {
-			return true;
-		}
+class SQLite extends \PDO {
+	public function createFunction( string $function_name, callable $callback, int $num_args = -1, int $flags = 0 ): bool {
+		return true;
 	}
 }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -4,6 +4,7 @@ includes:
 parameters:
     bootstrapFiles:
         - phpstan-bootstrap.php
+    stubFiles:
         - phpstan-stubs.php
     phpVersion: 70400
     level: 5
@@ -13,11 +14,11 @@ parameters:
         - reprint-exporter-wp
     excludePaths:
         analyseAndScan:
-            - packages/reprint-exporter/src/class-sqlite-driver-pdo.php
             - reprint-exporter-wp/wordpress/
             - reprint-exporter-wp/index.php
             - reprint-exporter-wp/vendor/
         analyse:
+            - packages/reprint-exporter/src/class-sqlite-driver-pdo.php
             - packages/reprint-importer/src/lib/mysql-query-stream/
             - reprint-exporter-wp/vendor/
     treatPhpDocTypesAsCertain: false


### PR DESCRIPTION
## Summary
Bumps the perf-report workflow's PHP version from 8.2 to 8.5 in all three jobs (build-pr-phar, build-trunk-phar, bench) so PR benchmarks run on the runtime we actually care about going forward.

## Test plan
- [ ] CI Performance Report job runs green on this PR using PHP 8.5
- [ ] Benchmark numbers post back as a sticky comment as before

> Note: based on `adamziel/fix-static-analysis` because that branch introduces `perf-report.yml`. Retarget to `trunk` once the base merges.