### PR TITLE
reprint-ui: rename _reprint_self_origin → _reprint_canonical_site_url

### DIFF
--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -11847,7 +11847,23 @@ if (
         $client = new ImportClient($remote_url, $state_dir, $fs_root);
         $client->audit_log_argv($command, $argv);
         $client->run($options ?? []);
-        exit($client->exit_code);
+        // EXIT_AFTER_IMPORT controls whether we hand control back to
+        // the caller after pull returns. Default true: standard CLI
+        // invocations (reprint pull, the phar bin, e2e tests) get the
+        // exit() they expect. Embedders that include the phar from a
+        // web SAPI — the Playground wizard in reprint-import.php is
+        // the live case — define EXIT_AFTER_IMPORT=false so cleanup
+        // logic can run AFTER pull, in the same try/catch scope as
+        // the include. Without that knob the bare exit() jumps the
+        // embedder's stack and forces it to wire activation through
+        // register_shutdown_function, where exceptions have no
+        // channel to surface as ndjson events. Stash the exit code on
+        // a global so the embedder can read it.
+        $GLOBALS['REPRINT_IMPORTER_EXIT_CODE'] = (int) $client->exit_code;
+        if (!defined('EXIT_AFTER_IMPORT') || EXIT_AFTER_IMPORT) {
+            exit($client->exit_code);
+        }
+        return;
     } catch (\Throwable $e) {
         $is_tty = function_exists("posix_isatty") && posix_isatty(STDERR);
         $error_code = isset($client) ? $client->last_error_code : null;
@@ -11867,6 +11883,13 @@ if (
             }
             fwrite(STDERR, $json . "\n");
         }
-        exit(1);
+        $GLOBALS['REPRINT_IMPORTER_EXIT_CODE'] = 1;
+        if (!defined('EXIT_AFTER_IMPORT') || EXIT_AFTER_IMPORT) {
+            exit(1);
+        }
+        // When EXIT_AFTER_IMPORT is false we still want the embedder
+        // to see the failure — re-throw so its try/catch around
+        // `include $phar` can surface a proper `{type:'error'}` event.
+        throw $e;
     }
 }

--- a/reprint-ui/reprint-import.php
+++ b/reprint-ui/reprint-import.php
@@ -336,19 +336,21 @@ window.addEventListener('DOMContentLoaded', runImport);
 // ─────────────────────────────────────────────────────────────────
 
 function stream_pull_and_activate(): void {
-    // The phar's CLI entry-point exit(0)s at the end of `pull`, so any
-    // code after stream_pull() returns is dead. Register the
-    // activation as a shutdown function instead — it runs whether
-    // the phar exits cleanly, throws, or returns.
-    register_shutdown_function(function () {
-        $activate = run_local_activation();
-        echo json_encode([
-            'type' => 'activate',
-            'status' => !empty($activate['ok']) ? 'complete' : 'error',
-            'data' => $activate,
-        ]) . "\n";
-    });
+    // The phar checks EXIT_AFTER_IMPORT; setting it to false makes
+    // it return control after pull instead of exit()ing. We run
+    // activation in the same try/catch scope as the include, so
+    // exceptions surface as proper {type:'error'} ndjson events
+    // instead of disappearing into a shutdown handler.
+    if (!defined('EXIT_AFTER_IMPORT')) {
+        define('EXIT_AFTER_IMPORT', false);
+    }
     stream_pull();
+    $activate = run_local_activation();
+    echo json_encode([
+        'type' => 'activate',
+        'status' => !empty($activate['ok']) ? 'complete' : 'error',
+        'data' => $activate,
+    ]) . "\n";
 }
 
 function stream_pull(): void {

--- a/reprint-ui/reprint-import.php
+++ b/reprint-ui/reprint-import.php
@@ -458,7 +458,7 @@ function stream_pull(): void {
         '--target-engine=sqlite',
         '--target-sqlite-path=/internal/shared/imported.sqlite',
         '--flatten-to=/wordpress',
-        '--new-site-url=' . _reprint_self_origin(),
+        '--new-site-url=' . _reprint_canonical_site_url(),
         // The web Playground iframe doesn't have a runtime= adapter
         // (no host-FS mounts, no start.sh). Skip apply-runtime; we do
         // a lightweight activation step ourselves on completion.
@@ -797,20 +797,24 @@ PHP;
     ];
 }
 
-function _reprint_self_origin(): string {
-    // Use Playground's full session URL — including the
-    // /scope:<slug>/ path segment — verbatim. Playground's PHP
-    // request handler defines WP_HOME / WP_SITEURL to this value,
-    // and WordPress runs option_home / option_siteurl through
-    // _config_wp_home() / _config_wp_siteurl(), so home_url() and
-    // site_url() always return the full scope-prefixed URL at
-    // runtime regardless of what we put in wp_options. If we
-    // pass anything different to --new-site-url, reprint's
-    // StructuredDataUrlRewriter writes one form into post content
-    // and serialized options while runtime URL generation uses
-    // another — half the links get the scope prefix and the other
-    // half don't. Returning WP_HOME unmodified keeps every URL the
-    // imported site emits consistent with the iframe it's running in.
+/**
+ * The canonical URL the imported site will be served from inside
+ * Playground — including the /scope:<slug>/ path segment. Returns
+ * the full URL, NOT just scheme+host (so "origin" would be a
+ * misleading name): Playground's PHP request handler defines
+ * WP_HOME and WP_SITEURL to this value, and WordPress runs
+ * option_home / option_siteurl through _config_wp_home() /
+ * _config_wp_siteurl(), so home_url() and site_url() always return
+ * the full scope-prefixed URL at runtime regardless of what we put
+ * in wp_options. Passing anything different to --new-site-url
+ * makes reprint's StructuredDataUrlRewriter rewrite post content
+ * and serialized options against one base while runtime URL
+ * generation uses another — half the links get the scope prefix
+ * and the other half don't. Returning WP_HOME verbatim keeps every
+ * URL the imported site emits consistent with the iframe it's
+ * running in.
+ */
+function _reprint_canonical_site_url(): string {
     if (defined('WP_HOME')) {
         return rtrim((string) constant('WP_HOME'), '/');
     }


### PR DESCRIPTION
Stacked on the IMPORTER_NO_EXIT PR.

\"origin\" in URL spec means scheme+host+port, but the function returns the full URL including the `/scope:<slug>/` path. Reading the call site `--new-site-url=` . `_reprint_self_origin()` invited the misreading that we were passing scheme+host only — and the code went through several rounds of confused fixes against that wrong mental model.

Pure rename, no behavioural change.