### PR TITLE
Add reprint-ui: in-browser WP.com → Playground wizard

### DIFF
--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -627,6 +627,19 @@ class AdaptiveTuner
      */
     public function get_request_params(string $endpoint): array
     {
+        // --no-adaptive turns the tuner off entirely. Contract:
+        //   • no max_execution_time / memory_threshold sent on requests
+        //     → server uses its own defaults (typically the highest
+        //       allowed values, e.g. 60s on wpcomsh)
+        //   • record_result returns sleep_seconds=0 and skips AIMD
+        //   • record_error skips backoff
+        // i.e. the importer becomes a passthrough that runs as fast
+        // as the server permits. Callers like the browser-hosted
+        // reprint-ui wizard depend on this to avoid artificial
+        // pauses inside a single Playground run.
+        if (empty($this->config["enabled"])) {
+            return [];
+        }
         $params = [
             "max_execution_time" => $this->config["max_execution_time"],
             "memory_threshold" => $this->config["memory_threshold"],
@@ -797,6 +810,19 @@ class AdaptiveTuner
      */
     public function record_error(string $endpoint, array $error): array
     {
+        // --no-adaptive disables the entire tuner: no AIMD size
+        // adjustments, no error backoff, no enforced sleep. The caller
+        // sees the raw error and decides what to do.
+        if (!$this->config["enabled"]) {
+            return [
+                "decision" => "disabled",
+                "http_code" => (int) ($error["http_code"] ?? 0),
+                "timeout" => (bool) ($error["timeout"] ?? false),
+                "curl_errno" => (int) ($error["curl_errno"] ?? 0),
+                "error_backoff_remaining" => 0,
+            ];
+        }
+
         $http_code = (int) ($error["http_code"] ?? 0);
         $timeout = (bool) ($error["timeout"] ?? false);
         $curl_errno = (int) ($error["curl_errno"] ?? 0);
@@ -10555,13 +10581,16 @@ function get_importer_version(): string {
 // IMPORTER_PHAR_ENTRY is defined by the phar stub and IMPORTER_WRAPPER_ENTRY is
 // defined by the repo/package wrapper scripts, so the guard also passes when
 // running as `php reprint.phar`, `php importer/import.php`, or the Composer bin.
+// IMPORTER_WEB_ENTRY lets a web-SAPI caller (e.g. the reprint-ui wizard running
+// inside WordPress Playground) invoke the importer with a hand-built $argv.
 if (
-    PHP_SAPI === "cli" &&
+    (PHP_SAPI === "cli" || defined('IMPORTER_WEB_ENTRY')) &&
     isset($argv) &&
     (
         realpath($argv[0] ?? "") === __FILE__ ||
         defined('IMPORTER_PHAR_ENTRY') ||
-        defined('IMPORTER_WRAPPER_ENTRY')
+        defined('IMPORTER_WRAPPER_ENTRY') ||
+        defined('IMPORTER_WEB_ENTRY')
     )
 ) {
     // Handle --version before anything else.
@@ -10680,7 +10709,7 @@ if (
             'type' => 'flag',
             'target' => 'tuning_config.enabled',
             'flag_value' => true,
-            'help' => 'Enable adaptive request tuning (default: on)',
+            'help' => 'Enable adaptive request tuning (default: on). When off, the importer omits max_execution_time/memory_threshold from requests and skips inter-request sleeps and AIMD/error backoff.',
             'help_section' => 'global',
             'commands' => [],
         ],

--- a/packages/reprint-importer/src/lib/pull/class-pull.php
+++ b/packages/reprint-importer/src/lib/pull/class-pull.php
@@ -491,6 +491,15 @@ class Pull
             "message" => "Starting server at {$url}",
         ], true);
 
+        // Under web SAPIs the caller doesn't want the blocking passthru —
+        // they just want the artifacts. The reprint-ui wizard in
+        // Playground sets IMPORTER_WEB_ENTRY and expects pull to return
+        // after apply-runtime so it can serve the blueprint/download.
+        if (defined('IMPORTER_WEB_ENTRY')) {
+            $this->client->exit_code = 0;
+            return;
+        }
+
         passthru("bash " . escapeshellarg($start_sh), $exit_code);
         $this->client->exit_code = $exit_code;
     }

--- a/reprint-ui/blueprint.json
+++ b/reprint-ui/blueprint.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://playground.wordpress.net/blueprint-schema.json",
+  "landingPage": "/wp-content/mu-plugins/reprint-ui/index.php",
+  "preferredVersions": { "php": "8.2", "wp": "latest" },
+  "features": { "networking": true },
+  "steps": [
+    {
+      "step": "writeFile",
+      "path": "/wordpress/wp-content/mu-plugins/reprint-loader.php",
+      "data": "<?php // Reprint UI loader. Serves the wizard at /wp-content/mu-plugins/reprint-ui/index.php via direct file access."
+    },
+    {
+      "step": "writeFile",
+      "path": "/wordpress/wp-content/mu-plugins/reprint-ui/index.php",
+      "data": {
+        "resource": "url",
+        "url": "https://raw.githubusercontent.com/Automattic/streaming-site-migration/trunk/reprint-ui/index.php"
+      }
+    },
+    {
+      "step": "writeFile",
+      "path": "/wordpress/wp-content/mu-plugins/reprint-ui/reprint.phar",
+      "data": {
+        "resource": "url",
+        "url": "https://raw.githubusercontent.com/Automattic/streaming-site-migration/trunk/reprint.phar"
+      }
+    }
+  ]
+}

--- a/reprint-ui/bootstrap.php
+++ b/reprint-ui/bootstrap.php
@@ -1,0 +1,185 @@
+<?php
+/**
+ * Shared bootstrap for the reprint-ui wizard and its OAuth callback.
+ *
+ * Loads WordPress just far enough to read WPCOM_CLIENT_ID / _SECRET from
+ * the options table — we don't need the full WP HTTP stack, just the DB.
+ * Falls back to environment variables when WordPress is absent (useful
+ * for local `php -S` testing).
+ */
+
+if (!defined('REPRINT_BOOTSTRAPPED')) {
+    define('REPRINT_BOOTSTRAPPED', true);
+}
+
+if (!defined('REPRINT_UI_DIR')) {
+    define('REPRINT_UI_DIR', __DIR__);
+}
+if (!defined('REPRINT_UI_URL_BASE')) {
+    // The path prefix under which the wizard is served.
+    define('REPRINT_UI_URL_BASE', '/reprint.php');
+}
+
+/**
+ * No-op kept for call-site compatibility. State is held in signed,
+ * encrypted, HttpOnly cookies — see reprint_cookie_get/set/clear. We
+ * deliberately avoid PHP sessions so nothing about the user (OAuth
+ * tokens, OAuth state nonces, blog IDs) is ever persisted server-side
+ * — not in /tmp session files and not in MySQL.
+ */
+function reprint_session_start(): void {}
+
+/**
+ * Returns a 32-byte symmetric key used to encrypt cookie payloads.
+ * Derived from the WP.com client secret (already stored in wp_options
+ * for OAuth) so it survives PHP-FPM restarts without any new server
+ * state. The cookie is opaque to the client and unforgeable without
+ * this key, so a leaked cookie can't be tampered with — but if the
+ * client_secret rotates, all outstanding cookies become invalid
+ * (which forces a re-login, the safe failure mode).
+ */
+function reprint_cookie_key(): string {
+    static $key = null;
+    if ($key !== null) return $key;
+    [, $secret] = reprint_client_credentials();
+    if ($secret === '') {
+        // No client_secret available — derive from a host-stable seed
+        // so cookies at least survive within a request. Re-login on
+        // restart in this degraded mode is acceptable.
+        $secret = (string) ($_SERVER['HTTP_HOST'] ?? 'reprint') . '|fallback';
+    }
+    return $key = hash('sha256', 'reprint-ui-cookie-v1|' . $secret, true);
+}
+
+/** AES-256-GCM encrypt + base64url. Returns '' on failure. */
+function reprint_cookie_encode(array $value): string {
+    $key = reprint_cookie_key();
+    $iv = random_bytes(12);
+    $tag = '';
+    $plain = json_encode($value, JSON_UNESCAPED_SLASHES);
+    $ct = openssl_encrypt($plain, 'aes-256-gcm', $key, OPENSSL_RAW_DATA, $iv, $tag);
+    if ($ct === false) return '';
+    return rtrim(strtr(base64_encode($iv . $tag . $ct), '+/', '-_'), '=');
+}
+
+function reprint_cookie_decode(string $blob): ?array {
+    if ($blob === '') return null;
+    $raw = base64_decode(strtr($blob, '-_', '+/'), true);
+    if ($raw === false || strlen($raw) < 28) return null;
+    $iv = substr($raw, 0, 12);
+    $tag = substr($raw, 12, 16);
+    $ct = substr($raw, 28);
+    $plain = openssl_decrypt($ct, 'aes-256-gcm', reprint_cookie_key(), OPENSSL_RAW_DATA, $iv, $tag);
+    if ($plain === false) return null;
+    $decoded = json_decode($plain, true);
+    return is_array($decoded) ? $decoded : null;
+}
+
+function reprint_cookie_get(string $name): ?array {
+    if (!isset($_COOKIE[$name])) return null;
+    return reprint_cookie_decode((string) $_COOKIE[$name]);
+}
+
+function reprint_cookie_set(string $name, array $value, int $ttl = 0): void {
+    $blob = reprint_cookie_encode($value);
+    if ($blob === '') return;
+    $params = [
+        'expires'  => $ttl > 0 ? time() + $ttl : 0,
+        'path'     => '/',
+        'secure'   => !empty($_SERVER['HTTPS']),
+        'httponly' => true,
+        'samesite' => 'Lax',
+    ];
+    setcookie($name, $blob, $params);
+    $_COOKIE[$name] = $blob;
+}
+
+function reprint_cookie_clear(string $name): void {
+    setcookie($name, '', [
+        'expires'  => time() - 3600,
+        'path'     => '/',
+        'secure'   => !empty($_SERVER['HTTPS']),
+        'httponly' => true,
+        'samesite' => 'Lax',
+    ]);
+    unset($_COOKIE[$name]);
+}
+
+/** Returns the WP.com access token, or '' if not authenticated. */
+function reprint_wpcom_token(): string {
+    $tok = reprint_cookie_get('rp_tok');
+    return is_array($tok) ? (string) ($tok['token'] ?? '') : '';
+}
+
+/** Absolute redirect URI registered with the WP.com app. */
+function reprint_redirect_uri(): string {
+    $scheme = !empty($_SERVER['HTTPS']) ? 'https' : 'http';
+    $host = $_SERVER['HTTP_HOST'] ?? 'localhost';
+    return "$scheme://$host/oauth-redirect.php";
+}
+
+function reprint_site_origin(): string {
+    $scheme = !empty($_SERVER['HTTPS']) ? 'https' : 'http';
+    $host = $_SERVER['HTTP_HOST'] ?? 'localhost';
+    return "$scheme://$host";
+}
+
+/**
+ * Returns [client_id, client_secret]. Reads from wp_options when WP is
+ * loadable, from env vars as a fallback.
+ */
+function reprint_client_credentials(): array {
+    static $cached = null;
+    if ($cached !== null) return $cached;
+
+    $id = getenv('WPCOM_CLIENT_ID') ?: '';
+    $secret = getenv('WPCOM_CLIENT_SECRET') ?: '';
+
+    if ($id === '' || $secret === '') {
+        $wp_load = reprint_find_wp_load();
+        if ($wp_load !== null) {
+            if (!defined('SHORTINIT')) define('SHORTINIT', true);
+            require_once $wp_load;
+            if (function_exists('get_option')) {
+                $id = $id !== '' ? $id : (string) get_option('WPCOM_CLIENT_ID', '');
+                $secret = $secret !== '' ? $secret : (string) get_option('WPCOM_CLIENT_SECRET', '');
+            }
+        }
+    }
+
+    return $cached = [$id, $secret];
+}
+
+function reprint_find_wp_load(): ?string {
+    $candidates = [
+        $_SERVER['DOCUMENT_ROOT'] ?? '',
+        __DIR__ . '/..',
+        __DIR__ . '/../..',
+        '/srv/htdocs',
+    ];
+    foreach ($candidates as $dir) {
+        if (!$dir) continue;
+        $path = rtrim((string) $dir, '/') . '/wp-load.php';
+        if (is_readable($path)) return $path;
+    }
+    return null;
+}
+
+/** Root directory under which per-job artifacts live. Publicly readable. */
+function reprint_jobs_root(): string {
+    $candidates = [
+        ($_SERVER['DOCUMENT_ROOT'] ?? '') . '/wp-content/uploads/reprint-jobs',
+        '/srv/htdocs/wp-content/uploads/reprint-jobs',
+        sys_get_temp_dir() . '/reprint-jobs',
+    ];
+    foreach ($candidates as $dir) {
+        if ($dir && @mkdir($dir, 0775, true) || is_dir($dir)) {
+            return $dir;
+        }
+    }
+    return sys_get_temp_dir() . '/reprint-jobs';
+}
+
+function reprint_jobs_url_base(): string {
+    return reprint_site_origin() . '/wp-content/uploads/reprint-jobs';
+}

--- a/reprint-ui/debug-hmac.php
+++ b/reprint-ui/debug-hmac.php
@@ -1,0 +1,185 @@
+<?php
+/**
+ * Hand-rolled rotate + sign + ping, with every byte dumped, so we can
+ * see whether wpcomsh's HMAC error is from our signing or from the
+ * site genuinely having a different stored secret.
+ */
+require __DIR__ . '/reprint-ui/bootstrap.php';
+reprint_session_start();
+header('Content-Type: text/plain; charset=utf-8');
+
+$token   = reprint_wpcom_token();
+$site_id = (int) ($_GET['site_id'] ?? 0);
+$site_url = $_GET['site_url'] ?? '';
+if (!$token || !$site_id || !$site_url) {
+    echo "Need an authenticated session and ?site_id=X&site_url=https://…\n";
+    exit;
+}
+
+function pp($label, $value) {
+    echo "── $label ──\n";
+    if (is_string($value)) {
+        echo $value . "\n  (len=" . strlen($value) . ", hex_head=" . bin2hex(substr($value, 0, 16)) . ", hex_tail=" . bin2hex(substr($value, -16)) . ")\n\n";
+    } else {
+        echo var_export($value, true) . "\n\n";
+    }
+}
+
+function http(string $method, string $url, array $headers = [], string $body = ''): array {
+    $ch = curl_init($url);
+    curl_setopt_array($ch, [
+        CURLOPT_RETURNTRANSFER => true,
+        CURLOPT_HEADER => true,
+        CURLOPT_FOLLOWLOCATION => true,
+        CURLOPT_TIMEOUT => 20,
+        CURLOPT_USERAGENT => 'Reprint-debug/1.0',
+        CURLOPT_HTTPHEADER => $headers,
+        CURLOPT_CUSTOMREQUEST => $method,
+    ]);
+    if ($body !== '') curl_setopt($ch, CURLOPT_POSTFIELDS, $body);
+    $resp = curl_exec($ch);
+    $info = curl_getinfo($ch);
+    $hsize = (int) $info['header_size'];
+    $hdrs = substr((string) $resp, 0, $hsize);
+    $b = substr((string) $resp, $hsize);
+    curl_close($ch);
+    return ['code' => (int) $info['http_code'], 'headers' => $hdrs, 'body' => (string) $b];
+}
+
+// 1) Enable
+$enable = http(
+    'POST',
+    "https://public-api.wordpress.com/rest/v1.1/sites/{$site_id}/settings",
+    ['Authorization: Bearer ' . $token, 'Accept: application/json', 'Content-Type: application/x-www-form-urlencoded'],
+    http_build_query(['reprint_exporter_enabled' => time()])
+);
+pp('ENABLE response code', (string) $enable['code']);
+pp('ENABLE response body', $enable['body']);
+
+// 2) Rotate
+$rotate = http(
+    'POST',
+    "https://public-api.wordpress.com/rest/v1.1/jetpack-blogs/{$site_id}/rest-api?http_envelope=1",
+    ['Authorization: Bearer ' . $token, 'Accept: application/json', 'Content-Type: application/json'],
+    json_encode(['path' => '/wpcomsh/v1/reprint/rotate-export-secret'])
+);
+pp('ROTATE response code', (string) $rotate['code']);
+pp('ROTATE response body (raw)', $rotate['body']);
+
+$env = json_decode($rotate['body'], true);
+pp('ROTATE parsed envelope', $env);
+
+$inner = $env['body'] ?? null;
+if (is_string($inner)) $inner = json_decode($inner, true);
+pp('ROTATE inner', $inner);
+
+$secret = $inner['data']['secret'] ?? ($inner['secret'] ?? null);
+pp('SECRET extracted', (string) $secret);
+
+if (!$secret) { echo "no secret, abort\n"; exit; }
+
+// 3) Sign + ping using exporter's algorithm
+$nonce = bin2hex(random_bytes(16));
+$ts = sprintf('%.6f', microtime(true));
+$content_hash = hash('sha256', '');
+$sig = hash_hmac('sha256', $nonce . $ts . $content_hash, $secret);
+
+pp('nonce', $nonce);
+pp('timestamp', $ts);
+pp('content_hash', $content_hash);
+pp('signature', $sig);
+
+$preflight_url = rtrim($site_url, '/') . '/?reprint-api&site-export-api&endpoint=preflight';
+echo "→ GET $preflight_url\n\n";
+
+$ping = http('GET', $preflight_url, [
+    'Accept: application/json',
+    'X-Auth-Signature: ' . $sig,
+    'X-Auth-Nonce: ' . $nonce,
+    'X-Auth-Timestamp: ' . $ts,
+    'X-Auth-Content-Hash: ' . $content_hash,
+]);
+
+pp('PREFLIGHT code', (string) $ping['code']);
+pp('PREFLIGHT response headers', $ping['headers']);
+pp('PREFLIGHT response body', substr($ping['body'], 0, 1500));
+
+// 4) Immediately rotate AGAIN to see if subsequent rotates return same or different secrets
+$rotate2 = http(
+    'POST',
+    "https://public-api.wordpress.com/rest/v1.1/jetpack-blogs/{$site_id}/rest-api?http_envelope=1",
+    ['Authorization: Bearer ' . $token, 'Accept: application/json', 'Content-Type: application/json'],
+    json_encode(['path' => '/wpcomsh/v1/reprint/rotate-export-secret'])
+);
+$env2 = json_decode($rotate2['body'], true);
+$inner2 = $env2['body'] ?? null;
+if (is_string($inner2)) $inner2 = json_decode($inner2, true);
+$secret2 = $inner2['data']['secret'] ?? ($inner2['secret'] ?? null);
+pp('SECOND ROTATE secret', (string) $secret2);
+echo $secret === $secret2 ? "‼️ Same secret returned twice\n" : "✓ Different secret on second rotate\n";
+
+// 5) Try ping with secret2
+$nonce = bin2hex(random_bytes(16));
+$ts = sprintf('%.6f', microtime(true));
+$sig = hash_hmac('sha256', $nonce . $ts . $content_hash, $secret2);
+$ping2 = http('GET', $preflight_url, [
+    'Accept: application/json',
+    'X-Auth-Signature: ' . $sig,
+    'X-Auth-Nonce: ' . $nonce,
+    'X-Auth-Timestamp: ' . $ts,
+    'X-Auth-Content-Hash: ' . $content_hash,
+]);
+pp('PREFLIGHT 2 code', (string) $ping2['code']);
+pp('PREFLIGHT 2 body', substr($ping2['body'], 0, 800));
+
+// 6) Read the site option directly via the Jetpack proxy — confirms what
+// the SITE has stored (vs what wpcom-side rotate returned). If rotate is
+// being intercepted by wpcom and never reaching the site, the site's
+// stored value will differ from what rotate returned.
+$opt = http(
+    'POST',
+    "https://public-api.wordpress.com/rest/v1.1/jetpack-blogs/{$site_id}/rest-api?http_envelope=1",
+    ['Authorization: Bearer ' . $token, 'Accept: application/json', 'Content-Type: application/json'],
+    json_encode(['path' => '/wp/v2/settings'])  // returns whitelisted settings; reprint_exporter_secret isn't whitelisted but reprint_exporter_enabled is
+);
+pp('SITE settings (Jetpack proxy)', substr($opt['body'], 0, 1500));
+
+// 7) Confirm the site_id resolves to the URL we expect
+$siteinfo = http(
+    'GET',
+    "https://public-api.wordpress.com/rest/v1.2/sites/{$site_id}?fields=ID,URL,name,is_wpcom_atomic,is_wpcom_simple,is_jetpack",
+    ['Authorization: Bearer ' . $token, 'Accept: application/json']
+);
+pp('SITE info from /sites/<id>', $siteinfo['body']);
+
+// 7b) Check whether wpcomsh's REST namespace is actually present on this
+// site (proves the reprint-exporter-api.php is loaded, with all its
+// filters/hooks). If wpcomsh/v1 is missing, rotate is being handled
+// somewhere wpcom-side rather than on the site itself.
+$nsroot = http(
+    'POST',
+    "https://public-api.wordpress.com/rest/v1.1/jetpack-blogs/{$site_id}/rest-api?http_envelope=1",
+    ['Authorization: Bearer ' . $token, 'Accept: application/json', 'Content-Type: application/json'],
+    json_encode(['path' => '/'])
+);
+$nsbody = $nsroot['body'];
+preg_match_all('/"namespaces":\[[^\]]+\]/', $nsbody, $m);
+pp('REST namespaces on site (wpcomsh/v1 present?)', $m[0][0] ?? '(no match)');
+pp('contains "wpcomsh/v1"', strpos($nsbody, 'wpcomsh/v1') !== false ? 'YES — wpcomsh is loaded on the site' : 'NO — wpcomsh appears to NOT be loaded on this site');
+
+// 7c) Read wpcomsh routes specifically
+$wpcomsh_routes = http(
+    'POST',
+    "https://public-api.wordpress.com/rest/v1.1/jetpack-blogs/{$site_id}/rest-api?http_envelope=1",
+    ['Authorization: Bearer ' . $token, 'Accept: application/json', 'Content-Type: application/json'],
+    json_encode(['path' => '/wpcomsh/v1'])
+);
+pp('wpcomsh/v1 route listing', substr($wpcomsh_routes['body'], 0, 1500));
+
+// 8) Hit the same ?reprint-api endpoint without HMAC headers to see if
+// the request actually reaches wpcomsh's handler (vs being intercepted
+// by a cache/proxy/CDN before reaching the site).
+$bare = http('GET', rtrim($site_url, '/') . '/?reprint-api', ['Accept: application/json']);
+pp('BARE preflight (no HMAC) code', (string) $bare['code']);
+pp('BARE preflight headers', $bare['headers']);
+pp('BARE preflight body', substr($bare['body'], 0, 600));

--- a/reprint-ui/docker-compose.yml
+++ b/reprint-ui/docker-compose.yml
@@ -1,0 +1,31 @@
+services:
+  db:
+    image: mariadb:10.11
+    environment:
+      MARIADB_ROOT_PASSWORD: wp
+      MARIADB_DATABASE: wp
+      MARIADB_USER: wp
+      MARIADB_PASSWORD: wp
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      interval: 3s
+      retries: 30
+
+  wp:
+    build:
+      context: .
+      dockerfile_inline: |
+        FROM wordpress:6.7-php8.2-apache
+        RUN docker-php-ext-install pdo pdo_mysql
+    depends_on:
+      db: { condition: service_healthy }
+    ports: ["8080:80"]
+    environment:
+      WORDPRESS_DB_HOST: db
+      WORDPRESS_DB_USER: wp
+      WORDPRESS_DB_PASSWORD: wp
+      WORDPRESS_DB_NAME: wp
+    volumes:
+      - ../reprint-exporter-wp:/var/www/html/wp-content/plugins/reprint-exporter-wp:ro
+
+# Install with: ./install.sh

--- a/reprint-ui/index.php
+++ b/reprint-ui/index.php
@@ -1,0 +1,1319 @@
+<?php
+/**
+ * Reprint Web Wizard — full WordPress.com → Playground experience.
+ *
+ * 1. Sign in with WordPress.com (OAuth authorization-code flow).
+ * 2. List the user's Atomic/WP.com sites.
+ * 3. PHP side enables the reprint exporter + rotates the HMAC secret
+ *    via the WP.com REST API and returns {api_url, secret}.
+ * 4. Browser boots a WordPress Playground iframe, copies reprint.phar
+ *    into it, and runs the importer FROM the Playground PHP runtime —
+ *    so HTTP requests come from the user's browser (with normal
+ *    User-Agent and direct routing) rather than from this server.
+ *    Playground polls a progress file and renders status live.
+ * 5. When the import completes, the Playground iframe IS the cloned
+ *    site — no Blueprint or artifact staging needed.
+ */
+
+require __DIR__ . '/bootstrap.php';
+
+reprint_session_start();
+
+$action = $_GET['action'] ?? $_POST['action'] ?? '';
+
+switch ($action) {
+    case 'login':       action_login(); exit;
+    case 'logout':      action_logout(); exit;
+    case 'sites':       action_sites(); exit;
+    case 'me':          action_me(); exit;
+    case 'provision':   action_provision(); exit;
+    case 'status':      action_status(); exit;
+}
+
+render_wizard();
+
+// ──────────────────────────────────────────────────────────────────────────
+// OAuth + WP.com site listing
+// ──────────────────────────────────────────────────────────────────────────
+
+function action_login(): void {
+    [$client_id, ] = reprint_client_credentials();
+    if ($client_id === '') { http_response_code(500); echo 'WPCOM_CLIENT_ID not configured.'; return; }
+    $state = bin2hex(random_bytes(16));
+    // 10-minute TTL — long enough to complete the WP.com authorize
+    // round-trip but bounded so a leaked nonce can't be reused later.
+    reprint_cookie_set('rp_state', ['s' => $state], 600);
+    $params = [
+        'client_id' => $client_id,
+        'redirect_uri' => reprint_redirect_uri(),
+        'response_type' => 'code',
+        'scope' => 'global',
+        'state' => $state,
+    ];
+    header('Location: https://public-api.wordpress.com/oauth2/authorize?' . http_build_query($params));
+}
+
+function action_logout(): void {
+    reprint_cookie_clear('rp_tok');
+    reprint_cookie_clear('rp_state');
+    header('Location: /reprint.php');
+}
+
+function action_sites(): void {
+    header('Content-Type: application/json');
+    $token = reprint_wpcom_token();
+    if ($token === '') { http_response_code(401); echo json_encode(['error' => 'not_authenticated']); return; }
+    $sites = wpcom_get([
+        'url' => 'https://public-api.wordpress.com/rest/v1.1/me/sites?filter=atomic,wpcom&fields=ID,URL,name,icon,is_wpcom_atomic',
+        'token' => $token,
+    ]);
+    echo $sites;
+}
+
+function action_me(): void {
+    header('Content-Type: application/json');
+    $token = reprint_wpcom_token();
+    if ($token === '') { http_response_code(401); echo json_encode(['error' => 'not_authenticated']); return; }
+    echo wpcom_get([
+        'url' => 'https://public-api.wordpress.com/rest/v1.1/me?fields=display_name,username,avatar_URL,email',
+        'token' => $token,
+    ]);
+}
+
+/** GET the given WP.com URL with a bearer token. Returns raw JSON string. */
+function wpcom_get(array $opts): string {
+    $ch = curl_init($opts['url']);
+    curl_setopt_array($ch, [
+        CURLOPT_RETURNTRANSFER => true,
+        CURLOPT_HTTPHEADER => [
+            'Authorization: Bearer ' . $opts['token'],
+            'Accept: application/json',
+        ],
+        CURLOPT_TIMEOUT => 15,
+    ]);
+    $body = curl_exec($ch);
+    $status = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+    curl_close($ch);
+    if ($body === false) return json_encode(['error' => 'network']);
+    if ($status >= 400) { http_response_code($status); }
+    return (string) $body;
+}
+
+/**
+ * $encoding: 'json' for endpoints that expect a JSON body (e.g. the
+ * Jetpack REST bridge at /jetpack-blogs/<id>/rest-api), 'form' for the
+ * classic WP.com REST endpoints (e.g. /sites/<id>/settings) — wpcom.js
+ * defaults to form-encoded and those endpoints silently ignore JSON
+ * bodies, dropping unknown keys with a 200 OK.
+ */
+function wpcom_post(string $url, string $token, array $body, string $encoding = 'json'): array {
+    $ch = curl_init($url);
+    $headers = ['Authorization: Bearer ' . $token, 'Accept: application/json'];
+    if ($encoding === 'form') {
+        $payload = http_build_query($body);
+        $headers[] = 'Content-Type: application/x-www-form-urlencoded';
+    } else {
+        $payload = json_encode($body);
+        $headers[] = 'Content-Type: application/json';
+    }
+    curl_setopt_array($ch, [
+        CURLOPT_RETURNTRANSFER => true,
+        CURLOPT_POST => true,
+        CURLOPT_HTTPHEADER => $headers,
+        CURLOPT_POSTFIELDS => $payload,
+        CURLOPT_TIMEOUT => 30,
+    ]);
+    $resp = curl_exec($ch);
+    $status = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+    curl_close($ch);
+    return ['status' => $status, 'body' => $resp, 'json' => json_decode((string) $resp, true)];
+}
+
+/**
+ * Enables the reprint exporter on the chosen site (sliding 60-min window),
+ * then rotates the HMAC secret. Returns [api_url, secret].
+ *
+ * Mirrors Studio's pull-reprint flow: enable → rotate → use.
+ *
+ * `$site_url` is passed by the client from the already-loaded site list
+ * — avoids an extra `/sites/<id>?fields=URL` round-trip that the
+ * current token scope doesn't always cover.
+ */
+function wpcom_provision_reprint(int $site_id, string $site_url, string $token): array {
+    // Step 1: set reprint_exporter_enabled=<timestamp> via /sites/<id>/settings.
+    // WP.com's settings endpoint whitelists keys and silently drops
+    // unknown ones with a 200 OK, so we verify that the key actually
+    // appears in the response's `updated` object — matching Studio's
+    // enableReprintExporter behavior in yangon/apps/cli/lib/api.ts.
+    $enabled = wpcom_post(
+        "https://public-api.wordpress.com/rest/v1.1/sites/{$site_id}/settings",
+        $token,
+        ['reprint_exporter_enabled' => time()],
+        'form'
+    );
+    if ($enabled['status'] >= 400) {
+        throw new RuntimeException("enable-export-api failed (HTTP {$enabled['status']}): " . substr((string)$enabled['body'], 0, 300));
+    }
+    $updated = $enabled['json']['updated'] ?? null;
+    if (!is_array($updated) || !array_key_exists('reprint_exporter_enabled', $updated)) {
+        throw new RuntimeException(
+            'The site did not acknowledge the reprint exporter activation. ' .
+            'The feature may not be available yet on this WordPress.com site. ' .
+            'Response: ' . substr((string) $enabled['body'], 0, 400)
+        );
+    }
+
+    // Step 2: rotate the HMAC secret via the Jetpack bridge.
+    $rotated = wpcom_post(
+        "https://public-api.wordpress.com/rest/v1.1/jetpack-blogs/{$site_id}/rest-api?http_envelope=1",
+        $token,
+        ['path' => '/wpcomsh/v1/reprint/rotate-export-secret']
+    );
+    $env = $rotated['json'] ?? null;
+    if (!is_array($env) || ($env['code'] ?? 0) !== 200) {
+        throw new RuntimeException('rotate-export-secret failed: ' . substr((string)$rotated['body'], 0, 300));
+    }
+    // Jetpack bridge returns the inner response in `body`. WP.com sometimes
+    // hands it back as an object, sometimes as a JSON-encoded string —
+    // normalise both shapes.
+    $inner = $env['body'] ?? null;
+    if (is_string($inner)) {
+        $inner = json_decode($inner, true);
+    }
+    $secret = is_array($inner) ? ($inner['data']['secret'] ?? null) : null;
+    if (!$secret) {
+        throw new RuntimeException('No secret in rotate response: ' . substr((string)$rotated['body'], 0, 400));
+    }
+
+    // Belt-and-suspenders: if the site also has the legacy
+    // `reprint-exporter-wp` standalone plugin installed, that plugin
+    // intercepts ?reprint-api at plugin-load time and reads its secret
+    // from the `site_export_secret` option (NOT wpcomsh's
+    // `reprint_exporter_secret`). Writing the rotated value to both
+    // options means whichever handler fires first will accept us.
+    // The settings endpoint silently drops keys it doesn't whitelist,
+    // so this is a no-op on sites without the legacy plugin.
+    $legacy_sync = wpcom_post(
+        "https://public-api.wordpress.com/rest/v1.1/sites/{$site_id}/settings",
+        $token,
+        ['site_export_secret' => $secret],
+        'form'
+    );
+
+    $debug = [
+        'enable_updated' => $updated,
+        'rotate_raw' => (string) $rotated['body'],
+        'legacy_sync_status' => $legacy_sync['status'],
+        'legacy_sync_updated' => $legacy_sync['json']['updated'] ?? null,
+    ];
+    return [rtrim($site_url, '/') . '/?reprint-api', $secret, $debug];
+}
+
+/**
+ * (Unused now that the import runs inside Playground; kept here in case
+ * a future debug action wants to verify HMAC server-side.) Pings
+ * <site>/?reprint-api&endpoint=preflight using the same
+ * Site_Export_HMAC_Client the phar bundles.
+ *
+ * Returns ['ok'=>bool, 'http'=>int, 'body'=>string, 'error'=>string|null].
+ */
+function reprint_phar_preflight_ping(string $api_url, string $secret, ?callable $emit = null): array {
+    $phar = REPRINT_UI_DIR . '/reprint.phar';
+    if (!file_exists($phar)) return ['ok'=>false,'http'=>0,'body'=>'','error'=>'reprint.phar missing'];
+
+    if (!class_exists('Site_Export_HMAC_Client', false)) {
+        if ($emit) $emit(['phase'=>'provision','status'=>'progress','message'=>'Loading HMAC client from phar…']);
+        try {
+            // loadPhar() registers the archive so subsequent phar://
+            // URLs resolve. It does NOT execute the stub, so import.php
+            // and its global side-effects stay dormant.
+            \Phar::loadPhar($phar);
+            // Inside the phar the exporter source lives under vendor/,
+            // not packages/ — confirmed via Phar iterator at deploy time.
+            $hmac_path = 'phar://' . $phar . '/vendor/wp-php-toolkit/reprint-exporter/src/class-hmac-client.php';
+            require_once $hmac_path;
+        } catch (\Throwable $e) {
+            return ['ok'=>false,'http'=>0,'body'=>'','error'=>'phar load failed: '.$e->getMessage()];
+        }
+        if (!class_exists('Site_Export_HMAC_Client', false)) {
+            return ['ok'=>false,'http'=>0,'body'=>'','error'=>'Site_Export_HMAC_Client not defined after require'];
+        }
+    }
+
+    // Drop the legacy &site-export-api alias — wpcomsh's handler only
+    // looks for ?reprint-api, and the alias can confuse $wp->request
+    // parsing on some hosts (the empty-value param ends up looking like
+    // a path component).
+    $url = $api_url . '&endpoint=preflight&_cache_bust=' . time();
+    if ($emit) $emit(['phase'=>'provision','status'=>'progress','message'=>'Pinging '.$url]);
+
+    $client = new \Site_Export_HMAC_Client($secret);
+    $headers = $client->get_curl_headers('');
+
+    // wp.com's edge / WAF will serve the homepage HTML to unrecognized
+    // User-Agents, even when the request is otherwise valid. Cycle
+    // through the same UA list the phar uses so we don't get false
+    // negatives just because Reprint/1.0 was the unlucky pick.
+    $uas = [
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36',
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:132.0) Gecko/20100101 Firefox/132.0',
+        'Reprint/1.0',
+    ];
+    $last_http = 0; $last_body = ''; $last_err = null;
+    foreach ($uas as $ua) {
+        $ch = curl_init($url);
+        curl_setopt_array($ch, [
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_FOLLOWLOCATION => true,
+            CURLOPT_TIMEOUT => 15,
+            CURLOPT_CONNECTTIMEOUT => 8,
+            CURLOPT_USERAGENT => $ua,
+            CURLOPT_HTTPHEADER => array_merge(['Accept: application/json'], $headers),
+        ]);
+        $body = curl_exec($ch);
+        $last_http = (int) curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        $last_err = curl_error($ch) ?: null;
+        curl_close($ch);
+
+        if ($body === false) continue;
+        $last_body = (string) $body;
+        $json = json_decode($last_body, true);
+        if (is_array($json)) {
+            if ($last_http >= 400) {
+                return ['ok'=>false,'http'=>$last_http,'body'=>$last_body,'error'=>(string)($json['error'] ?? 'HTTP error')];
+            }
+            return ['ok'=>true,'http'=>$last_http,'body'=>$last_body,'error'=>null];
+        }
+        // non-JSON → likely WAF/UA reject; try next UA
+    }
+    return ['ok'=>false,'http'=>$last_http,'body'=>$last_body,'error'=>$last_err ?? 'non-JSON response (WAF or wpcomsh not loaded)'];
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Import orchestration
+// ──────────────────────────────────────────────────────────────────────────
+
+/**
+ * Server-side provisioning: enables the reprint exporter on the chosen
+ * WP.com site and rotates the HMAC secret. Returns JSON with the
+ * `api_url` (site ?reprint-api endpoint) and `secret` so the browser
+ * can hand them to a Playground iframe that runs the actual import.
+ *
+ * No phar invocation, no streaming, no artifact staging — that all
+ * happens client-side now, inside Playground, where browser-class
+ * User-Agent and direct routing avoid the WAF/UA rejections we hit
+ * when calling from this server.
+ */
+function action_provision(): void {
+    header('Content-Type: application/json');
+    header('Cache-Control: no-store');
+
+    $token = reprint_wpcom_token();
+    if ($token === '') {
+        http_response_code(401);
+        echo json_encode(['error' => 'not_authenticated']);
+        return;
+    }
+
+    $site_id = (int) ($_POST['site_id'] ?? 0);
+    $site_url = (string) ($_POST['site_url'] ?? '');
+    if ($site_id <= 0 || $site_url === '' || !preg_match('~^https?://[^\s]+$~i', $site_url)) {
+        http_response_code(400);
+        echo json_encode(['error' => 'site_id and a valid site_url are required']);
+        return;
+    }
+
+    try {
+        [$api_url, $secret, ] = wpcom_provision_reprint($site_id, $site_url, $token);
+    } catch (Throwable $e) {
+        http_response_code(502);
+        echo json_encode(['error' => 'provision_failed', 'message' => $e->getMessage()]);
+        return;
+    }
+
+    echo json_encode([
+        'api_url' => $api_url,
+        'secret' => $secret,
+        'site_url' => $site_url,
+        'site_id' => $site_id,
+    ]);
+}
+
+function action_status(): void {
+    header('Content-Type: application/json');
+    echo json_encode([
+        'authenticated' => reprint_wpcom_token() !== '',
+        'client_id' => reprint_client_credentials()[0],
+    ]);
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// UI
+// ──────────────────────────────────────────────────────────────────────────
+
+function render_wizard(): void {
+    $authed = reprint_wpcom_token() !== '';
+    ?><!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Reprint · WordPress.com → Playground</title>
+<style>
+  :root {
+    --bg:#0b0d12; --panel:#12151c; --panel-2:#181c26; --border:#242936;
+    --fg:#e7ecf3; --muted:#8a94a7; --accent:#7c5cff; --accent-2:#4ad1c2;
+    --ok:#3ecf8e; --err:#ff6b6b;
+    --mono:ui-monospace,SFMono-Regular,Menlo,monospace;
+  }
+  *{box-sizing:border-box}
+  html,body{margin:0;background:var(--bg);color:var(--fg);font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,system-ui,sans-serif}
+  body{min-height:100vh;background:
+    radial-gradient(800px 400px at 10% -10%, rgba(124,92,255,.18), transparent 60%),
+    radial-gradient(600px 400px at 90% 0%, rgba(74,209,194,.12), transparent 60%),
+    var(--bg);}
+  .shell{max-width:880px;margin:0 auto;padding:48px 24px 96px}
+  header.brand{display:flex;align-items:center;gap:12px;margin-bottom:28px}
+  .logo{width:32px;height:32px;border-radius:8px;background:linear-gradient(135deg,var(--accent),var(--accent-2));box-shadow:0 4px 24px rgba(124,92,255,.35)}
+  h1{font-size:22px;font-weight:600;letter-spacing:-0.01em;margin:0}
+  .subtitle{color:var(--muted);font-size:14px;margin-top:2px}
+  .stepper{display:flex;gap:8px;margin:24px 0 20px}
+  .step{flex:1;padding:10px 12px;border:1px solid var(--border);border-radius:10px;background:var(--panel);font-size:13px;color:var(--muted);display:flex;align-items:center;gap:10px}
+  .step .num{width:22px;height:22px;border-radius:50%;background:var(--panel-2);display:grid;place-items:center;font-size:12px;color:var(--muted)}
+  .step.active{border-color:var(--accent);color:var(--fg)}
+  .step.active .num{background:var(--accent);color:#fff}
+  .step.done .num{background:var(--ok);color:#0b0d12}
+  .step.done{color:var(--fg)}
+  .card{background:var(--panel);border:1px solid var(--border);border-radius:14px;padding:28px;box-shadow:0 1px 0 rgba(255,255,255,.02) inset, 0 12px 32px rgba(0,0,0,.35)}
+  .card h2{margin:0 0 6px;font-size:17px}
+  .card p.desc{margin:0 0 20px;color:var(--muted);font-size:14px;line-height:1.5}
+  button.primary{background:linear-gradient(135deg,var(--accent),#5a3fe0);color:#fff;border:0;padding:11px 18px;border-radius:9px;font-size:14px;font-weight:500;cursor:pointer;box-shadow:0 6px 18px rgba(124,92,255,.35);transition:transform .06s,box-shadow .15s}
+  button.primary:hover{box-shadow:0 10px 24px rgba(124,92,255,.45)}
+  button.primary:active{transform:translateY(1px)}
+  button.primary:disabled{opacity:.5;cursor:not-allowed;box-shadow:none}
+  button.ghost{background:transparent;color:var(--muted);border:1px solid var(--border);padding:10px 14px;border-radius:9px;cursor:pointer;font-size:13px}
+  button.ghost:hover{color:var(--fg);border-color:var(--accent)}
+  .actions{display:flex;gap:10px;align-items:center;margin-top:22px}
+  .site-list{display:flex;flex-direction:column;gap:10px;margin-top:12px;max-height:380px;overflow-y:auto;padding-right:4px}
+  input[type="search"]{width:100%;padding:11px 13px;font-size:14px;background:var(--panel-2);color:var(--fg);border:1px solid var(--border);border-radius:9px;font-family:inherit;transition:border-color .15s,box-shadow .15s}
+  input[type="search"]:focus{outline:none;border-color:var(--accent);box-shadow:0 0 0 3px rgba(124,92,255,.22)}
+  .site{display:grid;grid-template-columns:40px 1fr auto;gap:14px;align-items:center;padding:12px 14px;background:var(--panel-2);border:1px solid var(--border);border-radius:10px;cursor:pointer;transition:border-color .1s}
+  .site:hover{border-color:var(--accent)}
+  .site.selected{border-color:var(--accent);box-shadow:0 0 0 2px rgba(124,92,255,.2)}
+  .site.disabled{opacity:.45;cursor:not-allowed;filter:grayscale(.6)}
+  .site.disabled:hover{border-color:var(--border);box-shadow:none}
+  .site .reason{font-size:11px;color:var(--muted);margin-top:3px;font-style:italic}
+  .user-pill img.avatar{width:22px;height:22px;border-radius:50%;object-fit:cover}
+  .site img,.site .site-icon{width:40px;height:40px;border-radius:8px;background:var(--panel);object-fit:cover;display:grid;place-items:center;color:var(--muted);font-size:14px;font-weight:600}
+  .site .site-title{font-size:14px;font-weight:500}
+  .site .site-url{font-size:12px;color:var(--muted);font-family:var(--mono);margin-top:2px}
+  .badge{font-size:11px;padding:3px 8px;border-radius:999px;background:var(--panel);color:var(--muted);border:1px solid var(--border)}
+  .progress-list{display:flex;flex-direction:column;gap:10px;margin-top:6px}
+  .phase{display:grid;grid-template-columns:28px 1fr auto;gap:12px;align-items:center;padding:12px 14px;background:var(--panel-2);border:1px solid var(--border);border-radius:10px}
+  .phase .dot{width:10px;height:10px;border-radius:50%;background:#35394a;justify-self:center}
+  .phase.active .dot{background:var(--accent);box-shadow:0 0 12px var(--accent);animation:pulse 1.4s infinite}
+  .phase.done .dot{background:var(--ok)}
+  .phase.error .dot{background:var(--err)}
+  .phase .name{font-size:14px}
+  .phase .meta{font-size:12px;color:var(--muted);font-family:var(--mono)}
+  @keyframes pulse{50%{opacity:.4}}
+  .bar{height:6px;background:var(--panel-2);border-radius:999px;overflow:hidden;margin-top:14px}
+  .bar > div{height:100%;background:linear-gradient(90deg,var(--accent),var(--accent-2));width:0%;transition:width .25s}
+  .log{margin-top:20px;padding:14px;background:#07080c;border:1px solid var(--border);border-radius:10px;font-family:var(--mono);font-size:12px;color:#c7cddb;max-height:260px;overflow:auto;white-space:pre-wrap}
+  .log .err{color:var(--err)}
+  .log .info{color:var(--accent-2)}
+  .hidden{display:none!important}
+  .playground-frame{width:100%;height:640px;border:1px solid var(--border);border-radius:10px;background:#000;margin-top:14px}
+  .user-pill{display:flex;align-items:center;gap:8px;margin-left:auto;font-size:12px;color:var(--muted)}
+  .user-pill a{color:var(--accent-2);text-decoration:none}
+  footer{text-align:center;color:var(--muted);font-size:12px;margin-top:40px}
+</style>
+</head>
+<body>
+<div class="shell">
+  <header class="brand">
+    <div class="logo"></div>
+    <div>
+      <h1>Reprint</h1>
+      <div class="subtitle">Clone a WordPress.com site into Playground</div>
+    </div>
+    <?php if ($authed): ?>
+      <div class="user-pill" id="user-pill"><span>Signed in to WordPress.com</span> · <a href="?action=logout">Not you?</a></div>
+    <?php endif; ?>
+  </header>
+
+  <div class="stepper">
+    <div class="step <?= $authed ? 'done' : 'active' ?>" data-step="1"><span class="num">1</span>Authorize</div>
+    <div class="step <?= $authed ? 'active' : '' ?>" data-step="2"><span class="num">2</span>Pick a site</div>
+    <div class="step" data-step="3"><span class="num">3</span>Clone into Playground</div>
+  </div>
+
+  <!-- STEP 1 — Connect WP.com -->
+  <section class="card <?= $authed ? 'hidden' : '' ?>" id="card-1">
+    <h2>Connect your WordPress.com account</h2>
+    <p class="desc">We'll redirect you to WordPress.com to authorize Reprint.
+      This lets us list your sites and temporarily enable the reprint exporter
+      on the one you choose. No secrets leave this browser.</p>
+    <div class="actions">
+      <a href="?action=login"><button class="primary">Sign in with WordPress.com →</button></a>
+    </div>
+  </section>
+
+  <!-- STEP 2 — Pick site -->
+  <section class="card <?= $authed ? '' : 'hidden' ?>" id="card-2">
+    <h2>Choose a site to clone</h2>
+    <p class="desc">These are the Atomic &amp; WordPress.com sites you can access. The reprint exporter gets enabled only on the site you pick, for a rolling 60-minute window.</p>
+    <input type="search" id="site-filter" placeholder="Filter by name or URL…" autocomplete="off" class="hidden">
+    <div class="site-list" id="site-list"><p class="desc">Loading your sites…</p></div>
+    <p class="desc site-count hidden" id="site-count" style="margin:10px 0 0"></p>
+    <div class="actions">
+      <button class="primary" id="start-btn" disabled>Start import →</button>
+      <span class="subtitle" id="start-hint"></span>
+    </div>
+  </section>
+
+  <!-- STEP 3 — Provision (server-side WP.com calls) -->
+  <section class="card hidden" id="card-3">
+    <h2>Cloning into Playground…</h2>
+    <p class="desc" id="playground-desc">Authorizing exporter, then booting Playground in your browser to run the import.</p>
+    <div class="progress-list" id="phases">
+      <div class="phase" data-phase="provision">   <div class="dot"></div><div class="name">Authorize exporter</div><div class="meta">—</div></div>
+      <div class="phase" data-phase="preflight">   <div class="dot"></div><div class="name">Boot Playground</div>  <div class="meta">—</div></div>
+      <div class="phase" data-phase="database">    <div class="dot"></div><div class="name">Database</div>        <div class="meta">—</div></div>
+      <div class="phase" data-phase="files">       <div class="dot"></div><div class="name">Files</div>           <div class="meta">—</div></div>
+      <div class="phase" data-phase="apply_runtime"><div class="dot"></div><div class="name">Finalize</div>         <div class="meta">—</div></div>
+    </div>
+    <div class="bar"><div id="overall-bar"></div></div>
+    <div class="log" id="log"></div>
+    <iframe id="playground-frame" class="playground-frame hidden"></iframe>
+    <div id="error-banner" class="hidden" style="margin-top:16px;padding:14px 16px;background:rgba(255,107,107,.08);border:1px solid rgba(255,107,107,.4);border-radius:10px;color:#ffb0b0;font-size:13px;line-height:1.5"></div>
+    <div class="actions">
+      <button class="primary hidden" id="download-uploads">Download uploads from source site →</button>
+      <button class="ghost hidden" id="retry-btn">← Pick a different site</button>
+    </div>
+  </section>
+
+  <footer>Powered by <code>reprint.phar</code> · HMAC secrets rotate per import</footer>
+</div>
+
+<script>
+const $ = (s) => document.querySelector(s);
+const $$ = (s) => document.querySelectorAll(s);
+const UI_BASE = <?= json_encode(REPRINT_UI_URL_BASE) ?>;
+
+function setStep(n) {
+  $$('.step').forEach(el => {
+    const i = +el.dataset.step;
+    el.classList.toggle('active', i === n);
+    el.classList.toggle('done', i < n);
+  });
+  [1,2,3].forEach(i => $('#card-' + i).classList.toggle('hidden', i !== n));
+}
+function logLine(text, cls) {
+  const el = $('#log');
+  const div = document.createElement('div');
+  if (cls) div.className = cls;
+  div.textContent = text;
+  el.appendChild(div);
+  el.scrollTop = el.scrollHeight;
+}
+function setPhase(phase, state, meta) {
+  const el = document.querySelector(`[data-phase="${phase}"]`);
+  if (!el) return;
+  el.classList.remove('active', 'done', 'error');
+  if (state) el.classList.add(state);
+  if (meta != null) el.querySelector('.meta').textContent = meta;
+}
+function fmtBytes(n){if(n<1024)return n+' B';if(n<1048576)return (n/1024).toFixed(1)+' KB';if(n<1073741824)return (n/1048576).toFixed(1)+' MB';return (n/1073741824).toFixed(2)+' GB';}
+
+let selectedSiteId = null;
+let selectedSiteUrl = null;
+
+<?php if ($authed): ?>
+(async function loadMe() {
+  try {
+    const res = await fetch(UI_BASE + '?action=me');
+    if (!res.ok) return;
+    const me = await res.json();
+    const pill = $('#user-pill');
+    if (!pill || !me) return;
+    const name = me.display_name || me.username || 'WordPress.com user';
+    const avatar = me.avatar_URL ? `<img class="avatar" src="${me.avatar_URL}" alt="">` : '';
+    pill.innerHTML = `${avatar}<span>Signed in as <strong>${name.replace(/</g,'&lt;')}</strong></span> · <a href="?action=logout">Not you?</a>`;
+  } catch {}
+})();
+(async function loadSites() {
+  setStep(2);
+  try {
+    const res = await fetch(UI_BASE + '?action=sites');
+    if (res.status === 401) { location.href = UI_BASE + '?action=login'; return; }
+    const data = await res.json();
+    const sites = data.sites || data; // depends on wpcom response shape
+    renderSites(Array.isArray(sites) ? sites : (sites?.sites || []));
+  } catch (e) {
+    $('#site-list').innerHTML = '<p class="desc" style="color:var(--err)">Failed to load sites: ' + e.message + '</p>';
+  }
+})();
+<?php endif; ?>
+
+let ALL_SITES = [];
+
+function renderSites(sites) {
+  ALL_SITES = sites || [];
+  const list = $('#site-list');
+  const filter = $('#site-filter');
+  const count = $('#site-count');
+  if (!ALL_SITES.length) {
+    list.innerHTML = '<p class="desc">No Atomic or WordPress.com sites found on this account.</p>';
+    return;
+  }
+  filter.classList.remove('hidden');
+  count.classList.remove('hidden');
+  filter.addEventListener('input', applySiteFilter);
+  filter.focus();
+  applySiteFilter();
+}
+
+function applySiteFilter() {
+  const q = ($('#site-filter').value || '').trim().toLowerCase();
+  const filtered = q
+    ? ALL_SITES.filter(s => (s.name || '').toLowerCase().includes(q) || (s.URL || '').toLowerCase().includes(q))
+    : ALL_SITES;
+
+  const list = $('#site-list');
+  list.innerHTML = '';
+  if (!filtered.length) {
+    list.innerHTML = '<p class="desc">No sites match that filter.</p>';
+  } else {
+    filtered.forEach(s => list.appendChild(renderSiteRow(s)));
+  }
+  $('#site-count').textContent = q
+    ? `${filtered.length} of ${ALL_SITES.length} sites`
+    : `${ALL_SITES.length} sites`;
+
+  // If the previously selected site got filtered out, clear selection.
+  if (selectedSiteId && !filtered.some(s => s.ID === selectedSiteId)) {
+    selectedSiteId = null;
+    $('#start-btn').disabled = true;
+    $('#start-hint').textContent = '';
+  }
+}
+
+function renderSiteRow(s) {
+  const el = document.createElement('div');
+  el.className = 'site';
+  const isAtomic = !!s.is_wpcom_atomic;
+  if (!isAtomic) el.classList.add('disabled');
+  if (s.ID === selectedSiteId) el.classList.add('selected');
+  el.dataset.siteId = s.ID;
+  const reason = isAtomic ? '' :
+    `<div class="reason">Reprint requires Atomic hosting — Simple WordPress.com sites can't be cloned.</div>`;
+  el.innerHTML = `
+    ${s.icon && s.icon.img ? `<img src="${s.icon.img}" alt="">` : `<div class="site-icon">${(s.name||'?')[0]}</div>`}
+    <div>
+      <div class="site-title">${(s.name || s.URL || 'Untitled').replace(/</g,'&lt;')}</div>
+      <div class="site-url">${(s.URL || '').replace(/</g,'&lt;')}</div>
+      ${reason}
+    </div>
+    <span class="badge">${isAtomic ? 'Atomic' : 'Simple'}</span>`;
+  if (!isAtomic) {
+    el.title = 'Reprint requires Atomic hosting';
+    return el;
+  }
+  el.addEventListener('click', () => {
+    $$('.site').forEach(x => x.classList.remove('selected'));
+    el.classList.add('selected');
+    selectedSiteId = s.ID;
+    selectedSiteUrl = s.URL;
+    $('#start-btn').disabled = false;
+    $('#start-hint').textContent = `Will clone ${s.URL}`;
+  });
+  return el;
+}
+
+$('#start-btn')?.addEventListener('click', async () => {
+  if (!selectedSiteId) return;
+  setStep(3);
+  $('#log').innerHTML = '';
+  ['provision','preflight','database','files','apply_runtime'].forEach(p => setPhase(p, '', '—'));
+  $('#error-banner').classList.add('hidden');
+  $('#retry-btn').classList.add('hidden');
+  $('#overall-bar').style.background = '';
+  $('#overall-bar').style.width = '0%';
+
+  setPhase('provision', 'active', 'Enabling exporter & rotating secret…');
+  logLine('Calling /sites/' + selectedSiteId + '/settings + rotate-export-secret on wp.com…');
+
+  let provisioned;
+  try {
+    const res = await fetch(UI_BASE + '?action=provision', {
+      method: 'POST',
+      headers: {'Content-Type':'application/x-www-form-urlencoded'},
+      body: 'site_id=' + encodeURIComponent(selectedSiteId)
+          + '&site_url=' + encodeURIComponent(selectedSiteUrl || ''),
+    });
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({}));
+      throw new Error(err.message || 'HTTP ' + res.status);
+    }
+    provisioned = await res.json();
+  } catch (e) {
+    setPhase('provision', 'error', e.message.slice(0, 80));
+    showImportError('Provision failed: ' + e.message);
+    return;
+  }
+
+  setPhase('provision', 'done', 'authorized');
+  logLine('api_url=' + provisioned.api_url);
+  logLine('secret length=' + provisioned.secret.length, 'info');
+
+  // Hand off to Playground.
+  await runImportInPlayground(provisioned);
+});
+
+/**
+ * Boot a Playground iframe, drop reprint.phar into it, and run
+ * `reprint.phar pull` from inside Playground. The HTTP requests then
+ * originate from the user's browser (origin: playground.wordpress.net,
+ * with browser User-Agent), which avoids the WAF/UA rejections we hit
+ * when calling the source site from this PHP server.
+ */
+async function runImportInPlayground({ api_url, secret, site_url }) {
+  setPhase('preflight', 'active', 'booting Playground…');
+  $('#playground-desc').textContent = 'Booting WordPress Playground (~10s)…';
+  const frame = $('#playground-frame');
+  frame.classList.remove('hidden');
+
+  let client;
+  try {
+    const mod = await import('https://playground.wordpress.net/client/index.js');
+    client = await mod.startPlaygroundWeb({
+      iframe: frame,
+      remoteUrl: 'https://playground.wordpress.net/remote.html',
+      blueprint: {
+        landingPage: '/',
+        preferredVersions: { php: '8.2', wp: 'latest' },
+        features: { networking: true },
+      },
+    });
+    await client.isReady();
+  } catch (e) {
+    setPhase('preflight', 'error', e.message.slice(0, 80));
+    showImportError('Could not boot Playground: ' + e.message);
+    return;
+  }
+
+  setPhase('preflight', 'done', 'Playground booted');
+  setPhase('database', 'active', 'fetching reprint.phar…');
+  $('#playground-desc').textContent = 'Importing ' + site_url + ' inside Playground…';
+
+  // Push reprint.phar into Playground's filesystem.
+  let pharBytes;
+  try {
+    const r = await fetch('/reprint.phar');
+    if (!r.ok) throw new Error('HTTP ' + r.status);
+    pharBytes = new Uint8Array(await r.arrayBuffer());
+    await client.writeFile('/internal/shared/reprint.phar', pharBytes);
+    logLine('reprint.phar uploaded to Playground (' + pharBytes.length + ' bytes)', 'info');
+  } catch (e) {
+    setPhase('database', 'error', 'phar upload failed');
+    showImportError('Could not upload reprint.phar to Playground: ' + e.message);
+    return;
+  }
+
+  // Reserve a SEPARATE docroot for the import, NOT /wordpress (which
+  // already has the freshly-booted WP and would trip the phar's
+  // "target directory is not empty" guard). The activation step at
+  // the end mounts the imported wp-content into /wordpress/wp-content.
+  // Open tag is split so PHP doesn't treat the JS template literal
+  // as PHP itself.
+  await client.run({ code: '<' + "?php\n" + `
+    @mkdir('/internal/shared/reprint-state', 0777, true);
+    @mkdir('/internal/shared/reprint-site',  0777, true);
+    // Wipe any state from a previous failed run so the phar starts
+    // fresh — leftover state files would cause "no cursor found"
+    // errors on subsequent attempts.
+    foreach (glob('/internal/shared/reprint-state/.*') ?: [] as $f) { if (is_file($f)) @unlink($f); }
+    @rmdir('/internal/shared/reprint-site');
+    @mkdir('/internal/shared/reprint-site',  0777, true);
+  ` });
+
+  // ─── Single long phar run with live streaming via post_message_to_js.
+  // The phar emits NDJSON lines to STDOUT; an output-buffer callback
+  // intercepts every chunk and forwards it to JS as a postMessage. JS
+  // updates the UI live as bytes arrive. No chunking, no --max-exec —
+  // the phar just runs to completion. ───
+  const phpPullCode = '<' + "?php\n" + `
+    @ini_set('display_errors', '0');
+    @ini_set('html_errors', '0');
+    error_reporting(E_ERROR | E_PARSE);
+    if (!defined('IMPORTER_WEB_ENTRY')) define('IMPORTER_WEB_ENTRY', true);
+    if (!defined('STDOUT')) define('STDOUT', fopen('php://output', 'w'));
+    if (!defined('STDERR')) define('STDERR', fopen('php://output', 'w'));
+    if (!defined('STDIN'))  define('STDIN',  fopen('php://memory', 'r'));
+
+    // Forward every output chunk to JS as it's produced. chunk_size=1
+    // makes the callback fire on every fflush() call, so each NDJSON
+    // line the phar emits crosses the worker→main boundary immediately.
+    ob_start(function ($chunk) {
+      if ($chunk !== '' && function_exists('post_message_to_js')) {
+        post_message_to_js($chunk);
+      }
+      return ''; // swallow — we don't need it captured in the final response
+    }, 1);
+
+    // No --max-exec / no execution caps — let pull run to completion
+    // in a single call. --no-adaptive disables the request-tuning
+    // backoffs/pauses that don't help in the browser environment.
+    $argv = [
+      '/internal/shared/reprint.phar',
+      'pull',
+      ${JSON.stringify(api_url)},
+      '--secret=' . ${JSON.stringify(secret)},
+      '--state-dir=/internal/shared/reprint-state',
+      '--fs-root=/internal/shared/reprint-site',
+      '--target-engine=sqlite',
+      // Write the SQLite DB to /tmp instead of straight into
+      // /wordpress — activation wipes /wordpress before copying the
+      // imported site over it, and we want the DB intact afterwards.
+      '--target-sqlite-path=/tmp/imported.sqlite',
+      '--new-site-url=https://playground.wordpress.net',
+      '--on-fs-root-nonempty=preserve-local',
+      // --no-adaptive turns off the request-budget tuner entirely;
+      // when set, the phar omits max_execution_time / memory_threshold
+      // from outgoing requests and the server uses its own defaults.
+      '--no-adaptive',
+      // Skip wp-content/uploads on the initial pull so the cloned
+      // site is usable in seconds. The skipped paths get recorded in
+      // .import-download-list-skipped.jsonl and can be fetched later
+      // via files-pull --filter=skipped-earlier (the wizard exposes a
+      // button for that). A mu-plugin installed during activation
+      // 302-redirects missing /wp-content/uploads/* to the source
+      // site so media still renders meanwhile.
+      '--filter=essential-files',
+      // The web Playground iframe is fundamentally different from the
+      // playground-cli Node binary — no host-FS mounts, no runtime.php
+      // hot-loading, no start.sh. The runtime= adapters (php-builtin,
+      // playground-cli, nginx-fpm) all generate config that doesn't
+      // apply here, so skip apply-runtime entirely. The wizard does
+      // its own activation (symlinks + uploads-proxy mu-plugin) in JS
+      // after the phar exits.
+      '--runtime=none',
+    ];
+    $argc = count($argv);
+    @ob_implicit_flush(true);
+    include '/internal/shared/reprint.phar';
+  `;
+
+  const readState = async () => {
+    try { return JSON.parse(await client.readFileAsText('/internal/shared/reprint-state/.import-state.json')); }
+    catch { return null; }
+  };
+
+  // Drains a stdout blob (NDJSON-ish) into the in-page log AND
+  // returns the latest progress event we found in it (so the caller
+  // can render live counts after each chunk).
+  const streamLog = (text) => {
+    const out = { lastFile: null, lastDb: null, lastApply: null, raw: [] };
+    if (!text) return out;
+    for (const line of text.split('\n')) {
+      const t = line.trim();
+      if (!t) continue;
+      try {
+        const ev = JSON.parse(t);
+        out.raw.push(ev);
+        if (ev.type === 'file_progress' || ev.type === 'file_downloaded' || (ev.heartbeat && ev.files_total)) {
+          out.lastFile = ev;
+        }
+        if (ev.phase === 'sql' || ev.phase === 'db-index' || ev.type === 'db_row' || ev.bytes_received) {
+          out.lastDb = ev;
+        }
+        if (ev.phase === 'db-apply' && (ev.statements_total || ev.statements_executed)) {
+          out.lastApply = ev;
+        }
+        if (ev.message) logLine(ev.message, ev.status === 'error' ? 'err' : (ev.status === 'complete' ? 'info' : ''));
+      } catch {
+        if (t.startsWith('#!')) continue; // shebang line from phar
+        logLine(t);
+      }
+    }
+    return out;
+  };
+
+  /**
+   * Run a sub-command repeatedly until it reports completion.
+   *
+   * The phar's files-pull / db-pull use a `--max-exec=N` budget: each
+   * invocation runs at most N seconds, persists cursor state, exits
+   * with code 2 if there's more work, code 0 when done. We loop and
+   * read the state file between iterations, which is when the worker
+   * is free and `readFileAsText` can actually return live counts.
+   *
+   * `renderFromState(state)` is called after every iteration so the
+   * UI reflects the latest state-file values.
+   */
+  const fmtBytes2 = (n) => {
+    if (!n) return '';
+    if (n < 1024) return n + 'B';
+    if (n < 1024*1024) return (n/1024).toFixed(1) + 'KB';
+    if (n < 1024*1024*1024) return (n/1024/1024).toFixed(1) + 'MB';
+    return (n/1024/1024/1024).toFixed(2) + 'GB';
+  };
+  const truncate = (s, n) => s && s.length > n ? '…' + s.slice(-n) : (s || '');
+
+  // ─── Live message handler: every chunk the phar writes to stdout
+  // arrives here as a separate string. Parse NDJSON lines and update
+  // the matching phase row in real time. ───
+  let msgBuffer = '';
+  const onChunkText = (chunk) => {
+    if (typeof chunk !== 'string') {
+      try { chunk = String(chunk); } catch { return; }
+    }
+    msgBuffer += chunk;
+    let nl;
+    while ((nl = msgBuffer.indexOf('\n')) !== -1) {
+      const line = msgBuffer.slice(0, nl).trim();
+      msgBuffer = msgBuffer.slice(nl + 1);
+      if (!line) continue;
+      let ev;
+      try { ev = JSON.parse(line); }
+      catch { if (!line.startsWith('#!')) logLine(line); continue; }
+      handleStreamEvent(ev);
+    }
+  };
+
+  // Subscribe to messages from the phar (one per output chunk).
+  client.onMessage(onChunkText);
+
+  setPhase('preflight', 'active', 'starting…');
+  setPhase('database', '', '—');
+  setPhase('files', '', '—');
+
+  // Aggregate counters for high-volume events so the log doesn't get
+  // flooded. We update a single sticky line per kind instead of
+  // appending one new line per event.
+  let symlinkCount = 0, skipCount = 0;
+  let symlinkLogEl = null, skipLogEl = null;
+  let lastFilePath = '';
+
+  const updateOrInsertCounter = (refSlot, label, count) => {
+    let el = refSlot();
+    if (!el) {
+      el = document.createElement('div');
+      $('#log').appendChild(el);
+      $('#log').scrollTop = $('#log').scrollHeight;
+    }
+    el.textContent = label.replace('{n}', count.toLocaleString());
+    return el;
+  };
+
+  function handleStreamEvent(ev) {
+    // Coalesce noisy event streams into a single in-place counter line.
+    if (ev.type === 'symlink_follow') {
+      symlinkCount++;
+      symlinkLogEl = updateOrInsertCounter(() => symlinkLogEl, 'Following {n} symlink targets', symlinkCount);
+      return;
+    }
+    if (ev.type === 'skip') {
+      skipCount++;
+      skipLogEl = updateOrInsertCounter(() => skipLogEl, 'Skipping {n} files (preserve-local)', skipCount);
+      // Reflect in the files row meta as well
+      const cur = document.querySelector('[data-phase="files"] .meta')?.textContent || '';
+      if (!cur.includes('skipped')) {
+        // Append a non-blinking suffix
+        document.querySelector('[data-phase="files"] .meta').textContent = cur + ' · ' + skipCount + ' skipped';
+      } else {
+        document.querySelector('[data-phase="files"] .meta').textContent =
+          cur.replace(/\d+ skipped/, skipCount + ' skipped');
+      }
+      return;
+    }
+
+    // Phase rows already show progress for these — don't double-print.
+    const renderedAsRow =
+      ev.type === 'lifecycle' ||
+      ev.type === 'file_progress' ||
+      ev.type === 'file_downloaded' ||
+      ev.heartbeat ||
+      ev.phase === 'db-apply' ||
+      ev.phase === 'db-index' ||
+      ev.phase === 'sql';
+    const shouldLog = ev.message && (
+      ev.status === 'error' ||
+      ev.status === 'complete' ||
+      !renderedAsRow
+    );
+    if (shouldLog) logLine(ev.message, ev.status === 'error' ? 'err' : (ev.status === 'complete' ? 'info' : ''));
+
+    // ── lifecycle: mark phase started/complete ──
+    if (ev.type === 'lifecycle') {
+      const c = ev.command;
+      if (c === 'preflight' && ev.event === 'starting') setPhase('preflight', 'active', 'probing…');
+      if (c === 'preflight' && ev.event === 'complete') setPhase('preflight', 'done', 'ok');
+      if (c === 'files-pull' && ev.event === 'starting') setPhase('files', 'active', 'starting…');
+      if (c === 'files-pull' && ev.event === 'complete') {
+        setPhase('files', 'done', (ev.files_indexed ?? 0).toLocaleString() + ' files');
+        $('#overall-bar').style.width = '85%';
+      }
+      if (c === 'db-pull' && ev.event === 'starting') setPhase('database', 'active', 'pulling SQL…');
+      if (c === 'db-pull' && ev.event === 'complete') $('#overall-bar').style.width = '92%';
+      if (c === 'db-apply' && ev.event === 'starting') setPhase('database', 'active', 'applying SQL…');
+      if (c === 'db-apply' && ev.event === 'complete') {
+        setPhase('database', 'done', 'imported');
+        $('#overall-bar').style.width = '97%';
+      }
+    }
+
+    // ── files: live counts ──
+    if (ev.type === 'file_progress' || (ev.heartbeat && ev.files_total != null)) {
+      const done = ev.files_done ?? 0;
+      const total = ev.files_total ?? 0;
+      const pct = total ? Math.round((done / total) * 100) : 0;
+      // Sticky last filename — keep the previous one when the current
+      // event doesn't carry a path (e.g. heartbeats), so the meta
+      // doesn't flicker between "with file" and "without file".
+      if (ev.path) lastFilePath = ev.path;
+      const last = lastFilePath ? ' · ' + truncate(lastFilePath, 36) : '';
+      const skipSuffix = skipCount ? ' · ' + skipCount.toLocaleString() + ' skipped' : '';
+      setPhase('files', 'active',
+        total ? `${done.toLocaleString()} / ${total.toLocaleString()} (${pct}%)${last}${skipSuffix}`
+              : `${done.toLocaleString()} files${skipSuffix}`);
+      // Files-pull is the bulk of the work, so weight it heavily on
+      // the overall bar: 5% (preflight) → 85% (files done).
+      if (total) $('#overall-bar').style.width = (5 + pct * 0.80) + '%';
+    }
+
+    // ── database pull progress ──
+    if (ev.phase === 'db-index' && ev.status === 'complete' && ev.tables_processed != null) {
+      setPhase('database', 'active', ev.tables_processed + ' tables fetched');
+    }
+    if (ev.phase === 'sql' && ev.status === 'starting') {
+      setPhase('database', 'active', 'downloading SQL dump…');
+    }
+    if (ev.phase === 'sql' && ev.status === 'complete' && ev.batches_processed != null) {
+      setPhase('database', 'active', ev.batches_processed + ' batches downloaded');
+      $('#overall-bar').style.width = '70%';
+    }
+
+    // ── database apply progress ──
+    if (ev.phase === 'db-apply') {
+      const done = ev.statements_executed ?? 0;
+      const total = ev.statements_total ?? 0;
+      if (total) {
+        const pct = Math.round((done / total) * 100);
+        setPhase('database', 'active', `${done.toLocaleString()} / ${total.toLocaleString()} statements (${pct}%)`);
+      } else if (done) {
+        setPhase('database', 'active', `${done.toLocaleString()} statements`);
+      }
+    }
+
+    // ── apply-runtime / final ──
+    if (ev.command === 'apply-runtime' && ev.status === 'complete') {
+      setPhase('database', 'done', 'imported');
+    }
+
+    if (ev.status === 'error') {
+      const failed = ev.failed_stage || ev.phase || ev.command;
+      const phaseId = failed === 'preflight' ? 'preflight'
+                    : failed === 'files-pull' ? 'files'
+                    : 'database';
+      setPhase(phaseId, 'error', (ev.error || ev.message || 'failed').slice(0, 80));
+    }
+  }
+
+  // ─── Mark preflight active and run the whole pull as one call. ───
+  setPhase('preflight', 'active', 'starting…');
+  setPhase('files', 'active', 'queued');
+  setPhase('database', 'active', 'queued');
+  logLine('→ reprint pull (single run, streaming)', 'info');
+
+  let runResult, runError = null;
+  try { runResult = await client.run({ code: phpPullCode }); }
+  catch (e) { runError = e; runResult = e?.result || {}; }
+
+  // Drain any tail of the buffer.
+  if (msgBuffer.trim()) {
+    try { handleStreamEvent(JSON.parse(msgBuffer.trim())); } catch {}
+    msgBuffer = '';
+  }
+
+  if (runResult.errors) logLine('STDERR: ' + runResult.errors, 'err');
+  if (runError)         logLine('JS error: ' + runError.message, 'err');
+
+  const exitCode = runResult.exitCode ?? (runError ? -1 : 0);
+  if (exitCode !== 0) {
+    showImportError('reprint.phar exited with code ' + exitCode + '. See log above.');
+    return;
+  }
+
+  const state = await readState();
+  if (!state || state.status !== 'complete') {
+    showImportError(
+      state ? 'Import stopped at ' + (state.command || 'unknown') + '.' : 'Import did not produce a state file.'
+    );
+    return;
+  }
+
+  // ─── Activation: symlink wp-content/* from the imported docroot
+  // into /wordpress/wp-content so the booted Playground sees the
+  // imported plugins/themes/uploads. db-apply already wrote the SQL
+  // straight into /wordpress/wp-content/database/.ht.sqlite so the
+  // database side is live without further work.
+  //
+  // Also installs a mu-plugin that 302-redirects missing
+  // /wp-content/uploads/* to the source site, since uploads were
+  // skipped on the initial pull. ───
+  setPhase('apply_runtime', 'active', 'mounting wp-content…');
+  const sourceOrigin = new URL(site_url).origin;
+  const proxyMuPlugin = '<' + "?php\n" + `
+    /**
+     * Reprint uploads proxy — redirects missing /wp-content/uploads/*
+     * requests to the source site, so media keeps rendering until
+     * the uploads are downloaded locally.
+     */
+    add_action('init', function () {
+      $req = $_SERVER['REQUEST_URI'] ?? '';
+      if (strpos($req, '/wp-content/uploads/') === false) return;
+      $path = parse_url($req, PHP_URL_PATH) ?: '';
+      $marker = '/wp-content/uploads/';
+      $pos = strpos($path, $marker);
+      if ($pos === false) return;
+      $rel = substr($path, $pos);
+      $local = WP_CONTENT_DIR . substr($rel, strlen('/wp-content'));
+      if (file_exists($local)) return;
+      header('Location: ${sourceOrigin}' . $rel, true, 302);
+      exit;
+    }, 0);
+  `;
+  const activatePhp = '<' + "?php\n" + `
+    // Resolve the imported wp-content directory. The importer prefixes
+    // remote paths with "base64:<encoded>" in some preflight fields,
+    // and on wpcom Atomic the ABSPATH (wp_detect.roots[0].path) points
+    // at the shared /wordpress/core/<ver> tree which has no
+    // wp-content — wp-content lives under the document_root instead.
+    // Decode all candidate paths, try them in order, and fall back to
+    // a recursive scan of the imported tree.
+    $decode = function ($p) {
+      if (!is_string($p) || $p === '') return null;
+      if (strpos($p, 'base64:') === 0) {
+        $d = base64_decode(substr($p, 7), true);
+        return $d === false ? null : $d;
+      }
+      return $p;
+    };
+    $state = json_decode(file_get_contents('/internal/shared/reprint-state/.import-state.json'), true);
+    $pf = $state['preflight']['data'] ?? [];
+
+    // Try (in order):
+    //  1. preflight.runtime.document_root  → e.g. /srv/htdocs
+    //  2. dirname(database.wp.paths_urls.content_dir)  → parent of wp-content
+    //  3. wp_detect.roots[*]  → ABSPATH(s); only useful when ABSPATH == docroot
+    //  4. recursive scan for any directory named wp-content
+    $candidates = [];
+    $candidates[] = $decode($pf['runtime']['document_root'] ?? null);
+    $cd = $decode($pf['database']['wp']['paths_urls']['content_dir'] ?? null);
+    if ($cd) $candidates[] = rtrim(dirname($cd), '/');
+    foreach ($pf['wp_detect']['roots'] ?? [] as $r) {
+      $candidates[] = $decode($r['path'] ?? null);
+    }
+
+    $fs_root = '/internal/shared/reprint-site';
+    $remote_root = null;
+    foreach ($candidates as $rel) {
+      if (!$rel) continue;
+      $full = $fs_root . $rel;
+      if (is_dir($full . '/wp-content')) { $remote_root = $full; break; }
+    }
+    if (!$remote_root) {
+      // Fallback: scan for the deepest dir containing wp-content/.
+      $find = function ($dir) use (&$find) {
+        if (is_dir($dir . '/wp-content')) return $dir;
+        foreach (scandir($dir) ?: [] as $e) {
+          if ($e === '.' || $e === '..') continue;
+          $p = $dir . '/' . $e;
+          if (is_dir($p) && !is_link($p)) {
+            $r = $find($p);
+            if ($r !== null) return $r;
+          }
+        }
+        return null;
+      };
+      $remote_root = $find($fs_root);
+    }
+    if (!$remote_root || !is_dir($remote_root . '/wp-content')) {
+      echo json_encode([
+        'error' => 'no wp-content found in imported site',
+        'candidates_tried' => $candidates,
+        'fs_root' => $fs_root,
+      ]);
+      exit(1);
+    }
+    echo json_encode(['site_root' => $remote_root]) . "\n";
+
+    // Helpers: recursive remove + copy. We want /wordpress to end up
+    // containing exactly the imported site (no stale Playground core,
+    // no symlinks pointing into /internal/shared), so wipe & copy.
+    function _rrmdir(string $d): void {
+      if (!is_dir($d)) { @unlink($d); return; }
+      foreach (scandir($d) ?: [] as $e) {
+        if ($e === '.' || $e === '..') continue;
+        $p = $d . '/' . $e;
+        if (is_link($p) || is_file($p)) @unlink($p);
+        elseif (is_dir($p)) _rrmdir($p);
+      }
+      @rmdir($d);
+    }
+    function _rcopy(string $src, string $dst): int {
+      $count = 0;
+      if (is_file($src)) {
+        @copy($src, $dst);
+        return 1;
+      }
+      if (is_link($src)) {
+        // Skip symlinks for safety — we want concrete files only.
+        return 0;
+      }
+      if (is_dir($src)) {
+        @mkdir($dst, 0777, true);
+        foreach (scandir($src) ?: [] as $e) {
+          if ($e === '.' || $e === '..') continue;
+          $count += _rcopy($src . '/' . $e, $dst . '/' . $e);
+        }
+      }
+      return $count;
+    }
+
+    // 1. Save Playground's SQLite drop-in (db.php) — not part of the
+    //    imported site, so we'd lose it on the wipe. Tiny file (~3KB).
+    $db_drop_in = @file_get_contents('/wordpress/wp-content/db.php');
+
+    // 2. Wipe /wordpress entirely. Don't touch /wordpress itself
+    //    (mount root) — clear its contents.
+    foreach (scandir('/wordpress') ?: [] as $e) {
+      if ($e === '.' || $e === '..') continue;
+      $p = '/wordpress/' . $e;
+      if (is_link($p) || is_file($p)) @unlink($p);
+      elseif (is_dir($p)) _rrmdir($p);
+    }
+
+    // 3. Copy the imported site_root verbatim into /wordpress. After
+    //    this, wp-config.php / wp-admin / wp-includes / wp-content
+    //    are all real files at /wordpress/* — __DIR__ resolves there
+    //    cleanly, no symlink-resolution surprises.
+    $copied = _rcopy($remote_root, '/wordpress');
+
+    // 4. Wire up the SQLite database the phar populated. Move the
+    //    file (don't copy) — it's a single .sqlite file that can be
+    //    arbitrarily large.
+    @mkdir('/wordpress/wp-content/database', 0777, true);
+    if (file_exists('/tmp/imported.sqlite')) {
+      if (!@rename('/tmp/imported.sqlite', '/wordpress/wp-content/database/.ht.sqlite')) {
+        @copy('/tmp/imported.sqlite', '/wordpress/wp-content/database/.ht.sqlite');
+        @unlink('/tmp/imported.sqlite');
+      }
+    }
+
+    // 5. Restore Playground's SQLite drop-in.
+    if (is_string($db_drop_in) && $db_drop_in !== '') {
+      file_put_contents('/wordpress/wp-content/db.php', $db_drop_in);
+    }
+
+    // 6. Re-drop the uploads-proxy mu-plugin (the wp-content we just
+    //    copied may have wiped a previous install).
+    @mkdir('/wordpress/wp-content/mu-plugins', 0777, true);
+    file_put_contents(
+      '/wordpress/wp-content/mu-plugins/0-reprint-uploads-proxy.php',
+      ${JSON.stringify(proxyMuPlugin)}
+    );
+
+    echo json_encode(['copied' => $copied]) . "\n";
+  `;
+  let actResult;
+  try { actResult = await client.run({ code: activatePhp }); } catch (e) { actResult = { text: '', errors: e?.message || String(e), exitCode: -1 }; }
+  if (actResult.exitCode !== 0) {
+    setPhase('apply_runtime', 'error', 'activation failed');
+    logLine('Activation stdout: ' + (actResult.text || '(empty)'), 'err');
+    logLine('Activation stderr: ' + (actResult.errors || '(empty)'), 'err');
+    showImportError('Could not mount imported wp-content into Playground.');
+    return;
+  }
+  logLine(actResult.text, 'info');
+
+  setPhase('apply_runtime', 'done', 'ok');
+  $('#overall-bar').style.width = '100%';
+  $('#playground-desc').textContent = 'Cloned site is live below. Uploads stream from the source site until you download them locally.';
+
+  // Show the "Download uploads" button now that the site is live.
+  // It runs files-pull --filter=skipped-earlier inside Playground,
+  // pulling in the uploads we deferred during the initial import.
+  const dl = $('#download-uploads');
+  if (dl) {
+    dl.classList.remove('hidden');
+    dl.onclick = async () => {
+      dl.disabled = true;
+      dl.textContent = 'Downloading uploads…';
+      setPhase('apply_runtime', 'active', 'downloading uploads…');
+      const uploadsCode = '<' + "?php\n" + `
+        @ini_set('display_errors', '0');
+        if (!defined('IMPORTER_WEB_ENTRY')) define('IMPORTER_WEB_ENTRY', true);
+        if (!defined('STDOUT')) define('STDOUT', fopen('php://output', 'w'));
+        if (!defined('STDERR')) define('STDERR', fopen('php://output', 'w'));
+        if (!defined('STDIN'))  define('STDIN',  fopen('php://memory', 'r'));
+        ob_start(function ($c) {
+          if ($c !== '' && function_exists('post_message_to_js')) post_message_to_js($c);
+          return '';
+        }, 1);
+        $argv = [
+          '/internal/shared/reprint.phar',
+          'files-pull',
+          ${JSON.stringify(api_url)},
+          '--secret=' . ${JSON.stringify(secret)},
+          '--state-dir=/internal/shared/reprint-state',
+          '--fs-root=/internal/shared/reprint-site',
+          '--on-fs-root-nonempty=preserve-local',
+          '--no-adaptive',
+          '--filter=skipped-earlier',
+        ];
+        $argc = count($argv);
+        @ob_implicit_flush(true);
+        include '/internal/shared/reprint.phar';
+      `;
+      // Reset the live counters so the file row tracks the new run.
+      lastFilePath = '';
+      try { await client.run({ code: uploadsCode }); }
+      catch (e) { logLine('uploads pull failed: ' + e.message, 'err'); }
+      setPhase('apply_runtime', 'done', 'uploads downloaded');
+      dl.textContent = 'Uploads downloaded ✓';
+      dl.disabled = true;
+      // Reload the iframe so WP picks up the now-local images.
+      try { await client.goTo('/'); } catch {}
+    };
+  }
+
+  // Navigate the iframe to the cloned site's home page.
+  try {
+    await client.goTo('/');
+  } catch {}
+}
+
+function showImportError(msg) {
+  const banner = $('#error-banner');
+  banner.textContent = msg;
+  banner.classList.remove('hidden');
+  $('#retry-btn').classList.remove('hidden');
+}
+
+$('#retry-btn')?.addEventListener('click', () => {
+  $('#error-banner').classList.add('hidden');
+  $('#retry-btn').classList.add('hidden');
+  $('#overall-bar').style.width = '0%';
+  $('#overall-bar').style.background = '';
+  ['provision','preflight','database','files','apply_runtime'].forEach(p => setPhase(p, '', '—'));
+  setStep(2);
+});
+
+</script>
+</body>
+</html>
+    <?php
+}

--- a/reprint-ui/index.php
+++ b/reprint-ui/index.php
@@ -844,49 +844,15 @@ async function runImportInPlayground({ api_url, secret, site_url }) {
       if (!$keep_root) @rmdir($d);
     }
 
-    // Stash Playground's SQLite integration before wiping /wordpress.
-    // It's NOT just db.php — db.php is a tiny drop-in that requires
-    // /wordpress/wp-content/plugins/sqlite-database-integration/load.php.
-    // Without that plugin tree restored after the wipe, db.php would
-    // fatal on the include and WP would fall back to MySQL with the
-    // imported wp-config's Atomic credentials, which can't connect,
-    // which shows the install wizard.
-    function _rcopy_pre(string $src, string $dst): void {
-      if (is_link($src)) {
-        $t = @readlink($src);
-        if ($t !== false) @symlink($t, $dst);
-        return;
-      }
-      if (is_file($src)) { @copy($src, $dst); return; }
-      if (is_dir($src)) {
-        @mkdir($dst, 0777, true);
-        foreach (scandir($src) ?: [] as $e) {
-          if ($e === '.' || $e === '..') continue;
-          _rcopy_pre($src . '/' . $e, $dst . '/' . $e);
-        }
-      }
-    }
-    _rrmdir('/tmp/saved-sqlite');
-    @mkdir('/tmp/saved-sqlite', 0777, true);
-    if (is_file('/wordpress/wp-content/db.php')) {
-      @copy('/wordpress/wp-content/db.php', '/tmp/saved-sqlite/db.php');
-    }
-    if (is_dir('/wordpress/wp-content/plugins/sqlite-database-integration')) {
-      _rcopy_pre(
-        '/wordpress/wp-content/plugins/sqlite-database-integration',
-        '/tmp/saved-sqlite/sqlite-database-integration'
-      );
-    }
-    if (is_dir('/wordpress/wp-content/mu-plugins/sqlite-database-integration')) {
-      _rcopy_pre(
-        '/wordpress/wp-content/mu-plugins/sqlite-database-integration',
-        '/tmp/saved-sqlite/mu-plugin-sqlite-database-integration'
-      );
-    }
-
+    // Playground's WASM build loads its SQLite integration via
+    // auto_prepend_file from /internal/, *before* wp-config.php runs.
+    // So nothing in /wordpress needs to survive the wipe — wpdb gets
+    // wired up to SQLite either way, and the integration reads from
+    // <WP_CONTENT_DIR>/database/.ht.sqlite which we'll populate during
+    // activation.
     _rrmdir('/internal/shared/reprint-state');
     _rrmdir('/internal/shared/reprint-site');
-    @unlink('/tmp/imported.sqlite');
+    @unlink('/internal/shared/imported.sqlite');
     @mkdir('/internal/shared/reprint-state', 0777, true);
     @mkdir('/internal/shared/reprint-site',  0777, true);
 
@@ -930,10 +896,10 @@ async function runImportInPlayground({ api_url, secret, site_url }) {
       '--state-dir=/internal/shared/reprint-state',
       '--fs-root=/internal/shared/reprint-site',
       '--target-engine=sqlite',
-      // Write the SQLite DB to /tmp instead of straight into
-      // /wordpress — activation wipes /wordpress before copying the
-      // imported site over it, and we want the DB intact afterwards.
-      '--target-sqlite-path=/tmp/imported.sqlite',
+      // Write the SQLite DB to /internal/shared (persistent across
+      // client.run calls in this session) instead of /tmp, which can
+      // get reset between PHP contexts in Playground's WASM VFS.
+      '--target-sqlite-path=/internal/shared/imported.sqlite',
       '--new-site-url=https://playground.wordpress.net',
       // No preserve-local: we already nuked /internal/shared/reprint-site
       // before invoking the phar, so fs-root is provably empty.
@@ -1222,6 +1188,33 @@ async function runImportInPlayground({ api_url, secret, site_url }) {
     return;
   }
 
+  // wp-config neutralizer that removes hardcoded path defines from
+  // the imported wp-config.php. Atomic sites bake in
+  //   define('WP_CONTENT_DIR', '/srv/htdocs/wp-content')
+  // and similar host-specific paths. In the WASM VFS those paths
+  // don't exist, so WP's SQLite drop-in reads from the wrong place
+  // and the install wizard pops up. Comment out anything that
+  // hardcodes a path so WP derives them from ABSPATH=/wordpress/.
+  //
+  // Built as a plain JS string (NOT a template literal) and base64-
+  // encoded before reaching PHP — the regex backslashes survive
+  // JS->PHP transit, and the $vars inside PHP single-quoted strings
+  // stay literal (no double-quote interpolation traps).
+  const wpConfigNeutralizePhp =
+    "$cfg_path = '/wordpress/wp-config.php';\n" +
+    "if (is_file($cfg_path)) {\n" +
+    "    $cfg = file_get_contents($cfg_path);\n" +
+    "    $orig = $cfg;\n" +
+    "    $names = ['ABSPATH','WP_CONTENT_DIR','WP_CONTENT_URL','WP_TEMP_DIR',\n" +
+    "              'WPMU_PLUGIN_DIR','WPMU_PLUGIN_URL','WP_PLUGIN_DIR','WP_PLUGIN_URL',\n" +
+    "              'WP_LANG_DIR','WP_HOME','WP_SITEURL','COOKIE_DOMAIN'];\n" +
+    "    foreach ($names as $n) {\n" +
+    "        $pattern = '/^[\\\\s]*(define\\\\s*\\\\(\\\\s*[\\\\\\'\\\"]' . preg_quote($n, '/') . '[\\\\\\'\\\"][^)]*\\\\)\\\\s*;)/m';\n" +
+    "        $cfg = preg_replace($pattern, '// reprint-ui neutralized: $1', $cfg);\n" +
+    "    }\n" +
+    "    if ($cfg !== $orig) file_put_contents($cfg_path, $cfg);\n" +
+    "}\n";
+
   // ─── Activation: symlink wp-content/* from the imported docroot
   // into /wordpress/wp-content so the booted Playground sees the
   // imported plugins/themes/uploads. db-apply already wrote the SQL
@@ -1263,53 +1256,32 @@ async function runImportInPlayground({ api_url, secret, site_url }) {
       exit(1);
     }
 
-    // 1. Restore Playground's SQLite integration. db.php is the thin
-    //    drop-in stub; sqlite-database-integration/ is the actual
-    //    plugin code db.php requires. Both were stashed in /tmp
-    //    before /wordpress got wiped.
-    function _rcopy_act(string $src, string $dst): void {
-      if (is_link($src)) {
-        $t = @readlink($src);
-        if ($t !== false) { @unlink($dst); @symlink($t, $dst); }
-        return;
-      }
-      if (is_file($src)) { @copy($src, $dst); return; }
-      if (is_dir($src)) {
-        @mkdir($dst, 0777, true);
-        foreach (scandir($src) ?: [] as $e) {
-          if ($e === '.' || $e === '..') continue;
-          _rcopy_act($src . '/' . $e, $dst . '/' . $e);
-        }
-      }
-    }
-    if (is_file('/tmp/saved-sqlite/db.php')) {
-      @copy('/tmp/saved-sqlite/db.php', '/wordpress/wp-content/db.php');
-    }
-    if (is_dir('/tmp/saved-sqlite/sqlite-database-integration')) {
-      @mkdir('/wordpress/wp-content/plugins', 0777, true);
-      _rcopy_act(
-        '/tmp/saved-sqlite/sqlite-database-integration',
-        '/wordpress/wp-content/plugins/sqlite-database-integration'
-      );
-    }
-    if (is_dir('/tmp/saved-sqlite/mu-plugin-sqlite-database-integration')) {
-      @mkdir('/wordpress/wp-content/mu-plugins', 0777, true);
-      _rcopy_act(
-        '/tmp/saved-sqlite/mu-plugin-sqlite-database-integration',
-        '/wordpress/wp-content/mu-plugins/sqlite-database-integration'
-      );
-    }
-
-    // 2. Move the SQLite database the phar populated into place.
+    // 1. Move the SQLite database the phar populated into place.
     @mkdir('/wordpress/wp-content/database', 0777, true);
-    if (file_exists('/tmp/imported.sqlite')) {
-      if (!@rename('/tmp/imported.sqlite', '/wordpress/wp-content/database/.ht.sqlite')) {
-        @copy('/tmp/imported.sqlite', '/wordpress/wp-content/database/.ht.sqlite');
-        @unlink('/tmp/imported.sqlite');
+    $src_db = '/internal/shared/imported.sqlite';
+    $dst_db = '/wordpress/wp-content/database/.ht.sqlite';
+    $sqlite_size = is_file($src_db) ? filesize($src_db) : 0;
+    if ($sqlite_size > 0) {
+      if (!@rename($src_db, $dst_db)) {
+        @copy($src_db, $dst_db);
+        @unlink($src_db);
       }
     }
+    echo json_encode([
+      'sqlite_src_size' => $sqlite_size,
+      'sqlite_dst_size' => is_file($dst_db) ? filesize($dst_db) : 0,
+    ]) . "\n";
 
-    // 3. Drop the uploads-proxy mu-plugin. Base64-encoded so the
+    // 1b. Neutralize hardcoded path defines in the imported wp-config.
+    //     Atomic sites have define('WP_CONTENT_DIR', '/srv/htdocs/...')
+    //     which makes WP's SQLite drop-in look in the wrong place and
+    //     fall into the install wizard. Run the snippet via eval +
+    //     base64 so the regex backslashes don't get eaten by JS or
+    //     by PHP's double-quoted string parsing.
+    eval(base64_decode(${JSON.stringify(btoa(unescape(encodeURIComponent(wpConfigNeutralizePhp))))}));
+    echo json_encode(['wp_config_neutralized' => true]) . "\n";
+
+    // 2. Drop the uploads-proxy mu-plugin. Base64-encoded so the
     //    $_SERVER / $req / $rel references in its source survive
     //    PHP's outer double-quoted string parsing.
     @mkdir('/wordpress/wp-content/mu-plugins', 0777, true);

--- a/reprint-ui/index.php
+++ b/reprint-ui/index.php
@@ -1188,32 +1188,50 @@ async function runImportInPlayground({ api_url, secret, site_url }) {
     return;
   }
 
-  // wp-config neutralizer that removes hardcoded path defines from
-  // the imported wp-config.php. Atomic sites bake in
+  // Pre-empt the source's wp-config.php path defines via a Playground
+  // preload file. Atomic sites bake in
   //   define('WP_CONTENT_DIR', '/srv/htdocs/wp-content')
-  // and similar host-specific paths. In the WASM VFS those paths
-  // don't exist, so WP's SQLite drop-in reads from the wrong place
-  // and the install wizard pops up. Comment out anything that
-  // hardcodes a path so WP derives them from ABSPATH=/wordpress/.
+  // and similar host-specific paths in their wp-config.php. Those
+  // paths don't exist in Playground's WASM VFS, so the SQLite drop-in
+  // would read from the wrong place and the install wizard pops up.
   //
-  // Built as a plain JS string (NOT a template literal) and base64-
-  // encoded before reaching PHP — the regex backslashes survive
-  // JS->PHP transit, and the $vars inside PHP single-quoted strings
-  // stay literal (no double-quote interpolation traps).
-  const wpConfigNeutralizePhp =
-    "$cfg_path = '/wordpress/wp-config.php';\n" +
-    "if (is_file($cfg_path)) {\n" +
-    "    $cfg = file_get_contents($cfg_path);\n" +
-    "    $orig = $cfg;\n" +
-    "    $names = ['ABSPATH','WP_CONTENT_DIR','WP_CONTENT_URL','WP_TEMP_DIR',\n" +
-    "              'WPMU_PLUGIN_DIR','WPMU_PLUGIN_URL','WP_PLUGIN_DIR','WP_PLUGIN_URL',\n" +
-    "              'WP_LANG_DIR','WP_HOME','WP_SITEURL','COOKIE_DOMAIN'];\n" +
-    "    foreach ($names as $n) {\n" +
-    "        $pattern = '/^[\\\\s]*(define\\\\s*\\\\(\\\\s*[\\\\\\'\\\"]' . preg_quote($n, '/') . '[\\\\\\'\\\"][^)]*\\\\)\\\\s*;)/m';\n" +
-    "        $cfg = preg_replace($pattern, '// reprint-ui neutralized: $1', $cfg);\n" +
-    "    }\n" +
-    "    if ($cfg !== $orig) file_put_contents($cfg_path, $cfg);\n" +
-    "}\n";
+  // PHP's define() is idempotent — once a constant is set, subsequent
+  // define() calls are no-ops. Playground's auto_prepend mechanism
+  // runs files from /internal/shared/preload/*.php before any request
+  // (including before wp-config.php loads). So if our preload defines
+  // these constants first, the source's wp-config define() calls
+  // become no-ops regardless of how they're written: plain define(),
+  // @define(), `if (!defined()) define()`, multi-line, or whatever
+  // exotic syntax the host uses. This is more reliable than trying
+  // to regex-strip the defines from wp-config.php — that approach
+  // breaks on any syntax we didn't anticipate.
+  // The "<" + "?php" split prevents PHP from re-opening a tag here:
+  // this whole file is served as PHP, so the literal opener inside
+  // an HTML/JS string would put the parser back into PHP mode and
+  // 500 the page.
+  const pathPreloadPhp =
+    "<" + "?php\n" +
+    "// Pre-empt path defines so the imported wp-config can't point them\n" +
+    "// at host filesystem paths that don't exist in the WASM VFS.\n" +
+    "if (!defined('ABSPATH'))         define('ABSPATH', '/wordpress/');\n" +
+    "if (!defined('WP_CONTENT_DIR'))  define('WP_CONTENT_DIR', '/wordpress/wp-content');\n" +
+    "if (!defined('WP_PLUGIN_DIR'))   define('WP_PLUGIN_DIR', '/wordpress/wp-content/plugins');\n" +
+    "if (!defined('WPMU_PLUGIN_DIR')) define('WPMU_PLUGIN_DIR', '/wordpress/wp-content/mu-plugins');\n" +
+    "if (!defined('WP_LANG_DIR'))     define('WP_LANG_DIR', '/wordpress/wp-content/languages');\n" +
+    "if (!defined('WP_TEMP_DIR'))     define('WP_TEMP_DIR', '/tmp');\n" +
+    "// Atomic / wpcomstaging wp-config relies on the host injecting\n" +
+    "// DB credentials and never defines DB_* constants. In Playground\n" +
+    "// there's no host injection, so the SQLite drop-in bails with\n" +
+    "// 'database name was not set' and \\$wpdb->dbh stays null. SQLite\n" +
+    "// only uses DB_NAME as an information_schema label; the other\n" +
+    "// DB_* values are ignored. Define safe defaults so the drop-in\n" +
+    "// can connect.\n" +
+    "if (!defined('DB_NAME'))         define('DB_NAME', 'wordpress');\n" +
+    "if (!defined('DB_USER'))         define('DB_USER', 'wordpress');\n" +
+    "if (!defined('DB_PASSWORD'))     define('DB_PASSWORD', 'wordpress');\n" +
+    "if (!defined('DB_HOST'))         define('DB_HOST', 'localhost');\n" +
+    "if (!defined('DB_CHARSET'))      define('DB_CHARSET', 'utf8mb4');\n" +
+    "if (!defined('DB_COLLATE'))      define('DB_COLLATE', '');\n";
 
   // ─── Activation: symlink wp-content/* from the imported docroot
   // into /wordpress/wp-content so the booted Playground sees the
@@ -1272,14 +1290,18 @@ async function runImportInPlayground({ api_url, secret, site_url }) {
       'sqlite_dst_size' => is_file($dst_db) ? filesize($dst_db) : 0,
     ]) . "\n";
 
-    // 1b. Neutralize hardcoded path defines in the imported wp-config.
-    //     Atomic sites have define('WP_CONTENT_DIR', '/srv/htdocs/...')
-    //     which makes WP's SQLite drop-in look in the wrong place and
-    //     fall into the install wizard. Run the snippet via eval +
-    //     base64 so the regex backslashes don't get eaten by JS or
-    //     by PHP's double-quoted string parsing.
-    eval(base64_decode(${JSON.stringify(btoa(unescape(encodeURIComponent(wpConfigNeutralizePhp))))}));
-    echo json_encode(['wp_config_neutralized' => true]) . "\n";
+    // 1b. Drop a preload file that pre-defines path constants. Loaded
+    //     by Playground's auto_prepend before any request — including
+    //     before wp-config.php. PHP's define() is idempotent, so the
+    //     source's wp-config(.php) define() calls turn into no-ops and
+    //     WP_CONTENT_DIR stays at /wordpress/wp-content (where we put
+    //     the SQLite). Path-agnostic — survives any wp-config syntax.
+    @mkdir('/internal/shared/preload', 0777, true);
+    file_put_contents(
+      '/internal/shared/preload/01-reprint-paths.php',
+      base64_decode(${JSON.stringify(btoa(unescape(encodeURIComponent(pathPreloadPhp))))})
+    );
+    echo json_encode(['paths_preload_written' => true]) . "\n";
 
     // 2. Drop the uploads-proxy mu-plugin. Base64-encoded so the
     //    $_SERVER / $req / $rel references in its source survive

--- a/reprint-ui/index.php
+++ b/reprint-ui/index.php
@@ -417,6 +417,8 @@ function render_wizard(): void {
   .phase .name{font-size:14px}
   .phase .meta{font-size:12px;color:var(--muted);font-family:var(--mono)}
   @keyframes pulse{50%{opacity:.4}}
+  @keyframes spin{to{transform:rotate(360deg)}}
+  #site-refresh{display:inline-flex;align-items:center;color:var(--accent-2);opacity:.85}
   .bar{height:6px;background:var(--panel-2);border-radius:999px;overflow:hidden;margin-top:14px}
   .bar > div{height:100%;background:linear-gradient(90deg,var(--accent),var(--accent-2));width:0%;transition:width .25s}
   .log{margin-top:20px;padding:14px;background:#07080c;border:1px solid var(--border);border-radius:10px;font-family:var(--mono);font-size:12px;color:#c7cddb;max-height:260px;overflow:auto;white-space:pre-wrap}
@@ -466,12 +468,60 @@ function render_wizard(): void {
     <h2>Choose a site to clone</h2>
     <p class="desc">Atomic sites can be cloned with reprint. Simple WordPress.com sites are listed for reference but are dimmed and not selectable — they don't run wpcomsh's export endpoint. The exporter is enabled on the site you pick for a rolling 60-minute window.</p>
     <input type="search" id="site-filter" placeholder="Filter by name or URL…" autocomplete="off" class="hidden">
-    <div class="site-list" id="site-list"><p class="desc">Loading your sites…</p></div>
-    <p class="desc site-count hidden" id="site-count" style="margin:10px 0 0"></p>
+    <div class="site-list" id="site-list"><p class="desc" id="sites-loading">Loading your sites…</p></div>
+    <p class="desc site-count hidden" id="site-count" style="margin:10px 0 0;display:flex;align-items:center;gap:8px">
+      <span id="site-count-text"></span>
+      <span id="site-refresh" class="hidden" title="Refreshing site list from WordPress.com…">
+        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" style="animation:spin 0.9s linear infinite">
+          <path d="M21 12a9 9 0 1 1-6.2-8.55"></path>
+          <path d="M21 4v5h-5"></path>
+        </svg>
+      </span>
+    </p>
     <div class="actions">
       <button class="primary" id="start-btn" disabled>Start import →</button>
       <span class="subtitle" id="start-hint"></span>
     </div>
+    <script>
+      // Synchronous cache hydrate. Placed AFTER all referenced
+      // elements (site-list, site-filter, site-count, site-count-text)
+      // so getElementById always succeeds. Renders minimal-HTML rows
+      // before the bottom-of-body JS upgrades them to interactive ones.
+      (function () {
+        try {
+          const key = 'reprint:sites:' + (window.__REPRINT_USER_ID__ || 'anon');
+          const raw = localStorage.getItem(key);
+          if (!raw) return;
+          const parsed = JSON.parse(raw);
+          const sites = parsed && parsed.sites;
+          if (!Array.isArray(sites) || !sites.length) return;
+          const sorted = sites.slice().sort((a, b) =>
+            (b.is_wpcom_atomic ? 1 : 0) - (a.is_wpcom_atomic ? 1 : 0));
+          const esc = (s) => String(s || '').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');
+          document.getElementById('site-list').innerHTML = sorted.map((s) => {
+            const atomic = !!s.is_wpcom_atomic;
+            const icon = s.icon && s.icon.img
+              ? '<img src="' + esc(s.icon.img) + '" alt="">'
+              : '<div class="site-icon">' + esc((s.name || '?')[0]) + '</div>';
+            const reason = atomic ? ''
+              : '<div class="reason">Reprint requires Atomic hosting — Simple WordPress.com sites can\'t be cloned.</div>';
+            return '<div class="site ' + (atomic ? '' : 'disabled') + '" data-pending="1">'
+              + icon
+              + '<div>'
+              +   '<div class="site-title">' + esc(s.name || s.URL || 'Untitled') + '</div>'
+              +   '<div class="site-url">' + esc(s.URL) + '</div>'
+              +   reason
+              + '</div>'
+              + '<span class="badge">' + (atomic ? 'Atomic' : 'Simple') + '</span>'
+              + '</div>';
+          }).join('');
+          document.getElementById('site-filter').classList.remove('hidden');
+          document.getElementById('site-count').classList.remove('hidden');
+          document.getElementById('site-count-text').textContent = sites.length + ' sites';
+          window.__REPRINT_CACHED_SITES__ = sites;
+        } catch (e) { console.warn('reprint cache hydrate failed:', e); }
+      })();
+    </script>
   </section>
 
   <!-- STEP 3 — Provision (server-side WP.com calls) -->
@@ -544,22 +594,56 @@ let selectedSiteUrl = null;
     pill.innerHTML = `${avatar}<span>Signed in as <strong>${name.replace(/</g,'&lt;')}</strong></span> · <a href="?action=logout">Not you?</a>`;
   } catch {}
 })();
+// Hoisted so the loadSites IIFE below isn't blocked by the TDZ.
+var ALL_SITES = [];
+function sitesFingerprint(sites) {
+  return (sites || [])
+    .map(s => `${s.ID}|${s.URL}|${s.name}|${s.is_wpcom_atomic ? 1 : 0}|${s.icon?.img || ''}`)
+    .sort()
+    .join('::');
+}
+
 (async function loadSites() {
   setStep(2);
+
+  // The inline <script> next to #site-list already painted the cached
+  // rows (or did nothing if no cache). Upgrade them to fully
+  // interactive ones, then refetch in the background.
+  const cacheKey = 'reprint:sites:' + (window.__REPRINT_USER_ID__ || 'anon');
+  const cachedSites = window.__REPRINT_CACHED_SITES__;
+  let renderedFingerprint = '';
+  if (Array.isArray(cachedSites) && cachedSites.length) {
+    renderSites(cachedSites);
+    renderedFingerprint = sitesFingerprint(cachedSites);
+    $('#site-refresh').classList.remove('hidden');
+  }
+
   try {
     const res = await fetch(UI_BASE + '?action=sites');
     if (res.status === 401) { location.href = UI_BASE + '?action=login'; return; }
     const data = await res.json();
-    const sites = data.sites || data; // depends on wpcom response shape
-    renderSites(Array.isArray(sites) ? sites : (sites?.sites || []));
+    const sites = Array.isArray(data) ? data : (data.sites || []);
+    try { localStorage.setItem(cacheKey, JSON.stringify({ sites, ts: Date.now() })); } catch {}
+    // Skip re-render when nothing meaningful changed — keeps the UI
+    // stable across the background refresh, no "jump" when fresh
+    // data arrives with the same sites.
+    const liveFingerprint = sitesFingerprint(sites);
+    if (liveFingerprint !== renderedFingerprint) {
+      renderSites(sites);
+    }
   } catch (e) {
-    $('#site-list').innerHTML = '<p class="desc" style="color:var(--err)">Failed to load sites: ' + e.message + '</p>';
+    if (!cachedSites) {
+      $('#site-list').innerHTML = '<p class="desc" style="color:var(--err)">Failed to load sites: ' + e.message + '</p>';
+    }
+    // If we had a cache, leave it on screen — better than wiping it.
+  } finally {
+    $('#site-refresh').classList.add('hidden');
   }
 })();
 <?php endif; ?>
 
-let ALL_SITES = [];
-
+// ALL_SITES is hoisted above the loadSites IIFE — declaring it again
+// here would shadow the assignment.
 function renderSites(sites) {
   // Atomic sites first (those are the importable ones), Simple sites
   // last so they don't crowd the picker. Within each group, keep the
@@ -578,8 +662,14 @@ function renderSites(sites) {
   }
   filter.classList.remove('hidden');
   count.classList.remove('hidden');
-  filter.addEventListener('input', applySiteFilter);
-  filter.focus();
+  // Bind the input listener once. Refocusing on every render would
+  // steal focus from the user mid-typing when the background refresh
+  // returns, so only focus on the very first call.
+  if (!filter.dataset.bound) {
+    filter.addEventListener('input', applySiteFilter);
+    filter.dataset.bound = '1';
+    filter.focus();
+  }
   applySiteFilter();
 }
 
@@ -596,7 +686,7 @@ function applySiteFilter() {
   } else {
     filtered.forEach(s => list.appendChild(renderSiteRow(s)));
   }
-  $('#site-count').textContent = q
+  $('#site-count-text').textContent = q
     ? `${filtered.length} of ${ALL_SITES.length} sites`
     : `${ALL_SITES.length} sites`;
 
@@ -743,7 +833,7 @@ async function runImportInPlayground({ api_url, secret, site_url }) {
   // template literal as a PHP open tag.
   setPhase('preflight', 'active', 'wiping previous import…');
   await client.run({ code: '<' + "?php\n" + `
-    function _rrmdir($d) {
+    function _rrmdir($d, $keep_root = false) {
       if (!is_dir($d)) return;
       foreach (scandir($d) ?: [] as $e) {
         if ($e === '.' || $e === '..') continue;
@@ -751,13 +841,58 @@ async function runImportInPlayground({ api_url, secret, site_url }) {
         if (is_link($p) || is_file($p)) @unlink($p);
         elseif (is_dir($p)) _rrmdir($p);
       }
-      @rmdir($d);
+      if (!$keep_root) @rmdir($d);
     }
+
+    // Stash Playground's SQLite integration before wiping /wordpress.
+    // It's NOT just db.php — db.php is a tiny drop-in that requires
+    // /wordpress/wp-content/plugins/sqlite-database-integration/load.php.
+    // Without that plugin tree restored after the wipe, db.php would
+    // fatal on the include and WP would fall back to MySQL with the
+    // imported wp-config's Atomic credentials, which can't connect,
+    // which shows the install wizard.
+    function _rcopy_pre(string $src, string $dst): void {
+      if (is_link($src)) {
+        $t = @readlink($src);
+        if ($t !== false) @symlink($t, $dst);
+        return;
+      }
+      if (is_file($src)) { @copy($src, $dst); return; }
+      if (is_dir($src)) {
+        @mkdir($dst, 0777, true);
+        foreach (scandir($src) ?: [] as $e) {
+          if ($e === '.' || $e === '..') continue;
+          _rcopy_pre($src . '/' . $e, $dst . '/' . $e);
+        }
+      }
+    }
+    _rrmdir('/tmp/saved-sqlite');
+    @mkdir('/tmp/saved-sqlite', 0777, true);
+    if (is_file('/wordpress/wp-content/db.php')) {
+      @copy('/wordpress/wp-content/db.php', '/tmp/saved-sqlite/db.php');
+    }
+    if (is_dir('/wordpress/wp-content/plugins/sqlite-database-integration')) {
+      _rcopy_pre(
+        '/wordpress/wp-content/plugins/sqlite-database-integration',
+        '/tmp/saved-sqlite/sqlite-database-integration'
+      );
+    }
+    if (is_dir('/wordpress/wp-content/mu-plugins/sqlite-database-integration')) {
+      _rcopy_pre(
+        '/wordpress/wp-content/mu-plugins/sqlite-database-integration',
+        '/tmp/saved-sqlite/mu-plugin-sqlite-database-integration'
+      );
+    }
+
     _rrmdir('/internal/shared/reprint-state');
     _rrmdir('/internal/shared/reprint-site');
     @unlink('/tmp/imported.sqlite');
     @mkdir('/internal/shared/reprint-state', 0777, true);
     @mkdir('/internal/shared/reprint-site',  0777, true);
+
+    // Wipe /wordpress contents (keep the mount point itself). Pull's
+    // flat-docroot stage will recreate it from the imported tree.
+    _rrmdir('/wordpress', true);
   ` });
 
   // ─── Single long phar run with live streaming via post_message_to_js.
@@ -824,6 +959,14 @@ async function runImportInPlayground({ api_url, secret, site_url }) {
       // its own activation (symlinks + uploads-proxy mu-plugin) in JS
       // after the phar exits.
       '--runtime=none',
+      // Flatten the split-root Atomic layout (docroot at /srv/htdocs,
+      // ABSPATH at /wordpress/core/<ver>) directly into Playground's
+      // document root at /wordpress. /wordpress was wiped before the
+      // pull, so flat-docroot writes there cleanly. wp-admin and
+      // wp-includes get symlinked into the imported core tree under
+      // /internal/shared/reprint-site/, which stays alive for the
+      // session.
+      '--flatten-to=/wordpress',
     ];
     $argc = count($argv);
     @ob_implicit_flush(true);
@@ -1111,125 +1254,53 @@ async function runImportInPlayground({ api_url, secret, site_url }) {
     }, 0);
   `;
   const activatePhp = '<' + "?php\n" + `
-    // Resolve the imported wp-content directory. The importer prefixes
-    // remote paths with "base64:<encoded>" in some preflight fields,
-    // and on wpcom Atomic the ABSPATH (wp_detect.roots[0].path) points
-    // at the shared /wordpress/core/<ver> tree which has no
-    // wp-content — wp-content lives under the document_root instead.
-    // Decode all candidate paths, try them in order, and fall back to
-    // a recursive scan of the imported tree.
-    $decode = function ($p) {
-      if (!is_string($p) || $p === '') return null;
-      if (strpos($p, 'base64:') === 0) {
-        $d = base64_decode(substr($p, 7), true);
-        return $d === false ? null : $d;
-      }
-      return $p;
-    };
-    $state = json_decode(file_get_contents('/internal/shared/reprint-state/.import-state.json'), true);
-    $pf = $state['preflight']['data'] ?? [];
-
-    // Try (in order):
-    //  1. preflight.runtime.document_root  → e.g. /srv/htdocs
-    //  2. dirname(database.wp.paths_urls.content_dir)  → parent of wp-content
-    //  3. wp_detect.roots[*]  → ABSPATH(s); only useful when ABSPATH == docroot
-    //  4. recursive scan for any directory named wp-content
-    $candidates = [];
-    $candidates[] = $decode($pf['runtime']['document_root'] ?? null);
-    $cd = $decode($pf['database']['wp']['paths_urls']['content_dir'] ?? null);
-    if ($cd) $candidates[] = rtrim(dirname($cd), '/');
-    foreach ($pf['wp_detect']['roots'] ?? [] as $r) {
-      $candidates[] = $decode($r['path'] ?? null);
-    }
-
-    $fs_root = '/internal/shared/reprint-site';
-    $remote_root = null;
-    foreach ($candidates as $rel) {
-      if (!$rel) continue;
-      $full = $fs_root . $rel;
-      if (is_dir($full . '/wp-content')) { $remote_root = $full; break; }
-    }
-    if (!$remote_root) {
-      // Fallback: scan for the deepest dir containing wp-content/.
-      $find = function ($dir) use (&$find) {
-        if (is_dir($dir . '/wp-content')) return $dir;
-        foreach (scandir($dir) ?: [] as $e) {
-          if ($e === '.' || $e === '..') continue;
-          $p = $dir . '/' . $e;
-          if (is_dir($p) && !is_link($p)) {
-            $r = $find($p);
-            if ($r !== null) return $r;
-          }
-        }
-        return null;
-      };
-      $remote_root = $find($fs_root);
-    }
-    if (!$remote_root || !is_dir($remote_root . '/wp-content')) {
-      echo json_encode([
-        'error' => 'no wp-content found in imported site',
-        'candidates_tried' => $candidates,
-        'fs_root' => $fs_root,
-      ]);
+    // Pull's flat-docroot stage wrote the imported site straight into
+    // /wordpress (we wiped it before the pull and passed
+    // --flatten-to=/wordpress). Activation is now just three small
+    // wiring steps: SQLite drop-in, SQLite database file, mu-plugin.
+    if (!is_dir('/wordpress/wp-content')) {
+      echo json_encode(['error' => '/wordpress/wp-content missing — flatten failed?']);
       exit(1);
     }
-    echo json_encode(['site_root' => $remote_root]) . "\n";
 
-    // Helpers: recursive remove + copy. We want /wordpress to end up
-    // containing exactly the imported site (no stale Playground core,
-    // no symlinks pointing into /internal/shared), so wipe & copy.
-    function _rrmdir(string $d): void {
-      if (!is_dir($d)) { @unlink($d); return; }
-      foreach (scandir($d) ?: [] as $e) {
-        if ($e === '.' || $e === '..') continue;
-        $p = $d . '/' . $e;
-        if (is_link($p) || is_file($p)) @unlink($p);
-        elseif (is_dir($p)) _rrmdir($p);
-      }
-      @rmdir($d);
-    }
-    function _rcopy(string $src, string $dst): int {
-      $count = 0;
-      if (is_file($src)) {
-        @copy($src, $dst);
-        return 1;
-      }
+    // 1. Restore Playground's SQLite integration. db.php is the thin
+    //    drop-in stub; sqlite-database-integration/ is the actual
+    //    plugin code db.php requires. Both were stashed in /tmp
+    //    before /wordpress got wiped.
+    function _rcopy_act(string $src, string $dst): void {
       if (is_link($src)) {
-        // Skip symlinks for safety — we want concrete files only.
-        return 0;
+        $t = @readlink($src);
+        if ($t !== false) { @unlink($dst); @symlink($t, $dst); }
+        return;
       }
+      if (is_file($src)) { @copy($src, $dst); return; }
       if (is_dir($src)) {
         @mkdir($dst, 0777, true);
         foreach (scandir($src) ?: [] as $e) {
           if ($e === '.' || $e === '..') continue;
-          $count += _rcopy($src . '/' . $e, $dst . '/' . $e);
+          _rcopy_act($src . '/' . $e, $dst . '/' . $e);
         }
       }
-      return $count;
+    }
+    if (is_file('/tmp/saved-sqlite/db.php')) {
+      @copy('/tmp/saved-sqlite/db.php', '/wordpress/wp-content/db.php');
+    }
+    if (is_dir('/tmp/saved-sqlite/sqlite-database-integration')) {
+      @mkdir('/wordpress/wp-content/plugins', 0777, true);
+      _rcopy_act(
+        '/tmp/saved-sqlite/sqlite-database-integration',
+        '/wordpress/wp-content/plugins/sqlite-database-integration'
+      );
+    }
+    if (is_dir('/tmp/saved-sqlite/mu-plugin-sqlite-database-integration')) {
+      @mkdir('/wordpress/wp-content/mu-plugins', 0777, true);
+      _rcopy_act(
+        '/tmp/saved-sqlite/mu-plugin-sqlite-database-integration',
+        '/wordpress/wp-content/mu-plugins/sqlite-database-integration'
+      );
     }
 
-    // 1. Save Playground's SQLite drop-in (db.php) — not part of the
-    //    imported site, so we'd lose it on the wipe. Tiny file (~3KB).
-    $db_drop_in = @file_get_contents('/wordpress/wp-content/db.php');
-
-    // 2. Wipe /wordpress entirely. Don't touch /wordpress itself
-    //    (mount root) — clear its contents.
-    foreach (scandir('/wordpress') ?: [] as $e) {
-      if ($e === '.' || $e === '..') continue;
-      $p = '/wordpress/' . $e;
-      if (is_link($p) || is_file($p)) @unlink($p);
-      elseif (is_dir($p)) _rrmdir($p);
-    }
-
-    // 3. Copy the imported site_root verbatim into /wordpress. After
-    //    this, wp-config.php / wp-admin / wp-includes / wp-content
-    //    are all real files at /wordpress/* — __DIR__ resolves there
-    //    cleanly, no symlink-resolution surprises.
-    $copied = _rcopy($remote_root, '/wordpress');
-
-    // 4. Wire up the SQLite database the phar populated. Move the
-    //    file (don't copy) — it's a single .sqlite file that can be
-    //    arbitrarily large.
+    // 2. Move the SQLite database the phar populated into place.
     @mkdir('/wordpress/wp-content/database', 0777, true);
     if (file_exists('/tmp/imported.sqlite')) {
       if (!@rename('/tmp/imported.sqlite', '/wordpress/wp-content/database/.ht.sqlite')) {
@@ -1238,22 +1309,16 @@ async function runImportInPlayground({ api_url, secret, site_url }) {
       }
     }
 
-    // 5. Restore Playground's SQLite drop-in.
-    if (is_string($db_drop_in) && $db_drop_in !== '') {
-      file_put_contents('/wordpress/wp-content/db.php', $db_drop_in);
-    }
-
-    // 6. Re-drop the uploads-proxy mu-plugin (the wp-content we just
-    //    copied may have wiped a previous install). The mu-plugin
-    //    source is base64-encoded here so its $_SERVER / $req / $rel
-    //    references survive PHP's outer double-quoted string parsing.
+    // 3. Drop the uploads-proxy mu-plugin. Base64-encoded so the
+    //    $_SERVER / $req / $rel references in its source survive
+    //    PHP's outer double-quoted string parsing.
     @mkdir('/wordpress/wp-content/mu-plugins', 0777, true);
     file_put_contents(
       '/wordpress/wp-content/mu-plugins/0-reprint-uploads-proxy.php',
       base64_decode(${JSON.stringify(btoa(unescape(encodeURIComponent(proxyMuPlugin))))})
     );
 
-    echo json_encode(['copied' => $copied]) . "\n";
+    echo json_encode(['ok' => true]) . "\n";
   `;
   let actResult;
   try { actResult = await client.run({ code: activatePhp }); } catch (e) { actResult = { text: '', errors: e?.message || String(e), exitCode: -1 }; }

--- a/reprint-ui/index.php
+++ b/reprint-ui/index.php
@@ -453,7 +453,9 @@ function render_wizard(): void {
     <h2>Connect your WordPress.com account</h2>
     <p class="desc">We'll redirect you to WordPress.com to authorize Reprint.
       This lets us list your sites and temporarily enable the reprint exporter
-      on the one you choose. No secrets leave this browser.</p>
+      on the one you choose. Your access token is kept in an HTTP-only session
+      cookie on this site only — nothing is written to a database, and it's
+      gone the moment you close the tab or click "Sign out".</p>
     <div class="actions">
       <a href="?action=login"><button class="primary">Sign in with WordPress.com →</button></a>
     </div>
@@ -462,7 +464,7 @@ function render_wizard(): void {
   <!-- STEP 2 — Pick site -->
   <section class="card <?= $authed ? '' : 'hidden' ?>" id="card-2">
     <h2>Choose a site to clone</h2>
-    <p class="desc">These are the Atomic &amp; WordPress.com sites you can access. The reprint exporter gets enabled only on the site you pick, for a rolling 60-minute window.</p>
+    <p class="desc">Atomic sites can be cloned with reprint. Simple WordPress.com sites are listed for reference but are dimmed and not selectable — they don't run wpcomsh's export endpoint. The exporter is enabled on the site you pick for a rolling 60-minute window.</p>
     <input type="search" id="site-filter" placeholder="Filter by name or URL…" autocomplete="off" class="hidden">
     <div class="site-list" id="site-list"><p class="desc">Loading your sites…</p></div>
     <p class="desc site-count hidden" id="site-count" style="margin:10px 0 0"></p>
@@ -559,7 +561,14 @@ let selectedSiteUrl = null;
 let ALL_SITES = [];
 
 function renderSites(sites) {
-  ALL_SITES = sites || [];
+  // Atomic sites first (those are the importable ones), Simple sites
+  // last so they don't crowd the picker. Within each group, keep the
+  // server-given order (recently active first).
+  ALL_SITES = (sites || []).slice().sort((a, b) => {
+    const aA = a.is_wpcom_atomic ? 1 : 0;
+    const bA = b.is_wpcom_atomic ? 1 : 0;
+    return bA - aA;
+  });
   const list = $('#site-list');
   const filter = $('#site-filter');
   const count = $('#site-count');
@@ -722,19 +731,32 @@ async function runImportInPlayground({ api_url, secret, site_url }) {
   }
 
   // Reserve a SEPARATE docroot for the import, NOT /wordpress (which
-  // already has the freshly-booted WP and would trip the phar's
-  // "target directory is not empty" guard). The activation step at
-  // the end mounts the imported wp-content into /wordpress/wp-content.
-  // Open tag is split so PHP doesn't treat the JS template literal
-  // as PHP itself.
+  // already has the freshly-booted WP). The activation step at the
+  // end wipes /wordpress and copies the imported tree over it, so
+  // pull-time and Playground-default files never coexist.
+  //
+  // Recursive wipe of any leftover from a prior import in this same
+  // Playground session — @rmdir only deletes empty dirs, so without
+  // this the phar's preserve-local mode walks the prior 30k files
+  // and "skips" each one (file_exists per file ≈ 6+ minutes in WASM).
+  // Open tag split keeps PHP's tokenizer from treating the JS
+  // template literal as a PHP open tag.
+  setPhase('preflight', 'active', 'wiping previous import…');
   await client.run({ code: '<' + "?php\n" + `
+    function _rrmdir($d) {
+      if (!is_dir($d)) return;
+      foreach (scandir($d) ?: [] as $e) {
+        if ($e === '.' || $e === '..') continue;
+        $p = $d . '/' . $e;
+        if (is_link($p) || is_file($p)) @unlink($p);
+        elseif (is_dir($p)) _rrmdir($p);
+      }
+      @rmdir($d);
+    }
+    _rrmdir('/internal/shared/reprint-state');
+    _rrmdir('/internal/shared/reprint-site');
+    @unlink('/tmp/imported.sqlite');
     @mkdir('/internal/shared/reprint-state', 0777, true);
-    @mkdir('/internal/shared/reprint-site',  0777, true);
-    // Wipe any state from a previous failed run so the phar starts
-    // fresh — leftover state files would cause "no cursor found"
-    // errors on subsequent attempts.
-    foreach (glob('/internal/shared/reprint-state/.*') ?: [] as $f) { if (is_file($f)) @unlink($f); }
-    @rmdir('/internal/shared/reprint-site');
     @mkdir('/internal/shared/reprint-site',  0777, true);
   ` });
 
@@ -778,7 +800,10 @@ async function runImportInPlayground({ api_url, secret, site_url }) {
       // imported site over it, and we want the DB intact afterwards.
       '--target-sqlite-path=/tmp/imported.sqlite',
       '--new-site-url=https://playground.wordpress.net',
-      '--on-fs-root-nonempty=preserve-local',
+      // No preserve-local: we already nuked /internal/shared/reprint-site
+      // before invoking the phar, so fs-root is provably empty.
+      // preserve-local would otherwise stat 30k+ files at ~10ms each.
+      '--on-fs-root-nonempty=error',
       // --no-adaptive turns off the request-budget tuner entirely;
       // when set, the phar omits max_execution_time / memory_threshold
       // from outgoing requests and the server uses its own defaults.
@@ -1219,11 +1244,13 @@ async function runImportInPlayground({ api_url, secret, site_url }) {
     }
 
     // 6. Re-drop the uploads-proxy mu-plugin (the wp-content we just
-    //    copied may have wiped a previous install).
+    //    copied may have wiped a previous install). The mu-plugin
+    //    source is base64-encoded here so its $_SERVER / $req / $rel
+    //    references survive PHP's outer double-quoted string parsing.
     @mkdir('/wordpress/wp-content/mu-plugins', 0777, true);
     file_put_contents(
       '/wordpress/wp-content/mu-plugins/0-reprint-uploads-proxy.php',
-      ${JSON.stringify(proxyMuPlugin)}
+      base64_decode(${JSON.stringify(btoa(unescape(encodeURIComponent(proxyMuPlugin))))})
     );
 
     echo json_encode(['copied' => $copied]) . "\n";
@@ -1270,6 +1297,9 @@ async function runImportInPlayground({ api_url, secret, site_url }) {
           '--secret=' . ${JSON.stringify(secret)},
           '--state-dir=/internal/shared/reprint-state',
           '--fs-root=/internal/shared/reprint-site',
+          // fs-root has the essential-files import; preserve-local is
+          // OK here because skipped-earlier only walks the (much
+          // smaller) skip list, not the full 30k+ tree.
           '--on-fs-root-nonempty=preserve-local',
           '--no-adaptive',
           '--filter=skipped-earlier',

--- a/reprint-ui/install.sh
+++ b/reprint-ui/install.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Provisions the dockerized source WP: installs WP, activates the exporter plugin,
+# sets the shared secret, and seeds some content. Idempotent.
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+docker compose up -d
+
+docker compose exec -T wp bash -c '
+  curl -sS -o /tmp/wp-cli.phar https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar
+  chmod +x /tmp/wp-cli.phar
+  WP="/tmp/wp-cli.phar --allow-root --path=/var/www/html"
+  until $WP db check 2>/dev/null; do sleep 2; done
+  if ! $WP core is-installed 2>/dev/null; then
+    $WP core install \
+      --url=http://localhost:8080 \
+      --title="Reprint Source" \
+      --admin_user=admin --admin_password=admin --admin_email=a@b.c \
+      --skip-email
+  fi
+  $WP plugin activate reprint-exporter-wp
+  $WP option update site_export_secret "demo-secret-12345"
+  $WP post generate --count=5 >/dev/null 2>&1 || true
+  echo "Ready: http://localhost:8080  secret: demo-secret-12345"
+'

--- a/reprint-ui/oauth-redirect.php
+++ b/reprint-ui/oauth-redirect.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * WordPress.com OAuth redirect handler.
+ *
+ * Registered redirect URI for our WP.com app. Exchanges the authorization
+ * code for an access token (server-side, using the client secret stored
+ * in wp_options), parks the token in the session, and bounces back to
+ * the wizard.
+ */
+
+require __DIR__ . '/reprint-ui/bootstrap.php';
+
+reprint_session_start();
+
+// Abort on OAuth error responses so the user sees something useful.
+if (!empty($_GET['error'])) {
+    http_response_code(400);
+    $err = htmlspecialchars((string) $_GET['error'], ENT_QUOTES, 'UTF-8');
+    $desc = htmlspecialchars((string) ($_GET['error_description'] ?? ''), ENT_QUOTES, 'UTF-8');
+    echo "<!doctype html><meta charset=utf-8><title>Authorization failed</title>";
+    echo "<p>WordPress.com returned: <strong>$err</strong></p><p>$desc</p>";
+    echo "<p><a href=\"/reprint.php\">Try again</a></p>";
+    exit;
+}
+
+$code = (string) ($_GET['code'] ?? '');
+$state = (string) ($_GET['state'] ?? '');
+
+if ($code === '') {
+    http_response_code(400);
+    echo 'Missing code parameter.';
+    exit;
+}
+
+$state_cookie = reprint_cookie_get('rp_state');
+$expected_state = is_array($state_cookie) ? (string) ($state_cookie['s'] ?? '') : '';
+if ($expected_state === '' || !hash_equals($expected_state, $state)) {
+    http_response_code(400);
+    echo 'State mismatch. Start over at <a href="/reprint.php">/reprint.php</a>.';
+    exit;
+}
+reprint_cookie_clear('rp_state');
+
+[$client_id, $client_secret] = reprint_client_credentials();
+$redirect_uri = reprint_redirect_uri();
+
+$ch = curl_init('https://public-api.wordpress.com/oauth2/token');
+curl_setopt_array($ch, [
+    CURLOPT_RETURNTRANSFER => true,
+    CURLOPT_POST => true,
+    CURLOPT_POSTFIELDS => http_build_query([
+        'client_id' => $client_id,
+        'client_secret' => $client_secret,
+        'redirect_uri' => $redirect_uri,
+        'grant_type' => 'authorization_code',
+        'code' => $code,
+    ]),
+    CURLOPT_TIMEOUT => 20,
+]);
+$body = curl_exec($ch);
+$status = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+$err = curl_error($ch);
+curl_close($ch);
+
+if ($body === false || $status < 200 || $status >= 300) {
+    http_response_code(502);
+    echo "<!doctype html><meta charset=utf-8><title>Token exchange failed</title>";
+    echo "<p>HTTP $status from WP.com token endpoint.</p>";
+    echo "<pre>" . htmlspecialchars($err ?: (string) $body, ENT_QUOTES, 'UTF-8') . "</pre>";
+    exit;
+}
+
+$data = json_decode((string) $body, true);
+if (!is_array($data) || empty($data['access_token'])) {
+    http_response_code(502);
+    echo 'Malformed token response.';
+    exit;
+}
+
+// Park the token in an encrypted, HttpOnly cookie. Nothing about this
+// session ever touches the database or session storage on disk.
+reprint_cookie_set('rp_tok', [
+    'token'   => (string) $data['access_token'],
+    'blog_id' => isset($data['blog_id']) ? (int) $data['blog_id'] : null,
+    'scope'   => (string) ($data['scope'] ?? ''),
+], 0);
+
+header('Location: /reprint.php');
+exit;

--- a/reprint-ui/reprint.php
+++ b/reprint-ui/reprint.php
@@ -1,0 +1,10 @@
+<?php
+/**
+ * Root-level entry point for the Reprint wizard.
+ *
+ * Deployed to /srv/htdocs/reprint.php so nginx/WordPress serves it
+ * directly (a subdirectory with index.php gets canonicalized by WP
+ * into a 403 on WP Cloud Atomic). All supporting files live under
+ * /srv/htdocs/reprint-ui/.
+ */
+require __DIR__ . '/reprint-ui/index.php';

--- a/tests/e2e/package-lock.json
+++ b/tests/e2e/package-lock.json
@@ -9,6 +9,8 @@
         "mysql2": "^3.9.0"
       },
       "devDependencies": {
+        "@wp-playground/blueprints": "^3.1.21",
+        "@wp-playground/cli": "^3.1.21",
         "vitest": "^4.0.18"
       }
     },
@@ -461,6 +463,885 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@octokit/app": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/app/-/app-14.1.0.tgz",
+      "integrity": "sha512-g3uEsGOQCBl1+W1rgfwoRFUIR6PtvB2T1E4RpygeUU5LrLvlOqcxrt5lfykIeRpUPpupreGJUYl70fqMDXdTpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/auth-app": "^6.0.0",
+        "@octokit/auth-unauthenticated": "^5.0.0",
+        "@octokit/core": "^5.0.0",
+        "@octokit/oauth-app": "^6.0.0",
+        "@octokit/plugin-paginate-rest": "^9.0.0",
+        "@octokit/types": "^12.0.0",
+        "@octokit/webhooks": "^12.0.4"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/auth-app": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-app/-/auth-app-6.1.4.tgz",
+      "integrity": "sha512-QkXkSOHZK4dA5oUqY5Dk3S+5pN2s1igPjEASNQV8/vgJgW034fQWR16u7VsNOK/EljA00eyjYF5mWNxWKWhHRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/auth-oauth-app": "^7.1.0",
+        "@octokit/auth-oauth-user": "^4.1.0",
+        "@octokit/request": "^8.3.1",
+        "@octokit/request-error": "^5.1.0",
+        "@octokit/types": "^13.1.0",
+        "deprecation": "^2.3.1",
+        "lru-cache": "npm:@wolfy1339/lru-cache@^11.0.2-patch.1",
+        "universal-github-app-jwt": "^1.1.2",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/auth-app/node_modules/@octokit/openapi-types": {
+      "version": "24.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+      "integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@octokit/auth-app/node_modules/@octokit/types": {
+      "version": "13.10.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+      "integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^24.2.0"
+      }
+    },
+    "node_modules/@octokit/auth-oauth-app": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-oauth-app/-/auth-oauth-app-7.1.0.tgz",
+      "integrity": "sha512-w+SyJN/b0l/HEb4EOPRudo7uUOSW51jcK1jwLa+4r7PA8FPFpoxEnHBHMITqCsc/3Vo2qqFjgQfz/xUUvsSQnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/auth-oauth-device": "^6.1.0",
+        "@octokit/auth-oauth-user": "^4.1.0",
+        "@octokit/request": "^8.3.1",
+        "@octokit/types": "^13.0.0",
+        "@types/btoa-lite": "^1.0.0",
+        "btoa-lite": "^1.0.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/auth-oauth-app/node_modules/@octokit/openapi-types": {
+      "version": "24.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+      "integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@octokit/auth-oauth-app/node_modules/@octokit/types": {
+      "version": "13.10.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+      "integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^24.2.0"
+      }
+    },
+    "node_modules/@octokit/auth-oauth-device": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-oauth-device/-/auth-oauth-device-6.1.0.tgz",
+      "integrity": "sha512-FNQ7cb8kASufd6Ej4gnJ3f1QB5vJitkoV1O0/g6e6lUsQ7+VsSNRHRmFScN2tV4IgKA12frrr/cegUs0t+0/Lw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/oauth-methods": "^4.1.0",
+        "@octokit/request": "^8.3.1",
+        "@octokit/types": "^13.0.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/auth-oauth-device/node_modules/@octokit/openapi-types": {
+      "version": "24.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+      "integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@octokit/auth-oauth-device/node_modules/@octokit/types": {
+      "version": "13.10.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+      "integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^24.2.0"
+      }
+    },
+    "node_modules/@octokit/auth-oauth-user": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-oauth-user/-/auth-oauth-user-4.1.0.tgz",
+      "integrity": "sha512-FrEp8mtFuS/BrJyjpur+4GARteUCrPeR/tZJzD8YourzoVhRics7u7we/aDcKv+yywRNwNi/P4fRi631rG/OyQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/auth-oauth-device": "^6.1.0",
+        "@octokit/oauth-methods": "^4.1.0",
+        "@octokit/request": "^8.3.1",
+        "@octokit/types": "^13.0.0",
+        "btoa-lite": "^1.0.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/auth-oauth-user/node_modules/@octokit/openapi-types": {
+      "version": "24.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+      "integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@octokit/auth-oauth-user/node_modules/@octokit/types": {
+      "version": "13.10.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+      "integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^24.2.0"
+      }
+    },
+    "node_modules/@octokit/auth-token": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-4.0.0.tgz",
+      "integrity": "sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/auth-unauthenticated": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-unauthenticated/-/auth-unauthenticated-5.0.1.tgz",
+      "integrity": "sha512-oxeWzmBFxWd+XolxKTc4zr+h3mt+yofn4r7OfoIkR/Cj/o70eEGmPsFbueyJE2iBAGpjgTnEOKM3pnuEGVmiqg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/request-error": "^5.0.0",
+        "@octokit/types": "^12.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/core": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.2.2.tgz",
+      "integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@octokit/auth-token": "^4.0.0",
+        "@octokit/graphql": "^7.1.0",
+        "@octokit/request": "^8.4.1",
+        "@octokit/request-error": "^5.1.1",
+        "@octokit/types": "^13.0.0",
+        "before-after-hook": "^2.2.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/core/node_modules/@octokit/openapi-types": {
+      "version": "24.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+      "integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@octokit/core/node_modules/@octokit/types": {
+      "version": "13.10.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+      "integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^24.2.0"
+      }
+    },
+    "node_modules/@octokit/endpoint": {
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-9.0.6.tgz",
+      "integrity": "sha512-H1fNTMA57HbkFESSt3Y9+FBICv+0jFceJFPWDePYlR/iMGrwM5ph+Dd4XRQs+8X+PUFURLQgX9ChPfhJ/1uNQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^13.1.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/endpoint/node_modules/@octokit/openapi-types": {
+      "version": "24.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+      "integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@octokit/endpoint/node_modules/@octokit/types": {
+      "version": "13.10.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+      "integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^24.2.0"
+      }
+    },
+    "node_modules/@octokit/graphql": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-7.1.1.tgz",
+      "integrity": "sha512-3mkDltSfcDUoa176nlGoA32RGjeWjl3K7F/BwHwRMJUW/IteSa4bnSV8p2ThNkcIcZU2umkZWxwETSSCJf2Q7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/request": "^8.4.1",
+        "@octokit/types": "^13.0.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/graphql/node_modules/@octokit/openapi-types": {
+      "version": "24.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+      "integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@octokit/graphql/node_modules/@octokit/types": {
+      "version": "13.10.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+      "integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^24.2.0"
+      }
+    },
+    "node_modules/@octokit/oauth-app": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/oauth-app/-/oauth-app-6.1.0.tgz",
+      "integrity": "sha512-nIn/8eUJ/BKUVzxUXd5vpzl1rwaVxMyYbQkNZjHrF7Vk/yu98/YDF/N2KeWO7uZ0g3b5EyiFXFkZI8rJ+DH1/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/auth-oauth-app": "^7.0.0",
+        "@octokit/auth-oauth-user": "^4.0.0",
+        "@octokit/auth-unauthenticated": "^5.0.0",
+        "@octokit/core": "^5.0.0",
+        "@octokit/oauth-authorization-url": "^6.0.2",
+        "@octokit/oauth-methods": "^4.0.0",
+        "@types/aws-lambda": "^8.10.83",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/oauth-authorization-url": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@octokit/oauth-authorization-url/-/oauth-authorization-url-6.0.2.tgz",
+      "integrity": "sha512-CdoJukjXXxqLNK4y/VOiVzQVjibqoj/xHgInekviUJV73y/BSIcwvJ/4aNHPBPKcPWFnd4/lO9uqRV65jXhcLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/oauth-methods": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/oauth-methods/-/oauth-methods-4.1.0.tgz",
+      "integrity": "sha512-4tuKnCRecJ6CG6gr0XcEXdZtkTDbfbnD5oaHBmLERTjTMZNi2CbfEHZxPU41xXLDG4DfKf+sonu00zvKI9NSbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/oauth-authorization-url": "^6.0.2",
+        "@octokit/request": "^8.3.1",
+        "@octokit/request-error": "^5.1.0",
+        "@octokit/types": "^13.0.0",
+        "btoa-lite": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/oauth-methods/node_modules/@octokit/openapi-types": {
+      "version": "24.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+      "integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@octokit/oauth-methods/node_modules/@octokit/types": {
+      "version": "13.10.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+      "integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^24.2.0"
+      }
+    },
+    "node_modules/@octokit/openapi-types": {
+      "version": "20.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-20.0.0.tgz",
+      "integrity": "sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@octokit/plugin-paginate-graphql": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-graphql/-/plugin-paginate-graphql-4.0.1.tgz",
+      "integrity": "sha512-R8ZQNmrIKKpHWC6V2gum4x9LG2qF1RxRjo27gjQcG3j+vf2tLsEfE7I/wRWEPzYMaenr1M+qDAtNcwZve1ce1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=5"
+      }
+    },
+    "node_modules/@octokit/plugin-paginate-rest": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-9.2.2.tgz",
+      "integrity": "sha512-u3KYkGF7GcZnSD/3UP0S7K5XUFT2FkOQdcfXZGZQPGv3lm4F2Xbf71lvjldr8c1H3nNbF+33cLEkWYbokGWqiQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^12.6.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@octokit/core": "5"
+      }
+    },
+    "node_modules/@octokit/plugin-rest-endpoint-methods": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-10.4.1.tgz",
+      "integrity": "sha512-xV1b+ceKV9KytQe3zCVqjg+8GTGfDYwaT1ATU5isiUyVtlVAO3HNdzpS4sr4GBx4hxQ46s7ITtZrAsxG22+rVg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^12.6.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@octokit/core": "5"
+      }
+    },
+    "node_modules/@octokit/plugin-retry": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-retry/-/plugin-retry-6.1.0.tgz",
+      "integrity": "sha512-WrO3bvq4E1Xh1r2mT9w6SDFg01gFmP81nIG77+p/MqW1JeXXgL++6umim3t6x0Zj5pZm3rXAN+0HEjmmdhIRig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/request-error": "^5.0.0",
+        "@octokit/types": "^13.0.0",
+        "bottleneck": "^2.15.3"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@octokit/core": "5"
+      }
+    },
+    "node_modules/@octokit/plugin-retry/node_modules/@octokit/openapi-types": {
+      "version": "24.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+      "integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@octokit/plugin-retry/node_modules/@octokit/types": {
+      "version": "13.10.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+      "integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^24.2.0"
+      }
+    },
+    "node_modules/@octokit/plugin-throttling": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-throttling/-/plugin-throttling-8.2.0.tgz",
+      "integrity": "sha512-nOpWtLayKFpgqmgD0y3GqXafMFuKcA4tRPZIfu7BArd2lEZeb1988nhWhwx4aZWmjDmUfdgVf7W+Tt4AmvRmMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^12.2.0",
+        "bottleneck": "^2.15.3"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@octokit/core": "^5.0.0"
+      }
+    },
+    "node_modules/@octokit/request": {
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-8.4.1.tgz",
+      "integrity": "sha512-qnB2+SY3hkCmBxZsR/MPCybNmbJe4KAlfWErXq+rBKkQJlbjdJeS85VI9r8UqeLYLvnAenU8Q1okM/0MBsAGXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/endpoint": "^9.0.6",
+        "@octokit/request-error": "^5.1.1",
+        "@octokit/types": "^13.1.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/request-error": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-5.1.1.tgz",
+      "integrity": "sha512-v9iyEQJH6ZntoENr9/yXxjuezh4My67CBSu9r6Ve/05Iu5gNgnisNWOsoJHTP6k0Rr0+HQIpnH+kyammu90q/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^13.1.0",
+        "deprecation": "^2.0.0",
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/request-error/node_modules/@octokit/openapi-types": {
+      "version": "24.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+      "integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@octokit/request-error/node_modules/@octokit/types": {
+      "version": "13.10.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+      "integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^24.2.0"
+      }
+    },
+    "node_modules/@octokit/request/node_modules/@octokit/openapi-types": {
+      "version": "24.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+      "integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@octokit/request/node_modules/@octokit/types": {
+      "version": "13.10.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+      "integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^24.2.0"
+      }
+    },
+    "node_modules/@octokit/types": {
+      "version": "12.6.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-12.6.0.tgz",
+      "integrity": "sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^20.0.0"
+      }
+    },
+    "node_modules/@octokit/webhooks": {
+      "version": "12.3.2",
+      "resolved": "https://registry.npmjs.org/@octokit/webhooks/-/webhooks-12.3.2.tgz",
+      "integrity": "sha512-exj1MzVXoP7xnAcAB3jZ97pTvVPkQF9y6GA/dvYC47HV7vLv+24XRS6b/v/XnyikpEuvMhugEXdGtAlU086WkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/request-error": "^5.0.0",
+        "@octokit/webhooks-methods": "^4.1.0",
+        "@octokit/webhooks-types": "7.6.1",
+        "aggregate-error": "^3.1.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/webhooks-methods": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/webhooks-methods/-/webhooks-methods-4.1.0.tgz",
+      "integrity": "sha512-zoQyKw8h9STNPqtm28UGOYFE7O6D4Il8VJwhAtMHFt2C4L0VQT1qGKLeefUOqHNs1mNRYSadVv7x0z8U2yyeWQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/webhooks-types": {
+      "version": "7.6.1",
+      "resolved": "https://registry.npmjs.org/@octokit/webhooks-types/-/webhooks-types-7.6.1.tgz",
+      "integrity": "sha512-S8u2cJzklBC0FgTwWVLaM8tMrDuDMVE4xiTK4EYXM9GntyvrdbSoxqDQa+Fh57CCNApyIpyeqPhhFEmHPfrXgw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@php-wasm/cli-util": {
+      "version": "3.1.21",
+      "resolved": "https://registry.npmjs.org/@php-wasm/cli-util/-/cli-util-3.1.21.tgz",
+      "integrity": "sha512-LQ/c+vtkLmmPtPoQ/6Nh22lERNzaQmMeE38UGzCvf6PhIj0IoASvA4HthIdrdLegMbp0iG4abfkzTfGkhQzHvg==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@php-wasm/util": "3.1.21",
+        "fast-xml-parser": "^5.5.1",
+        "jsonc-parser": "3.3.1"
+      },
+      "engines": {
+        "node": ">=20.10.0",
+        "npm": ">=10.2.3"
+      }
+    },
+    "node_modules/@php-wasm/logger": {
+      "version": "3.1.21",
+      "resolved": "https://registry.npmjs.org/@php-wasm/logger/-/logger-3.1.21.tgz",
+      "integrity": "sha512-ykuQcn2k7anSKOrkC46WHTKiC3/oh08RbHGiAMPnZymzG3fCHJbc1/LdH8CmkZdyNJqHt6nhAaYf7Ll8glG5Dg==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "engines": {
+        "node": ">=20.10.0",
+        "npm": ">=10.2.3"
+      }
+    },
+    "node_modules/@php-wasm/node": {
+      "version": "3.1.21",
+      "resolved": "https://registry.npmjs.org/@php-wasm/node/-/node-3.1.21.tgz",
+      "integrity": "sha512-KAUbGH8ITHabpSxYlR3zV+dq3ml1QN1TGcdLXMdLrbonKUO36g0TPZr1/ddtf05QBgFiyx7JHIiB1ljvFqMLSQ==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@php-wasm/cli-util": "3.1.21",
+        "@php-wasm/logger": "3.1.21",
+        "@php-wasm/node-5-2": "3.1.21",
+        "@php-wasm/node-7-4": "3.1.21",
+        "@php-wasm/node-8-0": "3.1.21",
+        "@php-wasm/node-8-1": "3.1.21",
+        "@php-wasm/node-8-2": "3.1.21",
+        "@php-wasm/node-8-3": "3.1.21",
+        "@php-wasm/node-8-4": "3.1.21",
+        "@php-wasm/node-8-5": "3.1.21",
+        "@php-wasm/universal": "3.1.21",
+        "@php-wasm/util": "3.1.21",
+        "@wp-playground/common": "3.1.21",
+        "express": "4.22.0",
+        "fast-xml-parser": "^5.5.1",
+        "fs-ext-extra-prebuilt": "2.2.7",
+        "ini": "4.1.2",
+        "jsonc-parser": "3.3.1",
+        "wasm-feature-detect": "1.8.0",
+        "ws": "8.18.0",
+        "yargs": "17.7.2"
+      },
+      "engines": {
+        "node": ">=20.10.0",
+        "npm": ">=10.2.3"
+      }
+    },
+    "node_modules/@php-wasm/node-5-2": {
+      "version": "3.1.21",
+      "resolved": "https://registry.npmjs.org/@php-wasm/node-5-2/-/node-5-2-3.1.21.tgz",
+      "integrity": "sha512-l06b+B+NVyUxP9/mfyUSkjbNt4/BFy/YUzfob0teFByFUbcps1dKNqE5B042IERf+Laz9kuoS8ly9+VbFqVDkA==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@php-wasm/universal": "3.1.21",
+        "ini": "4.1.2",
+        "wasm-feature-detect": "1.8.0",
+        "ws": "8.18.0"
+      },
+      "engines": {
+        "node": ">=20.10.0",
+        "npm": ">=10.2.3"
+      }
+    },
+    "node_modules/@php-wasm/node-7-4": {
+      "version": "3.1.21",
+      "resolved": "https://registry.npmjs.org/@php-wasm/node-7-4/-/node-7-4-3.1.21.tgz",
+      "integrity": "sha512-n9CRZRl0QI6/Q46W2HldKpAlVqZbyjvyvK2Ph2p6kktpCCAJsJ9JqTUjGSh3iuHgT+8DYBlxw1kMineqLLwNgQ==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@php-wasm/universal": "3.1.21",
+        "ini": "4.1.2",
+        "wasm-feature-detect": "1.8.0",
+        "ws": "8.18.0"
+      },
+      "engines": {
+        "node": ">=20.10.0",
+        "npm": ">=10.2.3"
+      }
+    },
+    "node_modules/@php-wasm/node-8-0": {
+      "version": "3.1.21",
+      "resolved": "https://registry.npmjs.org/@php-wasm/node-8-0/-/node-8-0-3.1.21.tgz",
+      "integrity": "sha512-dF2G6fcEYDm1yfoR5PWqasImYWPmRf76SLWx3WSXbhrunwDLVDgSuj4d17BmlA5fK/DkUnHHFf4QxwQWqyrUqQ==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@php-wasm/universal": "3.1.21",
+        "ini": "4.1.2",
+        "wasm-feature-detect": "1.8.0",
+        "ws": "8.18.0"
+      },
+      "engines": {
+        "node": ">=20.10.0",
+        "npm": ">=10.2.3"
+      }
+    },
+    "node_modules/@php-wasm/node-8-1": {
+      "version": "3.1.21",
+      "resolved": "https://registry.npmjs.org/@php-wasm/node-8-1/-/node-8-1-3.1.21.tgz",
+      "integrity": "sha512-SYIBDst+g8CNYw8t4VZ9yiv6GdmKX3NOIAqQ1tFo3fmAOc6VgK9qpQcmCmpwmMIxrHg6BcijvV7qTgJmZ93MmQ==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@php-wasm/universal": "3.1.21",
+        "ini": "4.1.2",
+        "wasm-feature-detect": "1.8.0",
+        "ws": "8.18.0"
+      },
+      "engines": {
+        "node": ">=20.10.0",
+        "npm": ">=10.2.3"
+      }
+    },
+    "node_modules/@php-wasm/node-8-2": {
+      "version": "3.1.21",
+      "resolved": "https://registry.npmjs.org/@php-wasm/node-8-2/-/node-8-2-3.1.21.tgz",
+      "integrity": "sha512-pB/fFHVtFiRTuXHCVa6ev6vSXwUq7075CLaGye04CpKi+CgsMhX54Qb9UOJNg5kbOp3fxSPnpYTB9ZwfUYnruw==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@php-wasm/universal": "3.1.21",
+        "ini": "4.1.2",
+        "wasm-feature-detect": "1.8.0",
+        "ws": "8.18.0"
+      },
+      "engines": {
+        "node": ">=20.10.0",
+        "npm": ">=10.2.3"
+      }
+    },
+    "node_modules/@php-wasm/node-8-3": {
+      "version": "3.1.21",
+      "resolved": "https://registry.npmjs.org/@php-wasm/node-8-3/-/node-8-3-3.1.21.tgz",
+      "integrity": "sha512-RKFVIaul0rgf2aal6QoulOPTF9JUbNd7d0p+p5FJrntUhbjdaW9rICOOmgbwUl1hXiq2HDmRaGX1ZpxCsbVXGQ==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@php-wasm/universal": "3.1.21",
+        "ini": "4.1.2",
+        "wasm-feature-detect": "1.8.0",
+        "ws": "8.18.0"
+      },
+      "engines": {
+        "node": ">=20.10.0",
+        "npm": ">=10.2.3"
+      }
+    },
+    "node_modules/@php-wasm/node-8-4": {
+      "version": "3.1.21",
+      "resolved": "https://registry.npmjs.org/@php-wasm/node-8-4/-/node-8-4-3.1.21.tgz",
+      "integrity": "sha512-ZI5Pd0T2KqL8XfAX3eCULPbeLM0YmkbPbwye5siS6NXPW1lO0oHyJ91eKfRFLttCdzrkWndW/x1uimKVJFqEqg==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@php-wasm/universal": "3.1.21",
+        "ini": "4.1.2",
+        "wasm-feature-detect": "1.8.0",
+        "ws": "8.18.0"
+      },
+      "engines": {
+        "node": ">=20.10.0",
+        "npm": ">=10.2.3"
+      }
+    },
+    "node_modules/@php-wasm/node-8-5": {
+      "version": "3.1.21",
+      "resolved": "https://registry.npmjs.org/@php-wasm/node-8-5/-/node-8-5-3.1.21.tgz",
+      "integrity": "sha512-i01P6zf+EWnVBRudPfokP4Z4Q1N4dy12mjDRfioANv0YqRCcyFgCc6ngJKN4/e0Ew+qhbkjTBkoRpscm4+RewA==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@php-wasm/universal": "3.1.21",
+        "ini": "4.1.2",
+        "wasm-feature-detect": "1.8.0",
+        "ws": "8.18.0"
+      },
+      "engines": {
+        "node": ">=20.10.0",
+        "npm": ">=10.2.3"
+      }
+    },
+    "node_modules/@php-wasm/progress": {
+      "version": "3.1.21",
+      "resolved": "https://registry.npmjs.org/@php-wasm/progress/-/progress-3.1.21.tgz",
+      "integrity": "sha512-fF7HCeXXptWGNSr8d3Tlyjelax8AnvpyZGWUtwNYI27428oIXhGEwsphlAHMfPfc5YEFz9BQEhHoTU7z/SRlbg==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@php-wasm/logger": "3.1.21"
+      },
+      "engines": {
+        "node": ">=20.10.0",
+        "npm": ">=10.2.3"
+      }
+    },
+    "node_modules/@php-wasm/scopes": {
+      "version": "3.1.21",
+      "resolved": "https://registry.npmjs.org/@php-wasm/scopes/-/scopes-3.1.21.tgz",
+      "integrity": "sha512-BTECa1MsKv/RJxOaP+M/4MjilZpnYvYKTB2Kng8hrmYBA6LjuGnP1UY8yiCCUHsxnFxfRm6pW+c8Duy+ZTpVpw==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "engines": {
+        "node": ">=20.10.0",
+        "npm": ">=10.2.3"
+      }
+    },
+    "node_modules/@php-wasm/stream-compression": {
+      "version": "3.1.21",
+      "resolved": "https://registry.npmjs.org/@php-wasm/stream-compression/-/stream-compression-3.1.21.tgz",
+      "integrity": "sha512-VB+M15HL0krTo2yK9xswWzxby+K+gAHMtYhg7NhL7fhFIv/dKRkCv/dYAazwGNXP4/T7RxlPpchRpeFi+7ndjA==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@php-wasm/util": "3.1.21"
+      }
+    },
+    "node_modules/@php-wasm/universal": {
+      "version": "3.1.21",
+      "resolved": "https://registry.npmjs.org/@php-wasm/universal/-/universal-3.1.21.tgz",
+      "integrity": "sha512-JuaLJvGE2jCmLY+GYkz2yFpxjTrb4QzqXodKo3IDYe+hO9nhmPhBg5oootftPfMMKlYdyIfOT1jv3AUy6ihb+Q==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@php-wasm/logger": "3.1.21",
+        "@php-wasm/progress": "3.1.21",
+        "@php-wasm/stream-compression": "3.1.21",
+        "@php-wasm/util": "3.1.21",
+        "ini": "4.1.2"
+      },
+      "engines": {
+        "node": ">=20.10.0",
+        "npm": ">=10.2.3"
+      }
+    },
+    "node_modules/@php-wasm/util": {
+      "version": "3.1.21",
+      "resolved": "https://registry.npmjs.org/@php-wasm/util/-/util-3.1.21.tgz",
+      "integrity": "sha512-D2JYnqKJv5n7qArvczEPa2aX/vlVbdOBZ+MJJKUHAgzqun8wRT7kJXfW0XQ2C9EYvW9mFQ4gm7sYbpiEHUB8+g==",
+      "dev": true,
+      "engines": {
+        "node": ">=20.10.0",
+        "npm": ">=10.2.3"
+      }
+    },
+    "node_modules/@php-wasm/web-service-worker": {
+      "version": "3.1.21",
+      "resolved": "https://registry.npmjs.org/@php-wasm/web-service-worker/-/web-service-worker-3.1.21.tgz",
+      "integrity": "sha512-ZLxbCfw+t3VKkZtVj7kUE3hNJ3PVFU47pakUcpvfDq9+yAOQggx3IPLH5/YokWHu3pm+G9eCIRuHcMZuLa5J/w==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@php-wasm/scopes": "3.1.21",
+        "@php-wasm/universal": "3.1.21",
+        "ini": "4.1.2"
+      },
+      "engines": {
+        "node": ">=20.10.0",
+        "npm": ">=10.2.3"
+      }
+    },
+    "node_modules/@php-wasm/xdebug-bridge": {
+      "version": "3.1.21",
+      "resolved": "https://registry.npmjs.org/@php-wasm/xdebug-bridge/-/xdebug-bridge-3.1.21.tgz",
+      "integrity": "sha512-BHeMn6EwFfV6hszwqPm0VNoFtdSoVr/5TTzZ9OpUZckPdxz2jfGEmix4tNrqW/+OtUUSi0oZmbPUZ8F8zv6YxA==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@php-wasm/logger": "3.1.21",
+        "@php-wasm/node": "3.1.21",
+        "@php-wasm/universal": "3.1.21",
+        "@wp-playground/common": "3.1.21",
+        "express": "4.22.0",
+        "fast-xml-parser": "^5.5.1",
+        "fs-ext-extra-prebuilt": "2.2.7",
+        "ini": "4.1.2",
+        "jsonc-parser": "3.3.1",
+        "wasm-feature-detect": "1.8.0",
+        "ws": "8.18.0",
+        "xml2js": "0.6.2",
+        "yargs": "17.7.2"
+      },
+      "bin": {
+        "xdebug-bridge": "xdebug-bridge.js"
+      },
+      "engines": {
+        "node": ">=20.10.0",
+        "npm": ">=10.2.3"
+      }
+    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.57.1",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.57.1.tgz",
@@ -818,6 +1699,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/aws-lambda": {
+      "version": "8.10.161",
+      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.161.tgz",
+      "integrity": "sha512-rUYdp+MQwSFocxIOcSsYSF3YYYC/uUpMbCY/mbO21vGqfrEYvNSoPyKYDj6RhXXpPfS0KstW9RwG3qXh9sL7FQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/btoa-lite": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@types/btoa-lite/-/btoa-lite-1.0.2.tgz",
+      "integrity": "sha512-ZYbcE2x7yrvNFJiU7xJGrpF/ihpkM7zKgw8bha3LNJSesvTtUNxbpzaT7WXBIryf6jovisrxTBvymxMeLLj1Mg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/chai": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
@@ -842,6 +1737,35 @@
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/jsonwebtoken": {
+      "version": "9.0.10",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.10.tgz",
+      "integrity": "sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~7.19.0"
+      }
     },
     "node_modules/@vitest/expect": {
       "version": "4.0.18",
@@ -954,6 +1878,311 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/@wp-playground/blueprints": {
+      "version": "3.1.21",
+      "resolved": "https://registry.npmjs.org/@wp-playground/blueprints/-/blueprints-3.1.21.tgz",
+      "integrity": "sha512-O9ry40j8y/zDXnDwza/qz3kKNHC1mXYKgqX7MD53jMTgkZZCzcQe3tUGf+k8LJV1WBWkaimI8cdUtU4r1KF6xA==",
+      "dev": true,
+      "dependencies": {
+        "@php-wasm/logger": "3.1.21",
+        "@php-wasm/node": "3.1.21",
+        "@php-wasm/progress": "3.1.21",
+        "@php-wasm/scopes": "3.1.21",
+        "@php-wasm/stream-compression": "3.1.21",
+        "@php-wasm/universal": "3.1.21",
+        "@php-wasm/util": "3.1.21",
+        "@php-wasm/web-service-worker": "3.1.21",
+        "@wp-playground/common": "3.1.21",
+        "@wp-playground/storage": "3.1.21",
+        "@wp-playground/wordpress": "3.1.21",
+        "@zip.js/zip.js": "2.7.57",
+        "ajv": "8.12.0",
+        "async-lock": "1.4.1",
+        "clean-git-ref": "2.0.1",
+        "crc-32": "1.2.2",
+        "diff3": "0.0.4",
+        "express": "4.22.0",
+        "fast-xml-parser": "^5.5.1",
+        "fs-ext-extra-prebuilt": "2.2.7",
+        "ignore": "5.3.2",
+        "ini": "4.1.2",
+        "jsonc-parser": "3.3.1",
+        "minimisted": "2.0.1",
+        "octokit": "3.1.2",
+        "pako": "1.0.10",
+        "pify": "2.3.0",
+        "readable-stream": "3.6.2",
+        "sha.js": "2.4.12",
+        "simple-get": "4.0.1",
+        "wasm-feature-detect": "1.8.0",
+        "ws": "8.18.0",
+        "yargs": "17.7.2"
+      },
+      "engines": {
+        "node": ">=20.10.0",
+        "npm": ">=10.2.3"
+      }
+    },
+    "node_modules/@wp-playground/cli": {
+      "version": "3.1.21",
+      "resolved": "https://registry.npmjs.org/@wp-playground/cli/-/cli-3.1.21.tgz",
+      "integrity": "sha512-FQjxHRF/fwL9Lg6MRTnVFeDzKdOy9e2uDxUiXx5o9uZEAQdMqMsD8U+aY8j7BrwlUedkZu2oTap2c0CP/Xqouw==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@php-wasm/cli-util": "3.1.21",
+        "@php-wasm/logger": "3.1.21",
+        "@php-wasm/node": "3.1.21",
+        "@php-wasm/progress": "3.1.21",
+        "@php-wasm/universal": "3.1.21",
+        "@php-wasm/util": "3.1.21",
+        "@php-wasm/xdebug-bridge": "3.1.21",
+        "@wp-playground/blueprints": "3.1.21",
+        "@wp-playground/common": "3.1.21",
+        "@wp-playground/storage": "3.1.21",
+        "@wp-playground/tools": "3.1.21",
+        "@wp-playground/wordpress": "3.1.21",
+        "@zip.js/zip.js": "2.7.57",
+        "ajv": "8.12.0",
+        "async-lock": "1.4.1",
+        "clean-git-ref": "2.0.1",
+        "crc-32": "1.2.2",
+        "diff3": "0.0.4",
+        "express": "4.22.0",
+        "fast-xml-parser": "^5.5.1",
+        "fs-ext-extra-prebuilt": "2.2.7",
+        "fs-extra": "11.1.1",
+        "ignore": "5.3.2",
+        "ini": "4.1.2",
+        "jsonc-parser": "3.3.1",
+        "minimisted": "2.0.1",
+        "octokit": "3.1.2",
+        "pako": "1.0.10",
+        "pify": "2.3.0",
+        "readable-stream": "3.6.2",
+        "sha.js": "2.4.12",
+        "simple-get": "4.0.1",
+        "tmp-promise": "3.0.3",
+        "wasm-feature-detect": "1.8.0",
+        "ws": "8.18.0",
+        "xml2js": "0.6.2",
+        "yargs": "17.7.2"
+      },
+      "bin": {
+        "wp-playground-cli": "wp-playground.js"
+      }
+    },
+    "node_modules/@wp-playground/common": {
+      "version": "3.1.21",
+      "resolved": "https://registry.npmjs.org/@wp-playground/common/-/common-3.1.21.tgz",
+      "integrity": "sha512-NEM8gwpksjiGohLuikvKo2+qOKE7LlatUEQBe3MqzMOpJtItxnCBBFTo21mH9/0ZzuHCn7udFdVwWoF5ZjbBMQ==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@php-wasm/universal": "3.1.21",
+        "@php-wasm/util": "3.1.21",
+        "ini": "4.1.2"
+      },
+      "engines": {
+        "node": ">=20.10.0",
+        "npm": ">=10.2.3"
+      }
+    },
+    "node_modules/@wp-playground/storage": {
+      "version": "3.1.21",
+      "resolved": "https://registry.npmjs.org/@wp-playground/storage/-/storage-3.1.21.tgz",
+      "integrity": "sha512-6Is8Pjx+WpWlVPE/7Oxks19sK4wiaeFbFnGNcw1ICT6i0ssbZIULWq1kwkshHM2czop/PKM2SyxjhiSMd++EMw==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@php-wasm/stream-compression": "3.1.21",
+        "@php-wasm/universal": "3.1.21",
+        "@php-wasm/util": "3.1.21",
+        "@zip.js/zip.js": "2.7.57",
+        "async-lock": "^1.4.1",
+        "clean-git-ref": "^2.0.1",
+        "crc-32": "^1.2.0",
+        "diff3": "0.0.3",
+        "ignore": "^5.1.4",
+        "ini": "4.1.2",
+        "minimisted": "^2.0.0",
+        "octokit": "3.1.2",
+        "pako": "^1.0.10",
+        "pify": "^4.0.1",
+        "readable-stream": "^3.4.0",
+        "sha.js": "^2.4.9",
+        "simple-get": "^4.0.1"
+      }
+    },
+    "node_modules/@wp-playground/storage/node_modules/diff3": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/diff3/-/diff3-0.0.3.tgz",
+      "integrity": "sha512-iSq8ngPOt0K53A6eVr4d5Kn6GNrM2nQZtC740pzIriHtn4pOQ2lyzEXQMBeVcWERN0ye7fhBsk9PbLLQOnUx/g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@wp-playground/storage/node_modules/pify": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+      "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@wp-playground/tools": {
+      "version": "3.1.21",
+      "resolved": "https://registry.npmjs.org/@wp-playground/tools/-/tools-3.1.21.tgz",
+      "integrity": "sha512-rmGRMojgajgyhXfJco3NxPRN7qgfbSBO8vydPxu/odYP5qtD2lcC9IJXBSKWRUmI+CaJmVw49yltCxojTk0J0w==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wp-playground/blueprints": "3.1.21",
+        "@zip.js/zip.js": "2.7.57",
+        "ajv": "8.12.0",
+        "async-lock": "1.4.1",
+        "clean-git-ref": "2.0.1",
+        "crc-32": "1.2.2",
+        "diff3": "0.0.4",
+        "express": "4.22.0",
+        "fast-xml-parser": "^5.5.1",
+        "fs-ext-extra-prebuilt": "2.2.7",
+        "ignore": "5.3.2",
+        "ini": "4.1.2",
+        "jsonc-parser": "3.3.1",
+        "minimisted": "2.0.1",
+        "octokit": "3.1.2",
+        "pako": "1.0.10",
+        "pify": "2.3.0",
+        "readable-stream": "3.6.2",
+        "sha.js": "2.4.12",
+        "simple-get": "4.0.1",
+        "wasm-feature-detect": "1.8.0",
+        "ws": "8.18.0",
+        "yargs": "17.7.2"
+      },
+      "engines": {
+        "node": ">=20.10.0",
+        "npm": ">=10.2.3"
+      }
+    },
+    "node_modules/@wp-playground/wordpress": {
+      "version": "3.1.21",
+      "resolved": "https://registry.npmjs.org/@wp-playground/wordpress/-/wordpress-3.1.21.tgz",
+      "integrity": "sha512-rEms03kG4DB9kKlK+9sOeO3TI8PvMhubRyXIhs/n061IqcEacCJvgr1Krwdb9IOViEaSusGkD6d/ao6IjqPxHA==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@php-wasm/logger": "3.1.21",
+        "@php-wasm/node": "3.1.21",
+        "@php-wasm/universal": "3.1.21",
+        "@php-wasm/util": "3.1.21",
+        "@wp-playground/common": "3.1.21",
+        "express": "4.22.0",
+        "fast-xml-parser": "^5.5.1",
+        "fs-ext-extra-prebuilt": "2.2.7",
+        "ini": "4.1.2",
+        "jsonc-parser": "3.3.1",
+        "wasm-feature-detect": "1.8.0",
+        "ws": "8.18.0",
+        "yargs": "17.7.2"
+      },
+      "engines": {
+        "node": ">=20.10.0",
+        "npm": ">=10.2.3"
+      }
+    },
+    "node_modules/@zip.js/zip.js": {
+      "version": "2.7.57",
+      "resolved": "https://registry.npmjs.org/@zip.js/zip.js/-/zip.js-2.7.57.tgz",
+      "integrity": "sha512-BtonQ1/jDnGiMed6OkV6rZYW78gLmLswkHOzyMrMb+CAR7CZO8phOHO6c2qw6qb1g1betN7kwEHhhZk30dv+NA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "bun": ">=0.7.0",
+        "deno": ">=1.0.0",
+        "node": ">=16.5.0"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/aggregate-error": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+      "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "clean-stack": "^2.0.0",
+        "indent-string": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -964,6 +2193,29 @@
         "node": ">=12"
       }
     },
+    "node_modules/async-lock": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/async-lock/-/async-lock-1.4.1.tgz",
+      "integrity": "sha512-Az2ZTpuytrtqENulXwO3GGv1Bztugx6TT37NIo7imr/Qo0gsYiGtSdBa2B6fsXhTpVZDNfu1Qn3pk531e3q+nQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/aws-ssl-profiles": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/aws-ssl-profiles/-/aws-ssl-profiles-1.1.2.tgz",
@@ -971,6 +2223,148 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/before-after-hook": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.3.tgz",
+      "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/body-parser": {
+      "version": "1.20.5",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
+      "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "~1.2.0",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "on-finished": "~2.4.1",
+        "qs": "~6.15.1",
+        "raw-body": "~2.5.3",
+        "type-is": "~1.6.18",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/body-parser/node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/body-parser/node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/bottleneck": {
+      "version": "2.19.5",
+      "resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.19.5.tgz",
+      "integrity": "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/btoa-lite": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/btoa-lite/-/btoa-lite-1.0.0.tgz",
+      "integrity": "sha512-gvW7InbIyF8AicrqWoptdW08pUxuhq8BEgowNajy9RhiE86fmGAGl+bLKo6oB8QP0CkqHLowfN0oJdKC/J6LbA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/chai": {
@@ -983,6 +2377,155 @@
         "node": ">=18"
       }
     },
+    "node_modules/clean-git-ref": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/clean-git-ref/-/clean-git-ref-2.0.1.tgz",
+      "integrity": "sha512-bLSptAy2P0s6hU4PzuIMKmMJJSE6gLXGH1cntDu7bWJUksvuM+7ReOK61mozULErYvP6a15rnYl0zFDef+pyPw==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/clean-stack": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/denque": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
@@ -992,12 +2535,129 @@
         "node": ">=0.10"
       }
     },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/deprecation": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
+      "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/diff3": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/diff3/-/diff3-0.0.4.tgz",
+      "integrity": "sha512-f1rQ7jXDn/3i37hdwRk9ohqcvLRH3+gEIgmA6qEM280WUOh7cOr3GXV8Jm5sPwUs46Nzl48SE8YNLGJoaLuodg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es-module-lexer": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
       "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.27.3",
@@ -1041,6 +2701,23 @@
         "@esbuild/win32-x64": "0.27.3"
       }
     },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/estree-walker": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -1051,6 +2728,16 @@
         "@types/estree": "^1.0.0"
       }
     },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -1059,6 +2746,98 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "4.22.0",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.0.tgz",
+      "integrity": "sha512-c2iPh3xp5vvCLgaHK03+mWLFPhox7j1LwyxcZwFVApEv5i0X+IjPpbT50SJJwwLpdBVfp45AkK/v+AFgv/XlfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "~1.20.3",
+        "content-disposition": "~0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "~0.7.1",
+        "cookie-signature": "~1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.3.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "~0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "~6.14.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "~0.19.0",
+        "serve-static": "~1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "~2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-xml-builder": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
+      "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.1.3"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.2.tgz",
+      "integrity": "sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.5",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
       }
     },
     "node_modules/fdir": {
@@ -1079,6 +2858,90 @@
         }
       }
     },
+    "node_modules/finalhandler": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
+      "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "~2.0.2",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/for-each": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fs-ext-extra-prebuilt": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/fs-ext-extra-prebuilt/-/fs-ext-extra-prebuilt-2.2.7.tgz",
+      "integrity": "sha512-Q7rayYRBDIvDF01HWOwSSjoaP+05N1g+o3BXL1Zf8Frw2JkjSmi4EtvCBITuW30l6hB2m2TW1pehdh8wyU/+gw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "nan": "^2.24.0"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.1.tgz",
+      "integrity": "sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -1094,6 +2957,16 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/generate-function": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
@@ -1101,6 +2974,151 @@
       "license": "MIT",
       "dependencies": {
         "is-property": "^1.0.2"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/iconv-lite": {
@@ -1119,10 +3137,232 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.2.tgz",
+      "integrity": "sha512-AMB1mvwR1pyBFY/nSevUX6y8nJWS63/SzUKD3JyQn97s4xgIdgQPT75IRouIiBAN4yLQBUShNYVW0+UG25daCw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-property": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
       "integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==",
+      "license": "MIT"
+    },
+    "node_modules/is-typed-array": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsonc-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^4.0.1",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jsonwebtoken/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/long": {
@@ -1130,6 +3370,17 @@
       "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
       "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
       "license": "Apache-2.0"
+    },
+    "node_modules/lru-cache": {
+      "name": "@wolfy1339/lru-cache",
+      "version": "11.0.2-patch.1",
+      "resolved": "https://registry.npmjs.org/@wolfy1339/lru-cache/-/lru-cache-11.0.2-patch.1.tgz",
+      "integrity": "sha512-BgYZfL2ADCXKOw2wJtkM3slhHotawWkgIRRxq4wEybnZQPjvAp71SPX35xepMykTw8gXlzWcWPTY31hlbnRsDA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "18 >=18.20 || 20 || >=22"
+      }
     },
     "node_modules/lru.min": {
       "version": "1.1.4",
@@ -1155,6 +3406,122 @@
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minimisted": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/minimisted/-/minimisted-2.0.1.tgz",
+      "integrity": "sha512-1oPjfuLQa2caorJUM8HV8lGgWCc0qqAO1MNv/k05G4qslmsndV/5WdNZrqCiyqiz3wohia2Ij2B7w2Dr7/IyrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.5"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/mysql2": {
       "version": "3.16.3",
@@ -1188,6 +3555,13 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/nan": {
+      "version": "2.26.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.26.2.tgz",
+      "integrity": "sha512-0tTvBTYkt3tdGw22nrAy50x7gpbGCCFH3AFcyS5WiUu7Eu4vWlri1woE6qHBSfy11vksDqkiwjOnlR7WV8G1Hw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/nanoid": {
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
@@ -1207,6 +3581,29 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/obug": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
@@ -1216,6 +3613,91 @@
         "https://github.com/sponsors/sxzz",
         "https://opencollective.com/debug"
       ],
+      "license": "MIT"
+    },
+    "node_modules/octokit": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/octokit/-/octokit-3.1.2.tgz",
+      "integrity": "sha512-MG5qmrTL5y8KYwFgE1A4JWmgfQBaIETE/lOlfwNYx1QOtCQHGVxkRJmdUJltFc1HVn73d61TlMhMyNTOtMl+ng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/app": "^14.0.2",
+        "@octokit/core": "^5.0.0",
+        "@octokit/oauth-app": "^6.0.0",
+        "@octokit/plugin-paginate-graphql": "^4.0.0",
+        "@octokit/plugin-paginate-rest": "^9.0.0",
+        "@octokit/plugin-rest-endpoint-methods": "^10.0.0",
+        "@octokit/plugin-retry": "^6.0.0",
+        "@octokit/plugin-throttling": "^8.0.0",
+        "@octokit/request-error": "^5.0.0",
+        "@octokit/types": "^12.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/pako": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.10.tgz",
+      "integrity": "sha512-0DTvPVU3ed8+HNXOu5Bs+o//Mbdj9VNQMUOe9oKCwh8l0GNwpTDMKCWbRjgtD291AWnkAgkqA/LOnQS8AmS1tw==",
+      "dev": true,
+      "license": "(MIT AND Zlib)"
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/pathe": {
@@ -1238,11 +3720,32 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/postcss": {
@@ -1272,6 +3775,120 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.14.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
+      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/raw-body/node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/rollup": {
@@ -1319,10 +3936,86 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/sax": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/send": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
+      "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.1",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "~2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "~2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/seq-queue": {
@@ -1330,12 +4023,197 @@
       "resolved": "https://registry.npmjs.org/seq-queue/-/seq-queue-0.0.5.tgz",
       "integrity": "sha512-hr3Wtp/GZIc/6DAGPDcV4/9WoZhjrkXsi5B/07QgX8tsdc6ilr7BFM6PM6rbdAX1kFSDYeZGLipIZZKyQP0O5Q=="
     },
+    "node_modules/serve-static": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
+      "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "~0.19.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/sha.js": {
+      "version": "2.4.12",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.12.tgz",
+      "integrity": "sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==",
+      "dev": true,
+      "license": "(MIT AND BSD-3-Clause)",
+      "dependencies": {
+        "inherits": "^2.0.4",
+        "safe-buffer": "^5.2.1",
+        "to-buffer": "^1.2.0"
+      },
+      "bin": {
+        "sha.js": "bin.js"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/siginfo": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
@@ -1363,11 +4241,72 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/std-env": {
       "version": "3.10.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
       "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strnum": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
+      "integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
       "license": "MIT"
     },
     "node_modules/tinybench": {
@@ -1414,12 +4353,169 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tmp": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/tmp-promise": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/tmp-promise/-/tmp-promise-3.0.3.tgz",
+      "integrity": "sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tmp": "^0.2.0"
+      }
+    },
+    "node_modules/to-buffer": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.2.2.tgz",
+      "integrity": "sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "isarray": "^2.0.5",
+        "safe-buffer": "^5.2.1",
+        "typed-array-buffer": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/typed-array-buffer": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+      "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/universal-github-app-jwt": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/universal-github-app-jwt/-/universal-github-app-jwt-1.2.0.tgz",
+      "integrity": "sha512-dncpMpnsKBk0eetwfN8D8OUHGfiDhhJ+mtsbMl+7PfW7mYjiH8LIcqRmYMtzYLgSh47HjfdBtrBwIQ/gizKR3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/jsonwebtoken": "^9.0.0",
+        "jsonwebtoken": "^9.0.2"
+      }
+    },
+    "node_modules/universal-user-agent": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.1.tgz",
+      "integrity": "sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/vite": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -1567,6 +4663,35 @@
         }
       }
     },
+    "node_modules/wasm-feature-detect": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/wasm-feature-detect/-/wasm-feature-detect-1.8.0.tgz",
+      "integrity": "sha512-zksaLKM2fVlnB5jQQDqKXXwYHLQUVH9es+5TOOHwGOVJOCeRBCiPjwSg+3tN2AdTCzjgli4jijCH290kXb/zWQ==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/which-typed-array": {
+      "version": "1.1.20",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
+      "integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -1582,6 +4707,116 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml2js": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
+      "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     }
   }

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -10,6 +10,8 @@
     "mysql2": "^3.9.0"
   },
   "devDependencies": {
+    "@wp-playground/blueprints": "^3.1.21",
+    "@wp-playground/cli": "^3.1.21",
     "vitest": "^4.0.18"
   }
 }

--- a/tests/e2e/tests/import-50-playground-wizard.test.js
+++ b/tests/e2e/tests/import-50-playground-wizard.test.js
@@ -151,35 +151,74 @@ describe('Wizard flow: pull → flatten → SQLite — playground-ready clone', 
             `imported.sqlite is only ${size} bytes — expected ≥ ~64KB for a populated WP DB`,
         );
 
-        // Query wp_options directly via PDO — this bypasses wpdb so
-        // we're checking the raw imported data, not WP's interpretation.
+        // Inspect the imported SQLite via PDO. Three things this catches:
+        //   1. The SQLite file exists at all.
+        //   2. The schema is COMPLETE — every table WordPress requires
+        //      to consider itself installed. Missing wp_users is the
+        //      classic "imported the data but install wizard still
+        //      shows up" symptom (db-apply bailed partway through, or
+        //      the source's dump was truncated, or the SQLite
+        //      translator dropped a CREATE TABLE).
+        //   3. wp_users has at least one row — wpdb's
+        //      is_blog_installed() returns false on an empty users
+        //      table even if wp_options.siteurl exists.
         const script = `
             $db = new PDO('sqlite:' . $argv[1]);
             $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-            $stmt = $db->prepare(
-                "SELECT option_name, option_value FROM wp_options "
-                . "WHERE option_name IN ('siteurl','home','blogname','template','active_plugins')"
-            );
+            // List of WP tables that exist in any default 6.x install.
+            $required = ['wp_users','wp_usermeta','wp_options','wp_posts','wp_postmeta','wp_terms','wp_termmeta','wp_term_taxonomy','wp_term_relationships','wp_comments','wp_commentmeta','wp_links'];
+            $tables = $db->query("SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE '\\_wp\\_sqlite\\_%' ESCAPE '\\\\' ORDER BY name")->fetchAll(PDO::FETCH_COLUMN);
+            $missing = array_values(array_diff($required, $tables));
+
+            $stmt = $db->prepare("SELECT option_name, option_value FROM wp_options WHERE option_name IN ('siteurl','home','blogname')");
             $stmt->execute();
-            echo json_encode($stmt->fetchAll(PDO::FETCH_KEY_PAIR));
+            $opts = $stmt->fetchAll(PDO::FETCH_KEY_PAIR);
+
+            $user_count = (int) $db->query("SELECT COUNT(*) FROM wp_users")->fetchColumn();
+
+            echo json_encode([
+                'tables' => $tables,
+                'missing_required_tables' => $missing,
+                'wp_users_count' => $user_count,
+                'options' => $opts,
+            ]);
         `;
         const out = execFileSync(PHP_BINARY, ['-r', script, sqlitePath], { encoding: 'utf-8' });
-        const opts = JSON.parse(out);
+        const data = JSON.parse(out);
 
-        assert.ok(opts.siteurl, `wp_options.siteurl missing — got: ${JSON.stringify(opts)}`);
-        assert.ok(opts.home, 'wp_options.home missing');
-        assert.ok(opts.blogname, 'wp_options.blogname missing');
+        // 1. Schema completeness — this is the assertion that catches
+        //    the "missing tables → install wizard" regression.
+        assert.deepEqual(
+            data.missing_required_tables, [],
+            `Imported SQLite is missing required WP tables: ${JSON.stringify(data.missing_required_tables)}.\n` +
+            `WP would consider itself uninstalled and serve the install wizard.\n` +
+            `All tables present: ${JSON.stringify(data.tables)}`,
+        );
+
+        // 2. wp_users must have at least one row, otherwise WP's
+        //    is_blog_installed() returns false even with a complete
+        //    schema. wp_users for a fresh source install has 1 row
+        //    (the admin user); copying a real site brings >= 1.
+        assert.ok(
+            data.wp_users_count >= 1,
+            `wp_users has ${data.wp_users_count} rows — WP needs at least 1 to consider itself installed`,
+        );
+
+        // 3. Critical wp_options rows.
+        assert.ok(data.options.siteurl, `wp_options.siteurl missing — got: ${JSON.stringify(data.options)}`);
+        assert.ok(data.options.home, 'wp_options.home missing');
+        assert.ok(data.options.blogname, 'wp_options.blogname missing');
 
         // --new-site-url should have rewritten the source URLs to the
         // local Playground URL. If it didn't, WP would redirect every
         // request back to the source domain.
         assert.ok(
-            opts.siteurl.includes('127.0.0.1') && opts.siteurl.includes(String(PLAYGROUND_PORT)),
-            `siteurl was not rewritten by --new-site-url; got: ${opts.siteurl}`,
+            data.options.siteurl.includes('127.0.0.1') && data.options.siteurl.includes(String(PLAYGROUND_PORT)),
+            `siteurl was not rewritten by --new-site-url; got: ${data.options.siteurl}`,
         );
         assert.ok(
-            opts.home.includes('127.0.0.1') && opts.home.includes(String(PLAYGROUND_PORT)),
-            `home was not rewritten by --new-site-url; got: ${opts.home}`,
+            data.options.home.includes('127.0.0.1') && data.options.home.includes(String(PLAYGROUND_PORT)),
+            `home was not rewritten by --new-site-url; got: ${data.options.home}`,
         );
     });
 
@@ -268,24 +307,54 @@ describe('Wizard flow: pull → flatten → SQLite — playground-ready clone', 
             const res = await fetch(serverUrl, { redirect: 'follow' });
             const body = await res.text();
             const headers = Object.fromEntries(res.headers.entries());
-            const snippet = body.slice(0, 1000);
+            const snippet = body.slice(0, 1500);
             assert.equal(
                 res.status, 200,
-                `Expected 200 from ${serverUrl}, got ${res.status}\nheaders: ${JSON.stringify(headers)}\nbody[0..1000]:\n${snippet}`,
+                `Expected 200 from ${serverUrl}, got ${res.status}\nheaders: ${JSON.stringify(headers)}\nbody[0..1500]:\n${snippet}`,
             );
-            // The install wizard contains a redirect to install.php
-            // and a "Welcome" page that asks for a language. If we see
-            // those, the SQLite drop-in didn't see the imported DB and
-            // WP fell back to "blog not installed" — exactly the bug
-            // we keep hitting in the deployed wizard.
+
+            // Hard rejection of the install wizard. WP redirects /
+            // straight to /wp-admin/install.php when is_blog_installed()
+            // is false, so the front-page response or a redirect chain
+            // ending in install.php is the regression. Multiple
+            // signals to maximise coverage of WP versions / themes /
+            // languages.
             assert.ok(
-                !/install\.php|Welcome to the famous/i.test(body),
-                `WordPress is showing the install wizard — DB not picked up.\nbody[0..1000]:\n${snippet}`,
+                !/install\.php/i.test(body),
+                `Response references install.php — WP thinks it isn't installed.\nbody[0..1500]:\n${snippet}`,
             );
-            // Sanity check: the response should be a real WP page.
             assert.ok(
-                /<title>[^<]+<\/title>/i.test(body),
-                `No <title> tag in response — WP didn't render the front page.\nbody[0..1000]:\n${snippet}`,
+                !/wp-admin\/setup-config\.php|installation\s+process|Welcome to the famous/i.test(body),
+                `Install wizard markup detected.\nbody[0..1500]:\n${snippet}`,
+            );
+
+            // Positive signal: WP actually rendered a front page. We
+            // pull the source site's blogname from the imported SQLite
+            // and assert it appears verbatim in the rendered HTML
+            // (default themes put it in <title> and many places in the
+            // header). This catches "WP booted but rendered an empty
+            // / unrelated page" cases.
+            const blognameScript = `
+                $db = new PDO('sqlite:' . $argv[1]);
+                $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+                echo $db->query("SELECT option_value FROM wp_options WHERE option_name='blogname'")
+                    ->fetchColumn();
+            `;
+            const blogname = execFileSync(
+                PHP_BINARY, ['-r', blognameScript, sqlitePath],
+                { encoding: 'utf-8' },
+            ).trim();
+            assert.ok(blogname, 'Could not read blogname from imported SQLite');
+
+            // The blogname might be HTML-escaped in the response (e.g.
+            // & → &amp;) — assert one of the two forms is there.
+            const blognameHtml = blogname
+                .replace(/&/g, '&amp;')
+                .replace(/</g, '&lt;')
+                .replace(/>/g, '&gt;');
+            assert.ok(
+                body.includes(blogname) || body.includes(blognameHtml),
+                `Imported blogname "${blogname}" not found in WP response — WP probably booted an unrelated page.\nbody[0..1500]:\n${snippet}`,
             );
         });
     });

--- a/tests/e2e/tests/import-50-playground-wizard.test.js
+++ b/tests/e2e/tests/import-50-playground-wizard.test.js
@@ -203,6 +203,11 @@ describe('Wizard flow: pull → flatten → SQLite — playground-ready clone', 
                 wordpressInstallMode: 'do-not-attempt-installing',
                 'mount-before-install': [{ hostPath: mountDir, vfsPath: '/wordpress' }],
                 php: '8.2',
+                // Tell the request handler that WP thinks it's at this
+                // origin — matches the --new-site-url we passed to pull,
+                // so wp_options.siteurl agrees with what WP sees, and
+                // we don't get an immediate redirect on the front page.
+                'site-url': 'https://playground.wordpress.net',
             });
             serverUrl = playgroundCli.serverUrl;
         }, 180000);

--- a/tests/e2e/tests/import-50-playground-wizard.test.js
+++ b/tests/e2e/tests/import-50-playground-wizard.test.js
@@ -54,7 +54,17 @@ import {
 import { ensureSite } from '../lib/site-setup.js';
 
 describe('Wizard flow: pull → flatten → SQLite — playground-ready clone', { timeout: 360000 }, () => {
-    const site = 'wpcloud-flatten';
+    // Use the 'basic' fixture rather than 'wpcloud-flatten' even
+    // though the latter better mirrors a real WP Cloud site's split
+    // root: tests 38 and 46 expect the wpcloud-flatten fixture set
+    // up with their own afterCreate (creating /tmp/e2e-wpcloud-core
+    // + __wp__ symlinks). ensureSite's marker file means whichever
+    // test runs first decides how the fixture is shaped, and a
+    // bare ensureSite('wpcloud-flatten') here shapes it as a
+    // regular WP install — breaking test 38's split-root
+    // assertions. Sticking to 'basic' avoids the cross-test
+    // contention; split-root coverage stays with test 38.
+    const site = 'basic';
     let tempDir;
     let importDir;     // what flat-docroot writes to (= wizard's /wordpress)
     let sqlitePath;    // where db-apply puts the SQLite (= wizard's /internal/shared/imported.sqlite)
@@ -103,27 +113,26 @@ describe('Wizard flow: pull → flatten → SQLite — playground-ready clone', 
     });
 
     it('flattened dir has the files WordPress needs to boot', () => {
-        // Real top-level files (NOT symlinks — __DIR__ / dirname(__FILE__)
-        // resolution depends on these living at the destination path).
+        // Real top-level files at the destination — these need to live
+        // at the flattened path so __DIR__ / dirname(__FILE__) resolves
+        // there.
         for (const f of ['wp-config.php', 'wp-load.php', 'index.php']) {
             const p = join(importDir, f);
             assert.ok(existsSync(p), `${f} missing in flattened dir at ${p}`);
         }
 
-        // wp-admin and wp-includes should be symlinks into the imported
-        // core tree (this is what flat-docroot does for split-root sites).
+        // wp-admin and wp-includes resolve through symlinks (split-root
+        // case) or are real dirs (basic fixture). Either way they must
+        // exist and contain a recognisable WP file. (The symlink shape
+        // is exercised separately by test 38 with the wpcloud-flatten
+        // fixture.)
         for (const dir of ['wp-admin', 'wp-includes']) {
             const p = join(importDir, dir);
             assert.ok(existsSync(p), `${dir} missing in flattened dir`);
-            assert.ok(
-                lstatSync(p).isSymbolicLink(),
-                `${dir} should be a symlink (flat-docroot's split-root output)`,
-            );
-            // The symlink should resolve to a directory with real WP files.
             const expectedFile = dir === 'wp-admin' ? 'admin.php' : 'version.php';
             assert.ok(
                 existsSync(join(p, expectedFile)),
-                `${dir} symlink doesn't resolve to a usable WP dir (${expectedFile} missing)`,
+                `${dir} doesn't contain ${expectedFile}`,
             );
         }
 

--- a/tests/e2e/tests/import-50-playground-wizard.test.js
+++ b/tests/e2e/tests/import-50-playground-wizard.test.js
@@ -190,12 +190,15 @@ describe('Wizard flow: pull → flatten → SQLite — playground-ready clone', 
             const { runCLI } = await import('@wp-playground/cli');
             playgroundCli = await runCLI({
                 command: 'server',
-                port: 0, // auto-pick a free port
+                port: 18745, // outside the 8081-8119 fixture range
                 skipBrowser: true,
                 quiet: true,
-                mode: 'mount-only',
-                mount: [{ hostPath: mountDir, vfsPath: '/wordpress' }],
-                'site-url': 'http://playground.test',
+                // The mount supplies WordPress + the imported site;
+                // setting wordpressInstallMode=do-not-attempt-installing
+                // tells boot not to download/install WP on top of it.
+                'wordpress-install-mode': 'do-not-attempt-installing',
+                wordpressInstallMode: 'do-not-attempt-installing',
+                'mount-before-install': [{ hostPath: mountDir, vfsPath: '/wordpress' }],
                 php: '8.2',
             });
             serverUrl = playgroundCli.serverUrl;

--- a/tests/e2e/tests/import-50-playground-wizard.test.js
+++ b/tests/e2e/tests/import-50-playground-wizard.test.js
@@ -219,25 +219,27 @@ describe('Wizard flow: pull → flatten → SQLite — playground-ready clone', 
         });
 
         it('responds with the imported site\'s blog title (no install wizard)', async () => {
-            const res = await fetch(serverUrl);
+            const res = await fetch(serverUrl, { redirect: 'manual' });
             const body = await res.text();
-            assert.equal(res.status, 200, `Expected 200, got ${res.status}`);
-            // The install wizard contains the literal "Welcome" header
-            // and a "language selection" form. If we see those, the
-            // SQLite drop-in didn't see the imported DB and WP fell
-            // back to "blog not installed" — exactly the bug we keep
-            // hitting in the deployed wizard.
+            const headers = Object.fromEntries(res.headers.entries());
+            const snippet = body.slice(0, 1000);
+            assert.equal(
+                res.status, 200,
+                `Expected 200 from ${serverUrl}, got ${res.status}\nheaders: ${JSON.stringify(headers)}\nbody[0..1000]:\n${snippet}`,
+            );
+            // The install wizard contains a redirect to install.php
+            // and a "Welcome" page that asks for a language. If we see
+            // those, the SQLite drop-in didn't see the imported DB and
+            // WP fell back to "blog not installed" — exactly the bug
+            // we keep hitting in the deployed wizard.
             assert.ok(
                 !/install\.php|Welcome to the famous/i.test(body),
-                'WordPress is showing the install wizard — DB not picked up',
+                `WordPress is showing the install wizard — DB not picked up.\nbody[0..1000]:\n${snippet}`,
             );
-            // Sanity check: the imported site's blogname should appear.
-            // We don't know the exact value, but a fresh WP fixture
-            // sets it to "Test Site" or similar; just assert it's
-            // not empty and not the default WP install body.
+            // Sanity check: the response should be a real WP page.
             assert.ok(
                 /<title>[^<]+<\/title>/i.test(body),
-                'No <title> tag in response — WP didn\'t render the front page',
+                `No <title> tag in response — WP didn't render the front page.\nbody[0..1000]:\n${snippet}`,
             );
         });
     });

--- a/tests/e2e/tests/import-50-playground-wizard.test.js
+++ b/tests/e2e/tests/import-50-playground-wizard.test.js
@@ -176,12 +176,22 @@ describe('Wizard flow: pull → flatten → SQLite — playground-ready clone', 
         let mountDir;
 
         beforeAll(async () => {
-            // Stage the imported tree in a writable dir, since the
-            // import dir will get mutated by Playground (cookies,
-            // .htaccess updates, mu-plugin writes etc.) and we don't
-            // want subsequent assertions on importDir to be polluted.
+            // Stage the imported tree in a writable, self-contained
+            // dir for Playground to mount.
+            //
+            // dereference: true is critical here. flat-docroot's
+            // output contains absolute symlinks pointing at the raw
+            // pulled tree (wp-admin → /tmp/.../e2e-wpcloud-core/wp-admin
+            // etc. for the wpcloud-flatten fixture). cpSync with
+            // dereference:false would copy those symlinks verbatim;
+            // when Playground mounts the dir at /wordpress, the WASM
+            // VFS sees the symlinks but can't resolve their host-FS
+            // targets that live outside the mount. Resolving them at
+            // copy time turns mountDir into a normal flat WP install
+            // — which is what the deployed wizard achieves by copying
+            // recursively in its activation step.
             mountDir = join(tempDir, 'playground-mount');
-            cpSync(importDir, mountDir, { recursive: true, dereference: false });
+            cpSync(importDir, mountDir, { recursive: true, dereference: true });
 
             // Place the imported SQLite where Playground's auto-loaded
             // SQLite drop-in expects it (this is what the wizard does
@@ -191,16 +201,19 @@ describe('Wizard flow: pull → flatten → SQLite — playground-ready clone', 
             copyFileSync(sqlitePath, join(dbDir, '.ht.sqlite'));
 
             const { runCLI } = await import('@wp-playground/cli');
+            // Mirror Studio's pull-reprint server flags: the imported
+            // tree IS the site, so SkipSqliteSetup keeps Playground
+            // from reinstalling the SQLite plugin on top of it, and
+            // followSymlinks lets the wp-admin / wp-includes symlinks
+            // produced by flat-docroot resolve.
             playgroundCli = await runCLI({
                 command: 'server',
                 port: 18745, // outside the 8081-8119 fixture range
                 skipBrowser: true,
                 quiet: true,
-                // The mount supplies WordPress + the imported site;
-                // setting wordpressInstallMode=do-not-attempt-installing
-                // tells boot not to download/install WP on top of it.
-                'wordpress-install-mode': 'do-not-attempt-installing',
                 wordpressInstallMode: 'do-not-attempt-installing',
+                skipSqliteSetup: true,
+                followSymlinks: true,
                 'mount-before-install': [{ hostPath: mountDir, vfsPath: '/wordpress' }],
                 php: '8.2',
                 // Tell the request handler that WP thinks it's at this

--- a/tests/e2e/tests/import-50-playground-wizard.test.js
+++ b/tests/e2e/tests/import-50-playground-wizard.test.js
@@ -236,7 +236,9 @@ describe('Wizard flow: pull → flatten → SQLite — playground-ready clone', 
         });
 
         it('responds with the imported site\'s blog title (no install wizard)', async () => {
-            const res = await fetch(serverUrl, { redirect: 'manual' });
+            // Playground's first request always 302s for the auto-login
+            // cookie handshake — fetch must follow redirects to reach WP.
+            const res = await fetch(serverUrl, { redirect: 'follow' });
             const body = await res.text();
             const headers = Object.fromEntries(res.headers.entries());
             const snippet = body.slice(0, 1000);

--- a/tests/e2e/tests/import-50-playground-wizard.test.js
+++ b/tests/e2e/tests/import-50-playground-wizard.test.js
@@ -1,0 +1,233 @@
+/**
+ * Test 50: Wizard flow — pull → flatten → SQLite, ready for Playground
+ *
+ * This test mirrors what the deployed reprint-ui wizard does, end-to-end,
+ * against a wpcom-Atomic-style fixture. It does NOT talk to wp.com — the
+ * fixture's reprint-exporter is reachable directly with a known shared
+ * secret, the way the wizard would talk to a real site after the OAuth
+ * + rotate-export-secret round-trip.
+ *
+ * Each `it` block models one piece the wizard relies on:
+ *
+ *   1. `pull` against a split-root Atomic layout, with the same flags
+ *      the wizard sets:
+ *         --target-engine=sqlite
+ *         --target-sqlite-path=...   (mirrors `/internal/shared/imported.sqlite`)
+ *         --flatten-to=...           (mirrors `/wordpress`)
+ *         --runtime=none
+ *         --no-adaptive
+ *      Produces a flat WP layout with wp-admin / wp-includes as symlinks
+ *      into the imported core tree, plus a populated SQLite database.
+ *
+ *   2. The flattened directory has the structure WP needs to boot:
+ *      real wp-config.php / wp-load.php / index.php at the top, working
+ *      symlinks for wp-admin and wp-includes, and wp-content with the
+ *      imported plugins.
+ *
+ *   3. The imported SQLite has the source site's wp_options
+ *      (`siteurl`, `home`, `blogname`, etc.) with URLs rewritten to the
+ *      `--new-site-url` value the wizard passes.
+ *
+ *   4. WordPress can actually serve the cloned site: we boot
+ *      Playground with the flattened dir mounted at /wordpress and the
+ *      imported SQLite in place, then HTTP-fetch `/` and assert the
+ *      blog title appears in the response. Catches the "install wizard
+ *      shows up instead of the cloned site" class of bug.
+ *
+ * If any of these breaks on CI, the wizard breaks for the user.
+ */
+import { describe, it, beforeAll, afterAll } from 'vitest';
+import assert from 'node:assert/strict';
+import {
+    existsSync, readFileSync, statSync,
+    lstatSync, readlinkSync, mkdirSync, writeFileSync, rmSync,
+    cpSync, copyFileSync,
+} from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { join } from 'node:path';
+import {
+    runImporter, createTempDir, cleanupTempDir,
+    getSiteUrl, getSiteSecret, getSiteDir,
+    PHP_BINARY,
+    PROJECT_ROOT,
+} from '../lib/test-helpers.js';
+import { ensureSite } from '../lib/site-setup.js';
+
+describe('Wizard flow: pull → flatten → SQLite — playground-ready clone', { timeout: 360000 }, () => {
+    const site = 'wpcloud-flatten';
+    let tempDir;
+    let importDir;     // what flat-docroot writes to (= wizard's /wordpress)
+    let sqlitePath;    // where db-apply puts the SQLite (= wizard's /internal/shared/imported.sqlite)
+
+    beforeAll(async () => {
+        await ensureSite(site);
+        tempDir = createTempDir('e2e-wizard-flow');
+        importDir = join(tempDir, 'site');
+        sqlitePath = join(tempDir, 'imported.sqlite');
+    });
+
+    afterAll(() => {
+        cleanupTempDir(tempDir);
+    });
+
+    function importUrl() {
+        return `${getSiteUrl(site)}&directory=${getSiteDir(site)}`;
+    }
+
+    it('pull --flatten-to + SQLite completes successfully (matches wizard flags)', () => {
+        const result = runImporter(importUrl(), tempDir, 'pull', {
+            secret: getSiteSecret(site),
+            timeout: 180000,
+            wallTimeout: 300000,
+            extraArgs: [
+                '--target-engine=sqlite',
+                `--target-sqlite-path=${sqlitePath}`,
+                `--flatten-to=${importDir}`,
+                '--new-site-url=https://playground.wordpress.net',
+                '--runtime=none',
+                '--no-adaptive',
+            ],
+        });
+        assert.equal(
+            result.exitCode, 0,
+            `pull exited ${result.exitCode}\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+        );
+    });
+
+    it('flattened dir has the files WordPress needs to boot', () => {
+        // Real top-level files (NOT symlinks — __DIR__ / dirname(__FILE__)
+        // resolution depends on these living at the destination path).
+        for (const f of ['wp-config.php', 'wp-load.php', 'index.php']) {
+            const p = join(importDir, f);
+            assert.ok(existsSync(p), `${f} missing in flattened dir at ${p}`);
+        }
+
+        // wp-admin and wp-includes should be symlinks into the imported
+        // core tree (this is what flat-docroot does for split-root sites).
+        for (const dir of ['wp-admin', 'wp-includes']) {
+            const p = join(importDir, dir);
+            assert.ok(existsSync(p), `${dir} missing in flattened dir`);
+            assert.ok(
+                lstatSync(p).isSymbolicLink(),
+                `${dir} should be a symlink (flat-docroot's split-root output)`,
+            );
+            // The symlink should resolve to a directory with real WP files.
+            const expectedFile = dir === 'wp-admin' ? 'admin.php' : 'version.php';
+            assert.ok(
+                existsSync(join(p, expectedFile)),
+                `${dir} symlink doesn't resolve to a usable WP dir (${expectedFile} missing)`,
+            );
+        }
+
+        // wp-content with the imported tree.
+        assert.ok(
+            existsSync(join(importDir, 'wp-content', 'plugins')),
+            'wp-content/plugins missing in flattened dir',
+        );
+    });
+
+    it('imported SQLite is populated with the source site\'s data', () => {
+        assert.ok(existsSync(sqlitePath), `imported.sqlite missing at ${sqlitePath}`);
+        const size = statSync(sqlitePath).size;
+        assert.ok(
+            size > 64 * 1024,
+            `imported.sqlite is only ${size} bytes — expected ≥ ~64KB for a populated WP DB`,
+        );
+
+        // Query wp_options directly via PDO — this bypasses wpdb so
+        // we're checking the raw imported data, not WP's interpretation.
+        const script = `
+            $db = new PDO('sqlite:' . $argv[1]);
+            $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+            $stmt = $db->prepare(
+                "SELECT option_name, option_value FROM wp_options "
+                . "WHERE option_name IN ('siteurl','home','blogname','template','active_plugins')"
+            );
+            $stmt->execute();
+            echo json_encode($stmt->fetchAll(PDO::FETCH_KEY_PAIR));
+        `;
+        const out = execFileSync(PHP_BINARY, ['-r', script, sqlitePath], { encoding: 'utf-8' });
+        const opts = JSON.parse(out);
+
+        assert.ok(opts.siteurl, `wp_options.siteurl missing — got: ${JSON.stringify(opts)}`);
+        assert.ok(opts.home, 'wp_options.home missing');
+        assert.ok(opts.blogname, 'wp_options.blogname missing');
+
+        // The wizard passes --new-site-url=https://playground.wordpress.net
+        // which makes pull rewrite siteurl/home in the dump. Confirm it
+        // actually happened — if it didn't, WP would redirect every
+        // request to the source domain.
+        assert.ok(
+            opts.siteurl.includes('playground.wordpress.net'),
+            `siteurl was not rewritten by --new-site-url; got: ${opts.siteurl}`,
+        );
+        assert.ok(
+            opts.home.includes('playground.wordpress.net'),
+            `home was not rewritten by --new-site-url; got: ${opts.home}`,
+        );
+    });
+
+    describe('Boot Playground against the imported site', () => {
+        let playgroundCli;
+        let serverUrl;
+        let mountDir;
+
+        beforeAll(async () => {
+            // Stage the imported tree in a writable dir, since the
+            // import dir will get mutated by Playground (cookies,
+            // .htaccess updates, mu-plugin writes etc.) and we don't
+            // want subsequent assertions on importDir to be polluted.
+            mountDir = join(tempDir, 'playground-mount');
+            cpSync(importDir, mountDir, { recursive: true, dereference: false });
+
+            // Place the imported SQLite where Playground's auto-loaded
+            // SQLite drop-in expects it (this is what the wizard does
+            // in its activation step).
+            const dbDir = join(mountDir, 'wp-content', 'database');
+            mkdirSync(dbDir, { recursive: true });
+            copyFileSync(sqlitePath, join(dbDir, '.ht.sqlite'));
+
+            const { runCLI } = await import('@wp-playground/cli');
+            playgroundCli = await runCLI({
+                command: 'server',
+                port: 0, // auto-pick a free port
+                skipBrowser: true,
+                quiet: true,
+                mode: 'mount-only',
+                mount: [{ hostPath: mountDir, vfsPath: '/wordpress' }],
+                'site-url': 'http://playground.test',
+                php: '8.2',
+            });
+            serverUrl = playgroundCli.serverUrl;
+        }, 180000);
+
+        afterAll(async () => {
+            if (playgroundCli && typeof playgroundCli[Symbol.asyncDispose] === 'function') {
+                await playgroundCli[Symbol.asyncDispose]();
+            }
+        });
+
+        it('responds with the imported site\'s blog title (no install wizard)', async () => {
+            const res = await fetch(serverUrl);
+            const body = await res.text();
+            assert.equal(res.status, 200, `Expected 200, got ${res.status}`);
+            // The install wizard contains the literal "Welcome" header
+            // and a "language selection" form. If we see those, the
+            // SQLite drop-in didn't see the imported DB and WP fell
+            // back to "blog not installed" — exactly the bug we keep
+            // hitting in the deployed wizard.
+            assert.ok(
+                !/install\.php|Welcome to the famous/i.test(body),
+                'WordPress is showing the install wizard — DB not picked up',
+            );
+            // Sanity check: the imported site's blogname should appear.
+            // We don't know the exact value, but a fresh WP fixture
+            // sets it to "Test Site" or similar; just assert it's
+            // not empty and not the default WP install body.
+            assert.ok(
+                /<title>[^<]+<\/title>/i.test(body),
+                'No <title> tag in response — WP didn\'t render the front page',
+            );
+        });
+    });
+});

--- a/tests/e2e/tests/import-50-playground-wizard.test.js
+++ b/tests/e2e/tests/import-50-playground-wizard.test.js
@@ -197,6 +197,24 @@ describe('Wizard flow: pull → flatten → SQLite — playground-ready clone', 
             mountDir = join(tempDir, 'playground-mount');
             cpSync(importDir, mountDir, { recursive: true, dereference: true });
 
+            // Neutralize hardcoded path defines in the imported
+            // wp-config.php. The wpcloud-flatten fixture's wp-config
+            // has e.g. WP_CONTENT_DIR=/tmp/e2e-wpcloud-wpcontent/wp-content
+            // — a host path that doesn't exist inside Playground's
+            // WASM VFS. WP would then mkdir that nonexistent dir and
+            // bail. Comment out anything that hardcodes a layout
+            // path so WP falls back to deriving them from ABSPATH=
+            // /wordpress/. (Real Atomic-site wp-configs need the same
+            // treatment in the deployed wizard — this is what the
+            // wizard's activation step does in PHP.)
+            const cfgPath = join(mountDir, 'wp-config.php');
+            const cfg = readFileSync(cfgPath, 'utf-8');
+            const neutralized = cfg.replace(
+                /^[ \t]*define\s*\(\s*['"](?:ABSPATH|WP_CONTENT_DIR|WP_CONTENT_URL|WP_TEMP_DIR|WPMU_PLUGIN_DIR|WPMU_PLUGIN_URL|WP_PLUGIN_DIR|WP_PLUGIN_URL|WP_LANG_DIR|WP_HOME|WP_SITEURL|COOKIE_DOMAIN)['"][^)]*\)\s*;.*$/gm,
+                '// import-50 neutralized: $&',
+            );
+            writeFileSync(cfgPath, neutralized);
+
             // Place the imported SQLite where Playground's auto-loaded
             // SQLite drop-in expects it (this is what the wizard does
             // in its activation step).

--- a/tests/e2e/tests/import-50-playground-wizard.test.js
+++ b/tests/e2e/tests/import-50-playground-wizard.test.js
@@ -77,6 +77,9 @@ describe('Wizard flow: pull → flatten → SQLite — playground-ready clone', 
     it('pull --flatten-to + SQLite completes successfully (matches wizard flags)', () => {
         const result = runImporter(importUrl(), tempDir, 'pull', {
             secret: getSiteSecret(site),
+            // pull internally runs preflight as its first stage, so
+            // skip the wrapper's auto-preflight to avoid running it twice.
+            skipPreflight: true,
             timeout: 180000,
             wallTimeout: 300000,
             extraArgs: [

--- a/tests/e2e/tests/import-50-playground-wizard.test.js
+++ b/tests/e2e/tests/import-50-playground-wizard.test.js
@@ -58,6 +58,11 @@ describe('Wizard flow: pull → flatten → SQLite — playground-ready clone', 
     let tempDir;
     let importDir;     // what flat-docroot writes to (= wizard's /wordpress)
     let sqlitePath;    // where db-apply puts the SQLite (= wizard's /internal/shared/imported.sqlite)
+    // Align the SQL's siteurl/home rewrite with the URL Playground will
+    // serve under in this test, so WP doesn't issue a canonical
+    // redirect on the front-page check.
+    const PLAYGROUND_PORT = 18745;
+    const PLAYGROUND_URL = `http://127.0.0.1:${PLAYGROUND_PORT}`;
 
     beforeAll(async () => {
         await ensureSite(site);
@@ -86,7 +91,7 @@ describe('Wizard flow: pull → flatten → SQLite — playground-ready clone', 
                 '--target-engine=sqlite',
                 `--target-sqlite-path=${sqlitePath}`,
                 `--flatten-to=${importDir}`,
-                '--new-site-url=https://playground.wordpress.net',
+                `--new-site-url=${PLAYGROUND_URL}`,
                 '--runtime=none',
                 '--no-adaptive',
             ],
@@ -156,16 +161,15 @@ describe('Wizard flow: pull → flatten → SQLite — playground-ready clone', 
         assert.ok(opts.home, 'wp_options.home missing');
         assert.ok(opts.blogname, 'wp_options.blogname missing');
 
-        // The wizard passes --new-site-url=https://playground.wordpress.net
-        // which makes pull rewrite siteurl/home in the dump. Confirm it
-        // actually happened — if it didn't, WP would redirect every
-        // request to the source domain.
+        // --new-site-url should have rewritten the source URLs to the
+        // local Playground URL. If it didn't, WP would redirect every
+        // request back to the source domain.
         assert.ok(
-            opts.siteurl.includes('playground.wordpress.net'),
+            opts.siteurl.includes('127.0.0.1') && opts.siteurl.includes(String(PLAYGROUND_PORT)),
             `siteurl was not rewritten by --new-site-url; got: ${opts.siteurl}`,
         );
         assert.ok(
-            opts.home.includes('playground.wordpress.net'),
+            opts.home.includes('127.0.0.1') && opts.home.includes(String(PLAYGROUND_PORT)),
             `home was not rewritten by --new-site-url; got: ${opts.home}`,
         );
     });
@@ -208,7 +212,7 @@ describe('Wizard flow: pull → flatten → SQLite — playground-ready clone', 
             // produced by flat-docroot resolve.
             playgroundCli = await runCLI({
                 command: 'server',
-                port: 18745, // outside the 8081-8119 fixture range
+                port: PLAYGROUND_PORT, // outside the 8081-8119 fixture range
                 skipBrowser: true,
                 quiet: true,
                 wordpressInstallMode: 'do-not-attempt-installing',
@@ -220,7 +224,7 @@ describe('Wizard flow: pull → flatten → SQLite — playground-ready clone', 
                 // origin — matches the --new-site-url we passed to pull,
                 // so wp_options.siteurl agrees with what WP sees, and
                 // we don't get an immediate redirect on the front page.
-                'site-url': 'https://playground.wordpress.net',
+                'site-url': PLAYGROUND_URL,
             });
             serverUrl = playgroundCli.serverUrl;
         }, 180000);

--- a/tests/e2e/tests/import-50-playground-wizard.test.js
+++ b/tests/e2e/tests/import-50-playground-wizard.test.js
@@ -175,11 +175,15 @@ describe('Wizard flow: pull → flatten → SQLite — playground-ready clone', 
             $opts = $stmt->fetchAll(PDO::FETCH_KEY_PAIR);
 
             $user_count = (int) $db->query("SELECT COUNT(*) FROM wp_users")->fetchColumn();
+            $option_count = (int) $db->query("SELECT COUNT(*) FROM wp_options")->fetchColumn();
+            $term_count = (int) $db->query("SELECT COUNT(*) FROM wp_terms")->fetchColumn();
 
             echo json_encode([
                 'tables' => $tables,
                 'missing_required_tables' => $missing,
                 'wp_users_count' => $user_count,
+                'wp_options_count' => $option_count,
+                'wp_terms_count' => $term_count,
                 'options' => $opts,
             ]);
         `;
@@ -204,7 +208,23 @@ describe('Wizard flow: pull → flatten → SQLite — playground-ready clone', 
             `wp_users has ${data.wp_users_count} rows — WP needs at least 1 to consider itself installed`,
         );
 
-        // 3. Critical wp_options rows.
+        // 3. Row-count sanity check. A bare `wp core install` writes
+        //    150+ rows to wp_options and 2+ to wp_terms. If the dump
+        //    got truncated mid-stream — the user's reported failure mode
+        //    where db-apply reported "complete" but later tables had
+        //    no data — these counts collapse to a handful. Catches
+        //    silent partial-import regressions that table existence
+        //    alone wouldn't.
+        assert.ok(
+            data.wp_options_count >= 50,
+            `wp_options has only ${data.wp_options_count} rows — dump likely truncated mid-stream (fresh WP install has 150+)`,
+        );
+        assert.ok(
+            data.wp_terms_count >= 1,
+            `wp_terms has ${data.wp_terms_count} rows — fresh WP install seeds at least the "Uncategorized" category`,
+        );
+
+        // 4. Critical wp_options rows.
         assert.ok(data.options.siteurl, `wp_options.siteurl missing — got: ${JSON.stringify(data.options)}`);
         assert.ok(data.options.home, 'wp_options.home missing');
         assert.ok(data.options.blogname, 'wp_options.blogname missing');


### PR DESCRIPTION
## Summary

A small PHP web app that turns "I want a copy of my WordPress.com site running in Playground" into three clicks. OAuth into wp.com on the server side to get the HMAC export secret, then run `reprint.phar` inside a Playground iframe so all HTTP traffic to the source site originates from the user's browser — no WAF/UA gymnastics, no server-side streaming pipeline, no temporary artifact hosting.

The wizard ships as static-ish PHP files behind a registered wp.com OAuth app and serves the phar over HTTP. The iframe runs the import itself; progress streams back via `post_message_to_js` so the UI can show real file counts (e.g. `4,812 / 33,634 (14%) · style.css`) instead of a spinner. Initial pull skips `wp-content/uploads` via `--filter=essential-files` to land a usable site in seconds; missing upload requests 302 to the source site through a tiny mu-plugin until the user clicks "Download uploads", which runs `files-pull --filter=skipped-earlier` and fills them in.

## Two upstream changes the wizard depends on

**`--no-adaptive` becomes a real switch.** It used to set a config flag that nothing read — every request still carried `max_execution_time` and `memory_threshold`, and inter-request sleep ran as usual. The flag now actually shuts the tuner off: `get_request_params` returns `[]`, `record_result` and `record_error` become no-ops, `sleep_seconds` stays at zero. The phar runs as fast as the server permits, which is the contract the wizard needs inside a single Playground run.

**`IMPORTER_WEB_ENTRY` lets a web SAPI invoke the importer.** The CLI guard at the bottom of `import.php` now accepts the sentinel alongside `PHP_SAPI === "cli"`, and `Pull`'s start stage returns early instead of `passthru`ing `start.sh` — that `passthru` is meaningless in WASM and would block the worker indefinitely.

## Files of note

- `reprint-ui/index.php` — wizard UI + WP.com REST glue (provision endpoint that calls `/sites/<id>/settings` to flip `reprint_exporter_enabled`, then the Jetpack bridge to rotate the HMAC secret)
- `reprint-ui/oauth-redirect.php` — OAuth callback, server-side token exchange using `WPCOM_CLIENT_SECRET` from `wp_options`
- `reprint-ui/bootstrap.php` — session + creds loader

## Test plan

- [ ] Open the deployed instance, walk through the OAuth flow with a real WP.com Atomic site, confirm the cloned site loads in the iframe at `/wordpress`
- [ ] Click "Download uploads" once, confirm media starts loading from the local Playground rather than via the 302 proxy
- [ ] Verify `--no-adaptive` actually omits `max_execution_time` from outgoing XHR (network tab)
- [ ] PHPUnit still passes for the importer changes