### PR TITLE
reprint-ui: share PDO + surface page-optimize deactivation failures

### DIFF
--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -5346,6 +5346,17 @@ class ImportClient
                     $this->audit_log("DB-APPLY | deactivated plugin {$basename} (host-specific)");
                 }
 
+                // Drop plugins whose URL builders break when the site
+                // URL has a non-/ path segment (e.g. WordPress Playground's
+                // /scope:<slug>/ iframe scope).
+                $deactivated = $this->deactivate_path_incompatible_plugins(
+                    $pdo,
+                    (string) ($options["new_site_url"] ?? ""),
+                );
+                foreach ($deactivated as $basename) {
+                    $this->audit_log("DB-APPLY | deactivated plugin {$basename} (path-incompatible siteurl)");
+                }
+
                 // Mark complete
                 $this->state["apply"]["statements_executed"] = $statements_executed;
                 $this->state["apply"]["bytes_read"] = $seek_offset + $query_stream->get_bytes_consumed();
@@ -5387,9 +5398,6 @@ class ImportClient
      * active_plugins option. Runs at the end of db-apply while the PDO
      * connection is still open.
      *
-     * Requires `$pdo` to support `FROM_BASE64()` — native on MySQL 5.6+,
-     * registered on SQLite by create_sqlite_target_pdo().
-     *
      * @return string[]  Plugin basenames actually removed.
      */
     private function deactivate_host_plugins(PDO $pdo): array
@@ -5406,10 +5414,63 @@ class ImportClient
             }
         }
 
+        return $this->deactivate_plugins_by_dir($pdo, $plugin_dirs, "host-specific");
+    }
+
+    /**
+     * Deactivate plugins whose URL builders break when the new site URL
+     * has a non-/ path segment.
+     *
+     * page-optimize's concat-css/js builds asset URLs by concatenating
+     * `$siteurl . $path`, which produces doubled prefixes (e.g.
+     * `/scope:abc/scope:abc/wp-content/...`) when `$siteurl` already
+     * carries a path component like WordPress Playground's
+     * `/scope:<slug>/` iframe scope.
+     *
+     * wpcomsh has the same shape but lives on WP Cloud, where
+     * WpcloudHostAnalyzer's paths_to_remove already feeds it through
+     * deactivate_host_plugins().
+     *
+     * Skipped when the new site URL is empty or has no path beyond `/`.
+     *
+     * @return string[]  Plugin basenames actually removed.
+     */
+    private function deactivate_path_incompatible_plugins(PDO $pdo, string $new_site_url): array
+    {
+        if ($new_site_url === "") {
+            return [];
+        }
+        $path = parse_url($new_site_url, PHP_URL_PATH);
+        if ($path === null || $path === "" || $path === "/") {
+            return [];
+        }
+
+        return $this->deactivate_plugins_by_dir(
+            $pdo,
+            ['page-optimize'],
+            "path-incompatible siteurl",
+        );
+    }
+
+    /**
+     * Remove plugin entries whose basename starts with one of $plugin_dirs
+     * from the `active_plugins` option in the target database.
+     *
+     * Requires `$pdo` to support `FROM_BASE64()` — native on MySQL 5.6+,
+     * registered on SQLite by create_sqlite_target_pdo().
+     *
+     * @param string[] $plugin_dirs  Plugin directory names to match against
+     *                               each `active_plugins` entry's basename.
+     * @param string   $reason       Short label used in audit log messages.
+     * @return string[]              Plugin basenames actually removed.
+     */
+    private function deactivate_plugins_by_dir(PDO $pdo, array $plugin_dirs, string $reason): array
+    {
         if (empty($plugin_dirs)) {
             return [];
         }
 
+        $preflight_data = $this->state["preflight"]["data"] ?? [];
         $table_prefix = $preflight_data["database"]["wp"]["table_prefix"] ?? 'wp_';
         // Quote the table name to prevent SQL injection from a crafted prefix.
         $options_table = '`' . str_replace('`', '``', $table_prefix . 'options') . '`';
@@ -5432,19 +5493,19 @@ class ImportClient
             return [];
         }
 
