### PR TITLE
Bump wp-php-toolkit deps to ^0.7.2

### DIFF
--- a/packages/reprint-exporter/composer.json
+++ b/packages/reprint-exporter/composer.json
@@ -7,8 +7,8 @@
         "php": ">=7.4",
         "ext-pdo": "*",
         "ext-pdo_mysql": "*",
-        "wp-php-toolkit/data-liberation": "^0.7.0",
-        "wp-php-toolkit/html": "^0.7.0"
+        "wp-php-toolkit/data-liberation": "^0.7.2",
+        "wp-php-toolkit/html": "^0.7.2"
     },
     "autoload": {
         "psr-4": {

--- a/packages/reprint-importer/composer.json
+++ b/packages/reprint-importer/composer.json
@@ -7,8 +7,8 @@
         "php": ">=7.4",
         "ext-pdo": "*",
         "ext-pdo_mysql": "*",
-        "wp-php-toolkit/data-liberation": "^0.7.0",
-        "wp-php-toolkit/html": "^0.7.0",
+        "wp-php-toolkit/data-liberation": "^0.7.2",
+        "wp-php-toolkit/html": "^0.7.2",
         "wp-php-toolkit/reprint-exporter": "*@dev"
     },
     "bin": [


### PR DESCRIPTION
Picks up the v0.7.2 fixes — PSR-4 vs WP `class-*.php` naming, the WP-coexistence regression where `html5-named-character-references.php` loaded `WP_Token_Map` at composer bootstrap (caused fatals in any consumer that also loads WordPress, e.g. wpcomsh tests), and the package-bootstrap fatals from v0.7.0/v0.7.1.