### PR TITLE
Download public uploads outside WordPress when possible

### DIFF
--- a/.github/workflows/perf-report.yml
+++ b/.github/workflows/perf-report.yml
@@ -138,13 +138,14 @@ jobs:
           BENCH_JSON_OUT: bench-pr.json
           BENCH_MD_OUT: bench-pr.md
           BENCH_STAGES: ${{ steps.stages.outputs.stages }}
+          BENCH_REQUIRE_DIRECT_PUBLIC_UPLOAD: '1'
           E2E_EXPORTER_PROJECT_ROOT: ${{ github.workspace }}
         run: node benchmark/bench-pull.mjs
 
       - name: Reset benchmark sites before trunk
         run: |
-          sudo rm -rf /srv/e2e-sites/large-directory /srv/e2e-sites/large-single-file
-          sudo rm -f /tmp/e2e-site-large-directory.lock /tmp/e2e-site-large-single-file.lock
+          sudo rm -rf /srv/e2e-sites/large-directory /srv/e2e-sites/large-single-file /srv/e2e-sites/public-upload-bench
+          sudo rm -f /tmp/e2e-site-large-directory.lock /tmp/e2e-site-large-single-file.lock /tmp/e2e-site-public-upload-bench.lock
 
       - name: Bench trunk
         working-directory: tests/e2e

