### PR TITLE
perf probe: trunk gzip + nginx fastcgi_buffering off

### DIFF
--- a/.github/workflows/perf-report.yml
+++ b/.github/workflows/perf-report.yml
@@ -71,6 +71,18 @@ jobs:
           path: trunk-exporter
           submodules: true
 
+      - name: Resolve focused bench stages
+        id: stages
+        run: |
+          file="tests/e2e/benchmark/focused-stages.txt"
+          if [ -f "$file" ]; then
+            stages="$(grep -v '^[[:space:]]*$' "$file" | grep -v '^[[:space:]]*#' | paste -sd, -)"
+          else
+            stages=""
+          fi
+          echo "stages=$stages" >> "$GITHUB_OUTPUT"
+          echo "Focused stages: $stages"
+
       - name: Download PR phar
         uses: actions/download-artifact@v4
         with:
@@ -125,6 +137,7 @@ jobs:
           BENCH_LABEL: pr
           BENCH_JSON_OUT: bench-pr.json
           BENCH_MD_OUT: bench-pr.md
+          BENCH_STAGES: ${{ steps.stages.outputs.stages }}
           E2E_EXPORTER_PROJECT_ROOT: ${{ github.workspace }}
         run: node benchmark/bench-pull.mjs
 
@@ -140,6 +153,7 @@ jobs:
           BENCH_LABEL: ${{ github.base_ref }}
           BENCH_JSON_OUT: bench-base.json
           BENCH_MD_OUT: bench-base.md
+          BENCH_STAGES: ${{ steps.stages.outputs.stages }}
           E2E_EXPORTER_PROJECT_ROOT: ${{ github.workspace }}/trunk-exporter
         # Don't fail the whole job if the baseline bench fails — we still
         # want to publish the PR's numbers.

--- a/tests/e2e/benchmark/bench-pull.mjs
+++ b/tests/e2e/benchmark/bench-pull.mjs
@@ -33,6 +33,7 @@ const SITE = 'large-directory';
 const FILE_BENCH_SITE = 'large-single-file';
 const FILE_BENCH_SIZE_MB = Number(process.env.BENCH_FILE_SIZE_MB || 24);
 const FILE_BENCH_SIZE = FILE_BENCH_SIZE_MB * 1024 * 1024;
+const FILE_BENCH_TUNED_CHUNK_SIZE = 16 * 1024 * 1024;
 const FILE_BENCH_RELATIVE_PATH = `test-data/bench-random-${FILE_BENCH_SIZE_MB}mb.bin`;
 const IMPORT_DB = 'e2e_bench_pull';
 // Seed enough posts/postmeta to make db-pull and db-apply dominate wall-clock
@@ -329,6 +330,16 @@ async function main() {
         `--output-dir=${runtimeOutDir}`,
     ];
 
