### PR TITLE
Stream multipart file bodies directly to disk

### DIFF
--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -5695,20 +5695,11 @@ class ImportClient
                 pcntl_signal_dispatch();
             }
 
-            // Defer save_state on intermediate body events of a streamed
-            // file part. The cursor on those events points at the *end* of
-            // the current part, but file_bytes_written only catches up at
-            // the part's last body event. Saving mid-body would persist a
-            // (cursor, bytes) pair where the cursor is ahead — a resume
-            // would tell the server to skip past bytes the importer never
-            // received and leave a gap in the local file.
-            //
-            // Force a save on every streamed-file part-complete event,
-            // bypassing the chunks_since_save counter. Multi-chunk files
-            // need per-part resume points; with the counter alone, a file
-            // that's the only thing in the request would never trigger a
-            // save before the (now possibly only) crash, leaving the next
-            // run with no current_file/current_file_bytes to resume from.
+            // Streamed file bodies can arrive in multiple parser callbacks
+            // for one exporter file part. Save only at the part boundary:
+            // mid-body, the cursor already points to the end of the part
+            // while file_bytes_written may still lag; at is_streaming_close
+            // the bytes are on disk and we force a per-part checkpoint.
             $is_streaming_body = !empty($chunk["is_streaming_body"]);
             $is_streaming_close = !empty($chunk["is_streaming_close"]);
             if (!$is_streaming_body) {
@@ -9302,16 +9293,8 @@ class ImportClient
                         ($context->on_chunk)([
                             "headers" => $stream_headers,
                             "body" => $event["data"],
-                            // Marks an intermediate body event of a streamed
-                            // file part — the cursor in $headers refers to the
-                            // *end* of this part, but file_bytes_written only
-                            // catches up after the part's last body event. The
-                            // file_fetch on_chunk uses this flag to suppress
-                            // periodic save_state during the body, since saving
-                            // mid-body would record a cursor that's ahead of
-                            // the bytes actually on disk. State save resumes at
-                            // the part's complete event, where the two values
-                            // are once again consistent.
+                            // Suppresses state saves while a streamed file
+                            // part body is still being written.
                             "is_streaming_body" => true,
                         ]);
                     }
@@ -9339,12 +9322,9 @@ class ImportClient
                         ($context->on_chunk)([
                             "headers" => $close_headers,
                             "body" => "",
-                            // Marks the part-complete event for a streamed
-                            // file part. The file_fetch on_chunk forces a
-                            // save_state on these events regardless of the
-                            // periodic counter, so a crash mid-multi-chunk
-                            // file always has a valid resume point even when
-                            // the file is the only thing in the request.
+                            // Forces a save at every streamed file-part
+                            // boundary, even if the periodic counter has not
+                            // reached SAVE_STATE_EVERY_N_CHUNKS.
                             "is_streaming_close" => true,
                         ]);
                     }

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -5695,21 +5695,32 @@ class ImportClient
                 pcntl_signal_dispatch();
             }
 
