### PR TITLE
Bump wp-php-toolkit packages to ^0.6.2

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e21abdea677e191878779abd9c299941",
+    "content-hash": "235fd4568fd52fc58afeaf434a8e167a",
     "packages": [
         {
             "name": "wp-php-toolkit/bytestream",
-            "version": "v0.5.1",
+            "version": "v0.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-php-toolkit/bytestream.git",
-                "reference": "664b3f6930afcd057acd3eb92370ba99853858f0"
+                "reference": "bf3e28e6f6e51e7abeec16e3f8c3a096e0aa2a02"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-php-toolkit/bytestream/zipball/664b3f6930afcd057acd3eb92370ba99853858f0",
-                "reference": "664b3f6930afcd057acd3eb92370ba99853858f0",
+                "url": "https://api.github.com/repos/wp-php-toolkit/bytestream/zipball/bf3e28e6f6e51e7abeec16e3f8c3a096e0aa2a02",
+                "reference": "bf3e28e6f6e51e7abeec16e3f8c3a096e0aa2a02",
                 "shasum": ""
             },
             "require": {
@@ -52,30 +52,30 @@
             "description": "ByteStream component for WordPress.",
             "support": {
                 "issues": "https://github.com/wp-php-toolkit/bytestream/issues",
-                "source": "https://github.com/wp-php-toolkit/bytestream/tree/v0.5.1"
+                "source": "https://github.com/wp-php-toolkit/bytestream/tree/v0.6.2"
             },
-            "time": "2025-09-11T23:53:08+00:00"
+            "time": "2026-04-10T20:16:27+00:00"
         },
         {
             "name": "wp-php-toolkit/data-liberation",
-            "version": "v0.5.1",
+            "version": "v0.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-php-toolkit/data-liberation.git",
-                "reference": "b42d4b045a3a0b124ec361de3b5873d85c9bb549"
+                "reference": "3502454cd1c760b929329cb4f744ada6eb08ba73"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-php-toolkit/data-liberation/zipball/b42d4b045a3a0b124ec361de3b5873d85c9bb549",
-                "reference": "b42d4b045a3a0b124ec361de3b5873d85c9bb549",
+                "url": "https://api.github.com/repos/wp-php-toolkit/data-liberation/zipball/3502454cd1c760b929329cb4f744ada6eb08ba73",
+                "reference": "3502454cd1c760b929329cb4f744ada6eb08ba73",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2",
-                "wp-php-toolkit/bytestream": "^0.5.1",
-                "wp-php-toolkit/filesystem": "^0.5.1",
-                "wp-php-toolkit/http-client": "^0.5.1",
-                "wp-php-toolkit/xml": "^0.5.1"
+                "wp-php-toolkit/bytestream": "^0.6.2",
+                "wp-php-toolkit/filesystem": "^0.6.2",
+                "wp-php-toolkit/http-client": "^0.6.2",
+                "wp-php-toolkit/xml": "^0.6.2"
             },
             "type": "library",
             "autoload": {
@@ -107,22 +107,22 @@
             "description": "Data Liberation component for WordPress.",
             "support": {
                 "issues": "https://github.com/wp-php-toolkit/data-liberation/issues",
-                "source": "https://github.com/wp-php-toolkit/data-liberation/tree/v0.5.1"
+                "source": "https://github.com/wp-php-toolkit/data-liberation/tree/v0.6.2"
             },
-            "time": "2026-04-02T14:37:51+00:00"
+            "time": "2026-04-27T14:15:30+00:00"
         },
         {
             "name": "wp-php-toolkit/encoding",
-            "version": "v0.5.1",
+            "version": "v0.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-php-toolkit/encoding.git",
-                "reference": "aafe834847cc45133836b0462f22fa1511eb3b5a"
+                "reference": "f814ff6cae957449baa16f7dabe840cca756db6a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-php-toolkit/encoding/zipball/aafe834847cc45133836b0462f22fa1511eb3b5a",
-                "reference": "aafe834847cc45133836b0462f22fa1511eb3b5a",
+                "url": "https://api.github.com/repos/wp-php-toolkit/encoding/zipball/f814ff6cae957449baa16f7dabe840cca756db6a",
+                "reference": "f814ff6cae957449baa16f7dabe840cca756db6a",
                 "shasum": ""
             },
             "require": {
@@ -156,27 +156,27 @@
             "description": "Encoding component for WordPress.",
             "support": {
                 "issues": "https://github.com/wp-php-toolkit/encoding/issues",
-                "source": "https://github.com/wp-php-toolkit/encoding/tree/v0.5.1"
+                "source": "https://github.com/wp-php-toolkit/encoding/tree/v0.6.2"
             },
-            "time": "2025-11-20T12:04:55+00:00"
+            "time": "2026-04-10T20:16:27+00:00"
         },
         {
             "name": "wp-php-toolkit/filesystem",
-            "version": "v0.5.1",
+            "version": "v0.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-php-toolkit/filesystem.git",
-                "reference": "900e4d8e1a8ef79e59e6efa52a1e0d46eb47e8e2"
+                "reference": "36c54d8007b949c98a9fc460914367bcdc9b778f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-php-toolkit/filesystem/zipball/900e4d8e1a8ef79e59e6efa52a1e0d46eb47e8e2",
-                "reference": "900e4d8e1a8ef79e59e6efa52a1e0d46eb47e8e2",
+                "url": "https://api.github.com/repos/wp-php-toolkit/filesystem/zipball/36c54d8007b949c98a9fc460914367bcdc9b778f",
+                "reference": "36c54d8007b949c98a9fc460914367bcdc9b778f",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2",
-                "wp-php-toolkit/bytestream": "^0.5.1"
+                "wp-php-toolkit/bytestream": "^0.6.2"
             },
             "require-dev": {
                 "phpunit/phpunit": "^9.5"
@@ -210,22 +210,22 @@
             "description": "Filesystem component for WordPress.",
             "support": {
                 "issues": "https://github.com/wp-php-toolkit/filesystem/issues",
-                "source": "https://github.com/wp-php-toolkit/filesystem/tree/v0.5.1"
+                "source": "https://github.com/wp-php-toolkit/filesystem/tree/v0.6.2"
             },
-            "time": "2026-04-02T14:37:51+00:00"
+            "time": "2026-04-27T14:15:30+00:00"
         },
         {
             "name": "wp-php-toolkit/html",
-            "version": "v0.5.1",
+            "version": "v0.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-php-toolkit/html.git",
-                "reference": "7b3863dfd82d76bd9c54e6e10a3ba317110a6e92"
+                "reference": "d7dac562cdaff693d830ede7f35cf490a397678e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-php-toolkit/html/zipball/7b3863dfd82d76bd9c54e6e10a3ba317110a6e92",
-                "reference": "7b3863dfd82d76bd9c54e6e10a3ba317110a6e92",
+                "url": "https://api.github.com/repos/wp-php-toolkit/html/zipball/d7dac562cdaff693d830ede7f35cf490a397678e",
+                "reference": "d7dac562cdaff693d830ede7f35cf490a397678e",
                 "shasum": ""
             },
             "require": {
@@ -260,29 +260,29 @@
             "description": "HTML component for WordPress.",
             "support": {
                 "issues": "https://github.com/wp-php-toolkit/html/issues",
-                "source": "https://github.com/wp-php-toolkit/html/tree/v0.5.1"
+                "source": "https://github.com/wp-php-toolkit/html/tree/v0.6.2"
             },
-            "time": "2025-09-08T13:34:24+00:00"
+            "time": "2026-04-10T20:16:27+00:00"
         },
         {
             "name": "wp-php-toolkit/http-client",
-            "version": "v0.5.1",
+            "version": "v0.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-php-toolkit/http-client.git",
-                "reference": "c9f79808c164578c6080ac87a4ecc335c78dd947"
+                "reference": "1174f1e20e1f4c60a3274006ebed791ac6bccd77"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-php-toolkit/http-client/zipball/c9f79808c164578c6080ac87a4ecc335c78dd947",
-                "reference": "c9f79808c164578c6080ac87a4ecc335c78dd947",
+                "url": "https://api.github.com/repos/wp-php-toolkit/http-client/zipball/1174f1e20e1f4c60a3274006ebed791ac6bccd77",
+                "reference": "1174f1e20e1f4c60a3274006ebed791ac6bccd77",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2",
-                "wp-php-toolkit/bytestream": "^0.5.1",
-                "wp-php-toolkit/data-liberation": "^0.5.1",
-                "wp-php-toolkit/filesystem": "^0.5.1"
+                "wp-php-toolkit/bytestream": "^0.6.2",
+                "wp-php-toolkit/data-liberation": "^0.6.2",
+                "wp-php-toolkit/filesystem": "^0.6.2"
             },
             "require-dev": {
                 "phpunit/phpunit": "^9.5"
@@ -313,24 +313,24 @@
             "description": "HttpClient component for WordPress.",
             "support": {
                 "issues": "https://github.com/wp-php-toolkit/http-client/issues",
-                "source": "https://github.com/wp-php-toolkit/http-client/tree/v0.5.1"
+                "source": "https://github.com/wp-php-toolkit/http-client/tree/v0.6.2"
             },
-            "time": "2026-04-02T14:37:51+00:00"
+            "time": "2026-04-27T14:15:30+00:00"
         },
         {
             "name": "wp-php-toolkit/reprint-exporter",
-            "version": "dev-codex/extract-export-dispatcher",
+            "version": "dev-adamziel/update-wp-php-toolkit",
             "dist": {
                 "type": "path",
                 "url": "packages/reprint-exporter",
-                "reference": "2131bfb359f8e04244d912d5eeddb55c284ce52e"
+                "reference": "aa1cacfffc1485420e0b7cb33486b077f12dccf9"
             },
             "require": {
                 "ext-pdo": "*",
                 "ext-pdo_mysql": "*",
                 "php": ">=7.4",
-                "wp-php-toolkit/data-liberation": "^0.5.1",
-                "wp-php-toolkit/html": "^0.5.1"
+                "wp-php-toolkit/data-liberation": "^0.6.2",
+                "wp-php-toolkit/html": "^0.6.2"
             },
             "type": "library",
             "autoload": {
@@ -352,7 +352,7 @@
             "license": [
                 "GPL-2.0-or-later"
             ],
-            "description": "Streaming export engine used by the Site Export WordPress plugin",
+            "description": "Streaming export engine used by the Reprint Exporter WordPress plugin",
             "transport-options": {
                 "symlink": false,
                 "relative": true
@@ -360,18 +360,18 @@
         },
         {
             "name": "wp-php-toolkit/reprint-importer",
-            "version": "dev-adamziel/new-site-url-sqlite",
+            "version": "dev-adamziel/update-wp-php-toolkit",
             "dist": {
                 "type": "path",
                 "url": "packages/reprint-importer",
-                "reference": "b6ab722bb7744ab5cb8112171b72a6aab5669390"
+                "reference": "7b788fc47371ba50f508efd99fe77c0cf01b156b"
             },
             "require": {
                 "ext-pdo": "*",
                 "ext-pdo_mysql": "*",
                 "php": ">=7.4",
-                "wp-php-toolkit/data-liberation": "^0.5.1",
-                "wp-php-toolkit/html": "^0.5.1",
+                "wp-php-toolkit/data-liberation": "^0.6.2",
+                "wp-php-toolkit/html": "^0.6.2",
                 "wp-php-toolkit/reprint-exporter": "*@dev"
             },
             "bin": [
@@ -389,21 +389,21 @@
         },
         {
             "name": "wp-php-toolkit/xml",
-            "version": "v0.5.1",
+            "version": "v0.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-php-toolkit/xml.git",
-                "reference": "8ec4e2f16b18313d52c8a61a6528afacf1ceb34a"
+                "reference": "65e8a47d350179a3217b4acaf4f3597f977a9194"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-php-toolkit/xml/zipball/8ec4e2f16b18313d52c8a61a6528afacf1ceb34a",
-                "reference": "8ec4e2f16b18313d52c8a61a6528afacf1ceb34a",
+                "url": "https://api.github.com/repos/wp-php-toolkit/xml/zipball/65e8a47d350179a3217b4acaf4f3597f977a9194",
+                "reference": "65e8a47d350179a3217b4acaf4f3597f977a9194",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2",
-                "wp-php-toolkit/encoding": "^0.5.1"
+                "wp-php-toolkit/encoding": "^0.6.2"
             },
             "require-dev": {
                 "phpunit/phpunit": "^9.5"
@@ -434,9 +434,9 @@
             "description": "XML component for WordPress.",
             "support": {
                 "issues": "https://github.com/wp-php-toolkit/xml/issues",
-                "source": "https://github.com/wp-php-toolkit/xml/tree/v0.5.1"
+                "source": "https://github.com/wp-php-toolkit/xml/tree/v0.6.2"
             },
-            "time": "2026-04-02T14:37:51+00:00"
+            "time": "2026-04-27T14:15:30+00:00"
         }
     ],
     "packages-dev": [

--- a/packages/reprint-exporter/composer.json
+++ b/packages/reprint-exporter/composer.json
@@ -7,8 +7,8 @@
         "php": ">=7.4",
         "ext-pdo": "*",
         "ext-pdo_mysql": "*",
-        "wp-php-toolkit/data-liberation": "^0.5.1",
-        "wp-php-toolkit/html": "^0.5.1"
+        "wp-php-toolkit/data-liberation": "^0.6.2",
+        "wp-php-toolkit/html": "^0.6.2"
     },
     "autoload": {
         "psr-4": {

--- a/packages/reprint-importer/composer.json
+++ b/packages/reprint-importer/composer.json
@@ -7,8 +7,8 @@
         "php": ">=7.4",
         "ext-pdo": "*",
         "ext-pdo_mysql": "*",
-        "wp-php-toolkit/data-liberation": "^0.5.1",
-        "wp-php-toolkit/html": "^0.5.1",
+        "wp-php-toolkit/data-liberation": "^0.6.2",
+        "wp-php-toolkit/html": "^0.6.2",
         "wp-php-toolkit/reprint-exporter": "*@dev"
     },
     "bin": [

--- a/reprint-exporter-wp/composer.lock
+++ b/reprint-exporter-wp/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f4bbe19261f51b3c3402e5fddd73016e",
+    "content-hash": "c5be971ccfa307949af2f876340c5310",
     "packages": [
         {
             "name": "wp-php-toolkit/bytestream",
-            "version": "v0.5.1",
+            "version": "v0.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-php-toolkit/bytestream.git",
-                "reference": "664b3f6930afcd057acd3eb92370ba99853858f0"
+                "reference": "bf3e28e6f6e51e7abeec16e3f8c3a096e0aa2a02"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-php-toolkit/bytestream/zipball/664b3f6930afcd057acd3eb92370ba99853858f0",
-                "reference": "664b3f6930afcd057acd3eb92370ba99853858f0",
+                "url": "https://api.github.com/repos/wp-php-toolkit/bytestream/zipball/bf3e28e6f6e51e7abeec16e3f8c3a096e0aa2a02",
+                "reference": "bf3e28e6f6e51e7abeec16e3f8c3a096e0aa2a02",
                 "shasum": ""
             },
             "require": {
@@ -52,30 +52,30 @@
             "description": "ByteStream component for WordPress.",
             "support": {
                 "issues": "https://github.com/wp-php-toolkit/bytestream/issues",
-                "source": "https://github.com/wp-php-toolkit/bytestream/tree/v0.5.1"
+                "source": "https://github.com/wp-php-toolkit/bytestream/tree/v0.6.2"
             },
-            "time": "2025-09-11T23:53:08+00:00"
+            "time": "2026-04-10T20:16:27+00:00"
         },
         {
             "name": "wp-php-toolkit/data-liberation",
-            "version": "v0.5.1",
+            "version": "v0.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-php-toolkit/data-liberation.git",
-                "reference": "b42d4b045a3a0b124ec361de3b5873d85c9bb549"
+                "reference": "3502454cd1c760b929329cb4f744ada6eb08ba73"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-php-toolkit/data-liberation/zipball/b42d4b045a3a0b124ec361de3b5873d85c9bb549",
-                "reference": "b42d4b045a3a0b124ec361de3b5873d85c9bb549",
+                "url": "https://api.github.com/repos/wp-php-toolkit/data-liberation/zipball/3502454cd1c760b929329cb4f744ada6eb08ba73",
+                "reference": "3502454cd1c760b929329cb4f744ada6eb08ba73",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2",
-                "wp-php-toolkit/bytestream": "^0.5.1",
-                "wp-php-toolkit/filesystem": "^0.5.1",
-                "wp-php-toolkit/http-client": "^0.5.1",
-                "wp-php-toolkit/xml": "^0.5.1"
+                "wp-php-toolkit/bytestream": "^0.6.2",
+                "wp-php-toolkit/filesystem": "^0.6.2",
+                "wp-php-toolkit/http-client": "^0.6.2",
+                "wp-php-toolkit/xml": "^0.6.2"
             },
             "type": "library",
             "autoload": {
@@ -107,22 +107,22 @@
             "description": "Data Liberation component for WordPress.",
             "support": {
                 "issues": "https://github.com/wp-php-toolkit/data-liberation/issues",
-                "source": "https://github.com/wp-php-toolkit/data-liberation/tree/v0.5.1"
+                "source": "https://github.com/wp-php-toolkit/data-liberation/tree/v0.6.2"
             },
-            "time": "2026-04-02T14:37:51+00:00"
+            "time": "2026-04-27T14:15:30+00:00"
         },
         {
             "name": "wp-php-toolkit/encoding",
-            "version": "v0.5.1",
+            "version": "v0.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-php-toolkit/encoding.git",
-                "reference": "aafe834847cc45133836b0462f22fa1511eb3b5a"
+                "reference": "f814ff6cae957449baa16f7dabe840cca756db6a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-php-toolkit/encoding/zipball/aafe834847cc45133836b0462f22fa1511eb3b5a",
-                "reference": "aafe834847cc45133836b0462f22fa1511eb3b5a",
+                "url": "https://api.github.com/repos/wp-php-toolkit/encoding/zipball/f814ff6cae957449baa16f7dabe840cca756db6a",
+                "reference": "f814ff6cae957449baa16f7dabe840cca756db6a",
                 "shasum": ""
             },
             "require": {
@@ -156,27 +156,27 @@
             "description": "Encoding component for WordPress.",
             "support": {
                 "issues": "https://github.com/wp-php-toolkit/encoding/issues",
-                "source": "https://github.com/wp-php-toolkit/encoding/tree/v0.5.1"
+                "source": "https://github.com/wp-php-toolkit/encoding/tree/v0.6.2"
             },
-            "time": "2025-11-20T12:04:55+00:00"
+            "time": "2026-04-10T20:16:27+00:00"
         },
         {
             "name": "wp-php-toolkit/filesystem",
-            "version": "v0.5.1",
+            "version": "v0.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-php-toolkit/filesystem.git",
-                "reference": "900e4d8e1a8ef79e59e6efa52a1e0d46eb47e8e2"
+                "reference": "36c54d8007b949c98a9fc460914367bcdc9b778f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-php-toolkit/filesystem/zipball/900e4d8e1a8ef79e59e6efa52a1e0d46eb47e8e2",
-                "reference": "900e4d8e1a8ef79e59e6efa52a1e0d46eb47e8e2",
+                "url": "https://api.github.com/repos/wp-php-toolkit/filesystem/zipball/36c54d8007b949c98a9fc460914367bcdc9b778f",
+                "reference": "36c54d8007b949c98a9fc460914367bcdc9b778f",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2",
-                "wp-php-toolkit/bytestream": "^0.5.1"
+                "wp-php-toolkit/bytestream": "^0.6.2"
             },
             "require-dev": {
                 "phpunit/phpunit": "^9.5"
@@ -210,22 +210,22 @@
             "description": "Filesystem component for WordPress.",
             "support": {
                 "issues": "https://github.com/wp-php-toolkit/filesystem/issues",
-                "source": "https://github.com/wp-php-toolkit/filesystem/tree/v0.5.1"
+                "source": "https://github.com/wp-php-toolkit/filesystem/tree/v0.6.2"
             },
-            "time": "2026-04-02T14:37:51+00:00"
+            "time": "2026-04-27T14:15:30+00:00"
         },
         {
             "name": "wp-php-toolkit/html",
-            "version": "v0.5.1",
+            "version": "v0.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-php-toolkit/html.git",
-                "reference": "7b3863dfd82d76bd9c54e6e10a3ba317110a6e92"
+                "reference": "d7dac562cdaff693d830ede7f35cf490a397678e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-php-toolkit/html/zipball/7b3863dfd82d76bd9c54e6e10a3ba317110a6e92",
-                "reference": "7b3863dfd82d76bd9c54e6e10a3ba317110a6e92",
+                "url": "https://api.github.com/repos/wp-php-toolkit/html/zipball/d7dac562cdaff693d830ede7f35cf490a397678e",
+                "reference": "d7dac562cdaff693d830ede7f35cf490a397678e",
                 "shasum": ""
             },
             "require": {
@@ -260,29 +260,29 @@
             "description": "HTML component for WordPress.",
             "support": {
                 "issues": "https://github.com/wp-php-toolkit/html/issues",
-                "source": "https://github.com/wp-php-toolkit/html/tree/v0.5.1"
+                "source": "https://github.com/wp-php-toolkit/html/tree/v0.6.2"
             },
-            "time": "2025-09-08T13:34:24+00:00"
+            "time": "2026-04-10T20:16:27+00:00"
         },
         {
             "name": "wp-php-toolkit/http-client",
-            "version": "v0.5.1",
+            "version": "v0.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-php-toolkit/http-client.git",
-                "reference": "c9f79808c164578c6080ac87a4ecc335c78dd947"
+                "reference": "1174f1e20e1f4c60a3274006ebed791ac6bccd77"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-php-toolkit/http-client/zipball/c9f79808c164578c6080ac87a4ecc335c78dd947",
-                "reference": "c9f79808c164578c6080ac87a4ecc335c78dd947",
+                "url": "https://api.github.com/repos/wp-php-toolkit/http-client/zipball/1174f1e20e1f4c60a3274006ebed791ac6bccd77",
+                "reference": "1174f1e20e1f4c60a3274006ebed791ac6bccd77",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2",
-                "wp-php-toolkit/bytestream": "^0.5.1",
-                "wp-php-toolkit/data-liberation": "^0.5.1",
-                "wp-php-toolkit/filesystem": "^0.5.1"
+                "wp-php-toolkit/bytestream": "^0.6.2",
+                "wp-php-toolkit/data-liberation": "^0.6.2",
+                "wp-php-toolkit/filesystem": "^0.6.2"
             },
             "require-dev": {
                 "phpunit/phpunit": "^9.5"
@@ -313,24 +313,24 @@
             "description": "HttpClient component for WordPress.",
             "support": {
                 "issues": "https://github.com/wp-php-toolkit/http-client/issues",
-                "source": "https://github.com/wp-php-toolkit/http-client/tree/v0.5.1"
+                "source": "https://github.com/wp-php-toolkit/http-client/tree/v0.6.2"
             },
-            "time": "2026-04-02T14:37:51+00:00"
+            "time": "2026-04-27T14:15:30+00:00"
         },
         {
             "name": "wp-php-toolkit/reprint-exporter",
-            "version": "dev-codex/extract-export-dispatcher",
+            "version": "dev-adamziel/update-wp-php-toolkit",
             "dist": {
                 "type": "path",
                 "url": "../packages/reprint-exporter",
-                "reference": "2131bfb359f8e04244d912d5eeddb55c284ce52e"
+                "reference": "aa1cacfffc1485420e0b7cb33486b077f12dccf9"
             },
             "require": {
                 "ext-pdo": "*",
                 "ext-pdo_mysql": "*",
                 "php": ">=7.4",
-                "wp-php-toolkit/data-liberation": "^0.5.1",
-                "wp-php-toolkit/html": "^0.5.1"
+                "wp-php-toolkit/data-liberation": "^0.6.2",
+                "wp-php-toolkit/html": "^0.6.2"
             },
             "type": "library",
             "autoload": {
@@ -352,7 +352,7 @@
             "license": [
                 "GPL-2.0-or-later"
             ],
-            "description": "Streaming export engine used by the Site Export WordPress plugin",
+            "description": "Streaming export engine used by the Reprint Exporter WordPress plugin",
             "transport-options": {
                 "symlink": false,
                 "relative": true
@@ -360,21 +360,21 @@
         },
         {
             "name": "wp-php-toolkit/xml",
-            "version": "v0.5.1",
+            "version": "v0.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-php-toolkit/xml.git",
-                "reference": "8ec4e2f16b18313d52c8a61a6528afacf1ceb34a"
+                "reference": "65e8a47d350179a3217b4acaf4f3597f977a9194"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-php-toolkit/xml/zipball/8ec4e2f16b18313d52c8a61a6528afacf1ceb34a",
-                "reference": "8ec4e2f16b18313d52c8a61a6528afacf1ceb34a",
+                "url": "https://api.github.com/repos/wp-php-toolkit/xml/zipball/65e8a47d350179a3217b4acaf4f3597f977a9194",
+                "reference": "65e8a47d350179a3217b4acaf4f3597f977a9194",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2",
-                "wp-php-toolkit/encoding": "^0.5.1"
+                "wp-php-toolkit/encoding": "^0.6.2"
             },
             "require-dev": {
                 "phpunit/phpunit": "^9.5"
@@ -405,9 +405,9 @@
             "description": "XML component for WordPress.",
             "support": {
                 "issues": "https://github.com/wp-php-toolkit/xml/issues",
-                "source": "https://github.com/wp-php-toolkit/xml/tree/v0.5.1"
+                "source": "https://github.com/wp-php-toolkit/xml/tree/v0.6.2"
             },
-            "time": "2026-04-02T14:37:51+00:00"
+            "time": "2026-04-27T14:15:30+00:00"
         }
     ],
     "packages-dev": [],


### PR DESCRIPTION
## Summary
Updates the `wp-php-toolkit/*` deps (data-liberation, html, and transitively bytestream/encoding/filesystem/http-client/xml) from 0.5.1 to 0.6.2 in both producer packages so we pick up the latest fixes across the toolkit.

## Test plan
- [ ] CI green (PHPUnit + static analysis + e2e)
- [ ] Perf-report sticky comment shows no regressions vs. trunk