+    // Optional stage filter — when BENCH_STAGES is set (comma-separated
+    // list of stage names), only those stages run on both sides of the
+    // PR-vs-trunk comparison. Used here to focus the probe on a single
+    // file_fetch scenario.
+    const stageFilter = (process.env.BENCH_STAGES || '')
+        .split(',')
+        .map((s) => s.trim())
+        .filter(Boolean);
+    const shouldRun = (name) => stageFilter.length === 0 || stageFilter.includes(name);
+
     const stages = [
         { name: 'preflight', extra: [] },
         { name: 'files-pull', extra: [] },
@@ -340,6 +351,7 @@ async function main() {
 
     const results = [];
     for (const { name, extra, includeUrl } of stages) {
+        if (!shouldRun(name)) continue;
         console.log(`-> ${name}`);
         const r = runStage(name, stateDir, extra, { includeUrl });
         results.push(r);
@@ -350,19 +362,43 @@ async function main() {
         }
     }
 
-    console.log(`Provisioning site: ${FILE_BENCH_SITE}`);
-    const fileBench = await ensureFileBenchSite();
-    console.log('-> file-fetch-untuned-random');
-    const untunedFetch = await runFileFetchScenario({
-        stage: 'file-fetch-untuned-random',
-        site: fileBench.site,
-        filePath: fileBench.filePath,
-        details: {
-            condition: 'file_fetch without chunk_size',
-        },
-    });
-    results.push(untunedFetch);
-    console.log(`   ${untunedFetch.ok ? 'ok' : 'FAIL'} in ${fmtMs(untunedFetch.elapsedMs)} (${fmtDetails(untunedFetch.details)})`);
+    const fileFetchScenarios = ['file-fetch-untuned-random', 'file-fetch-binary-compression'];
+    let fileBench = null;
+    if (fileFetchScenarios.some(shouldRun)) {
+        console.log(`Provisioning site: ${FILE_BENCH_SITE}`);
+        fileBench = await ensureFileBenchSite();
+    }
+
+    if (shouldRun('file-fetch-untuned-random')) {
+        console.log('-> file-fetch-untuned-random');
+        const untunedFetch = await runFileFetchScenario({
+            stage: 'file-fetch-untuned-random',
+            site: fileBench.site,
+            filePath: fileBench.filePath,
+            details: {
+                condition: 'file_fetch without chunk_size',
+            },
+        });
+        results.push(untunedFetch);
+        console.log(`   ${untunedFetch.ok ? 'ok' : 'FAIL'} in ${fmtMs(untunedFetch.elapsedMs)} (${fmtDetails(untunedFetch.details)})`);
+    }
+
+    if (shouldRun('file-fetch-binary-compression')) {
+        console.log('-> file-fetch-binary-compression');
+        const binaryCompressionFetch = await runFileFetchScenario({
+            stage: 'file-fetch-binary-compression',
+            site: fileBench.site,
+            filePath: fileBench.filePath,
+            params: {
+                chunk_size: FILE_BENCH_TUNED_CHUNK_SIZE,
+            },
+            details: {
+                condition: 'random binary file_fetch with tuned chunk_size',
+            },
+        });
+        results.push(binaryCompressionFetch);
+        console.log(`   ${binaryCompressionFetch.ok ? 'ok' : 'FAIL'} in ${fmtMs(binaryCompressionFetch.elapsedMs)} (${fmtDetails(binaryCompressionFetch.details)})`);
+    }
 
     const phpVersion = execFileSync(PHP_BINARY, ['-r', 'echo PHP_VERSION;'], { encoding: 'utf-8' }).trim();
     const meta = {

--- a/tests/e2e/benchmark/focused-stages.txt
+++ b/tests/e2e/benchmark/focused-stages.txt
@@ -1,0 +1,10 @@
+# Stages this PR's perf comment will benchmark.
+# One stage name per line; comments and blank lines ignored.
+#
+# This branch is a one-off probe: it disables nginx fastcgi_buffering
+# and runs the binary-compression scenario against trunk's exporter
+# (gzip on, unchanged) to see how much of the 5+ s wall time on the
+# original PR 194 baseline came from nginx buffering vs. real gzip
+# CPU cost. After we read the number off the perf comment we close
+# this PR; nothing here is meant to merge.
+file-fetch-binary-compression

--- a/tests/e2e/ci/setup-infrastructure.sh
+++ b/tests/e2e/ci/setup-infrastructure.sh
@@ -186,9 +186,11 @@ server {
         include fastcgi_params;
         fastcgi_param SITE_EXPORT_TEST_MODE "1";
         fastcgi_read_timeout 120s;
-        fastcgi_buffering on;
-        fastcgi_buffer_size 128k;
-        fastcgi_buffers 8 128k;
+        # Probe: disable nginx FastCGI response buffering so we can see how
+        # much of trunk's gzip-stream slowness was actually nginx waiting
+        # for buffer fills, vs. real gzip-CPU cost. PR comment will compare
+        # this branch's number against the buffered baseline on PR 194.
+        fastcgi_buffering off;
     }
 }
 VHOST


### PR DESCRIPTION
One-off probe — not for merge.

PR #194 saw trunk's gzip `file_fetch` path take ~5.4 s for a 24 MiB random binary while the identity path took 122 ms on the same scenario. That's ~44× — far more than gzip-level-6 CPU on incompressible bytes should cost. Suspicion: nginx FastCGI buffering holding response bytes server-side, with the gzip stream's `ZLIB_NO_FLUSH` writes making the buffer-fill stalls visible.

This branch keeps trunk's gzip exporter unchanged and only flips nginx to `fastcgi_buffering off;` in the vhost. The perf comment will run only `file-fetch-binary-compression` (via `focused-stages.txt`) on both columns; both columns use trunk's exporter, so any delta is noise — the value of interest is the absolute wall time.

Reading the result against PR #194's 5.4 s buffered baseline:

- ≈ hundreds of ms → nginx buffering was the dominant cost
- ≈ 5 s → gzip CPU was the dominant cost
- somewhere between → split

Close once the number is in.