### PR TITLE
deps: bump wp-php-toolkit/* to ^0.7.3

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -8,16 +8,16 @@
     "packages": [
         {
             "name": "wp-php-toolkit/bytestream",
-            "version": "v0.7.0",
+            "version": "v0.7.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-php-toolkit/bytestream.git",
-                "reference": "275c423f714e8a16278b939eede1c1c1a21f6561"
+                "reference": "0c4adfc82065d52e0060b8072e7812b6d05e3c16"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-php-toolkit/bytestream/zipball/275c423f714e8a16278b939eede1c1c1a21f6561",
-                "reference": "275c423f714e8a16278b939eede1c1c1a21f6561",
+                "url": "https://api.github.com/repos/wp-php-toolkit/bytestream/zipball/0c4adfc82065d52e0060b8072e7812b6d05e3c16",
+                "reference": "0c4adfc82065d52e0060b8072e7812b6d05e3c16",
                 "shasum": ""
             },
             "require": {
@@ -50,32 +50,39 @@
                 }
             ],
             "description": "ByteStream component for WordPress.",
+            "homepage": "https://wordpress.github.io/php-toolkit/reference/bytestream.html",
+            "keywords": [
+                "php-toolkit",
+                "wordpress"
+            ],
             "support": {
-                "issues": "https://github.com/wp-php-toolkit/bytestream/issues",
-                "source": "https://github.com/wp-php-toolkit/bytestream/tree/v0.7.0"
+                "docs": "https://wordpress.github.io/php-toolkit/reference/bytestream.html",
+                "issues": "https://github.com/WordPress/php-toolkit/issues",
+                "source": "https://github.com/WordPress/php-toolkit"
             },
-            "time": "2026-04-29T23:59:06+00:00"
+            "time": "2026-05-03T23:19:57+00:00"
         },
         {
             "name": "wp-php-toolkit/data-liberation",
-            "version": "v0.7.0",
+            "version": "v0.7.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-php-toolkit/data-liberation.git",
-                "reference": "25f3385ae145b9befcc53cfbeeb71264d82f3df1"
+                "reference": "791a54f89b6540b7ef25f9f518a92f0631c81335"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-php-toolkit/data-liberation/zipball/25f3385ae145b9befcc53cfbeeb71264d82f3df1",
-                "reference": "25f3385ae145b9befcc53cfbeeb71264d82f3df1",
+                "url": "https://api.github.com/repos/wp-php-toolkit/data-liberation/zipball/791a54f89b6540b7ef25f9f518a92f0631c81335",
+                "reference": "791a54f89b6540b7ef25f9f518a92f0631c81335",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2",
-                "wp-php-toolkit/bytestream": "^0.7",
-                "wp-php-toolkit/filesystem": "^0.7",
-                "wp-php-toolkit/http-client": "^0.7",
-                "wp-php-toolkit/xml": "^0.7"
+                "wp-php-toolkit/bytestream": "^0.7.3",
+                "wp-php-toolkit/filesystem": "^0.7.3",
+                "wp-php-toolkit/html": "^0.7.3",
+                "wp-php-toolkit/http-client": "^0.7.3",
+                "wp-php-toolkit/xml": "^0.7.3"
             },
             "type": "library",
             "autoload": {
@@ -87,7 +94,8 @@
                     "vendor-patched/"
                 ],
                 "exclude-from-classmap": [
-                    "/Tests/"
+                    "/Tests/",
+                    "/bin/"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -105,24 +113,30 @@
                 }
             ],
             "description": "Data Liberation component for WordPress.",
+            "homepage": "https://wordpress.github.io/php-toolkit/reference/dataliberation.html",
+            "keywords": [
+                "php-toolkit",
+                "wordpress"
+            ],
             "support": {
-                "issues": "https://github.com/wp-php-toolkit/data-liberation/issues",
-                "source": "https://github.com/wp-php-toolkit/data-liberation/tree/v0.7.0"
+                "docs": "https://wordpress.github.io/php-toolkit/reference/dataliberation.html",
+                "issues": "https://github.com/WordPress/php-toolkit/issues",
+                "source": "https://github.com/WordPress/php-toolkit"
             },
-            "time": "2026-04-29T23:59:06+00:00"
+            "time": "2026-05-04T13:39:30+00:00"
         },
         {
             "name": "wp-php-toolkit/encoding",
-            "version": "v0.7.0",
+            "version": "v0.7.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-php-toolkit/encoding.git",
-                "reference": "14ce8b2fed7c1f259f31bde60a11e431ec7fc8c9"
+                "reference": "f333f2292d7f3c70a4c3f540012f3fe3da956bdf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-php-toolkit/encoding/zipball/14ce8b2fed7c1f259f31bde60a11e431ec7fc8c9",
-                "reference": "14ce8b2fed7c1f259f31bde60a11e431ec7fc8c9",
+                "url": "https://api.github.com/repos/wp-php-toolkit/encoding/zipball/f333f2292d7f3c70a4c3f540012f3fe3da956bdf",
+                "reference": "f333f2292d7f3c70a4c3f540012f3fe3da956bdf",
                 "shasum": ""
             },
             "require": {
@@ -154,29 +168,35 @@
                 }
             ],
             "description": "Encoding component for WordPress.",
+            "homepage": "https://wordpress.github.io/php-toolkit/reference/encoding.html",
+            "keywords": [
+                "php-toolkit",
+                "wordpress"
+            ],
             "support": {
-                "issues": "https://github.com/wp-php-toolkit/encoding/issues",
-                "source": "https://github.com/wp-php-toolkit/encoding/tree/v0.7.0"
+                "docs": "https://wordpress.github.io/php-toolkit/reference/encoding.html",
+                "issues": "https://github.com/WordPress/php-toolkit/issues",
+                "source": "https://github.com/WordPress/php-toolkit"
             },
-            "time": "2026-04-29T23:59:06+00:00"
+            "time": "2026-05-03T23:19:57+00:00"
         },
         {
             "name": "wp-php-toolkit/filesystem",
-            "version": "v0.7.0",
+            "version": "v0.7.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-php-toolkit/filesystem.git",
-                "reference": "0452bd4784287039b24cea5d760a6657b6c7998c"
+                "reference": "52e533feb3579f814bbdb936d53b4426aab84498"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-php-toolkit/filesystem/zipball/0452bd4784287039b24cea5d760a6657b6c7998c",
-                "reference": "0452bd4784287039b24cea5d760a6657b6c7998c",
+                "url": "https://api.github.com/repos/wp-php-toolkit/filesystem/zipball/52e533feb3579f814bbdb936d53b4426aab84498",
+                "reference": "52e533feb3579f814bbdb936d53b4426aab84498",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2",
-                "wp-php-toolkit/bytestream": "^0.7"
+                "wp-php-toolkit/bytestream": "^0.7.3"
             },
             "require-dev": {
                 "phpunit/phpunit": "^9.5"
@@ -186,9 +206,9 @@
                 "files": [
                     "functions.php"
                 ],
-                "psr-4": {
-                    "WordPress\\Filesystem\\": ""
-                },
+                "classmap": [
+                    "./"
+                ],
                 "exclude-from-classmap": [
                     "/Tests/"
                 ]
@@ -208,28 +228,94 @@
                 }
             ],
             "description": "Filesystem component for WordPress.",
+            "homepage": "https://wordpress.github.io/php-toolkit/reference/filesystem.html",
+            "keywords": [
+                "php-toolkit",
+                "wordpress"
+            ],
             "support": {
-                "issues": "https://github.com/wp-php-toolkit/filesystem/issues",
-                "source": "https://github.com/wp-php-toolkit/filesystem/tree/v0.7.0"
+                "docs": "https://wordpress.github.io/php-toolkit/reference/filesystem.html",
+                "issues": "https://github.com/WordPress/php-toolkit/issues",
+                "source": "https://github.com/WordPress/php-toolkit"
             },
-            "time": "2026-04-29T23:59:06+00:00"
+            "time": "2026-05-04T13:39:30+00:00"
         },
         {
             "name": "wp-php-toolkit/html",
-            "version": "v0.7.0",
+            "version": "v0.7.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-php-toolkit/html.git",
-                "reference": "bc02065e16da7b7a3072a0a63642b48d944e5c37"
+                "reference": "7ec3f8f4df9cc0f850eaa00655fb9ed21bf9ca4e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-php-toolkit/html/zipball/bc02065e16da7b7a3072a0a63642b48d944e5c37",
-                "reference": "bc02065e16da7b7a3072a0a63642b48d944e5c37",
+                "url": "https://api.github.com/repos/wp-php-toolkit/html/zipball/7ec3f8f4df9cc0f850eaa00655fb9ed21bf9ca4e",
+                "reference": "7ec3f8f4df9cc0f850eaa00655fb9ed21bf9ca4e",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.5"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "./"
+                ],
+                "exclude-from-classmap": [
+                    "/Tests/",
+                    "/html5-named-character-references.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Adam Zielinski",
+                    "email": "adam@adamziel.com"
+                },
+                {
+                    "name": "WordPress Team",
+                    "email": "wordpress@wordpress.org"
+                }
+            ],
+            "description": "HTML component for WordPress.",
+            "homepage": "https://wordpress.github.io/php-toolkit/reference/html.html",
+            "keywords": [
+                "php-toolkit",
+                "wordpress"
+            ],
+            "support": {
+                "docs": "https://wordpress.github.io/php-toolkit/reference/html.html",
+                "issues": "https://github.com/WordPress/php-toolkit/issues",
+                "source": "https://github.com/WordPress/php-toolkit"
+            },
+            "time": "2026-05-03T23:19:57+00:00"
+        },
+        {
+            "name": "wp-php-toolkit/http-client",
+            "version": "v0.7.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/wp-php-toolkit/http-client.git",
+                "reference": "c956d60d0983799d25d6761db1454942bdc19e4d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/wp-php-toolkit/http-client/zipball/c956d60d0983799d25d6761db1454942bdc19e4d",
+                "reference": "c956d60d0983799d25d6761db1454942bdc19e4d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2",
+                "wp-php-toolkit/bytestream": "^0.7.3",
+                "wp-php-toolkit/data-liberation": "^0.7.3",
+                "wp-php-toolkit/filesystem": "^0.7.3"
             },
             "require-dev": {
                 "phpunit/phpunit": "^9.5"
@@ -257,65 +343,18 @@
                     "email": "wordpress@wordpress.org"
                 }
             ],
-            "description": "HTML component for WordPress.",
-            "support": {
-                "issues": "https://github.com/wp-php-toolkit/html/issues",
-                "source": "https://github.com/wp-php-toolkit/html/tree/v0.7.0"
-            },
-            "time": "2026-04-29T23:59:06+00:00"
-        },
-        {
-            "name": "wp-php-toolkit/http-client",
-            "version": "v0.7.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/wp-php-toolkit/http-client.git",
-                "reference": "35eeea11f95801e8d1d788a3301b6cb880373b32"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/wp-php-toolkit/http-client/zipball/35eeea11f95801e8d1d788a3301b6cb880373b32",
-                "reference": "35eeea11f95801e8d1d788a3301b6cb880373b32",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.2",
-                "wp-php-toolkit/bytestream": "^0.7",
-                "wp-php-toolkit/data-liberation": "^0.7",
-                "wp-php-toolkit/filesystem": "^0.7"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.5"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "WordPress\\HttpClient\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "GPL-2.0-or-later"
-            ],
-            "authors": [
-                {
-                    "name": "Adam Zielinski",
-                    "email": "adam@adamziel.com"
-                },
-                {
-                    "name": "WordPress Team",
-                    "email": "wordpress@wordpress.org"
-                }
-            ],
             "description": "HttpClient component for WordPress.",
+            "homepage": "https://wordpress.github.io/php-toolkit/reference/httpclient.html",
+            "keywords": [
+                "php-toolkit",
+                "wordpress"
+            ],
             "support": {
-                "issues": "https://github.com/wp-php-toolkit/http-client/issues",
-                "source": "https://github.com/wp-php-toolkit/http-client/tree/v0.7.0"
+                "docs": "https://wordpress.github.io/php-toolkit/reference/httpclient.html",
+                "issues": "https://github.com/WordPress/php-toolkit/issues",
+                "source": "https://github.com/WordPress/php-toolkit"
             },
-            "time": "2026-04-29T23:59:06+00:00"
+            "time": "2026-05-04T13:39:30+00:00"
         },
         {
             "name": "wp-php-toolkit/reprint-exporter",
@@ -389,21 +428,21 @@
         },
         {
             "name": "wp-php-toolkit/xml",
-            "version": "v0.7.0",
+            "version": "v0.7.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-php-toolkit/xml.git",
-                "reference": "650fd70a788fa4189126aed79676c70ca69500d2"
+                "reference": "023c17dcc0165f65e28d7633f7fa306350105c04"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-php-toolkit/xml/zipball/650fd70a788fa4189126aed79676c70ca69500d2",
-                "reference": "650fd70a788fa4189126aed79676c70ca69500d2",
+                "url": "https://api.github.com/repos/wp-php-toolkit/xml/zipball/023c17dcc0165f65e28d7633f7fa306350105c04",
+                "reference": "023c17dcc0165f65e28d7633f7fa306350105c04",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2",
-                "wp-php-toolkit/encoding": "^0.7"
+                "wp-php-toolkit/encoding": "^0.7.3"
             },
             "require-dev": {
                 "phpunit/phpunit": "^9.5"
@@ -432,11 +471,17 @@
                 }
             ],
             "description": "XML component for WordPress.",
+            "homepage": "https://wordpress.github.io/php-toolkit/reference/xml.html",
+            "keywords": [
+                "php-toolkit",
+                "wordpress"
+            ],
             "support": {
-                "issues": "https://github.com/wp-php-toolkit/xml/issues",
-                "source": "https://github.com/wp-php-toolkit/xml/tree/v0.7.0"
+                "docs": "https://wordpress.github.io/php-toolkit/reference/xml.html",
+                "issues": "https://github.com/WordPress/php-toolkit/issues",
+                "source": "https://github.com/WordPress/php-toolkit"
             },
-            "time": "2026-04-29T23:59:06+00:00"
+            "time": "2026-05-04T13:39:30+00:00"
         }
     ],
     "packages-dev": [
@@ -2414,5 +2459,5 @@
         "ext-pdo_mysql": "*"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/packages/reprint-exporter/composer.json
+++ b/packages/reprint-exporter/composer.json
@@ -7,8 +7,8 @@
         "php": ">=7.4",
         "ext-pdo": "*",
         "ext-pdo_mysql": "*",
-        "wp-php-toolkit/data-liberation": "^0.7.2",
-        "wp-php-toolkit/html": "^0.7.2"
+        "wp-php-toolkit/data-liberation": "^0.7.3",
+        "wp-php-toolkit/html": "^0.7.3"
     },
     "autoload": {
         "psr-4": {

--- a/packages/reprint-importer/composer.json
+++ b/packages/reprint-importer/composer.json
@@ -7,8 +7,8 @@
         "php": ">=7.4",
         "ext-pdo": "*",
         "ext-pdo_mysql": "*",
-        "wp-php-toolkit/data-liberation": "^0.7.2",
-        "wp-php-toolkit/html": "^0.7.2",
+        "wp-php-toolkit/data-liberation": "^0.7.3",
+        "wp-php-toolkit/html": "^0.7.3",
         "wp-php-toolkit/reprint-exporter": "*@dev"
     },
     "bin": [


### PR DESCRIPTION
## Summary

Picks up [wp-php-toolkit v0.7.3](https://github.com/WordPress/php-toolkit/releases/tag/v0.7.3), which fixed the published-package autoload regressions caught by WordPress/php-toolkit#264. The most relevant fixes for reprint:

- data-liberation@0.7.3 now correctly declares its dependency on wp-php-toolkit/html
- polyfill@0.7.3 no longer eagerly declares WP_Error through autoload.files
- Various optional integrations bundled in vendored Symfony / webuni packages are excluded from the classmap

## Changes

- packages/reprint-exporter/composer.json: ^0.7.2 -> ^0.7.3 for data-liberation and html
- packages/reprint-importer/composer.json: same
- composer.lock refreshed; all transitive toolkit packages resolve to v0.7.3

## Test plan

- [x] composer update wp-php-toolkit/data-liberation wp-php-toolkit/html resolves cleanly to v0.7.3 across all transitive packages
- [x] composer compat (PHP 7.4 compatibility) passes
- [x] ExportLibraryLoadTest and BuildPdoDsnTest pass locally
- [ ] PHPUnit matrix green on CI