### PR TITLE
importer: EXIT_AFTER_IMPORT lets embedders run cleanup after pull

### DIFF
--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -11847,7 +11847,23 @@ if (
         $client = new ImportClient($remote_url, $state_dir, $fs_root);
         $client->audit_log_argv($command, $argv);
         $client->run($options ?? []);
-        exit($client->exit_code);
+        // EXIT_AFTER_IMPORT controls whether we hand control back to
+        // the caller after pull returns. Default true: standard CLI
+        // invocations (reprint pull, the phar bin, e2e tests) get the
+        // exit() they expect. Embedders that include the phar from a
+        // web SAPI — the Playground wizard in reprint-import.php is
+        // the live case — define EXIT_AFTER_IMPORT=false so cleanup
+        // logic can run AFTER pull, in the same try/catch scope as
+        // the include. Without that knob the bare exit() jumps the
+        // embedder's stack and forces it to wire activation through
+        // register_shutdown_function, where exceptions have no
+        // channel to surface as ndjson events. Stash the exit code on
+        // a global so the embedder can read it.
+        $GLOBALS['REPRINT_IMPORTER_EXIT_CODE'] = (int) $client->exit_code;
+        if (!defined('EXIT_AFTER_IMPORT') || EXIT_AFTER_IMPORT) {
+            exit($client->exit_code);
+        }
+        return;
     } catch (\Throwable $e) {
         $is_tty = function_exists("posix_isatty") && posix_isatty(STDERR);
         $error_code = isset($client) ? $client->last_error_code : null;
@@ -11867,6 +11883,13 @@ if (
             }
             fwrite(STDERR, $json . "\n");
         }
-        exit(1);
+        $GLOBALS['REPRINT_IMPORTER_EXIT_CODE'] = 1;
+        if (!defined('EXIT_AFTER_IMPORT') || EXIT_AFTER_IMPORT) {
+            exit(1);
+        }
+        // When EXIT_AFTER_IMPORT is false we still want the embedder
+        // to see the failure — re-throw so its try/catch around
+        // `include $phar` can surface a proper `{type:'error'}` event.
+        throw $e;
     }
 }

--- a/reprint-ui/reprint-import.php
+++ b/reprint-ui/reprint-import.php
@@ -336,19 +336,21 @@ window.addEventListener('DOMContentLoaded', runImport);
 // ─────────────────────────────────────────────────────────────────
 
 function stream_pull_and_activate(): void {
-    // The phar's CLI entry-point exit(0)s at the end of `pull`, so any
-    // code after stream_pull() returns is dead. Register the
-    // activation as a shutdown function instead — it runs whether
-    // the phar exits cleanly, throws, or returns.
-    register_shutdown_function(function () {
-        $activate = run_local_activation();
-        echo json_encode([
-            'type' => 'activate',
-            'status' => !empty($activate['ok']) ? 'complete' : 'error',
-            'data' => $activate,
-        ]) . "\n";
-    });
+    // The phar checks EXIT_AFTER_IMPORT; setting it to false makes
+    // it return control after pull instead of exit()ing. We run
+    // activation in the same try/catch scope as the include, so
+    // exceptions surface as proper {type:'error'} ndjson events
+    // instead of disappearing into a shutdown handler.
+    if (!defined('EXIT_AFTER_IMPORT')) {
+        define('EXIT_AFTER_IMPORT', false);
+    }
     stream_pull();
+    $activate = run_local_activation();
+    echo json_encode([
+        'type' => 'activate',
+        'status' => !empty($activate['ok']) ? 'complete' : 'error',
+        'data' => $activate,
+    ]) . "\n";
 }
 
 function stream_pull(): void {


### PR DESCRIPTION
First in the stacked review-fixes chain off #185.

The phar's CLI dispatcher `exit($exit_code)`s at the end of `pull`, which forces embedders that include the phar from a web SAPI (the Playground wizard in `reprint-import.php` is the live case) to wire post-pull cleanup through `register_shutdown_function`. Shutdown handlers have no exception channel — anything that throws there disappears instead of becoming a `{type:'error'}` ndjson event the embedder can surface.

Add an `EXIT_AFTER_IMPORT` define. **Default true:** standard CLI invocations (`reprint pull`, the phar bin, e2e tests) keep the `exit()` they expect. Embedders define it to `false` to keep control after pull, in the same `try/catch` scope as the include. The exit code is stashed on `$GLOBALS['REPRINT_IMPORTER_EXIT_CODE']` for the embedder to read. The error-catch path mirrors that — sets exit code on the global, re-throws when `EXIT_AFTER_IMPORT` is false so the embedder's `try/catch` produces a proper error event.

Wizard side: defines `EXIT_AFTER_IMPORT=false` before `include $phar` and runs `run_local_activation()` in the same `try/catch` as the include instead of in a shutdown function.

## Test plan

- [ ] CI green (PHPUnit + E2E + Playground CLI)
- [ ] Manual: re-run the wizard, verify a) activation events appear in the wizard's progress log; b) any phar-side error during pull surfaces in the wizard log instead of the previous "activate event missing" branch