--- a/packages/reprint-exporter/src/class-http-server.php
+++ b/packages/reprint-exporter/src/class-http-server.php
@@ -281,6 +281,7 @@ final class Site_Export_HTTP_Server {
         return [
             'file_index' => 'endpoint_file_index',
             'file_fetch' => 'endpoint_file_fetch',
+            'file_prefix_hash' => 'endpoint_file_prefix_hash',
             'sql_chunk' => 'endpoint_sql_chunk',
             'db_index' => 'endpoint_db_index',
             'preflight' => 'endpoint_preflight',

--- a/packages/reprint-exporter/src/export.php
+++ b/packages/reprint-exporter/src/export.php
@@ -7,6 +7,7 @@ use function WordPress\Reprint\Exporter\assert_valid_path;
 use function WordPress\Reprint\Exporter\build_pdo_dsn;
 use function WordPress\Reprint\Exporter\json_encode_or_throw;
 use function WordPress\Reprint\Exporter\parse_size;
+use function WordPress\Reprint\Exporter\path_is_within_root;
 
 // Capture any accidental output before headers are set so we can discard it
 // when switching to streaming mode later.
@@ -3368,6 +3369,142 @@ function endpoint_file_fetch(
         $config,
         file_fetch_paths_should_gzip($paths),
     );
+}
+
+/**
+ * Hashes a prefix of one regular file for validating a resumed public download.
+ */
+function endpoint_file_prefix_hash(
+    array $config,
+    ResourceBudget $budget
+): array {
+    unset($budget);
+    clearstatcache(true);
+
+    $algorithm = (string) ($config["algorithm"] ?? "md5");
+    if ($algorithm !== "md5") {
+        throw new InvalidArgumentException("Unsupported hash algorithm");
+    }
+
+    $path_b64 = $config["path"] ?? null;
+    if (!is_string($path_b64) || $path_b64 === "") {
+        throw new InvalidArgumentException("path is required");
+    }
+
+    $path = base64_decode($path_b64, true);
+    if (!is_string($path) || $path === "") {
+        throw new InvalidArgumentException("path must be base64-encoded");
+    }
+    assert_valid_path($path, "path");
+
+    $bytes = require_int_range(
+        "bytes",
+        (int) ($config["bytes"] ?? 0),
+        1,
+        PHP_INT_MAX,
+    );
+    $expected_size = isset($config["size"]) ? (int) $config["size"] : null;
+    $expected_ctime = isset($config["ctime"]) ? (int) $config["ctime"] : null;
+
+    $directories = resolve_directories($config);
+    $real_path = realpath($path);
+    if ($real_path === false || !is_file($real_path)) {
+        return endpoint_file_prefix_hash_response([
+            "ok" => false,
+            "reason" => "missing",
+        ]);
+    }
+
+    $within_root = false;
+    foreach ($directories as $root) {
+        if (path_is_within_root($real_path, rtrim($root, "/"))) {
+            $within_root = true;
+            break;
+        }
+    }
+    if (!$within_root) {
+        return endpoint_file_prefix_hash_response([
+            "ok" => false,
+            "reason" => "outside_root",
+        ]);
+    }
+
+    $stat = stat($real_path);
+    if ($stat === false) {
+        return endpoint_file_prefix_hash_response([
+            "ok" => false,
+            "reason" => "stat_failed",
+        ]);
+    }
+
+    $size = (int) $stat["size"];
+    $ctime = (int) $stat["ctime"];
+    if (
+        ($expected_size !== null && $expected_size !== $size) ||
+        ($expected_ctime !== null && $expected_ctime !== $ctime) ||
+        $bytes > $size
+    ) {
+        return endpoint_file_prefix_hash_response([
+            "ok" => false,
+            "reason" => "metadata_mismatch",
+            "bytes" => $bytes,
+            "size" => $size,
+            "ctime" => $ctime,
+        ]);
+    }
+
+    $handle = fopen($real_path, "rb");
+    if (!$handle) {
+        return endpoint_file_prefix_hash_response([
+            "ok" => false,
+            "reason" => "open_failed",
+        ]);
+    }
+
+    $hash = hash_init($algorithm);
+    $remaining = $bytes;
+    while ($remaining > 0 && !feof($handle)) {
+        $chunk = fread($handle, min(1024 * 1024, $remaining));
+        if ($chunk === false) {
+            fclose($handle);
+            return endpoint_file_prefix_hash_response([
+                "ok" => false,
+                "reason" => "read_failed",
+            ]);
+        }
+        $remaining -= strlen($chunk);
+        hash_update($hash, $chunk);
+    }
+    fclose($handle);
+
+    if ($remaining !== 0) {
+        return endpoint_file_prefix_hash_response([
+            "ok" => false,
+            "reason" => "short_read",
+        ]);
+    }
+
+    return endpoint_file_prefix_hash_response([
+        "ok" => true,
+        "algorithm" => $algorithm,
+        "bytes" => $bytes,
+        "hash" => hash_final($hash),
+        "size" => $size,
+        "ctime" => $ctime,
+    ]);
+}
+
+/**
+ * Emits a JSON response for endpoint_file_prefix_hash().
+ */
+function endpoint_file_prefix_hash_response(array $response): array
+{
+    header("Content-Type: application/json");
+    echo json_encode_or_throw($response, JSON_UNESCAPED_SLASHES);
+    return [
+        "status" => !empty($response["ok"]) ? "ok" : "error",
+        "stats" => $response,
+    ];
 }
 
 /**

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -1132,6 +1132,9 @@ class ImportClient
     /** @var int|null Total number of pipeline steps. Set via --steps. */
     private $pipeline_steps = null;
 
+    /** @var bool Current files-pull invocation is resuming persisted progress. */
+    private bool $files_sync_resuming = false;
+
     /** @var string Path to .import-status.json — machine-readable status for external progress readers. */
     private $status_file;
 
@@ -2536,6 +2539,7 @@ class ImportClient
             $state_command === "files-pull" &&
             $current_status !== null &&
             $current_status !== "complete";
+        $this->files_sync_resuming = $has_progress;
 
         $this->recover_index_updates();
 
@@ -2855,6 +2859,7 @@ class ImportClient
             $complete = $this->download_files_from_list(
                 $this->download_list_file,
                 "fetch",
+                !$this->files_sync_resuming,
             );
             if (!$complete) {
                 $this->state["status"] = "partial";
@@ -2906,6 +2911,7 @@ class ImportClient
             $complete = $this->download_files_from_list(
                 $this->skipped_download_list_file,
                 "fetch_skipped",
+                !$this->files_sync_resuming,
             );
             if (!$complete) {
                 $this->state["status"] = "partial";
@@ -6278,7 +6284,8 @@ class ImportClient
 
     private function download_files_from_list(
         string $list_file,
-        string $state_key
+        string $state_key,
+        bool $allow_public_uploads = true
     ): bool {
         if (!file_exists($list_file)) {
             return true;
@@ -6308,7 +6315,7 @@ class ImportClient
         $fallback_entries = (int) ($fetch_state["fallback_entries"] ?? $batch_entries);
 
         if ($batch_file === null || !file_exists($batch_file)) {
-            $batch = $this->prepare_fetch_batch($list_file, $batch_offset);
+            $batch = $this->prepare_fetch_batch($list_file, $batch_offset, $allow_public_uploads);
             if ($batch === null) {
                 return true;
             }
@@ -6408,7 +6415,11 @@ class ImportClient
      *         The temp file path, byte offsets, and entry count, or null if
      *         no paths remain.
      */
-    private function prepare_fetch_batch(string $list_file, int $offset): ?array
+    private function prepare_fetch_batch(
+        string $list_file,
+        int $offset,
+        bool $allow_public_uploads = true
+    ): ?array
     {
         // Cap the batch at 80% of the server's max request size so the
         // multipart envelope and headers still fit.  Floor at 256 KB so
@@ -6512,7 +6523,7 @@ class ImportClient
             }
 
             $entries++;
-            if ($this->try_download_public_upload($entry)) {
+            if ($allow_public_uploads && $this->try_download_public_upload($entry)) {
                 $bytes += strlen($chunk);
                 if ($oversized_first_entry) {
                     break;

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -6170,6 +6170,9 @@ class ImportClient
                     $this->append_download_list(
                         $remote["path"],
                         $target_handle,
+                        $remote["ctime"],
+                        $remote["size"],
+                        $remote["type"],
                     );
                 }
                 $local_after = $local["path"];
@@ -6186,7 +6189,13 @@ class ImportClient
                     $target_handle = ($skipped_handle !== null && $this->is_uploads_path($remote["path"], $uploads_basedir))
                         ? $skipped_handle
                         : $download_handle;
-                    $this->append_download_list($remote["path"], $target_handle);
+                    $this->append_download_list(
+                        $remote["path"],
+                        $target_handle,
+                        $remote["ctime"],
+                        $remote["size"],
+                        $remote["type"],
+                    );
                 }
             }
 
@@ -6296,6 +6305,7 @@ class ImportClient
         $cursor = $fetch_state["cursor"] ?? null;
 
         $batch_entries = (int) ($fetch_state["batch_entries"] ?? 0);
+        $fallback_entries = (int) ($fetch_state["fallback_entries"] ?? $batch_entries);
 
         if ($batch_file === null || !file_exists($batch_file)) {
             $batch = $this->prepare_fetch_batch($list_file, $batch_offset);
@@ -6306,15 +6316,41 @@ class ImportClient
             $batch_offset = $batch["offset"];
             $next_offset = $batch["next_offset"];
             $batch_entries = $batch["entries"];
+            $fallback_entries = $batch["fallback_entries"];
             $cursor = null;
             $this->state[$state_key] = [
                 "offset" => $batch_offset,
                 "next_offset" => $next_offset,
                 "batch_file" => $batch_file,
                 "batch_entries" => $batch_entries,
+                "fallback_entries" => $fallback_entries,
                 "cursor" => null,
             ];
             $this->save_state($this->state);
+        }
+
+        if ($batch_entries > 0 && $fallback_entries === 0) {
+            if (file_exists($batch_file)) {
+                @unlink($batch_file);
+                $this->audit_log("FILE DELETE | {$batch_file} | direct upload batch complete");
+            }
+
+            $this->finalize_index_updates();
+
+            if ($this->download_list_done !== null) {
+                $this->download_list_done += $batch_entries;
+            }
+            $this->files_imported = 0;
+
+            $this->state[$state_key] = [
+                "offset" => $next_offset,
+                "next_offset" => $next_offset,
+                "batch_file" => null,
+                "cursor" => null,
+            ];
+            $this->save_state($this->state);
+
+            return $next_offset >= filesize($list_file);
         }
 
         $post_data = [
@@ -6368,7 +6404,7 @@ class ImportClient
      *
      * @param string $list_file Path to the JSONL download list.
      * @param int    $offset    Byte offset into the download list file.
-     * @return array{file: string, offset: int, next_offset: int, entries: int}|null
+     * @return array{file: string, offset: int, next_offset: int, entries: int, fallback_entries: int}|null
      *         The temp file path, byte offsets, and entry count, or null if
      *         no paths remain.
      */
@@ -6409,9 +6445,10 @@ class ImportClient
         // accumulate them into the JSON array until we approach the size limit.
         // The download list supports two formats:
         //   - A bare JSON string:   "/path/to/file"
-        //   - A JSON object:        {"path": "<base64-encoded path>"}
+        //   - A JSON object:        {"path": "<base64-encoded path>", "ctime": 0, "size": 0, "type": "file"}
         $bytes = 0;
         $entries = 0;
+        $fallback_entries = 0;
         $first = true;
         fwrite($out, "[");
         $bytes = 1;
@@ -6428,15 +6465,32 @@ class ImportClient
                 continue;
             }
             $decoded = json_decode($line, true);
+            $entry = null;
             if (is_string($decoded)) {
                 $path = $decoded;
             } elseif (is_array($decoded) && isset($decoded["path"])) {
                 $path = base64_decode($decoded["path"]);
+                if (is_string($path) && $path !== "") {
+                    $entry = [
+                        "path" => $path,
+                        "ctime" => isset($decoded["ctime"]) ? (int) $decoded["ctime"] : null,
+                        "size" => isset($decoded["size"]) ? (int) $decoded["size"] : null,
+                        "type" => isset($decoded["type"]) ? (string) $decoded["type"] : "file",
+                    ];
+                }
             } else {
                 continue;
             }
             if (!is_string($path) || $path === "") {
                 continue;
+            }
+            if ($entry === null) {
+                $entry = [
+                    "path" => $path,
+                    "ctime" => null,
+                    "size" => null,
+                    "type" => "file",
+                ];
             }
             $json_path = json_encode(
                 $path,
@@ -6448,31 +6502,33 @@ class ImportClient
             $prefix = $first ? "" : ",";
             $chunk = $prefix . $json_path;
             $needed = $bytes + strlen($chunk) + 1; // +1 for closing bracket
+            $oversized_first_entry = $first && $needed > $limit;
 
             // Would this entry push us over the limit?
-            if (!$first && $needed > $limit) {
+            if ($entries > 0 && $needed > $limit) {
                 // Rewind to the start of this line so the next batch picks it up.
                 fseek($handle, $line_start);
                 break;
             }
-            if ($first && $needed > $limit) {
-                // Still write at least one entry even if it exceeds the limit,
-                // otherwise we'd loop forever on a single long path.
-                if (fwrite($out, $chunk) === false) {
-                    throw new RuntimeException("Failed to write fetch batch file (disk full?)");
-                }
+
+            $entries++;
+            if ($this->try_download_public_upload($entry)) {
                 $bytes += strlen($chunk);
-                $entries++;
-                $first = false;
-                break;
+                if ($oversized_first_entry) {
+                    break;
+                }
+                continue;
             }
 
             if (fwrite($out, $chunk) === false) {
                 throw new RuntimeException("Failed to write fetch batch file (disk full?)");
             }
             $bytes += strlen($chunk);
-            $entries++;
+            $fallback_entries++;
             $first = false;
+            if ($oversized_first_entry) {
+                break;
+            }
         }
         fwrite($out, "]");
         $bytes += 1;
@@ -6481,8 +6537,8 @@ class ImportClient
         fclose($handle);
         fclose($out);
 
-        // An empty batch (just "[]") means we've exhausted the download list.
-        if ($bytes <= 2) {
+        // No consumed entries means we've exhausted the download list.
+        if ($entries === 0) {
             @unlink($tmp);
             return null;
         }
@@ -6492,6 +6548,7 @@ class ImportClient
             "offset" => $offset,
             "next_offset" => $next_offset,
             "entries" => $entries,
+            "fallback_entries" => $fallback_entries,
         ];
     }
 
@@ -6547,13 +6604,211 @@ class ImportClient
         return strpos($path, "wp-content/uploads/") !== false;
     }
 
+    private function get_uploads_baseurl(): ?string
+    {
+        $paths_urls = $this->state["preflight"]["data"]["database"]["wp"]["paths_urls"] ?? null;
+        if (!is_array($paths_urls)) {
+            return null;
+        }
+        $baseurl = $paths_urls["uploads"]["baseurl"] ?? null;
+        if (!is_string($baseurl) || $baseurl === "") {
+            return null;
+        }
+        return rtrim($baseurl, "/");
+    }
+
+    private function get_uploads_relative_path(string $path): ?string
+    {
+        $uploads_basedir = $this->get_uploads_basedir();
+        if ($uploads_basedir !== null) {
+            if (strpos($path, $uploads_basedir) !== 0) {
+                return null;
+            }
+            $relative = substr($path, strlen($uploads_basedir));
+            return $relative === false ? null : ltrim($relative, "/");
+        }
+
+        $needle = "wp-content/uploads/";
+        $pos = strpos($path, $needle);
+        if ($pos === false) {
+            return null;
+        }
+        return substr($path, $pos + strlen($needle));
+    }
+
+    private function public_upload_url_for_path(string $path): ?string
+    {
+        $baseurl = $this->get_uploads_baseurl();
+        if ($baseurl === null) {
+            return null;
+        }
+
+        $relative = $this->get_uploads_relative_path($path);
+        if ($relative === null || $relative === "") {
+            return null;
+        }
+
+        $segments = array_map("rawurlencode", explode("/", $relative));
+        return $baseurl . "/" . implode("/", $segments);
+    }
+
+    /**
+     * Try to download a public upload directly from the source web server/CDN.
+     *
+     * Returns false whenever the path cannot be mapped to uploads.baseurl or
+     * the public download does not exactly match the exported size; callers
+     * then fall back to file_fetch through WordPress/PHP.
+     */
+    private function try_download_public_upload(array $entry): bool
+    {
+        $path = $entry["path"] ?? null;
+        if (!is_string($path) || $path === "") {
+            return false;
+        }
+
+        if (($entry["type"] ?? "file") !== "file") {
+            return false;
+        }
+
+        $ctime = $entry["ctime"] ?? null;
+        $size = $entry["size"] ?? null;
+        if (!is_int($ctime) || $ctime <= 0 || !is_int($size) || $size < 0) {
+            return false;
+        }
+
+        $url = $this->public_upload_url_for_path($path);
+        if ($url === null) {
+            return false;
+        }
+
+        try {
+            $local_path = $this->remote_path_to_local_path_within_import_root($path);
+        } catch (RuntimeException $e) {
+            $this->audit_log(
+                "Public upload download skipped for invalid path '{$path}': " . $e->getMessage(),
+                true,
+            );
+            return false;
+        }
+
+        $dir = dirname($local_path);
+        try {
+            if (!is_dir($dir)) {
+                $this->ensure_directory_path($dir);
+            }
+        } catch (PreserveLocalSkipException $e) {
+            $this->audit_log($e->getMessage(), true);
+            $this->emit_skip_progress($path);
+            return true;
+        }
+
+        if (
+            (file_exists($local_path) || is_link($local_path)) &&
+            is_dir($local_path) &&
+            !is_link($local_path)
+        ) {
+            if (!$this->remove_local_path_without_following_symlinks($local_path)) {
+                $this->audit_log("Public upload download could not replace directory: {$path}", true);
+                return false;
+            }
+        }
+
+        $tmp = $local_path . ".reprint-download-" . getmypid() . "-" . str_replace(".", "", uniqid("", true));
+        $handle = fopen($tmp, "wb");
+        if (!$handle) {
+            $this->audit_log("Public upload download could not open temp file: {$tmp}", true);
+            return false;
+        }
+
+        $this->audit_log("HTTP_REQUEST | GET | {$url} | public_upload_path={$path}", false);
+
+        $ch = curl_init($url);
+        reprint_apply_curl_proxy_from_env($ch);
+        curl_setopt_array($ch, [
+            CURLOPT_FILE => $handle,
+            CURLOPT_FOLLOWLOCATION => true,
+            CURLOPT_MAXREDIRS => 5,
+            CURLOPT_CONNECTTIMEOUT => 30,
+            CURLOPT_LOW_SPEED_LIMIT => 1,
+            CURLOPT_LOW_SPEED_TIME => 300,
+            CURLOPT_HTTPHEADER => [
+                "User-Agent: " . ($this->state["user_agent"] ?? self::USER_AGENTS[0]),
+                "Accept: */*",
+                "Accept-Encoding: identity",
+                "Cache-Control: no-cache",
+                "Pragma: no-cache",
+            ],
+            CURLOPT_FAILONERROR => false,
+            CURLOPT_NOPROGRESS => false,
+            CURLOPT_PROGRESSFUNCTION =>
+                function ($ch, $dl_total, $dl_now, $ul_total, $ul_now) {
+                    $this->progress->tick_spinner();
+                    return 0;
+                },
+        ]);
+
+        $ok = curl_exec($ch);
+        $errno = curl_errno($ch);
+        $error = curl_error($ch);
+        $http_code = (int) curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        curl_close($ch);
+        fclose($handle);
+
+        clearstatcache(true, $tmp);
+        $actual_size = is_file($tmp) ? filesize($tmp) : false;
+        if ($ok !== true || $errno !== 0 || $http_code !== 200 || $actual_size !== $size) {
+            @unlink($tmp);
+            $this->audit_log(
+                sprintf(
+                    "Public upload download fallback | path=%s | http=%d | errno=%d | size=%s/%d | error=%s",
+                    $path,
+                    $http_code,
+                    $errno,
+                    $actual_size === false ? "missing" : (string) $actual_size,
+                    $size,
+                    $error,
+                ),
+                false,
+            );
+            return false;
+        }
+
+        if (!rename($tmp, $local_path)) {
+            @unlink($tmp);
+            $this->audit_log("Public upload download could not move temp file into place: {$path}", true);
+            return false;
+        }
+
+        touch($local_path, $ctime);
+        $this->upsert_index_entry($path, $ctime, $size, "file");
+        $this->files_imported++;
+        $this->clear_volatile_file($path);
+        $this->audit_log("Public upload downloaded: {$path}", false);
+
+        return true;
+    }
+
     /**
      * Append a path to the download list file.
      */
-    private function append_download_list(string $path, $handle): void
+    private function append_download_list(
+        string $path,
+        $handle,
+        ?int $ctime = null,
+        ?int $size = null,
+        string $type = "file"
+    ): void
     {
+        $entry = ["path" => base64_encode($path)];
+        if ($ctime !== null) {
+            $entry["ctime"] = $ctime;
+        }
+        if ($size !== null) {
+            $entry["size"] = $size;
+        }
+        $entry["type"] = $type;
         $line = json_encode(
-            ["path" => base64_encode($path)],
+            $entry,
             JSON_UNESCAPED_SLASHES,
         );
         if ($line !== false) {
@@ -10115,12 +10370,16 @@ class ImportClient
                 "offset" => 0,
                 "next_offset" => 0,
                 "batch_file" => null,
+                "batch_entries" => 0,
+                "fallback_entries" => 0,
                 "cursor" => null,
             ],
             "fetch_skipped" => [
                 "offset" => 0,
                 "next_offset" => 0,
                 "batch_file" => null,
+                "batch_entries" => 0,
+                "fallback_entries" => 0,
                 "cursor" => null,
             ],
             // Crash recovery: track in-progress file downloads
@@ -10199,6 +10458,12 @@ class ImportClient
         }
         $fetch = array_intersect_key($fetch, $defaults["fetch"]);
         $state["fetch"] = array_merge($defaults["fetch"], $fetch);
+        $fetch_skipped = $state["fetch_skipped"] ?? [];
+        if (!is_array($fetch_skipped)) {
+            $fetch_skipped = [];
+        }
+        $fetch_skipped = array_intersect_key($fetch_skipped, $defaults["fetch_skipped"]);
+        $state["fetch_skipped"] = array_merge($defaults["fetch_skipped"], $fetch_skipped);
         $tuning = $state["tuning"] ?? [];
         if (!is_array($tuning)) {
             $tuning = [];

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -1132,9 +1132,6 @@ class ImportClient
     /** @var int|null Total number of pipeline steps. Set via --steps. */
     private $pipeline_steps = null;
 
-    /** @var bool Current files-pull invocation is resuming persisted progress. */
-    private bool $files_sync_resuming = false;
-
     /** @var string Path to .import-status.json — machine-readable status for external progress readers. */
     private $status_file;
 
@@ -2539,7 +2536,6 @@ class ImportClient
             $state_command === "files-pull" &&
             $current_status !== null &&
             $current_status !== "complete";
-        $this->files_sync_resuming = $has_progress;
 
         $this->recover_index_updates();
 
@@ -2859,7 +2855,6 @@ class ImportClient
             $complete = $this->download_files_from_list(
                 $this->download_list_file,
                 "fetch",
-                !$this->files_sync_resuming,
             );
             if (!$complete) {
                 $this->state["status"] = "partial";
@@ -2911,7 +2906,6 @@ class ImportClient
             $complete = $this->download_files_from_list(
                 $this->skipped_download_list_file,
                 "fetch_skipped",
-                !$this->files_sync_resuming,
             );
             if (!$complete) {
                 $this->state["status"] = "partial";
@@ -6284,8 +6278,7 @@ class ImportClient
 
     private function download_files_from_list(
         string $list_file,
-        string $state_key,
-        bool $allow_public_uploads = true
+        string $state_key
     ): bool {
         if (!file_exists($list_file)) {
             return true;
@@ -6315,7 +6308,7 @@ class ImportClient
         $fallback_entries = (int) ($fetch_state["fallback_entries"] ?? $batch_entries);
 
         if ($batch_file === null || !file_exists($batch_file)) {
-            $batch = $this->prepare_fetch_batch($list_file, $batch_offset, $allow_public_uploads);
+            $batch = $this->prepare_fetch_batch($list_file, $batch_offset);
             if ($batch === null) {
                 return true;
             }
@@ -6415,11 +6408,7 @@ class ImportClient
      *         The temp file path, byte offsets, and entry count, or null if
      *         no paths remain.
      */
-    private function prepare_fetch_batch(
-        string $list_file,
-        int $offset,
-        bool $allow_public_uploads = true
-    ): ?array
+    private function prepare_fetch_batch(string $list_file, int $offset): ?array
     {
         // Cap the batch at 80% of the server's max request size so the
         // multipart envelope and headers still fit.  Floor at 256 KB so
@@ -6523,7 +6512,7 @@ class ImportClient
             }
 
             $entries++;
-            if ($allow_public_uploads && $this->try_download_public_upload($entry)) {
+            if ($this->try_download_public_upload($entry)) {
                 $bytes += strlen($chunk);
                 if ($oversized_first_entry) {
                     break;
@@ -6663,6 +6652,11 @@ class ImportClient
         return $baseurl . "/" . implode("/", $segments);
     }
 
+    private function public_upload_temp_path(string $local_path): string
+    {
+        return $local_path . ".reprint-public-download";
+    }
+
     /**
      * Try to download a public upload directly from the source web server/CDN.
      *
@@ -6724,17 +6718,59 @@ class ImportClient
             }
         }
 
-        $tmp = $local_path . ".reprint-download-" . getmypid() . "-" . str_replace(".", "", uniqid("", true));
-        $handle = fopen($tmp, "wb");
+        $tmp = $this->public_upload_temp_path($local_path);
+        $resume_state = $this->state["public_upload"] ?? [];
+        $can_resume =
+            is_array($resume_state) &&
+            ($resume_state["path"] ?? null) === $path &&
+            ($resume_state["url"] ?? null) === $url &&
+            ($resume_state["local_path"] ?? null) === $local_path &&
+            ($resume_state["tmp_path"] ?? null) === $tmp &&
+            (int) ($resume_state["ctime"] ?? 0) === $ctime &&
+            (int) ($resume_state["size"] ?? -1) === $size;
+
+        if (!$can_resume && file_exists($tmp)) {
+            @unlink($tmp);
+        }
+
+        clearstatcache(true, $tmp);
+        $resume_from = ($can_resume && is_file($tmp)) ? (int) filesize($tmp) : 0;
+        if ($resume_from < 0 || $resume_from > $size) {
+            @unlink($tmp);
+            $resume_from = 0;
+        }
+
+        $this->state["public_upload"] = [
+            "path" => $path,
+            "url" => $url,
+            "local_path" => $local_path,
+            "tmp_path" => $tmp,
+            "ctime" => $ctime,
+            "size" => $size,
+            "bytes" => $resume_from,
+        ];
+        $this->save_state($this->state);
+
+        if ($resume_from === $size && is_file($tmp)) {
+            return $this->finish_public_upload_download($tmp, $local_path, $path, $ctime, $size);
+        }
+
+        $handle = fopen($tmp, $resume_from > 0 ? "ab" : "wb");
         if (!$handle) {
             $this->audit_log("Public upload download could not open temp file: {$tmp}", true);
+            $this->clear_public_upload_resume_state();
             return false;
         }
 
-        $this->audit_log("HTTP_REQUEST | GET | {$url} | public_upload_path={$path}", false);
+        $this->audit_log(
+            "HTTP_REQUEST | GET | {$url} | public_upload_path={$path} | resume_from={$resume_from}",
+            false,
+        );
 
         $ch = curl_init($url);
         reprint_apply_curl_proxy_from_env($ch);
+        reprint_apply_curl_ca_bundle($ch);
+        $last_state_save = microtime(true);
         curl_setopt_array($ch, [
             CURLOPT_FILE => $handle,
             CURLOPT_FOLLOWLOCATION => true,
@@ -6752,11 +6788,31 @@ class ImportClient
             CURLOPT_FAILONERROR => false,
             CURLOPT_NOPROGRESS => false,
             CURLOPT_PROGRESSFUNCTION =>
-                function ($ch, $dl_total, $dl_now, $ul_total, $ul_now) {
+                function ($ch, $dl_total, $dl_now, $ul_total, $ul_now) use (
+                    $tmp,
+                    $resume_from,
+                    &$last_state_save
+                ) {
                     $this->progress->tick_spinner();
+                    $bytes = $resume_from + (int) $dl_now;
+                    $this->state["public_upload"]["bytes"] = $bytes;
+                    if (microtime(true) - $last_state_save >= 2.0) {
+                        clearstatcache(true, $tmp);
+                        if (is_file($tmp)) {
+                            $this->state["public_upload"]["bytes"] = (int) filesize($tmp);
+                        }
+                        $this->save_state($this->state);
+                        $last_state_save = microtime(true);
+                    }
                     return 0;
                 },
         ]);
+        if ($resume_from > 0) {
+            $resume_option = defined("CURLOPT_RESUME_FROM_LARGE")
+                ? constant("CURLOPT_RESUME_FROM_LARGE")
+                : CURLOPT_RESUME_FROM;
+            curl_setopt($ch, $resume_option, $resume_from);
+        }
 
         $ok = curl_exec($ch);
         $errno = curl_errno($ch);
@@ -6767,8 +6823,21 @@ class ImportClient
 
         clearstatcache(true, $tmp);
         $actual_size = is_file($tmp) ? filesize($tmp) : false;
-        if ($ok !== true || $errno !== 0 || $http_code !== 200 || $actual_size !== $size) {
+        $expected_http_code = $resume_from > 0 ? 206 : 200;
+        if (
+            $ok !== true ||
+            $errno !== 0 ||
+            $http_code !== $expected_http_code ||
+            $actual_size !== $size
+        ) {
+            if ($resume_from > 0 && $http_code !== 206) {
+                $this->audit_log(
+                    "Public upload range resume unsupported | path={$path} | http={$http_code}",
+                    false,
+                );
+            }
             @unlink($tmp);
+            $this->clear_public_upload_resume_state();
             $this->audit_log(
                 sprintf(
                     "Public upload download fallback | path=%s | http=%d | errno=%d | size=%s/%d | error=%s",
@@ -6784,8 +6853,25 @@ class ImportClient
             return false;
         }
 
+        return $this->finish_public_upload_download($tmp, $local_path, $path, $ctime, $size);
+    }
+
+    private function clear_public_upload_resume_state(): void
+    {
+        $this->state["public_upload"] = $this->default_state()["public_upload"];
+        $this->save_state($this->state);
+    }
+
+    private function finish_public_upload_download(
+        string $tmp,
+        string $local_path,
+        string $path,
+        int $ctime,
+        int $size
+    ): bool {
         if (!rename($tmp, $local_path)) {
             @unlink($tmp);
+            $this->clear_public_upload_resume_state();
             $this->audit_log("Public upload download could not move temp file into place: {$path}", true);
             return false;
         }
@@ -6794,6 +6880,7 @@ class ImportClient
         $this->upsert_index_entry($path, $ctime, $size, "file");
         $this->files_imported++;
         $this->clear_volatile_file($path);
+        $this->clear_public_upload_resume_state();
         $this->audit_log("Public upload downloaded: {$path}", false);
 
         return true;
@@ -10393,6 +10480,15 @@ class ImportClient
                 "fallback_entries" => 0,
                 "cursor" => null,
             ],
+            "public_upload" => [
+                "path" => null,
+                "url" => null,
+                "local_path" => null,
+                "tmp_path" => null,
+                "ctime" => null,
+                "size" => null,
+                "bytes" => 0,
+            ],
             // Crash recovery: track in-progress file downloads
             // If we crash mid-write, we can truncate to the expected size on resume
             "current_file" => null,        // Path to file being written
@@ -10475,6 +10571,12 @@ class ImportClient
         }
         $fetch_skipped = array_intersect_key($fetch_skipped, $defaults["fetch_skipped"]);
         $state["fetch_skipped"] = array_merge($defaults["fetch_skipped"], $fetch_skipped);
+        $public_upload = $state["public_upload"] ?? [];
+        if (!is_array($public_upload)) {
+            $public_upload = [];
+        }
+        $public_upload = array_intersect_key($public_upload, $defaults["public_upload"]);
+        $state["public_upload"] = array_merge($defaults["public_upload"], $public_upload);
         $tuning = $state["tuning"] ?? [];
         if (!is_array($tuning)) {
             $tuning = [];
@@ -10521,6 +10623,15 @@ class ImportClient
         $state["fetch"]["batch_file"] = $this->encode_state_path_value(
             $state["fetch"]["batch_file"] ?? null,
         );
+        $state["public_upload"]["path"] = $this->encode_state_path_value(
+            $state["public_upload"]["path"] ?? null,
+        );
+        $state["public_upload"]["local_path"] = $this->encode_state_path_value(
+            $state["public_upload"]["local_path"] ?? null,
+        );
+        $state["public_upload"]["tmp_path"] = $this->encode_state_path_value(
+            $state["public_upload"]["tmp_path"] ?? null,
+        );
         $state["current_file"] = $this->encode_state_path_value(
             $state["current_file"] ?? null,
         );
@@ -10554,6 +10665,15 @@ class ImportClient
         );
         $state["fetch"]["batch_file"] = $this->decode_state_path_value(
             $state["fetch"]["batch_file"] ?? null,
+        );
+        $state["public_upload"]["path"] = $this->decode_state_path_value(
+            $state["public_upload"]["path"] ?? null,
+        );
+        $state["public_upload"]["local_path"] = $this->decode_state_path_value(
+            $state["public_upload"]["local_path"] ?? null,
+        );
+        $state["public_upload"]["tmp_path"] = $this->decode_state_path_value(
+            $state["public_upload"]["tmp_path"] ?? null,
         );
         $state["current_file"] = $this->decode_state_path_value(
             $state["current_file"] ?? null,

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -1023,6 +1023,12 @@ class ImportClient
     /** @var int Running count of files imported in the current invocation. */
     private $files_imported = 0;
 
+    /**
+     * @var array{cursor: string, current_file: string, current_file_bytes: int}|null
+     * File-fetch resume details synthesized from a validated public temp prefix.
+     */
+    private $pending_file_fetch_resume = null;
+
     /** @var int|null Total entries in the current download list.  Set once
      *  at the start of download_files_from_list() by counting newlines. */
     private $download_list_total = null;
@@ -6317,15 +6323,19 @@ class ImportClient
             $next_offset = $batch["next_offset"];
             $batch_entries = $batch["entries"];
             $fallback_entries = $batch["fallback_entries"];
-            $cursor = null;
+            $cursor = $batch["cursor"] ?? null;
             $this->state[$state_key] = [
                 "offset" => $batch_offset,
                 "next_offset" => $next_offset,
                 "batch_file" => $batch_file,
                 "batch_entries" => $batch_entries,
                 "fallback_entries" => $fallback_entries,
-                "cursor" => null,
+                "cursor" => $cursor,
             ];
+            if (isset($batch["current_file"], $batch["current_file_bytes"])) {
+                $this->state["current_file"] = $batch["current_file"];
+                $this->state["current_file_bytes"] = $batch["current_file_bytes"];
+            }
             $this->save_state($this->state);
         }
 
@@ -6404,12 +6414,14 @@ class ImportClient
      *
      * @param string $list_file Path to the JSONL download list.
      * @param int    $offset    Byte offset into the download list file.
-     * @return array{file: string, offset: int, next_offset: int, entries: int, fallback_entries: int}|null
+     * @return array{file: string, offset: int, next_offset: int, entries: int, fallback_entries: int, cursor?: string, current_file?: string, current_file_bytes?: int}|null
      *         The temp file path, byte offsets, and entry count, or null if
      *         no paths remain.
      */
     private function prepare_fetch_batch(string $list_file, int $offset): ?array
     {
+        $this->pending_file_fetch_resume = null;
+
         // Cap the batch at 80% of the server's max request size so the
         // multipart envelope and headers still fit.  Floor at 256 KB so
         // tiny max_request values don't produce degenerate single-file batches.
@@ -6512,7 +6524,8 @@ class ImportClient
             }
 
             $entries++;
-            if ($this->try_download_public_upload($entry)) {
+            $allow_php_prefix_resume = $fallback_entries === 0 && $first;
+            if ($this->try_download_public_upload($entry, $allow_php_prefix_resume)) {
                 $bytes += strlen($chunk);
                 if ($oversized_first_entry) {
                     break;
@@ -6526,6 +6539,9 @@ class ImportClient
             $bytes += strlen($chunk);
             $fallback_entries++;
             $first = false;
+            if ($this->pending_file_fetch_resume !== null) {
+                break;
+            }
             if ($oversized_first_entry) {
                 break;
             }
@@ -6543,13 +6559,19 @@ class ImportClient
             return null;
         }
 
-        return [
+        $batch = [
             "file" => $tmp,
             "offset" => $offset,
             "next_offset" => $next_offset,
             "entries" => $entries,
             "fallback_entries" => $fallback_entries,
         ];
+        if ($this->pending_file_fetch_resume !== null) {
+            $batch["cursor"] = $this->pending_file_fetch_resume["cursor"];
+            $batch["current_file"] = $this->pending_file_fetch_resume["current_file"];
+            $batch["current_file_bytes"] = $this->pending_file_fetch_resume["current_file_bytes"];
+        }
+        return $batch;
     }
 
     /**
@@ -6664,7 +6686,7 @@ class ImportClient
      * the public download does not exactly match the exported size; callers
      * then fall back to file_fetch through WordPress/PHP.
      */
-    private function try_download_public_upload(array $entry): bool
+    private function try_download_public_upload(array $entry, bool $allow_php_prefix_resume = false): bool
     {
         $path = $entry["path"] ?? null;
         if (!is_string($path) || $path === "") {
@@ -6835,6 +6857,20 @@ class ImportClient
                     "Public upload range resume unsupported | path={$path} | http={$http_code}",
                     false,
                 );
+                if (
+                    $allow_php_prefix_resume &&
+                    is_file($tmp) &&
+                    $this->prepare_public_upload_file_fetch_resume(
+                        $path,
+                        $tmp,
+                        $local_path,
+                        $ctime,
+                        $size,
+                        $resume_from,
+                    )
+                ) {
+                    return false;
+                }
             }
             @unlink($tmp);
             $this->clear_public_upload_resume_state();
@@ -6884,6 +6920,176 @@ class ImportClient
         $this->audit_log("Public upload downloaded: {$path}", false);
 
         return true;
+    }
+
+    private function prepare_public_upload_file_fetch_resume(
+        string $path,
+        string $tmp,
+        string $local_path,
+        int $ctime,
+        int $size,
+        int $resume_from
+    ): bool {
+        clearstatcache(true, $tmp);
+        $tmp_size = is_file($tmp) ? filesize($tmp) : false;
+        if ($tmp_size === false || $tmp_size < $resume_from) {
+            return false;
+        }
+
+        if ($tmp_size !== $resume_from) {
+            $handle = fopen($tmp, "r+");
+            if (!$handle) {
+                return false;
+            }
+            $truncated = ftruncate($handle, $resume_from);
+            fclose($handle);
+            if (!$truncated) {
+                return false;
+            }
+        }
+
+        if (!$this->validate_public_upload_prefix_with_php($path, $tmp, $resume_from, $ctime, $size)) {
+            return false;
+        }
+
+        $cursor = $this->build_file_fetch_resume_cursor($path, $ctime, $resume_from);
+        if ($cursor === null) {
+            return false;
+        }
+
+        if (!rename($tmp, $local_path)) {
+            return false;
+        }
+
+        $this->pending_file_fetch_resume = [
+            "cursor" => $cursor,
+            "current_file" => $local_path,
+            "current_file_bytes" => $resume_from,
+        ];
+        $this->clear_public_upload_resume_state();
+        $this->audit_log(
+            "Public upload prefix validated; resuming via file_fetch | path={$path} | bytes={$resume_from}",
+            false,
+        );
+        return true;
+    }
+
+    private function validate_public_upload_prefix_with_php(
+        string $path,
+        string $tmp,
+        int $bytes,
+        int $ctime,
+        int $size
+    ): bool {
+        $local_hash = $this->hash_file_prefix($tmp, $bytes, "md5");
+        if ($local_hash === null) {
+            return false;
+        }
+
+        $params = [
+            "path" => base64_encode($path),
+            "bytes" => $bytes,
+            "ctime" => $ctime,
+            "size" => $size,
+            "algorithm" => "md5",
+        ];
+        $export_dirs = $this->get_export_directories();
+        if (empty($export_dirs)) {
+            return false;
+        }
+        $params["directory"] = $export_dirs;
+
+        $response = $this->fetch_json($this->build_url("file_prefix_hash", null, $params));
+        if (!$response["ok"] || !is_array($response["json"])) {
+            $this->audit_log(
+                "Public upload prefix validation failed: " . ($response["error"] ?? "invalid response"),
+                false,
+            );
+            return false;
+        }
+
+        $remote = $response["json"];
+        if (
+            empty($remote["ok"]) ||
+            ($remote["algorithm"] ?? null) !== "md5" ||
+            (int) ($remote["bytes"] ?? 0) !== $bytes ||
+            !is_string($remote["hash"] ?? null) ||
+            !hash_equals($remote["hash"], $local_hash)
+        ) {
+            $reason = isset($remote["reason"]) && is_string($remote["reason"])
+                ? $remote["reason"]
+                : "hash_mismatch";
+            $this->audit_log(
+                "Public upload prefix validation rejected | path={$path} | reason={$reason}",
+                false,
+            );
+            return false;
+        }
+
+        return true;
+    }
+
+    private function hash_file_prefix(string $path, int $bytes, string $algorithm): ?string
+    {
+        if ($bytes <= 0 || !in_array($algorithm, hash_algos(), true)) {
+            return null;
+        }
+
+        $handle = fopen($path, "rb");
+        if (!$handle) {
+            return null;
+        }
+
+        $hash = hash_init($algorithm);
+        $remaining = $bytes;
+        while ($remaining > 0 && !feof($handle)) {
+            $chunk = fread($handle, min(1024 * 1024, $remaining));
+            if ($chunk === false) {
+                fclose($handle);
+                return null;
+            }
+            $remaining -= strlen($chunk);
+            hash_update($hash, $chunk);
+        }
+        fclose($handle);
+
+        if ($remaining !== 0) {
+            return null;
+        }
+
+        return hash_final($hash);
+    }
+
+    private function build_file_fetch_resume_cursor(string $path, int $ctime, int $bytes): ?string
+    {
+        $export_dirs = $this->get_export_directories();
+        if (empty($export_dirs) || $bytes <= 0) {
+            return null;
+        }
+
+        $root = null;
+        foreach ($export_dirs as $dir) {
+            $dir = rtrim($dir, "/");
+            if ($path === $dir || str_starts_with($path, $dir . "/")) {
+                $root = $dir;
+                break;
+            }
+        }
+        if ($root === null) {
+            $root = rtrim($export_dirs[0], "/");
+        }
+
+        $cursor = json_encode(
+            [
+                "phase" => "streaming",
+                "root" => base64_encode($root),
+                "path" => base64_encode($path),
+                "ctime" => $ctime,
+                "bytes" => $bytes,
+            ],
+            JSON_UNESCAPED_SLASHES,
+        );
+        return $cursor === false ? null : base64_encode($cursor);
     }
 
     /**
@@ -8610,6 +8816,10 @@ class ImportClient
                 $progress_record["files_total"] = $this->download_list_total;
             }
             $this->output_progress($progress_record);
+        }
+
+        if (!$is_first && $context->file_ctime === null && isset($headers["x-file-ctime"])) {
+            $context->file_ctime = (int) $headers["x-file-ctime"];
         }
 
         // Skip body/close for files being preserved

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -6735,7 +6735,7 @@ class ImportClient
 
         clearstatcache(true, $tmp);
         $resume_from = ($can_resume && is_file($tmp)) ? (int) filesize($tmp) : 0;
-        if ($resume_from < 0 || $resume_from > $size) {
+        if ($resume_from > $size) {
             @unlink($tmp);
             $resume_from = 0;
         }

--- a/tests/Import/FileBodyStreamingTest.php
+++ b/tests/Import/FileBodyStreamingTest.php
@@ -170,7 +170,7 @@ class FileBodyStreamingTest extends TestCase
         $context2 = new \StreamingContext();
         $context2->file_handle = fopen($target, 'ab');
         $context2->file_path = $target;
-        $context2->file_ctime = 1234567890;
+        $context2->file_ctime = null;
         $context2->file_bytes_written = $trackedBytes;
         $context2->on_chunk = function (array $chunk) use ($client, $handleFileChunk, $context2): void {
             $handleFileChunk->invoke($client, $chunk, $context2);

--- a/tests/Import/PublicUploadDownloadTest.php
+++ b/tests/Import/PublicUploadDownloadTest.php
@@ -105,29 +105,56 @@ class PublicUploadDownloadTest extends TestCase
         @unlink($batch['file']);
     }
 
-    public function testPrepareFetchBatchUsesFileFetchWhenPublicUploadsDisabled(): void
+    public function testDownloadFilesFromListResumesPublicUploadWithHttpRange(): void
     {
-        $contents = str_repeat('direct upload body ', 128);
-        $remotePath = '/var/www/html/wp-content/uploads/2024/05/resume-photo.jpg';
+        $sourceRoot = $this->tempDir . '/range-source-uploads';
+        mkdir($sourceRoot . '/2024/05', 0755, true);
+        $contents = str_repeat('resumable public upload body ', 256);
+        file_put_contents($sourceRoot . '/2024/05/resume-photo.txt', $contents);
+        $rangeLog = $this->tempDir . '/range.log';
+        $baseurl = $this->startRangeServer($sourceRoot, $rangeLog);
+
+        $ctime = 1700000000;
+        $remotePath = '/var/www/html/wp-content/uploads/2024/05/resume-photo.txt';
         $listFile = $this->writeDownloadList([
             [
                 'path' => base64_encode($remotePath),
-                'ctime' => 1700000000,
+                'ctime' => $ctime,
                 'size' => strlen($contents),
                 'type' => 'file',
             ],
         ]);
 
-        $client = $this->makeClient('/var/www/html/wp-content/uploads/', 'http://127.0.0.1:1');
-        $batch = (new \ReflectionClass($client))->getMethod('prepare_fetch_batch')
-            ->invoke($client, $listFile, 0, false);
+        $localPath = realpath($this->fsRoot) . $remotePath;
+        $tmpPath = $localPath . '.reprint-public-download';
+        mkdir(dirname($tmpPath), 0755, true);
+        $resumeFrom = 37;
+        file_put_contents($tmpPath, substr($contents, 0, $resumeFrom));
 
-        $this->assertNotNull($batch);
-        $this->assertSame(1, $batch['entries']);
-        $this->assertSame(1, $batch['fallback_entries']);
-        $this->assertSame([$remotePath], json_decode(file_get_contents($batch['file']), true));
-        $this->assertFileDoesNotExist($this->fsRoot . $remotePath);
-        @unlink($batch['file']);
+        $client = $this->makeClient('/var/www/html/wp-content/uploads/', $baseurl);
+        $client->state['public_upload'] = [
+            'path' => $remotePath,
+            'url' => $baseurl . '/2024/05/resume-photo.txt',
+            'local_path' => $localPath,
+            'tmp_path' => $tmpPath,
+            'ctime' => $ctime,
+            'size' => strlen($contents),
+            'bytes' => $resumeFrom,
+        ];
+
+        $complete = (new \ReflectionClass($client))->getMethod('download_files_from_list')
+            ->invoke($client, $listFile, 'fetch');
+
+        $this->assertTrue($complete);
+        $this->assertSame($contents, file_get_contents($localPath));
+        $this->assertFileDoesNotExist($tmpPath);
+        $this->assertNull($client->state['public_upload']['path']);
+        $this->assertSame(filesize($listFile), $client->state['fetch']['offset']);
+        $this->assertStringContainsString(
+            'bytes=' . $resumeFrom . '-',
+            file_get_contents($rangeLog),
+            file_get_contents($this->stateDir . '/.import-audit.log'),
+        );
     }
 
     private function makeClient(string $uploadsBasedir, string $uploadsBaseurl): \ImportClient
@@ -178,7 +205,72 @@ class PublicUploadDownloadTest extends TestCase
         return $entries;
     }
 
-    private function startServer(string $docroot): string
+    private function startRangeServer(string $docroot, string $rangeLog): string
+    {
+        $router = $this->tempDir . '/range-router.php';
+        $serverRoot = $this->tempDir . '/range-server-root';
+        mkdir($serverRoot, 0755, true);
+        $routerSource = strtr(
+            <<<'PHP'
+<?php
+$uriPath = rawurldecode(parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH) ?: '/');
+if ($uriPath === '/__ready__') {
+    http_response_code(204);
+    return;
+}
+
+$docroot = realpath(__DOCROOT__);
+$file = realpath($docroot . '/' . ltrim($uriPath, '/'));
+if (
+    $docroot === false ||
+    $file === false ||
+    strpos($file, $docroot . DIRECTORY_SEPARATOR) !== 0 ||
+    !is_file($file)
+) {
+    http_response_code(404);
+    return;
+}
+
+$range = $_SERVER['HTTP_RANGE'] ?? '';
+file_put_contents(__RANGE_LOG__, $range . PHP_EOL, FILE_APPEND);
+
+$size = filesize($file);
+$start = 0;
+$status = 200;
+if (preg_match('/^bytes=(\d+)-$/', $range, $matches)) {
+    $start = (int) $matches[1];
+    if ($start >= $size) {
+        http_response_code(416);
+        header('Content-Range: bytes */' . $size);
+        return;
+    }
+    $status = 206;
+}
+
+http_response_code($status);
+header('Accept-Ranges: bytes');
+header('Content-Type: application/octet-stream');
+header('Content-Length: ' . ($size - $start));
+if ($status === 206) {
+    header('Content-Range: bytes ' . $start . '-' . ($size - 1) . '/' . $size);
+}
+
+$handle = fopen($file, 'rb');
+fseek($handle, $start);
+fpassthru($handle);
+fclose($handle);
+PHP
+            ,
+            [
+                '__DOCROOT__' => var_export($docroot, true),
+                '__RANGE_LOG__' => var_export($rangeLog, true),
+            ],
+        );
+        file_put_contents($router, $routerSource);
+        return $this->startServer($serverRoot, $router);
+    }
+
+    private function startServer(string $docroot, ?string $router = null): string
     {
         $socket = stream_socket_server('tcp://127.0.0.1:0', $errno, $errstr);
         if (!$socket) {
@@ -189,6 +281,9 @@ class PublicUploadDownloadTest extends TestCase
         $port = (int) substr(strrchr($name, ':'), 1);
 
         $cmd = escapeshellarg(PHP_BINARY) . ' -S 127.0.0.1:' . $port . ' -t ' . escapeshellarg($docroot);
+        if ($router !== null) {
+            $cmd .= ' ' . escapeshellarg($router);
+        }
         $this->serverProcess = proc_open(
             $cmd,
             [

--- a/tests/Import/PublicUploadDownloadTest.php
+++ b/tests/Import/PublicUploadDownloadTest.php
@@ -105,6 +105,31 @@ class PublicUploadDownloadTest extends TestCase
         @unlink($batch['file']);
     }
 
+    public function testPrepareFetchBatchUsesFileFetchWhenPublicUploadsDisabled(): void
+    {
+        $contents = str_repeat('direct upload body ', 128);
+        $remotePath = '/var/www/html/wp-content/uploads/2024/05/resume-photo.jpg';
+        $listFile = $this->writeDownloadList([
+            [
+                'path' => base64_encode($remotePath),
+                'ctime' => 1700000000,
+                'size' => strlen($contents),
+                'type' => 'file',
+            ],
+        ]);
+
+        $client = $this->makeClient('/var/www/html/wp-content/uploads/', 'http://127.0.0.1:1');
+        $batch = (new \ReflectionClass($client))->getMethod('prepare_fetch_batch')
+            ->invoke($client, $listFile, 0, false);
+
+        $this->assertNotNull($batch);
+        $this->assertSame(1, $batch['entries']);
+        $this->assertSame(1, $batch['fallback_entries']);
+        $this->assertSame([$remotePath], json_decode(file_get_contents($batch['file']), true));
+        $this->assertFileDoesNotExist($this->fsRoot . $remotePath);
+        @unlink($batch['file']);
+    }
+
     private function makeClient(string $uploadsBasedir, string $uploadsBaseurl): \ImportClient
     {
         $client = new \ImportClient('http://fake.url', $this->stateDir, $this->fsRoot);

--- a/tests/Import/PublicUploadDownloadTest.php
+++ b/tests/Import/PublicUploadDownloadTest.php
@@ -157,12 +157,82 @@ class PublicUploadDownloadTest extends TestCase
         );
     }
 
-    private function makeClient(string $uploadsBasedir, string $uploadsBaseurl): \ImportClient
+    public function testPrepareFetchBatchResumesUnsupportedPublicRangeViaFileFetchOffset(): void
     {
-        $client = new \ImportClient('http://fake.url', $this->stateDir, $this->fsRoot);
+        $sourceRoot = $this->tempDir . '/no-range-source-uploads';
+        mkdir($sourceRoot . '/2024/05', 0755, true);
+        $contents = str_repeat('fallback resume body ', 256);
+        $sourceFile = $sourceRoot . '/2024/05/resume-photo.txt';
+        file_put_contents($sourceFile, $contents);
+        clearstatcache(true, $sourceFile);
+        $ctime = filectime($sourceFile);
+        $rangeLog = $this->tempDir . '/no-range.log';
+        $remoteUploads = '/var/www/html/wp-content/uploads/';
+        $baseurl = $this->startNoRangeHashServer($sourceRoot, $rangeLog, $remoteUploads);
+
+        $remotePath = $remoteUploads . '2024/05/resume-photo.txt';
+        $listFile = $this->writeDownloadList([
+            [
+                'path' => base64_encode($remotePath),
+                'ctime' => $ctime,
+                'size' => strlen($contents),
+                'type' => 'file',
+            ],
+        ]);
+
+        $localPath = realpath($this->fsRoot) . $remotePath;
+        $tmpPath = $localPath . '.reprint-public-download';
+        mkdir(dirname($tmpPath), 0755, true);
+        $resumeFrom = 37;
+        file_put_contents($tmpPath, substr($contents, 0, $resumeFrom));
+
+        $client = $this->makeClient($remoteUploads, $baseurl, $baseurl);
+        $client->state['public_upload'] = [
+            'path' => $remotePath,
+            'url' => $baseurl . '/2024/05/resume-photo.txt',
+            'local_path' => $localPath,
+            'tmp_path' => $tmpPath,
+            'ctime' => $ctime,
+            'size' => strlen($contents),
+            'bytes' => $resumeFrom,
+        ];
+
+        $batch = (new \ReflectionClass($client))->getMethod('prepare_fetch_batch')
+            ->invoke($client, $listFile, 0);
+
+        $this->assertNotNull($batch);
+        $this->assertSame(1, $batch['entries']);
+        $this->assertSame(1, $batch['fallback_entries']);
+        $this->assertSame([$remotePath], json_decode(file_get_contents($batch['file']), true));
+        $this->assertSame($localPath, $batch['current_file']);
+        $this->assertSame($resumeFrom, $batch['current_file_bytes']);
+        $this->assertSame(substr($contents, 0, $resumeFrom), file_get_contents($localPath));
+        $this->assertFileDoesNotExist($tmpPath);
+        $this->assertStringContainsString('bytes=' . $resumeFrom . '-', file_get_contents($rangeLog));
+
+        $cursor = json_decode(base64_decode($batch['cursor']), true);
+        $this->assertSame('streaming', $cursor['phase']);
+        $this->assertSame($remotePath, base64_decode($cursor['path']));
+        $this->assertSame($ctime, $cursor['ctime']);
+        $this->assertSame($resumeFrom, $cursor['bytes']);
+        @unlink($batch['file']);
+    }
+
+    private function makeClient(string $uploadsBasedir, string $uploadsBaseurl, ?string $remoteUrl = null): \ImportClient
+    {
+        $client = new \ImportClient($remoteUrl ?? 'http://fake.url', $this->stateDir, $this->fsRoot);
         $client->state = $client->default_state();
+        $root = rtrim($uploadsBasedir, '/');
+        $needle = '/wp-content/uploads';
+        $pos = strpos($root, $needle);
+        $root = $pos === false ? dirname($root) : substr($root, 0, $pos);
         $client->state['preflight'] = [
             'data' => [
+                'wp_detect' => [
+                    'roots' => [
+                        ['path' => $root],
+                    ],
+                ],
                 'database' => [
                     'wp' => [
                         'paths_urls' => [
@@ -264,6 +334,94 @@ PHP
             [
                 '__DOCROOT__' => var_export($docroot, true),
                 '__RANGE_LOG__' => var_export($rangeLog, true),
+            ],
+        );
+        file_put_contents($router, $routerSource);
+        return $this->startServer($serverRoot, $router);
+    }
+
+    private function startNoRangeHashServer(string $docroot, string $rangeLog, string $remoteUploads): string
+    {
+        $router = $this->tempDir . '/no-range-router.php';
+        $serverRoot = $this->tempDir . '/no-range-server-root';
+        mkdir($serverRoot, 0755, true);
+        $routerSource = strtr(
+            <<<'PHP'
+<?php
+$docroot = realpath(__DOCROOT__);
+$remoteUploads = rtrim(__REMOTE_UPLOADS__, '/') . '/';
+
+if (($_GET['endpoint'] ?? '') === 'file_prefix_hash') {
+    header('Content-Type: application/json');
+    $remotePath = base64_decode($_GET['path'] ?? '', true);
+    $bytes = (int) ($_GET['bytes'] ?? 0);
+    $expectedSize = (int) ($_GET['size'] ?? -1);
+    $expectedCtime = (int) ($_GET['ctime'] ?? -1);
+    if (!is_string($remotePath) || strpos($remotePath, $remoteUploads) !== 0) {
+        echo json_encode(['ok' => false, 'reason' => 'bad_path']);
+        return;
+    }
+    $relative = substr($remotePath, strlen($remoteUploads));
+    $file = realpath($docroot . '/' . $relative);
+    if ($file === false || strpos($file, $docroot . DIRECTORY_SEPARATOR) !== 0 || !is_file($file)) {
+        echo json_encode(['ok' => false, 'reason' => 'missing']);
+        return;
+    }
+    clearstatcache(true, $file);
+    if (filesize($file) !== $expectedSize || filectime($file) !== $expectedCtime || $bytes <= 0) {
+        echo json_encode(['ok' => false, 'reason' => 'metadata_mismatch']);
+        return;
+    }
+    $handle = fopen($file, 'rb');
+    $hash = hash_init('md5');
+    $remaining = $bytes;
+    while ($remaining > 0 && !feof($handle)) {
+        $chunk = fread($handle, min(1024 * 1024, $remaining));
+        $remaining -= strlen($chunk);
+        hash_update($hash, $chunk);
+    }
+    fclose($handle);
+    echo json_encode([
+        'ok' => $remaining === 0,
+        'algorithm' => 'md5',
+        'bytes' => $bytes,
+        'hash' => hash_final($hash),
+        'size' => $expectedSize,
+        'ctime' => $expectedCtime,
+    ]);
+    return;
+}
+
+$uriPath = rawurldecode(parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH) ?: '/');
+if ($uriPath === '/__ready__') {
+    http_response_code(204);
+    return;
+}
+
+$file = realpath($docroot . '/' . ltrim($uriPath, '/'));
+if (
+    $docroot === false ||
+    $file === false ||
+    strpos($file, $docroot . DIRECTORY_SEPARATOR) !== 0 ||
+    !is_file($file)
+) {
+    http_response_code(404);
+    return;
+}
+
+$range = $_SERVER['HTTP_RANGE'] ?? '';
+file_put_contents(__RANGE_LOG__, $range . PHP_EOL, FILE_APPEND);
+
+http_response_code(200);
+header('Content-Type: application/octet-stream');
+header('Content-Length: ' . filesize($file));
+readfile($file);
+PHP
+            ,
+            [
+                '__DOCROOT__' => var_export($docroot, true),
+                '__RANGE_LOG__' => var_export($rangeLog, true),
+                '__REMOTE_UPLOADS__' => var_export($remoteUploads, true),
             ],
         );
         file_put_contents($router, $routerSource);

--- a/tests/Import/PublicUploadDownloadTest.php
+++ b/tests/Import/PublicUploadDownloadTest.php
@@ -1,0 +1,236 @@
+<?php
+
+namespace ImportTests;
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../packages/reprint-importer/src/import.php';
+
+class PublicUploadDownloadTest extends TestCase
+{
+    private string $tempDir;
+    private string $stateDir;
+    private string $fsRoot;
+    private $serverProcess = null;
+    private array $serverPipes = [];
+    private $allProxy;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->tempDir = sys_get_temp_dir() . '/public-upload-download-test-' . uniqid();
+        $this->stateDir = $this->tempDir . '/state';
+        $this->fsRoot = $this->tempDir . '/fs-root';
+        mkdir($this->stateDir, 0755, true);
+        mkdir($this->fsRoot, 0755, true);
+
+        $this->allProxy = getenv('ALL_PROXY');
+        putenv('ALL_PROXY=');
+    }
+
+    protected function tearDown(): void
+    {
+        $this->stopServer();
+        if ($this->allProxy === false) {
+            putenv('ALL_PROXY');
+        } else {
+            putenv('ALL_PROXY=' . $this->allProxy);
+        }
+        $this->recursiveDelete($this->tempDir);
+        parent::tearDown();
+    }
+
+    public function testDownloadFilesFromListDownloadsPublicUploadDirectly(): void
+    {
+        $sourceRoot = $this->tempDir . '/source-uploads';
+        mkdir($sourceRoot . '/2024/05', 0755, true);
+        $contents = str_repeat('direct upload body ', 128);
+        file_put_contents($sourceRoot . '/2024/05/space photo.txt', $contents);
+        $baseurl = $this->startServer($sourceRoot);
+
+        $remotePath = '/var/www/html/wp-content/uploads/2024/05/space photo.txt';
+        $listFile = $this->writeDownloadList([
+            [
+                'path' => base64_encode($remotePath),
+                'ctime' => 1700000000,
+                'size' => strlen($contents),
+                'type' => 'file',
+            ],
+        ]);
+
+        $client = $this->makeClient('/var/www/html/wp-content/uploads/', $baseurl);
+        $reflection = new \ReflectionClass($client);
+        $complete = $reflection->getMethod('download_files_from_list')
+            ->invoke($client, $listFile, 'fetch');
+
+        $this->assertTrue($complete);
+        $this->assertSame(
+            $contents,
+            file_get_contents($this->fsRoot . $remotePath),
+        );
+        $this->assertSame(filesize($listFile), $client->state['fetch']['offset']);
+        $this->assertNull($client->state['fetch']['batch_file']);
+
+        $index = $this->readIndex();
+        $this->assertCount(1, $index);
+        $this->assertSame($remotePath, $index[0]['path']);
+        $this->assertSame(strlen($contents), $index[0]['size']);
+    }
+
+    public function testPrepareFetchBatchFallsBackWhenPublicUploadDownloadFails(): void
+    {
+        $sourceRoot = $this->tempDir . '/empty-source-uploads';
+        mkdir($sourceRoot, 0755, true);
+        $baseurl = $this->startServer($sourceRoot);
+
+        $remotePath = '/var/www/html/wp-content/uploads/2024/05/missing.jpg';
+        $listFile = $this->writeDownloadList([
+            [
+                'path' => base64_encode($remotePath),
+                'ctime' => 1700000000,
+                'size' => 123,
+                'type' => 'file',
+            ],
+        ]);
+
+        $client = $this->makeClient('/var/www/html/wp-content/uploads/', $baseurl);
+        $batch = (new \ReflectionClass($client))->getMethod('prepare_fetch_batch')
+            ->invoke($client, $listFile, 0);
+
+        $this->assertNotNull($batch);
+        $this->assertSame(1, $batch['entries']);
+        $this->assertSame(1, $batch['fallback_entries']);
+        $this->assertSame([$remotePath], json_decode(file_get_contents($batch['file']), true));
+        $this->assertFileDoesNotExist($this->fsRoot . $remotePath);
+        @unlink($batch['file']);
+    }
+
+    private function makeClient(string $uploadsBasedir, string $uploadsBaseurl): \ImportClient
+    {
+        $client = new \ImportClient('http://fake.url', $this->stateDir, $this->fsRoot);
+        $client->state = $client->default_state();
+        $client->state['preflight'] = [
+            'data' => [
+                'database' => [
+                    'wp' => [
+                        'paths_urls' => [
+                            'uploads' => [
+                                'basedir' => $uploadsBasedir,
+                                'baseurl' => $uploadsBaseurl,
+                            ],
+                        ],
+                    ],
+                ],
+                'limits' => [
+                    'max_request_bytes' => 4 * 1024 * 1024,
+                ],
+            ],
+            'http_code' => 200,
+        ];
+        return $client;
+    }
+
+    private function writeDownloadList(array $entries): string
+    {
+        $listFile = $this->stateDir . '/download-list.jsonl';
+        $handle = fopen($listFile, 'w');
+        foreach ($entries as $entry) {
+            fwrite($handle, json_encode($entry, JSON_UNESCAPED_SLASHES) . "\n");
+        }
+        fclose($handle);
+        return $listFile;
+    }
+
+    private function readIndex(): array
+    {
+        $indexFile = $this->stateDir . '/.import-index.jsonl';
+        $entries = [];
+        foreach (file($indexFile, FILE_IGNORE_NEW_LINES) ?: [] as $line) {
+            $entry = json_decode($line, true);
+            $entry['path'] = base64_decode($entry['path']);
+            $entries[] = $entry;
+        }
+        return $entries;
+    }
+
+    private function startServer(string $docroot): string
+    {
+        $socket = stream_socket_server('tcp://127.0.0.1:0', $errno, $errstr);
+        if (!$socket) {
+            $this->fail("Failed to allocate test server port: {$errstr}");
+        }
+        $name = stream_socket_get_name($socket, false);
+        fclose($socket);
+        $port = (int) substr(strrchr($name, ':'), 1);
+
+        $cmd = escapeshellarg(PHP_BINARY) . ' -S 127.0.0.1:' . $port . ' -t ' . escapeshellarg($docroot);
+        $this->serverProcess = proc_open(
+            $cmd,
+            [
+                0 => ['pipe', 'r'],
+                1 => ['pipe', 'w'],
+                2 => ['pipe', 'w'],
+            ],
+            $this->serverPipes,
+        );
+        if (!is_resource($this->serverProcess)) {
+            $this->fail('Failed to start PHP test server');
+        }
+
+        $baseurl = 'http://127.0.0.1:' . $port;
+        for ($i = 0; $i < 30; $i++) {
+            $ch = curl_init($baseurl . '/__ready__');
+            curl_setopt_array($ch, [
+                CURLOPT_RETURNTRANSFER => true,
+                CURLOPT_CONNECTTIMEOUT => 1,
+                CURLOPT_TIMEOUT => 1,
+            ]);
+            curl_exec($ch);
+            $httpCode = (int) curl_getinfo($ch, CURLINFO_HTTP_CODE);
+            curl_close($ch);
+            if ($httpCode > 0) {
+                return $baseurl;
+            }
+            usleep(100000);
+        }
+
+        $this->fail('PHP test server did not become ready');
+    }
+
+    private function stopServer(): void
+    {
+        foreach ($this->serverPipes as $pipe) {
+            if (is_resource($pipe)) {
+                fclose($pipe);
+            }
+        }
+        $this->serverPipes = [];
+
+        if (is_resource($this->serverProcess)) {
+            proc_terminate($this->serverProcess);
+            proc_close($this->serverProcess);
+        }
+        $this->serverProcess = null;
+    }
+
+    private function recursiveDelete(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        foreach (scandir($dir) as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $path = $dir . '/' . $item;
+            if (is_link($path)) {
+                unlink($path);
+            } elseif (is_dir($path)) {
+                $this->recursiveDelete($path);
+            } else {
+                unlink($path);
+            }
+        }
+        rmdir($dir);
+    }
+}

--- a/tests/e2e/benchmark/bench-pull.mjs
+++ b/tests/e2e/benchmark/bench-pull.mjs
@@ -35,6 +35,7 @@ const FILE_BENCH_SIZE_MB = Number(process.env.BENCH_FILE_SIZE_MB || 24);
 const FILE_BENCH_SIZE = FILE_BENCH_SIZE_MB * 1024 * 1024;
 const FILE_BENCH_TUNED_CHUNK_SIZE = 16 * 1024 * 1024;
 const FILE_BENCH_RELATIVE_PATH = `test-data/bench-random-${FILE_BENCH_SIZE_MB}mb.bin`;
+const FILE_BENCH_UPLOAD_RELATIVE_PATH = `wp-content/uploads/bench/bench-random-${FILE_BENCH_SIZE_MB}mb.bin`;
 const IMPORT_DB = 'e2e_bench_pull';
 // Seed enough posts/postmeta to make db-pull and db-apply dominate wall-clock
 // (the default WP install has ~1 post). Mirrors the dataset shape used in
@@ -218,6 +219,7 @@ async function ensureFileBenchSite() {
 
     const siteDir = getSiteDir(FILE_BENCH_SITE);
     const filePath = join(siteDir, FILE_BENCH_RELATIVE_PATH);
+    const uploadFilePath = join(siteDir, FILE_BENCH_UPLOAD_RELATIVE_PATH);
     const needsFile = !existsSync(filePath) || statSync(filePath).size !== FILE_BENCH_SIZE;
     if (needsFile) {
         console.log(`Creating ${fmtBytes(FILE_BENCH_SIZE)} random file for file-transfer benchmark...`);
@@ -227,7 +229,16 @@ async function ensureFileBenchSite() {
         execSync(`sudo chown nginx:nginx ${JSON.stringify(filePath)}`);
     }
 
-    return { site: FILE_BENCH_SITE, siteDir, filePath };
+    const needsUploadFile = !existsSync(uploadFilePath) || statSync(uploadFilePath).size !== FILE_BENCH_SIZE;
+    if (needsUploadFile) {
+        console.log(`Creating ${fmtBytes(FILE_BENCH_SIZE)} random upload for public-upload benchmark...`);
+        execSync(`sudo mkdir -p ${JSON.stringify(dirname(uploadFilePath))}`);
+        execSync(`sudo rm -f ${JSON.stringify(uploadFilePath)}`);
+        execSync(`sudo dd if=/dev/urandom of=${JSON.stringify(uploadFilePath)} bs=1M count=${FILE_BENCH_SIZE_MB} status=none`);
+        execSync(`sudo chown nginx:nginx ${JSON.stringify(uploadFilePath)}`);
+    }
+
+    return { site: FILE_BENCH_SITE, siteDir, filePath, uploadFilePath };
 }
 
 async function runFileFetchScenario({ stage, site, filePath, params = {}, details = {} }) {
@@ -400,6 +411,73 @@ function runPreflightForSite(site, stateDir) {
     throw lastErr;
 }
 
+function readUploadsBaseUrl(stateDir) {
+    const statePath = join(stateDir, '.import-state.json');
+    if (!existsSync(statePath)) return '';
+    const state = JSON.parse(readFileSync(statePath, 'utf-8'));
+    return state.preflight?.data?.database?.wp?.paths_urls?.uploads?.baseurl || '';
+}
+
+function runPublicUploadsFilePull({ site, stateDir, uploadFilePath, uploadsBaseUrl }) {
+    const url = `${getSiteUrl(site)}&directory=${getSiteDir(site)}`;
+    const args = [
+        IMPORTER_PATH,
+        'files-pull',
+        url,
+        `--state-dir=${stateDir}`,
+        `--fs-root=${fsRootDir(stateDir)}`,
+        `--secret=${getSiteSecret(site)}`,
+        '--duty=1',
+        '--max-exec=60',
+    ];
+
+    const start = performance.now();
+    let attempts = 0;
+    let lastErr = null;
+    while (true) {
+        attempts += 1;
+        try {
+            execFileSync(PHP_BINARY, args, {
+                timeout: 900_000,
+                encoding: 'utf-8',
+                maxBuffer: 64 * 1024 * 1024,
+                stdio: ['ignore', 'pipe', 'pipe'],
+            });
+            return {
+                stage: 'files-pull-public-uploads',
+                elapsedMs: performance.now() - start,
+                attempts,
+                ok: true,
+                details: {
+                    condition: 'files-pull public wp-content/uploads file',
+                    upload: fmtBytes(statSync(uploadFilePath).size),
+                    uploads_baseurl: uploadsBaseUrl ? 'present' : 'missing',
+                },
+            };
+        } catch (e) {
+            lastErr = e;
+            const exitCode = e.status === null ? -1 : (e.status || 1);
+            if (exitCode === 2 && attempts < 50) {
+                continue;
+            }
+            return {
+                stage: 'files-pull-public-uploads',
+                elapsedMs: performance.now() - start,
+                attempts,
+                ok: false,
+                exitCode,
+                stderr: (lastErr.stderr || '').toString().slice(-2000),
+                stdout: (lastErr.stdout || '').toString().slice(-2000),
+                details: {
+                    condition: 'files-pull public wp-content/uploads file',
+                    upload: fmtBytes(statSync(uploadFilePath).size),
+                    uploads_baseurl: uploadsBaseUrl ? 'present' : 'missing',
+                },
+            };
+        }
+    }
+}
+
 function renderMarkdown(results, meta) {
     const total = results.reduce((s, r) => s + r.elapsedMs, 0);
     const lines = [];
@@ -538,6 +616,27 @@ async function main() {
         });
         results.push(largePartPull);
         console.log(`   ${largePartPull.ok ? 'ok' : 'FAIL'} in ${fmtMs(largePartPull.elapsedMs)} (${fmtDetails(largePartPull.details)})`);
+    }
+
+    if (shouldRun('files-pull-public-uploads')) {
+        if (!fileBench) {
+            console.log(`Provisioning site: ${FILE_BENCH_SITE}`);
+            fileBench = await ensureFileBenchSite();
+        }
+        const publicUploadsStateDir = join(tmpdir(), `bench-public-uploads-${Date.now()}`);
+        mkdirSync(publicUploadsStateDir, { recursive: true });
+        mkdirSync(fsRootDir(publicUploadsStateDir), { recursive: true });
+        runPreflightForSite(fileBench.site, publicUploadsStateDir);
+        const uploadsBaseUrl = readUploadsBaseUrl(publicUploadsStateDir);
+        console.log('-> files-pull-public-uploads');
+        const publicUploadsPull = runPublicUploadsFilePull({
+            site: fileBench.site,
+            stateDir: publicUploadsStateDir,
+            uploadFilePath: fileBench.uploadFilePath,
+            uploadsBaseUrl,
+        });
+        results.push(publicUploadsPull);
+        console.log(`   ${publicUploadsPull.ok ? 'ok' : 'FAIL'} in ${fmtMs(publicUploadsPull.elapsedMs)} (${fmtDetails(publicUploadsPull.details)})`);
     }
 
     const phpVersion = execFileSync(PHP_BINARY, ['-r', 'echo PHP_VERSION;'], { encoding: 'utf-8' }).trim();

--- a/tests/e2e/benchmark/bench-pull.mjs
+++ b/tests/e2e/benchmark/bench-pull.mjs
@@ -31,6 +31,7 @@ import {
 
 const SITE = 'large-directory';
 const FILE_BENCH_SITE = 'large-single-file';
+const PUBLIC_UPLOAD_BENCH_SITE = 'public-upload-bench';
 const FILE_BENCH_SIZE_MB = Number(process.env.BENCH_FILE_SIZE_MB || 24);
 const FILE_BENCH_SIZE = FILE_BENCH_SIZE_MB * 1024 * 1024;
 const FILE_BENCH_TUNED_CHUNK_SIZE = 16 * 1024 * 1024;
@@ -219,7 +220,6 @@ async function ensureFileBenchSite() {
 
     const siteDir = getSiteDir(FILE_BENCH_SITE);
     const filePath = join(siteDir, FILE_BENCH_RELATIVE_PATH);
-    const uploadFilePath = join(siteDir, FILE_BENCH_UPLOAD_RELATIVE_PATH);
     const needsFile = !existsSync(filePath) || statSync(filePath).size !== FILE_BENCH_SIZE;
     if (needsFile) {
         console.log(`Creating ${fmtBytes(FILE_BENCH_SIZE)} random file for file-transfer benchmark...`);
@@ -227,6 +227,19 @@ async function ensureFileBenchSite() {
         execSync(`sudo rm -f ${JSON.stringify(filePath)}`);
         execSync(`sudo dd if=/dev/urandom of=${JSON.stringify(filePath)} bs=1M count=${FILE_BENCH_SIZE_MB} status=none`);
         execSync(`sudo chown nginx:nginx ${JSON.stringify(filePath)}`);
+    }
+
+    return { site: FILE_BENCH_SITE, siteDir, filePath };
+}
+
+async function ensurePublicUploadBenchSite() {
+    await ensureSite(PUBLIC_UPLOAD_BENCH_SITE, { files: 'none' });
+
+    const siteDir = getSiteDir(PUBLIC_UPLOAD_BENCH_SITE);
+    const filePath = join(siteDir, FILE_BENCH_RELATIVE_PATH);
+    const uploadFilePath = join(siteDir, FILE_BENCH_UPLOAD_RELATIVE_PATH);
+    if (existsSync(filePath)) {
+        execSync(`sudo rm -f ${JSON.stringify(filePath)}`);
     }
 
     const needsUploadFile = !existsSync(uploadFilePath) || statSync(uploadFilePath).size !== FILE_BENCH_SIZE;
@@ -238,7 +251,7 @@ async function ensureFileBenchSite() {
         execSync(`sudo chown nginx:nginx ${JSON.stringify(uploadFilePath)}`);
     }
 
-    return { site: FILE_BENCH_SITE, siteDir, filePath, uploadFilePath };
+    return { site: PUBLIC_UPLOAD_BENCH_SITE, siteDir, uploadFilePath };
 }
 
 async function runFileFetchScenario({ stage, site, filePath, params = {}, details = {} }) {
@@ -418,7 +431,9 @@ function readUploadsBaseUrl(stateDir) {
     return state.preflight?.data?.database?.wp?.paths_urls?.uploads?.baseurl || '';
 }
 
-function runPublicUploadsFilePull({ site, stateDir, uploadFilePath, uploadsBaseUrl }) {
+function runPublicUploadsFilePull({
+    site, stateDir, uploadFilePath, uploadsBaseUrl, requireDirectUpload = false,
+}) {
     const url = `${getSiteUrl(site)}&directory=${getSiteDir(site)}`;
     const args = [
         IMPORTER_PATH,
@@ -443,6 +458,29 @@ function runPublicUploadsFilePull({ site, stateDir, uploadFilePath, uploadsBaseU
                 maxBuffer: 64 * 1024 * 1024,
                 stdio: ['ignore', 'pipe', 'pipe'],
             });
+            const auditLog = join(stateDir, '.import-audit.log');
+            const audit = existsSync(auditLog) ? readFileSync(auditLog, 'utf-8') : '';
+            const uploadRemotePath = uploadFilePath;
+            const sawDirectUpload = audit.includes(`Public upload downloaded: ${uploadRemotePath}`);
+            const sawFallbackForUpload = audit.includes(`Public upload download fallback | path=${uploadRemotePath}`);
+            if (requireDirectUpload && (!sawDirectUpload || sawFallbackForUpload)) {
+                return {
+                    stage: 'files-pull-public-uploads',
+                    elapsedMs: performance.now() - start,
+                    attempts,
+                    ok: false,
+                    exitCode: 1,
+                    stderr: `Expected direct public upload download for ${uploadRemotePath}`,
+                    stdout: audit.slice(-2000),
+                    details: {
+                        condition: 'files-pull public wp-content/uploads file',
+                        upload: fmtBytes(statSync(uploadFilePath).size),
+                        uploads_baseurl: uploadsBaseUrl ? 'present' : 'missing',
+                        direct_upload: sawDirectUpload ? 'yes' : 'no',
+                        public_fallback: sawFallbackForUpload ? 'yes' : 'no',
+                    },
+                };
+            }
             return {
                 stage: 'files-pull-public-uploads',
                 elapsedMs: performance.now() - start,
@@ -452,6 +490,8 @@ function runPublicUploadsFilePull({ site, stateDir, uploadFilePath, uploadsBaseU
                     condition: 'files-pull public wp-content/uploads file',
                     upload: fmtBytes(statSync(uploadFilePath).size),
                     uploads_baseurl: uploadsBaseUrl ? 'present' : 'missing',
+                    direct_upload: sawDirectUpload ? 'yes' : 'no',
+                    public_fallback: sawFallbackForUpload ? 'yes' : 'no',
                 },
             };
         } catch (e) {
@@ -472,6 +512,7 @@ function runPublicUploadsFilePull({ site, stateDir, uploadFilePath, uploadsBaseU
                     condition: 'files-pull public wp-content/uploads file',
                     upload: fmtBytes(statSync(uploadFilePath).size),
                     uploads_baseurl: uploadsBaseUrl ? 'present' : 'missing',
+                    direct_upload: 'unknown',
                 },
             };
         }
@@ -619,21 +660,20 @@ async function main() {
     }
 
     if (shouldRun('files-pull-public-uploads')) {
-        if (!fileBench) {
-            console.log(`Provisioning site: ${FILE_BENCH_SITE}`);
-            fileBench = await ensureFileBenchSite();
-        }
+        console.log(`Provisioning site: ${PUBLIC_UPLOAD_BENCH_SITE}`);
+        const publicUploadBench = await ensurePublicUploadBenchSite();
         const publicUploadsStateDir = join(tmpdir(), `bench-public-uploads-${Date.now()}`);
         mkdirSync(publicUploadsStateDir, { recursive: true });
         mkdirSync(fsRootDir(publicUploadsStateDir), { recursive: true });
-        runPreflightForSite(fileBench.site, publicUploadsStateDir);
+        runPreflightForSite(publicUploadBench.site, publicUploadsStateDir);
         const uploadsBaseUrl = readUploadsBaseUrl(publicUploadsStateDir);
         console.log('-> files-pull-public-uploads');
         const publicUploadsPull = runPublicUploadsFilePull({
-            site: fileBench.site,
+            site: publicUploadBench.site,
             stateDir: publicUploadsStateDir,
-            uploadFilePath: fileBench.uploadFilePath,
+            uploadFilePath: publicUploadBench.uploadFilePath,
             uploadsBaseUrl,
+            requireDirectUpload: process.env.BENCH_REQUIRE_DIRECT_PUBLIC_UPLOAD === '1',
         });
         results.push(publicUploadsPull);
         console.log(`   ${publicUploadsPull.ok ? 'ok' : 'FAIL'} in ${fmtMs(publicUploadsPull.elapsedMs)} (${fmtDetails(publicUploadsPull.details)})`);

--- a/tests/e2e/benchmark/focused-stages.txt
+++ b/tests/e2e/benchmark/focused-stages.txt
@@ -3,8 +3,7 @@
 # Both the PR build and the trunk baseline run the same set, so the
 # table shows two like-for-like wall-time numbers per row.
 #
-# This PR streams multipart file bodies directly to disk, so the
-# relevant scenario is a single oversized multipart part — the
-# per-stage details include importer peak memory, which is the
-# real signal for the streaming change.
-files-pull-large-part-peak-memory
+# This PR pulls public uploads directly from the source web server
+# / CDN, so the relevant scenario is a single public-uploads pull
+# with paths_urls.uploads.baseurl present.
+files-pull-public-uploads

--- a/tests/e2e/site-registry.json
+++ b/tests/e2e/site-registry.json
@@ -124,6 +124,9 @@
     },
     "file-body-resume": {
       "port": 8120
+    },
+    "public-upload-bench": {
+      "port": 8121
     }
   }
 }


### PR DESCRIPTION
## What it does

Downloads mapped public `wp-content/uploads/` files directly from the source site's public upload URL when the path can be mapped from `paths_urls.uploads.basedir` to `paths_urls.uploads.baseurl`.

Interrupted public-upload downloads are resumable in both cases:

- If the public server supports HTTP Range, the importer resumes the `.reprint-public-download` temp file with `Range: bytes=<offset>-` and requires HTTP `206`.
- If the public server does not support HTTP Range, the importer validates the existing temp prefix against PHP with a per-file `md5` prefix hash, moves that prefix into the final local path, and resumes `file_fetch` from the same byte offset.

Falls back to normal `file_fetch` whenever the public path is unavailable, unmapped, returns the wrong status/size, cannot be validated, or cannot be resumed safely.

Stack: based on #195. The perf job compares this PR against #195's branch, so the reported delta isolates the direct-upload change.

## Rationale

Large media files spend too much time moving through WordPress/PHP when they are already publicly reachable through the source site's upload URLs. Pulling those files over plain HTTP avoids PHP reading, chunking, and re-streaming every large JPEG/PDF/ZIP.

The public URL is still only the happy path. `file_fetch` remains the correctness path for private uploads, unmapped paths, unsupported public responses, validation failures, and resumed transfers that cannot continue through HTTP Range.

## Implementation

Adds a public-upload fast path while building `file_fetch` batches:

- Maps upload paths to public URLs from preflight `paths_urls.uploads`.
- Downloads mapped files directly to a deterministic `.reprint-public-download` temp file.
- Persists `state["public_upload"]` so an interrupted process can resume the public transfer.
- Uses cURL resume support for HTTP Range and requires `206` on resumed requests.
- Adds a lightweight exporter `file_prefix_hash` endpoint for one-file `md5` prefix validation.
- Synthesizes a `file_fetch` cursor for the validated interrupted file so PHP streaming starts at the same byte offset.
- Keeps failed or unvalidated public transfers on the existing `file_fetch` fallback path.

Adds the `files-pull-public-uploads` benchmark with a dedicated public-upload benchmark site. The timed large transfer is the upload file itself. CI requires the PR run to prove `direct_upload=yes`; the trunk/#195 baseline is allowed to report `direct_upload=no`.

Latest completed Performance Report on commit `b523ff96`, using the isolated 24 MiB public-upload benchmark:

- PR: `2.92 s`, `direct_upload=yes`, `public_fallback=no`
- trunk/#195 baseline: `5.27 s`, `direct_upload=no`, `public_fallback=no`
- delta: `-2.35 s` / `-44.6%`

## Testing instructions

```bash
php -l packages/reprint-exporter/src/export.php
php -l packages/reprint-exporter/src/class-http-server.php
php -l packages/reprint-importer/src/import.php
php -l tests/Import/PublicUploadDownloadTest.php
php -l tests/Import/FileBodyStreamingTest.php
vendor/bin/phpunit --bootstrap tests/bootstrap.php tests/Import/PublicUploadDownloadTest.php --testdox
vendor/bin/phpunit --bootstrap tests/bootstrap.php tests/Import/FileBodyStreamingTest.php --testdox
composer analyze
git diff --check
```