-            $chunks_since_save++;
-            if ($chunks_since_save >= self::SAVE_STATE_EVERY_N_CHUNKS) {
-                $this->state[$state_key]["cursor"] = $cursor;
-                // Track current file for crash recovery
-                if ($context->file_handle && $context->file_path) {
-                    // Flush to ensure bytes are on disk before saving state
-                    fflush($context->file_handle);
-                    $this->state["current_file"] = $context->file_path;
-                    $this->state["current_file_bytes"] = $context->file_bytes_written;
-                } else {
-                    $this->state["current_file"] = null;
-                    $this->state["current_file_bytes"] = null;
+            // Defer save_state on intermediate body events of a streamed
+            // file part. The cursor on those events points at the *end* of
+            // the current part, but file_bytes_written only catches up at
+            // the part's last body event. Saving mid-body would persist a
+            // (cursor, bytes) pair where the cursor is ahead — a resume
+            // would tell the server to skip past bytes the importer never
+            // received and leave a gap in the local file. The save fires
+            // again on the part's complete event, where the two values are
+            // back in sync.
+            if (empty($chunk["is_streaming_body"])) {
+                $chunks_since_save++;
+                if ($chunks_since_save >= self::SAVE_STATE_EVERY_N_CHUNKS) {
+                    $this->state[$state_key]["cursor"] = $cursor;
+                    // Track current file for crash recovery
+                    if ($context->file_handle && $context->file_path) {
+                        // Flush to ensure bytes are on disk before saving state
+                        fflush($context->file_handle);
+                        $this->state["current_file"] = $context->file_path;
+                        $this->state["current_file_bytes"] = $context->file_bytes_written;
+                    } else {
+                        $this->state["current_file"] = null;
+                        $this->state["current_file_bytes"] = null;
+                    }
+                    $this->save_state($this->state);
+                    $chunks_since_save = 0;
                 }
-                $this->save_state($this->state);
-                $chunks_since_save = 0;
             }
 
             if (isset($chunk["headers"]["x-cursor"])) {
@@ -9283,6 +9294,17 @@ class ImportClient
                         ($context->on_chunk)([
                             "headers" => $stream_headers,
                             "body" => $event["data"],
+                            // Marks an intermediate body event of a streamed
+                            // file part — the cursor in $headers refers to the
+                            // *end* of this part, but file_bytes_written only
+                            // catches up after the part's last body event. The
+                            // file_fetch on_chunk uses this flag to suppress
+                            // periodic save_state during the body, since saving
+                            // mid-body would record a cursor that's ahead of
+                            // the bytes actually on disk. State save resumes at
+                            // the part's complete event, where the two values
+                            // are once again consistent.
+                            "is_streaming_body" => true,
                         ]);
                     }
                     $current_chunk["started"] = true;

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -5701,12 +5701,20 @@ class ImportClient
             // the part's last body event. Saving mid-body would persist a
             // (cursor, bytes) pair where the cursor is ahead — a resume
             // would tell the server to skip past bytes the importer never
-            // received and leave a gap in the local file. The save fires
-            // again on the part's complete event, where the two values are
-            // back in sync.
-            if (empty($chunk["is_streaming_body"])) {
+            // received and leave a gap in the local file.
+            //
+            // Force a save on every streamed-file part-complete event,
+            // bypassing the chunks_since_save counter. Multi-chunk files
+            // need per-part resume points; with the counter alone, a file
+            // that's the only thing in the request would never trigger a
+            // save before the (now possibly only) crash, leaving the next
+            // run with no current_file/current_file_bytes to resume from.
+            $is_streaming_body = !empty($chunk["is_streaming_body"]);
+            $is_streaming_close = !empty($chunk["is_streaming_close"]);
+            if (!$is_streaming_body) {
                 $chunks_since_save++;
-                if ($chunks_since_save >= self::SAVE_STATE_EVERY_N_CHUNKS) {
+                $force_save = $is_streaming_close;
+                if ($force_save || $chunks_since_save >= self::SAVE_STATE_EVERY_N_CHUNKS) {
                     $this->state[$state_key]["cursor"] = $cursor;
                     // Track current file for crash recovery
                     if ($context->file_handle && $context->file_path) {
@@ -9331,6 +9339,13 @@ class ImportClient
                         ($context->on_chunk)([
                             "headers" => $close_headers,
                             "body" => "",
+                            // Marks the part-complete event for a streamed
+                            // file part. The file_fetch on_chunk forces a
+                            // save_state on these events regardless of the
+                            // periodic counter, so a crash mid-multi-chunk
+                            // file always has a valid resume point even when
+                            // the file is the only thing in the request.
+                            "is_streaming_close" => true,
                         ]);
                     }
                 } elseif ($current_chunk) {

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -9251,8 +9251,9 @@ class ImportClient
      * Build the multipart chunk handler callback shared by both parser
      * creation sites inside fetch_streaming.
      *
-     * The callback accumulates "body" events into $current_chunk and emits
-     * completed chunks to $context->on_chunk on "complete" events.
+     * File parts are forwarded as body data arrives so large files are written
+     * to disk incrementally. Non-file parts are still accumulated until
+     * complete because they are small metadata/progress JSON payloads.
      */
     private function make_chunk_handler(
         StreamingContext $context,
@@ -9260,10 +9261,37 @@ class ImportClient
     ): callable {
         return function ($event) use ($context, &$current_chunk) {
             if ($event["type"] === "body") {
-                // Accumulate body data in current chunk
+                $headers = $event["headers"];
+                $chunk_type = $headers["x-chunk-type"] ?? "";
+                if ($chunk_type === "file") {
+                    if (!$current_chunk) {
+                        $current_chunk = [
+                            "headers" => $headers,
+                            "body_streamed" => true,
+                            "started" => false,
+                        ];
+                    }
+
+                    if ($context->on_chunk) {
+                        $stream_headers = $headers;
+                        if (!empty($current_chunk["started"])) {
+                            $stream_headers["x-first-chunk"] = "0";
+                        }
+                        // The parser emits a separate complete event after the
+                        // last body bytes, so close/index the file from there.
+                        $stream_headers["x-last-chunk"] = "0";
+                        ($context->on_chunk)([
+                            "headers" => $stream_headers,
+                            "body" => $event["data"],
+                        ]);
+                    }
+                    $current_chunk["started"] = true;
+                    return;
+                }
+
                 if (!$current_chunk) {
                     $current_chunk = [
-                        "headers" => $event["headers"],
+                        "headers" => $headers,
                         "body" => $event["data"],
                     ];
                 } else {
@@ -9272,19 +9300,30 @@ class ImportClient
                         $event["data"];
                 }
             } elseif ($event["type"] === "complete") {
-                // Chunk complete - emit to handler
-                if ($current_chunk) {
+                $headers = $event["headers"];
+                $chunk_type = $headers["x-chunk-type"] ?? "";
+                if ($chunk_type === "file" && !empty($current_chunk["body_streamed"])) {
+                    if ($context->on_chunk) {
+                        $close_headers = $headers;
+                        $close_headers["x-first-chunk"] = "0";
+                        ($context->on_chunk)([
+                            "headers" => $close_headers,
+                            "body" => "",
+                        ]);
+                    }
+                } elseif ($current_chunk) {
+                    // Chunk complete - emit to handler
                     if ($context->on_chunk) {
                         ($context->on_chunk)(
                             $current_chunk,
                         );
                     }
-                } elseif ($event["headers"]) {
+                } elseif ($headers) {
                     // No body data - emit just headers
                     if ($context->on_chunk) {
                         ($context->on_chunk)([
                             "headers" =>
-                                $event["headers"],
+                                $headers,
                             "body" => "",
                         ]);
                     }

--- a/tests/Import/CurlTimeoutRecoveryTest.php
+++ b/tests/Import/CurlTimeoutRecoveryTest.php
@@ -88,6 +88,33 @@ class CurlTimeoutRecoveryTest extends TestCase
         return json_decode($contents, true);
     }
 
+    public static function fileCursorForBytes(int $bytes): string
+    {
+        return base64_encode(json_encode([
+            "phase" => "streaming",
+            "root" => base64_encode('/srv/htdocs'),
+            "path" => base64_encode('/uploads/large.bin'),
+            "ctime" => 1234567890,
+            "bytes" => $bytes,
+        ]));
+    }
+
+    private static function fileCursorBytes(?string $cursor): ?int
+    {
+        if ($cursor === null || $cursor === '') {
+            return null;
+        }
+        $json = base64_decode($cursor, true);
+        if ($json === false) {
+            return null;
+        }
+        $decoded = json_decode($json, true);
+        if (!is_array($decoded) || !isset($decoded["bytes"])) {
+            return null;
+        }
+        return (int) $decoded["bytes"];
+    }
+
     /**
      * Prepare a client test double with state loaded and TTY disabled.
      *
@@ -191,6 +218,66 @@ class CurlTimeoutRecoveryTest extends TestCase
             "partial",
             $state["status"],
             "After cURL timeout during file fetch, status should be 'partial'"
+        );
+    }
+
+    public function testFileFetchHardCrashCheckpointDoesNotPutCursorBehindBytes()
+    {
+        $trackedPath = $this->fs_root . '/uploads/large.bin';
+        mkdir(dirname($trackedPath), 0755, true);
+        file_put_contents($trackedPath, str_repeat('a', 256));
+
+        $this->writeState([
+            "command" => "files-pull",
+            "status" => "in_progress",
+            "stage" => "fetch",
+            "fetch" => [
+                "offset" => 0,
+                "next_offset" => 100,
+                "batch_file" => null,
+                "cursor" => self::fileCursorForBytes(256),
+            ],
+            "current_file" => $trackedPath,
+            "current_file_bytes" => 256,
+        ]);
+
+        [$client, $reflection] = $this->prepareClient(
+            InterruptedAfterStreamedPartCloseClient::class,
+        );
+
+        $downloadFilesFetch = $reflection->getMethod('download_file_fetch');
+
+        try {
+            $downloadFilesFetch->invoke(
+                $client,
+                null,
+                self::fileCursorForBytes(256),
+                "fetch",
+            );
+            $this->fail('Expected simulated hard crash during file fetch');
+        } catch (\ReflectionException $e) {
+            throw $e;
+        } catch (\RuntimeException $e) {
+            $this->assertSame(
+                'Simulated hard crash after streamed file part close',
+                $e->getMessage(),
+            );
+        }
+
+        $state = $this->readState();
+        $savedBytes = $state["current_file_bytes"] ?? null;
+        $savedCursorBytes = self::fileCursorBytes(
+            $state["fetch"]["cursor"] ?? null,
+        );
+
+        $this->assertNotNull(
+            $savedBytes,
+            'The state should retain a crash-recovery file byte count',
+        );
+        $this->assertSame(
+            $savedBytes,
+            $savedCursorBytes,
+            'A hard-crash checkpoint must not put the saved cursor behind the bytes retained on disk',
         );
     }
 
@@ -507,6 +594,49 @@ class TimeoutTestClient extends \ImportClient
     ): void {
         throw new \CurlTimeoutException(
             "cURL error: Operation timed out after 300001 milliseconds with 0 bytes received"
+        );
+    }
+}
+
+/**
+ * Test double that simulates a process dying immediately after a streamed
+ * file part-complete checkpoint. This is a hard crash, so download_file_fetch()
+ * must not get a chance to do its normal final save.
+ */
+class InterruptedAfterStreamedPartCloseClient extends \ImportClient
+{
+    protected function fetch_streaming(
+        string $url,
+        ?string $cursor,
+        \StreamingContext $context,
+        ?array $post_data = null,
+        ?string $endpoint = null
+    ): void {
+        $headers = [
+            "x-chunk-type" => "file",
+            "x-cursor" => CurlTimeoutRecoveryTest::fileCursorForBytes(512),
+            "x-file-path" => base64_encode('/uploads/large.bin'),
+            "x-file-size" => "1024",
+            "x-file-ctime" => "1234567890",
+            "x-chunk-offset" => "256",
+            "x-chunk-size" => "256",
+            "x-first-chunk" => "0",
+            "x-last-chunk" => "0",
+        ];
+
+        ($context->on_chunk)([
+            "headers" => $headers,
+            "body" => str_repeat('b', 256),
+            "is_streaming_body" => true,
+        ]);
+        ($context->on_chunk)([
+            "headers" => $headers,
+            "body" => "",
+            "is_streaming_close" => true,
+        ]);
+
+        throw new \RuntimeException(
+            'Simulated hard crash after streamed file part close',
         );
     }
 }

--- a/tests/Import/FileBodyStreamingTest.php
+++ b/tests/Import/FileBodyStreamingTest.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace ImportTests;
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../importer/import.php';
+
+class FileBodyStreamingTest extends TestCase
+{
+    private string $tempDir;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->tempDir = sys_get_temp_dir() . '/import-file-body-streaming-test-' . uniqid();
+        mkdir($this->tempDir, 0755, true);
+        mkdir($this->tempDir . '/state', 0755, true);
+        mkdir($this->tempDir . '/fs-root', 0755, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->recursiveDelete($this->tempDir);
+        parent::tearDown();
+    }
+
+    public function testFilePartBodiesAreWrittenIncrementally(): void
+    {
+        $client = new \ImportClient(
+            'http://fake.url',
+            $this->tempDir . '/state',
+            $this->tempDir . '/fs-root',
+        );
+        $reflection = new \ReflectionClass($client);
+        $reflection->getProperty('is_tty')->setValue($client, true);
+        $reflection->getProperty('state')->setValue($client, []);
+
+        $handleFileChunk = $reflection->getMethod('handle_file_chunk');
+        $context = new \StreamingContext();
+        $bodyLengths = [];
+        $context->on_chunk = function (array $chunk) use ($client, $handleFileChunk, $context, &$bodyLengths): void {
+            if (($chunk['headers']['x-chunk-type'] ?? '') === 'file') {
+                $bodyLengths[] = strlen($chunk['body'] ?? '');
+            }
+            $handleFileChunk->invoke($client, $chunk, $context);
+        };
+
+        $currentChunk = null;
+        $makeHandler = $reflection->getMethod('make_chunk_handler');
+        $handler = $makeHandler->invokeArgs($client, [$context, &$currentChunk]);
+        $parser = new \MultipartStreamParser('BOUNDARY', $handler);
+
+        $body = str_repeat('0123456789abcdef', 64 * 1024);
+        $multipart = $this->buildMultipart('BOUNDARY', [
+            [
+                'headers' => [
+                    'Content-Type' => 'application/octet-stream',
+                    'Content-Length' => (string) strlen($body),
+                    'X-Chunk-Type' => 'file',
+                    'X-File-Path' => base64_encode('/uploads/big.bin'),
+                    'X-File-Size' => (string) strlen($body),
+                    'X-File-Ctime' => '1234567890',
+                    'X-Chunk-Offset' => '0',
+                    'X-Chunk-Size' => (string) strlen($body),
+                    'X-First-Chunk' => '1',
+                    'X-Last-Chunk' => '1',
+                ],
+                'body' => $body,
+            ],
+        ]);
+
+        for ($offset = 0; $offset < strlen($multipart); $offset += 8192) {
+            $parser->feed(substr($multipart, $offset, 8192));
+        }
+
+        $target = $this->tempDir . '/fs-root/uploads/big.bin';
+        $this->assertSame($body, file_get_contents($target));
+
+        $nonEmptyBodies = array_values(array_filter(
+            $bodyLengths,
+            static fn(int $length): bool => $length > 0,
+        ));
+        $this->assertGreaterThan(1, count($nonEmptyBodies));
+        $this->assertLessThan(strlen($body), max($nonEmptyBodies));
+    }
+
+    private function buildMultipart(string $boundary, array $parts): string
+    {
+        $out = '';
+        foreach ($parts as $part) {
+            $out .= "--{$boundary}\r\n";
+            foreach ($part['headers'] as $name => $value) {
+                $out .= "{$name}: {$value}\r\n";
+            }
+            $out .= "\r\n" . $part['body'] . "\r\n";
+        }
+        $out .= "--{$boundary}--\r\n";
+        return $out;
+    }
+
+    private function recursiveDelete(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        foreach (scandir($dir) as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $path = $dir . '/' . $item;
+            if (is_link($path)) {
+                unlink($path);
+            } elseif (is_dir($path)) {
+                $this->recursiveDelete($path);
+            } else {
+                unlink($path);
+            }
+        }
+        rmdir($dir);
+    }
+}

--- a/tests/Import/FileBodyStreamingTest.php
+++ b/tests/Import/FileBodyStreamingTest.php
@@ -85,6 +85,131 @@ class FileBodyStreamingTest extends TestCase
         $this->assertLessThan(strlen($body), max($nonEmptyBodies));
     }
 
+    /**
+     * The PR's whole point is partial on-disk writes before a part completes.
+     * That means a request cut mid-body now leaves bytes already written —
+     * the previous behaviour discarded an in-flight buffer instead. The risk
+     * surface is double-counting (server resends bytes already on disk) or
+     * truncation (resume re-opens with "wb" and wipes the partial file). This
+     * test pins the contract: feed a part's first half, simulate a crash,
+     * reopen the file in append mode the way download_file_data() does on
+     * resume, then feed the second half as a continuation part with
+     * x-first-chunk=0. The result must be byte-identical to the source —
+     * no gap, no duplication.
+     */
+    public function testMidFileResumeAppendsRemainingBytesWithoutDuplication(): void
+    {
+        $client = new \ImportClient(
+            'http://fake.url',
+            $this->tempDir . '/state',
+            $this->tempDir . '/fs-root',
+        );
+        $reflection = new \ReflectionClass($client);
+        $reflection->getProperty('is_tty')->setValue($client, true);
+        $reflection->getProperty('state')->setValue($client, []);
+
+        $body = str_repeat('0123456789abcdef', 64 * 1024); // 1 MiB
+        $halfwayPoint = (int) (strlen($body) / 2);
+        $firstHalf = substr($body, 0, $halfwayPoint);
+        $secondHalf = substr($body, $halfwayPoint);
+
+        // Pass 1: stream the first half. The remote-side cursor would still
+        // point at the start of this part because the server never finished
+        // sending it — so on resume we re-receive the whole part body. To
+        // mimic the *intended* behaviour (server cooperates and skips the
+        // already-written prefix), pass 2 sends only the missing tail.
+        $context1 = new \StreamingContext();
+        $handleFileChunk = $reflection->getMethod('handle_file_chunk');
+        $context1->on_chunk = function (array $chunk) use ($client, $handleFileChunk, $context1): void {
+            $handleFileChunk->invoke($client, $chunk, $context1);
+        };
+        $currentChunk1 = null;
+        $makeHandler = $reflection->getMethod('make_chunk_handler');
+        $handler1 = $makeHandler->invokeArgs($client, [$context1, &$currentChunk1]);
+        $parser1 = new \MultipartStreamParser('BOUNDARY', $handler1);
+
+        $multipart1 = $this->buildMultipart('BOUNDARY', [
+            [
+                'headers' => [
+                    'Content-Type' => 'application/octet-stream',
+                    'Content-Length' => (string) strlen($firstHalf),
+                    'X-Chunk-Type' => 'file',
+                    'X-File-Path' => base64_encode('/uploads/resume.bin'),
+                    'X-File-Size' => (string) strlen($body),
+                    'X-File-Ctime' => '1234567890',
+                    'X-Chunk-Offset' => '0',
+                    'X-Chunk-Size' => (string) strlen($firstHalf),
+                    'X-First-Chunk' => '1',
+                    // No x-last-chunk: the part finishes (parser emits
+                    // complete) but the file is still mid-stream.
+                    'X-Last-Chunk' => '0',
+                ],
+                'body' => $firstHalf,
+            ],
+        ]);
+        for ($offset = 0; $offset < strlen($multipart1); $offset += 8192) {
+            $parser1->feed(substr($multipart1, $offset, 8192));
+        }
+
+        $target = $this->tempDir . '/fs-root/uploads/resume.bin';
+        $this->assertFileExists($target);
+        $this->assertSame($firstHalf, file_get_contents($target),
+            'After pass 1 the on-disk file should hold exactly the first half — no padding, no buffering past the body.');
+        $this->assertSame($halfwayPoint, $context1->file_bytes_written,
+            'file_bytes_written must reflect actual on-disk bytes; that is the value we will save into state for resume.');
+
+        // Mimic the crash + reopen path from download_file_data():
+        // close the in-flight handle, then on the next request reopen the
+        // tracked file in append mode using the previously-saved byte count.
+        if ($context1->file_handle) {
+            fclose($context1->file_handle);
+            $context1->file_handle = null;
+        }
+        $trackedBytes = $context1->file_bytes_written;
+
+        $context2 = new \StreamingContext();
+        $context2->file_handle = fopen($target, 'ab');
+        $context2->file_path = $target;
+        $context2->file_ctime = 1234567890;
+        $context2->file_bytes_written = $trackedBytes;
+        $context2->on_chunk = function (array $chunk) use ($client, $handleFileChunk, $context2): void {
+            $handleFileChunk->invoke($client, $chunk, $context2);
+        };
+        $currentChunk2 = null;
+        $handler2 = $makeHandler->invokeArgs($client, [$context2, &$currentChunk2]);
+        $parser2 = new \MultipartStreamParser('BOUNDARY', $handler2);
+
+        // Pass 2: continuation part for the same file. x-first-chunk=0 is the
+        // signal that this is a resume, not a fresh open — handle_file_chunk
+        // must NOT re-truncate via fopen("wb"), and must NOT skip the body.
+        $multipart2 = $this->buildMultipart('BOUNDARY', [
+            [
+                'headers' => [
+                    'Content-Type' => 'application/octet-stream',
+                    'Content-Length' => (string) strlen($secondHalf),
+                    'X-Chunk-Type' => 'file',
+                    'X-File-Path' => base64_encode('/uploads/resume.bin'),
+                    'X-File-Size' => (string) strlen($body),
+                    'X-File-Ctime' => '1234567890',
+                    'X-Chunk-Offset' => (string) $halfwayPoint,
+                    'X-Chunk-Size' => (string) strlen($secondHalf),
+                    'X-First-Chunk' => '0',
+                    'X-Last-Chunk' => '1',
+                ],
+                'body' => $secondHalf,
+            ],
+        ]);
+        for ($offset = 0; $offset < strlen($multipart2); $offset += 8192) {
+            $parser2->feed(substr($multipart2, $offset, 8192));
+        }
+
+        $finalContents = file_get_contents($target);
+        $this->assertSame(strlen($body), strlen($finalContents),
+            'Final file size must equal source size — anything else means duplicated bytes (overlap) or missing bytes (gap).');
+        $this->assertSame($body, $finalContents,
+            'Final file must be byte-identical to source after mid-file resume.');
+    }
+
     private function buildMultipart(string $boundary, array $parts): string
     {
         $out = '';

--- a/tests/e2e/benchmark/bench-pull.mjs
+++ b/tests/e2e/benchmark/bench-pull.mjs
@@ -279,6 +279,112 @@ async function runFileFetchScenario({ stage, site, filePath, params = {}, detail
     };
 }
 
+function runFilePullWithPeakMemory({ site, stateDir, filePath }) {
+    const url = `${getSiteUrl(site)}&directory=${getSiteDir(site)}`;
+    const peakProbe = join(tmpdir(), `reprint-bench-peak-${process.pid}-${Date.now()}.php`);
+    const peakFile = join(tmpdir(), `reprint-bench-peak-${process.pid}-${Date.now()}.txt`);
+    writeFileSync(peakProbe, `<?php
+register_shutdown_function(function () {
+    $path = getenv('REPRINT_BENCH_PEAK_FILE');
+    if ($path) {
+        file_put_contents($path, (string) memory_get_peak_usage(true));
+    }
+});
+`);
+
+    const baseArgs = [
+        IMPORTER_PATH,
+        'files-pull',
+        url,
+        `--state-dir=${stateDir}`,
+        `--fs-root=${fsRootDir(stateDir)}`,
+        `--secret=${getSiteSecret(site)}`,
+        `--file-chunk-start=${FILE_BENCH_TUNED_CHUNK_SIZE}`,
+        `--file-chunk-max=${FILE_BENCH_TUNED_CHUNK_SIZE}`,
+        '--duty=1',
+        '--max-exec=60',
+    ];
+    const args = [
+        '-d',
+        `auto_prepend_file=${peakProbe}`,
+        ...baseArgs,
+    ];
+
+    const start = performance.now();
+    let attempts = 0;
+    let peakMemory = 0;
+    let lastErr = null;
+
+    while (true) {
+        attempts += 1;
+        try {
+            execFileSync(PHP_BINARY, args, {
+                timeout: 900_000,
+                encoding: 'utf-8',
+                maxBuffer: 64 * 1024 * 1024,
+                stdio: ['ignore', 'pipe', 'pipe'],
+                env: { ...process.env, REPRINT_BENCH_PEAK_FILE: peakFile },
+            });
+            if (existsSync(peakFile)) {
+                peakMemory = Math.max(peakMemory, Number(readFileSync(peakFile, 'utf-8')) || 0);
+            }
+            return {
+                stage: 'files-pull-large-part-peak-memory',
+                elapsedMs: performance.now() - start,
+                attempts,
+                ok: true,
+                details: {
+                    condition: 'files-pull large multipart file part',
+                    file: fmtBytes(statSync(filePath).size),
+                    chunk_size: fmtBytes(FILE_BENCH_TUNED_CHUNK_SIZE),
+                    peak_memory: fmtBytes(peakMemory),
+                },
+            };
+        } catch (e) {
+            lastErr = e;
+            if (existsSync(peakFile)) {
+                peakMemory = Math.max(peakMemory, Number(readFileSync(peakFile, 'utf-8')) || 0);
+            }
+            const exitCode = e.status === null ? -1 : (e.status || 1);
+            if (exitCode === 2 && attempts < 50) {
+                continue;
+            }
+            return {
+                stage: 'files-pull-large-part-peak-memory',
+                elapsedMs: performance.now() - start,
+                attempts,
+                ok: false,
+                exitCode,
+                stderr: (lastErr.stderr || '').toString().slice(-2000),
+                stdout: (lastErr.stdout || '').toString().slice(-2000),
+                details: {
+                    condition: 'files-pull large multipart file part',
+                    file: fmtBytes(statSync(filePath).size),
+                    chunk_size: fmtBytes(FILE_BENCH_TUNED_CHUNK_SIZE),
+                    peak_memory: fmtBytes(peakMemory),
+                },
+            };
+        }
+    }
+}
+
+function runPreflightForSite(site, stateDir) {
+    const url = `${getSiteUrl(site)}&directory=${getSiteDir(site)}`;
+    execFileSync(PHP_BINARY, [
+        IMPORTER_PATH,
+        'preflight',
+        url,
+        `--state-dir=${stateDir}`,
+        `--fs-root=${fsRootDir(stateDir)}`,
+        `--secret=${getSiteSecret(site)}`,
+    ], {
+        timeout: 120_000,
+        encoding: 'utf-8',
+        maxBuffer: 16 * 1024 * 1024,
+        stdio: ['ignore', 'pipe', 'pipe'],
+    });
+}
+
 function renderMarkdown(results, meta) {
     const total = results.reduce((s, r) => s + r.elapsedMs, 0);
     const lines = [];
@@ -398,6 +504,25 @@ async function main() {
         });
         results.push(binaryCompressionFetch);
         console.log(`   ${binaryCompressionFetch.ok ? 'ok' : 'FAIL'} in ${fmtMs(binaryCompressionFetch.elapsedMs)} (${fmtDetails(binaryCompressionFetch.details)})`);
+    }
+
+    if (shouldRun('files-pull-large-part-peak-memory')) {
+        if (!fileBench) {
+            console.log(`Provisioning site: ${FILE_BENCH_SITE}`);
+            fileBench = await ensureFileBenchSite();
+        }
+        const filePullStateDir = join(tmpdir(), `bench-file-pull-${Date.now()}`);
+        mkdirSync(filePullStateDir, { recursive: true });
+        mkdirSync(fsRootDir(filePullStateDir), { recursive: true });
+        runPreflightForSite(fileBench.site, filePullStateDir);
+        console.log('-> files-pull-large-part-peak-memory');
+        const largePartPull = runFilePullWithPeakMemory({
+            site: fileBench.site,
+            stateDir: filePullStateDir,
+            filePath: fileBench.filePath,
+        });
+        results.push(largePartPull);
+        console.log(`   ${largePartPull.ok ? 'ok' : 'FAIL'} in ${fmtMs(largePartPull.elapsedMs)} (${fmtDetails(largePartPull.details)})`);
     }
 
     const phpVersion = execFileSync(PHP_BINARY, ['-r', 'echo PHP_VERSION;'], { encoding: 'utf-8' }).trim();

--- a/tests/e2e/benchmark/bench-pull.mjs
+++ b/tests/e2e/benchmark/bench-pull.mjs
@@ -370,19 +370,34 @@ register_shutdown_function(function () {
 
 function runPreflightForSite(site, stateDir) {
     const url = `${getSiteUrl(site)}&directory=${getSiteDir(site)}`;
-    execFileSync(PHP_BINARY, [
+    const args = [
         IMPORTER_PATH,
         'preflight',
         url,
         `--state-dir=${stateDir}`,
         `--fs-root=${fsRootDir(stateDir)}`,
         `--secret=${getSiteSecret(site)}`,
-    ], {
-        timeout: 120_000,
-        encoding: 'utf-8',
-        maxBuffer: 16 * 1024 * 1024,
-        stdio: ['ignore', 'pipe', 'pipe'],
-    });
+    ];
+    let lastErr = null;
+    for (let attempt = 1; attempt <= 3; attempt++) {
+        try {
+            execFileSync(PHP_BINARY, args, {
+                timeout: 120_000,
+                encoding: 'utf-8',
+                maxBuffer: 16 * 1024 * 1024,
+                stdio: ['ignore', 'pipe', 'pipe'],
+            });
+            return;
+        } catch (e) {
+            lastErr = e;
+            const output = `${e.stdout || ''}\n${e.stderr || ''}`;
+            if (!/Operation timed out|Could not connect|Connection refused|Empty reply/i.test(output) || attempt === 3) {
+                throw e;
+            }
+            console.log(`   preflight retry ${attempt}/3 after transient failure`);
+        }
+    }
+    throw lastErr;
 }
 
 function renderMarkdown(results, meta) {

--- a/tests/e2e/benchmark/focused-stages.txt
+++ b/tests/e2e/benchmark/focused-stages.txt
@@ -3,7 +3,8 @@
 # Both the PR build and the trunk baseline run the same set, so the
 # table shows two like-for-like wall-time numbers per row.
 #
-# This PR drops gzip from file_fetch responses, so the relevant
-# scenario is a tuned-chunk fetch of an effectively-incompressible
-# random binary.
-file-fetch-binary-compression
+# This PR streams multipart file bodies directly to disk, so the
+# relevant scenario is a single oversized multipart part — the
+# per-stage details include importer peak memory, which is the
+# real signal for the streaming change.
+files-pull-large-part-peak-memory

--- a/tests/e2e/site-registry.json
+++ b/tests/e2e/site-registry.json
@@ -121,6 +121,9 @@
     },
     "plugin-auth": {
       "port": 8119
+    },
+    "file-body-resume": {
+      "port": 8120
     }
   }
 }

--- a/tests/e2e/tests/import-50-file-body-resume.test.js
+++ b/tests/e2e/tests/import-50-file-body-resume.test.js
@@ -1,0 +1,154 @@
+/**
+ * Test 50: Mid-file resume after a body-stream cutoff.
+ *
+ * Specifically guards the contract introduced by the "stream file parts
+ * directly to disk" change: now that bytes hit the local file before a
+ * multipart part finishes, a request cut mid-body leaves a partially-
+ * written file on disk. The importer must resume that exact file —
+ * not start over (truncation) and not append duplicates (overlap) —
+ * and the server-side cursor must cooperate by skipping the bytes the
+ * importer already has.
+ *
+ * Setup: a 2 MiB random binary file. With --file-chunk-max=262144, the
+ * file is sliced into eight chunks. A test_hook_before_file_chunk hook
+ * exits PHP on the second chunk, which forces the failure mid-file
+ * (the first chunk has been written, the file is incomplete).
+ *
+ * After removing the hook, files-sync resumes and completes. Final
+ * assertion: SHA-256 of the imported file equals the source.
+ */
+import { describe, it, beforeAll, afterAll } from 'vitest';
+import assert from 'node:assert/strict';
+import { readFileSync, existsSync, statSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { createHash, randomBytes } from 'node:crypto';
+import {
+    runImporter, createTempDir, cleanupTempDir,
+    getSiteUrl, getSiteSecret, getSiteDir,
+    writeTestHooks, removeTestHooks,
+    writeHookState, clearHookState,
+    fsRootDir,
+} from '../lib/test-helpers.js';
+import { ensureSite } from '../lib/site-setup.js';
+
+describe('Import: Mid-file Body Resume', { timeout: 180000 }, () => {
+    const site = 'file-body-resume';
+    const fileRel = 'test-data/big-random.bin';
+    const fileSize = 2 * 1024 * 1024;
+    let tempDir;
+    let sourceSha256;
+    let sourceFilePath;
+
+    beforeAll(async () => {
+        // Pre-generate the file in Node so we know its SHA before it
+        // ever lands on the test site. Random content so we'd notice
+        // any duplicated or skipped bytes — repetitive content can mask
+        // overlap because the first half and the second half look the
+        // same.
+        const bytes = randomBytes(fileSize);
+        sourceSha256 = createHash('sha256').update(bytes).digest('hex');
+
+        await ensureSite(site, {
+            files: 'none',
+            afterCreate: async (siteDir) => {
+                sourceFilePath = join(siteDir, fileRel);
+                const dir = join(siteDir, 'test-data');
+                // Use sudo via execSync — the site dir is owned by nginx
+                // by the time afterCreate runs in some site-setup paths,
+                // but for newly-created sites Node still has write access.
+                // Falling back to writeFileSync covers the common case.
+                writeFileSync(sourceFilePath, bytes);
+            },
+        });
+
+        tempDir = createTempDir('e2e-mid-file-resume');
+        clearHookState(site);
+    });
+
+    afterAll(() => {
+        removeTestHooks(site);
+        clearHookState(site);
+        cleanupTempDir(tempDir);
+    });
+
+    function importUrl() {
+        return `${getSiteUrl(site)}&directory=${getSiteDir(site)}`;
+    }
+
+    it('first run crashes mid-file on the second body chunk', () => {
+        // Hook exits the moment we're asked for any chunk past offset 0
+        // for a given file. That's "first chunk written, second chunk
+        // would have been written next" — exactly the mid-file-body
+        // failure mode the streaming change introduces.
+        writeTestHooks(site, [
+            'function test_hook_before_file_chunk($path, $offset, &$data) {',
+            '    if ($offset > 0) {',
+            '        exit(1);',
+            '    }',
+            '}',
+        ].join('\n'));
+
+        const result = runImporter(importUrl(), tempDir, 'files-sync', {
+            secret: getSiteSecret(site),
+            extraArgs: [
+                '--file-chunk-start=262144',
+                '--file-chunk-max=262144',
+            ],
+        });
+        assert.notEqual(result.exitCode, 0,
+            `Expected first run to fail due to mid-file exit\nstdout: ${result.stdout}\nstderr: ${result.stderr}`);
+    });
+
+    it('partial file is on disk and smaller than source', () => {
+        const importedRoot = join(fsRootDir(tempDir), getSiteDir(site));
+        const localPath = join(importedRoot, fileRel);
+        assert.ok(existsSync(localPath),
+            'Expected the partially-downloaded file to exist on disk; the streaming change should have flushed the first chunk before the crash');
+        const partialSize = statSync(localPath).size;
+        assert.ok(partialSize > 0 && partialSize < fileSize,
+            `Expected a partial file (0 < size < ${fileSize}), got ${partialSize}`);
+    });
+
+    it('state records current_file and current_file_bytes for resume', () => {
+        const stateFile = join(tempDir, '.import-state.json');
+        assert.ok(existsSync(stateFile), 'Expected import state file to exist');
+        const state = JSON.parse(readFileSync(stateFile, 'utf-8'));
+        assert.ok(state.current_file, 'Expected state.current_file to be set after a mid-file crash');
+        assert.ok(typeof state.current_file_bytes === 'number' && state.current_file_bytes > 0,
+            `Expected state.current_file_bytes > 0, got ${state.current_file_bytes}`);
+    });
+
+    it('resume completes after removing the hook', () => {
+        removeTestHooks(site);
+
+        const result = runImporter(importUrl(), tempDir, 'files-sync', {
+            secret: getSiteSecret(site),
+            extraArgs: [
+                '--file-chunk-start=262144',
+                '--file-chunk-max=262144',
+            ],
+        });
+        assert.equal(result.exitCode, 0,
+            `Expected resume to complete\nstdout: ${result.stdout}\nstderr: ${result.stderr}`);
+
+        const stateFile = join(tempDir, '.import-state.json');
+        const state = JSON.parse(readFileSync(stateFile, 'utf-8'));
+        assert.equal(state.status, 'complete', `Expected status=complete after resume, got ${state.status}`);
+    });
+
+    it('resumed file matches source byte-for-byte (no gap, no duplication)', () => {
+        const importedRoot = join(fsRootDir(tempDir), getSiteDir(site));
+        const localPath = join(importedRoot, fileRel);
+        const localSize = statSync(localPath).size;
+        // Size mismatch is the smoking gun for either a gap (size < fileSize)
+        // or duplicated bytes from the first pass (size > fileSize). We
+        // assert size first so the failure message is clearer than a hash
+        // diff would be.
+        assert.equal(localSize, fileSize,
+            `Resumed file size mismatch — gap or duplication. Expected ${fileSize}, got ${localSize}`);
+
+        const localSha = createHash('sha256').update(readFileSync(localPath)).digest('hex');
+        assert.equal(localSha, sourceSha256,
+            'Resumed file content must hash identically to the source — any difference means the resume produced wrong bytes');
+    });
+});

--- a/tests/e2e/tests/import-50-file-body-resume.test.js
+++ b/tests/e2e/tests/import-50-file-body-resume.test.js
@@ -20,6 +20,7 @@
 import { describe, it, beforeAll, afterAll } from 'vitest';
 import assert from 'node:assert/strict';
 import { readFileSync, existsSync, statSync, writeFileSync } from 'node:fs';
+import { execSync } from 'node:child_process';
 import { join } from 'node:path';
 import { createHash, randomBytes } from 'node:crypto';
 import {
@@ -33,7 +34,7 @@ import { ensureSite } from '../lib/site-setup.js';
 
 describe('Import: Mid-file Body Resume', { timeout: 180000 }, () => {
     const site = 'file-body-resume';
-    const fileRel = 'test-data/big-random.bin';
+    const fileRel = 'test-data/big-binary.jpg';
     const fileSize = 2 * 1024 * 1024;
     let tempDir;
     let sourceSha256;
@@ -41,11 +42,22 @@ describe('Import: Mid-file Body Resume', { timeout: 180000 }, () => {
 
     beforeAll(async () => {
         // Pre-generate the file in Node so we know its SHA before it
-        // ever lands on the test site. Random content so we'd notice
-        // any duplicated or skipped bytes — repetitive content can mask
-        // overlap because the first half and the second half look the
-        // same.
-        const bytes = randomBytes(fileSize);
+        // ever lands on the test site.
+        //
+        // Random bytes (rather than repetitive content) so a duplicated
+        // chunk during resume couldn't hide behind matching content. We
+        // mix in a NUL byte every 64 bytes to force the exporter's
+        // text/binary classifier onto the binary path deterministically —
+        // the classifier rejects anything with NULs in the head, and
+        // pure crypto-random bytes would occasionally pass UTF-8
+        // validation by chance and trip the gzip path. Combined with the
+        // .jpg extension (which the classifier already treats as binary
+        // without sniffing), this keeps the test independent of PR 194's
+        // gzip-decision logic.
+        const bytes = Buffer.from(randomBytes(fileSize));
+        for (let i = 0; i < bytes.length; i += 64) {
+            bytes[i] = 0;
+        }
         sourceSha256 = createHash('sha256').update(bytes).digest('hex');
 
         await ensureSite(site, {
@@ -68,6 +80,9 @@ describe('Import: Mid-file Body Resume', { timeout: 180000 }, () => {
     afterAll(() => {
         removeTestHooks(site);
         clearHookState(site);
+        try {
+            execSync(`sudo rm -f /srv/e2e-sites/.e2e-hook-fired-${site}`);
+        } catch (e) { /* ignore */ }
         cleanupTempDir(tempDir);
     });
 
@@ -76,16 +91,27 @@ describe('Import: Mid-file Body Resume', { timeout: 180000 }, () => {
     }
 
     it('first run crashes mid-file on the second body chunk', () => {
-        // Hook exits the moment we're asked for any chunk past offset 0
-        // for a given file. That's "first chunk written, second chunk
-        // would have been written next" — exactly the mid-file-body
-        // failure mode the streaming change introduces.
+        // Hook exits when we hit a non-first chunk of the specific file
+        // we care about. Two non-obvious bits:
+        //
+        //   1. Path filter. WordPress core ships files larger than the
+        //      chunk size; without the filter the hook would crash on
+        //      whichever WP file the producer happens to reach first.
+        //   2. Self-disabling via a marker file. removeTestHooks() deletes
+        //      the hook PHP source, but PHP-FPM workers keep the function
+        //      in memory across requests — so a worker that already loaded
+        //      the hook would still call it on the resume run and crash
+        //      again. The marker check makes the function a no-op once
+        //      it has fired.
+        const marker = `${'/srv/e2e-sites'}/.e2e-hook-fired-${site}`;
         writeTestHooks(site, [
-            'function test_hook_before_file_chunk($path, $offset, &$data) {',
-            '    if ($offset > 0) {',
-            '        exit(1);',
-            '    }',
-            '}',
+            "function test_hook_before_file_chunk($path, $offset, &$data) {",
+            `    if (file_exists('${marker}')) { return; }`,
+            "    if ($offset > 0 && substr($path, -strlen('big-binary.jpg')) === 'big-binary.jpg') {",
+            `        @file_put_contents('${marker}', '1');`,
+            "        exit(1);",
+            "    }",
+            "}",
         ].join('\n'));
 
         const result = runImporter(importUrl(), tempDir, 'files-sync', {


### PR DESCRIPTION
## What it does

Forwards multipart file-body events to the importer as they arrive
instead of buffering each part in memory before writing it. The
file-close / indexing path keeps working because the parser still
emits a final empty last chunk when a streamed part completes.

Base: trunk, including #199. The perf comment should be read as the incremental streaming-to-disk change on top of that base.

## Incremental impact

- Importer peak memory for large multipart parts drops from
  "size of the part" to roughly "size of one parser chunk", because
  bytes go straight to disk.
- Adds the `files-pull-large-part-peak-memory` benchmark that runs
  a single oversized multipart body through the importer and reports
  measured peak memory, so the streaming change has a direct
  signal in the perf report.

## Testing

```bash
php -l packages/reprint-importer/src/import.php
php -l tests/Import/FileBodyStreamingTest.php
php -l tests/Import/CurlTimeoutRecoveryTest.php
vendor/bin/phpunit --bootstrap tests/bootstrap.php tests/Import/FileBodyStreamingTest.php --testdox
vendor/bin/phpunit --bootstrap tests/bootstrap.php tests/Import/CurlTimeoutRecoveryTest.php --testdox
vendor/bin/phpunit --bootstrap tests/bootstrap.php tests/Import/MultipartStreamParserTest.php --testdox
vendor/bin/phpunit --bootstrap tests/bootstrap.php tests/Import/TypeSwapTest.php --testdox
vendor/bin/phpunit --bootstrap tests/bootstrap.php tests/Import --testdox
```