-        // List plugins to deactivate based on the removed directories.
+        // Partition active_plugins entries against the directory list.
         $deactivated_plugins = [];
         $retained_plugins = [];
         while ($processor->next_value()) {
             $basename = $processor->get_value();
-            $is_host_specific = false;
+            $is_match = false;
             foreach ($plugin_dirs as $dir) {
                 if (strpos($basename, $dir . '/') === 0) {
-                    $is_host_specific = true;
+                    $is_match = true;
                     break;
                 }
             }
-            if ($is_host_specific) {
+            if ($is_match) {
                 $deactivated_plugins[] = $basename;
             } else {
                 $retained_plugins[] = $basename;
@@ -5452,7 +5513,7 @@ class ImportClient
         }
 
         if (empty($deactivated_plugins)) {
-            $this->audit_log("DB-APPLY | no host-specific plugins found in active_plugins");
+            $this->audit_log("DB-APPLY | no {$reason} plugins found in active_plugins");
             return [];
         }
 
@@ -5469,7 +5530,7 @@ class ImportClient
 
         $this->audit_log(
             "DB-APPLY | updated active_plugins (" .
-            count($deactivated_plugins) . " plugin(s) removed)",
+            count($deactivated_plugins) . " {$reason} plugin(s) removed)",
         );
 
         return $deactivated_plugins;

--- a/reprint-ui/reprint-import.php
+++ b/reprint-ui/reprint-import.php
@@ -508,42 +508,6 @@ function run_local_activation(): array {
     }
     $sqlite_size = is_file($dst) ? filesize($dst) : 0;
 
-    // 1a. Deactivate page-optimize in wp_options.active_plugins.
-    //
-    //     Why: page-optimize concat-css.php builds the <link href> for
-    //     each enqueued stylesheet via cache_bust_mtime( $path, $siteurl ),
-    //     which does literally "$siteurl . $path". $path is the URL
-    //     path of the stylesheet (e.g. /scope:foo/wp-content/...) and
-    //     $siteurl is the WP site URL (https://playground.wordpress.net/scope:foo).
-    //     The plugin assumes siteurl has no path component, so when
-    //     it does have one — Playground's case — the resulting href
-    //     doubles the /scope:foo/ segment and every concat'd
-    //     stylesheet 404s. The plugin's bundling endpoint
-    //     /_static/?<base64> only works on Atomic anyway, so just
-    //     drop it from active_plugins. WP enqueues each asset
-    //     directly and the URLs come out single-scoped.
-    if ($sqlite_size > 0) {
-        try {
-            $pdo = new PDO('sqlite:' . $dst);
-            $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-            $cur = $pdo->query("SELECT option_value FROM wp_options WHERE option_name = 'active_plugins'")->fetchColumn();
-            if (is_string($cur) && $cur !== '') {
-                $plugins = @unserialize($cur);
-                if (is_array($plugins)) {
-                    $filtered = array_values(array_filter($plugins, function ($p) {
-                        return !is_string($p)
-                            || (strpos($p, 'page-optimize/') !== 0
-                                && strpos($p, 'wpcomsh/') !== 0);
-                    }));
-                    if (count($filtered) !== count($plugins)) {
-                        $stmt = $pdo->prepare("UPDATE wp_options SET option_value = :v WHERE option_name = 'active_plugins'");
-                        $stmt->execute([':v' => serialize($filtered)]);
-                    }
-                }
-            }
-        } catch (Throwable $e) { /* non-fatal — surface via row_counts */ }
-    }
-
     // 2. Validate the SQLite actually has WordPress data. A bare
     //    393KB file means WP_PDO_MySQL_On_SQLite created its
     //    information_schema scaffolding but db-apply never landed
@@ -677,12 +641,12 @@ function run_local_activation(): array {
 // the activation step already collapses the path mismatch that was
 // behind the visible doubling, so we leave WP's URL output alone now.
 
-// Page-optimize is deactivated at import time (see run_local_activation
-// in reprint-import.php) — its concat-css/js URL builder can't cope
-// with Playground's siteurl having a /scope:<slug>/ path component
-// and emits doubled-prefix hrefs that 404. Belt-and-braces: also
-// disable Jetpack's frontend CSS imploder (same family of asset
-// bundling that needs Atomic-side route handlers to serve bundles).
+// page-optimize is deactivated at db-apply time by reprint's
+// deactivate_path_incompatible_plugins() — its concat-css/js URL
+// builder doubles Playground's /scope:<slug>/ prefix into hrefs
+// that 404. Belt-and-braces: also disable Jetpack's frontend CSS
+// imploder (same family of asset bundling that needs Atomic-side
+// route handlers).
 add_filter('jetpack_implode_frontend_css', '__return_false');
 add_filter('jetpack_force_disable_site_accelerator', '__return_true');
 


### PR DESCRIPTION
Stacked on the rename PR.

Two related cleanups in `run_local_activation()`:

1. **Open the imported SQLite once.** The deactivation UPDATE and the row-count probe each used to instantiate their own PDO. Sharing one handle keeps any future PRAGMA / function-registration setup in a single place and removes the duplicate connection-failure path.

2. **Stop swallowing the deactivation Throwable.** The previous catch was annotated `non-fatal — surface via row_counts`, but `row_counts` is the wp_options/wp_users probe — completely unrelated. If the UPDATE failed (PDO disconnect, serialize mismatch, etc.) we'd report `ok=true` and the user would land on a site with page-optimize still active — the very bug deactivation was meant to fix. Push the exception string into a `warnings[]` array on the activate event payload; the JS prints each one as a `logLine`.

## Test plan

- [ ] CI green
- [ ] Manual: simulate a UPDATE failure (e.g. lock the SQLite) and verify the wizard log shows the warning instead of pretending success