### PR TITLE
Fix backfill workflow apt repo conflict

### DIFF
--- a/.github/workflows/perf-history-backfill.yml
+++ b/.github/workflows/perf-history-backfill.yml
@@ -46,10 +46,10 @@ jobs:
           git clone --no-local host src-historical
           (cd src-historical && git fetch origin '+refs/heads/trunk:refs/remotes/origin/trunk')
 
-      - uses: shivammathur/setup-php@v2
-        with:
-          php-version: '8.5'
-          extensions: pdo, pdo_mysql, json, hash, zlib, mbstring
+      # Don't add shivammathur/setup-php here — it adds the ondrej PPA with a
+      # different Signed-By keyring than setup-infrastructure.sh, which makes
+      # apt-get update fail later. setup-infrastructure.sh installs PHP 8.5
+      # itself, and composer is preinstalled on ubuntu-22.04 runners.
 
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
First backfill run failed because shivammathur/setup-php and setup-infrastructure.sh both register the ondrej PPA but with different Signed-By keyrings, breaking apt-get update. Dropping the setup-php step fixes it; the infra script installs PHP 8.5 itself.