### PR TITLE
Use Rust SQLite parser extension in Playground CI

### DIFF
--- a/.github/workflows/e2e-playground.yml
+++ b/.github/workflows/e2e-playground.yml
@@ -33,6 +33,9 @@ jobs:
     needs: build-phar
     runs-on: ubuntu-22.04
     timeout-minutes: 60
+    env:
+      PLAYGROUND_PHP_VERSION: '8.3'
+      WP_MYSQL_PARSER_EXTENSION_MANIFEST: https://wordpress.github.io/sqlite-database-integration/wp_mysql_parser-wasm-extension/latest/manifest.json
 
     steps:
       - uses: actions/checkout@v4
@@ -45,10 +48,10 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "24"
 
       # The export side still needs real PHP-FPM + nginx.
-      # Use PHP 8.2 for the server; the importer will use Playground CLI's PHP 8.0.
+      # Use PHP 8.2 for the server; the importer runs under PHP.wasm.
       # PHP comes from the runner's pre-cached toolcache via this
       # action; we don't try to apt-install ondrej/php ourselves
       # because every Launchpad endpoint flakes regularly.
@@ -82,6 +85,13 @@ jobs:
           echo "=== Test PHAR with mount ==="
           npx @wp-playground/cli php --mount="${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE}" -- "${GITHUB_WORKSPACE}/reprint.phar" --help || echo "EXIT: $?"
 
+      - name: Verify wp_mysql_parser extension is selected
+        env:
+          PHP_BINARY: ${{ github.workspace }}/tests/e2e/ci/playground-php.sh
+        run: |
+          output="$("$PHP_BINARY" "${GITHUB_WORKSPACE}/tests/e2e/ci/verify-wp-mysql-parser.php" "${GITHUB_WORKSPACE}" parser)"
+          echo "$output"
+
       - name: Provision basic site and smoke-test API
         env:
           IMPORTER_PATH: ${{ github.workspace }}/reprint.phar
@@ -107,7 +117,7 @@ jobs:
           DIR="/srv/e2e-sites/basic"
 
           echo "=== Playground CLI importer preflight ==="
-          timeout 60 "$PHP_BINARY" "$IMPORTER_PATH" preflight "${BASE}&directory=${DIR}" /tmp/e2e-smoke --secret="${SECRET}" 2>&1 | head -50 || echo "EXIT: $?"
+          timeout 120 "$PHP_BINARY" "$IMPORTER_PATH" preflight "${BASE}&directory=${DIR}" /tmp/e2e-smoke --secret="${SECRET}" 2>&1 | head -50 || echo "EXIT: $?"
 
       - name: Run E2E tests
         env:

--- a/.github/workflows/perf-report.yml
+++ b/.github/workflows/perf-report.yml
@@ -97,7 +97,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
 
       # PHP comes from the runner's pre-cached toolcache via this
       # action; we don't try to apt-install ondrej/php ourselves
@@ -139,6 +139,14 @@ jobs:
           BENCH_MD_OUT: bench-pr.md
           BENCH_STAGES: ${{ steps.stages.outputs.stages }}
           E2E_EXPORTER_PROJECT_ROOT: ${{ github.workspace }}
+          # Keep the PHP.wasm SQLite benchmark large enough to exercise the
+          # parser without pushing a PR check into the workflow timeout.
+          BENCH_SEED_POSTS: '10000'
+          BENCH_SEED_POSTMETA: '25000'
+          BENCH_PLAYGROUND_PHP_BINARY: ${{ github.workspace }}/tests/e2e/ci/playground-php.sh
+          PLAYGROUND_PHP_USE_WASM_RUNNER: '1'
+          PLAYGROUND_PHP_VERSION: '8.3'
+          WP_MYSQL_PARSER_EXTENSION_MANIFEST: https://wordpress.github.io/sqlite-database-integration/wp_mysql_parser-wasm-extension/latest/manifest.json
         run: node benchmark/bench-pull.mjs
 
       - name: Reset benchmark sites before trunk
@@ -155,6 +163,11 @@ jobs:
           BENCH_MD_OUT: bench-trunk.md
           BENCH_STAGES: ${{ steps.stages.outputs.stages }}
           E2E_EXPORTER_PROJECT_ROOT: ${{ github.workspace }}/trunk-exporter
+          BENCH_SEED_POSTS: '10000'
+          BENCH_SEED_POSTMETA: '25000'
+          BENCH_PLAYGROUND_PHP_BINARY: ${{ github.workspace }}/tests/e2e/ci/playground-php.sh
+          PLAYGROUND_PHP_USE_WASM_RUNNER: '1'
+          PLAYGROUND_PHP_VERSION: '8.3'
         # Don't fail the whole job if trunk's bench fails — we still want
         # to publish the PR's numbers.
         continue-on-error: true

--- a/.github/workflows/perf-report.yml
+++ b/.github/workflows/perf-report.yml
@@ -64,13 +64,6 @@ jobs:
         with:
           submodules: true
 
-      - name: Checkout trunk exporter baseline
-        uses: actions/checkout@v5
-        with:
-          ref: trunk
-          path: trunk-exporter
-          submodules: true
-
       - name: Resolve focused bench stages
         id: stages
         run: |
@@ -113,11 +106,6 @@ jobs:
 
       - name: Setup test sites
         run: tests/e2e/setup.sh
-
-      - name: Install trunk exporter dependencies
-        run: |
-          composer install --no-dev --no-interaction --prefer-dist --working-dir=trunk-exporter
-          composer install --no-dev --no-interaction --prefer-dist --working-dir=trunk-exporter/reprint-exporter-wp
 
       - name: Install e2e dependencies
         working-directory: tests/e2e
@@ -162,9 +150,10 @@ jobs:
           BENCH_JSON_OUT: bench-trunk.json
           BENCH_MD_OUT: bench-trunk.md
           BENCH_STAGES: ${{ steps.stages.outputs.stages }}
-          E2E_EXPORTER_PROJECT_ROOT: ${{ github.workspace }}/trunk-exporter
+          E2E_EXPORTER_PROJECT_ROOT: ${{ github.workspace }}
           BENCH_SEED_POSTS: '10000'
           BENCH_SEED_POSTMETA: '25000'
+          BENCH_PREFLIGHT_IMPORTER_PATH: ${{ github.workspace }}/phars/pr/reprint.phar
           BENCH_PLAYGROUND_PHP_BINARY: ${{ github.workspace }}/tests/e2e/ci/playground-php.sh
           PLAYGROUND_PHP_USE_WASM_RUNNER: '1'
           PLAYGROUND_PHP_VERSION: '8.3'

--- a/README.md
+++ b/README.md
@@ -412,6 +412,16 @@ INI values), SiteGround, and a generic default.
 Currently supported target runtimes: nginx + PHP-FPM, PHP's built-in
 development server, and WordPress Playground CLI.
 
+For Playground CI, set `PHP_BINARY=tests/e2e/ci/playground-php.sh`. The wrapper
+delegates to `@wp-playground/cli php` by default. When
+`WP_MYSQL_PARSER_EXTENSION_MANIFEST` is set, it runs the local `@php-wasm/node`
+runner instead so it can load the SQLite Integration plugin's Rust
+`wp_mysql_parser` PHP.wasm extension. CI verifies that this path does more than
+load the `.so`: `tests/e2e/ci/verify-wp-mysql-parser.php` asserts that
+`WP_MySQL_Lexer` resolves to the native lexer and that the SQLite driver creates
+a native-backed parser before benchmarking Playground `db-pull` and `db-apply`.
+That path requires Node.js with JSPI support; CI uses Node 24.
+
 #### Shoehorning the site onto your platform
 
 You've got a copy of the remote files in the `--fs-root` directory and

--- a/bin/build-reprint-phar.sh
+++ b/bin/build-reprint-phar.sh
@@ -22,7 +22,7 @@ if ! command -v php >/dev/null 2>&1; then
 fi
 
 # Verify the submodule is initialised
-if [ ! -f "$PROJECT_ROOT/lib/sqlite-database-integration/wp-includes/parser/class-wp-parser.php" ]; then
+if [ ! -f "$PROJECT_ROOT/lib/sqlite-database-integration/packages/mysql-on-sqlite/src/parser/class-wp-parser.php" ]; then
     echo "Error: sqlite-database-integration submodule not initialised." >&2
     echo "Run: git submodule update --init" >&2
     exit 1

--- a/box.json
+++ b/box.json
@@ -22,28 +22,17 @@
         },
         {
             "name": "*.php",
-            "in": "lib/sqlite-database-integration/wp-includes/parser"
+            "in": "lib/sqlite-database-integration/packages/mysql-on-sqlite/src"
         },
         {
             "name": "*.php",
-            "in": "lib/sqlite-database-integration/wp-includes/mysql"
-        },
-        {
-            "name": "*.php",
-            "in": "lib/sqlite-database-integration/wp-includes/sqlite"
-        },
-        {
-            "name": "*.php",
-            "in": "lib/sqlite-database-integration/wp-includes/sqlite-ast"
+            "in": "lib/sqlite-database-integration/packages/plugin-sqlite-database-integration"
         }
     ],
 
     "files": [
         "packages/reprint-importer/src/VERSION",
-        "lib/sqlite-database-integration/constants.php",
-        "lib/sqlite-database-integration/php-polyfills.php",
         "lib/sqlite-database-integration/wp-pdo-mysql-on-sqlite.php",
-        "lib/sqlite-database-integration/version.php",
         "vendor/autoload.php"
     ],
 

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -165,15 +165,44 @@ register_shutdown_function(function () {
 
 function resolve_sqlite_integration_path(string $suffix = ''): string
 {
+    $suffixes = [$suffix];
+    $moved_paths = [
+        '/php-polyfills.php' => '/packages/mysql-on-sqlite/src/php-polyfills.php',
+        '/version.php' => '/packages/mysql-on-sqlite/src/version.php',
+    ];
+    if (isset($moved_paths[$suffix])) {
+        $suffixes[] = $moved_paths[$suffix];
+    }
+
     foreach ([dirname(__DIR__, 3), dirname(__DIR__, 4)] as $project_root) {
-        $candidate = $project_root . '/lib/sqlite-database-integration' . $suffix;
-        if (file_exists($candidate)) {
-            return $candidate;
+        foreach ($suffixes as $candidate_suffix) {
+            $candidate = $project_root . '/lib/sqlite-database-integration' . $candidate_suffix;
+            if (file_exists($candidate)) {
+                return $candidate;
+            }
         }
     }
 
     throw new RuntimeException(
         'SQLite target support requires lib/sqlite-database-integration to be initialized.'
+    );
+}
+
+function resolve_sqlite_integration_plugin_path(): string
+{
+    foreach ([dirname(__DIR__, 3), dirname(__DIR__, 4)] as $project_root) {
+        $root = $project_root . '/lib/sqlite-database-integration';
+        $package = $root . '/packages/plugin-sqlite-database-integration';
+        if (is_dir($package)) {
+            return $package;
+        }
+        if (is_dir($root . '/wp-includes/sqlite')) {
+            return $root;
+        }
+    }
+
+    throw new RuntimeException(
+        'SQLite runtime support requires lib/sqlite-database-integration to be initialized.'
     );
 }
 
@@ -3906,7 +3935,7 @@ class ImportClient
                 $db_file = '.ht.sqlite';
             }
             $manifest->sqlite = [
-                'plugin_source' => resolve_sqlite_integration_path(),
+                'plugin_source' => resolve_sqlite_integration_plugin_path(),
                 'plugin_dir' => '',  // resolved after copy_sqlite_plugin()
                 'db_dir' => $db_dir,
                 'db_file' => $db_file,
@@ -4788,24 +4817,19 @@ class ImportClient
             );
         }
 
-        // The bundled wp-pdo-mysql-on-sqlite.php require_onces a fixed
-        // set of class files relative to its own dirname. When the host
-        // already loaded a *different* copy of those same classes
-        // (notably WordPress Playground's auto_prepend, which preloads
-        // /internal/shared/sqlite-database-integration), each class
-        // declaration in the bundled tree throws a fatal "name already
-        // in use". The require_once path-guard doesn't help because the
-        // two trees live at different paths. Skip the loader entirely
-        // when the host's copy is already in memory — both trees expose
-        // the same class names, so the existing instance is fine.
+        // The bundled loader require_onces a fixed set of class files
+        // relative to its own dirname. When the host already loaded a
+        // different copy of those same classes (notably WordPress
+        // Playground's auto_prepend), each class declaration would throw
+        // a fatal "name already in use". Skip the loader entirely when the
+        // host's copy is already in memory — both trees expose the same
+        // public class names, so the existing instance is fine.
         $driver_loader = resolve_sqlite_integration_path("/wp-pdo-mysql-on-sqlite.php");
-        $polyfills = resolve_sqlite_integration_path("/php-polyfills.php");
         if (
             class_exists("WP_PDO_MySQL_On_SQLite", false) &&
             class_exists("WP_Parser_Grammar", false)
         ) {
             $driver_loader = null;
-            $polyfills = null;
         }
 
         if ($target_path !== ':memory:') {
@@ -4819,7 +4843,6 @@ class ImportClient
             }
         }
 
-        if ($polyfills !== null)     { require_once $polyfills; }
         if ($driver_loader !== null) { require_once $driver_loader; }
 
         $dsn = sprintf(

--- a/packages/reprint-importer/src/lib/mysql-query-stream/load.php
+++ b/packages/reprint-importer/src/lib/mysql-query-stream/load.php
@@ -3,41 +3,33 @@
  * Loader for MySQL lexer, parser, and query stream classes.
  *
  * The lexer, parser, and grammar come from the WordPress/sqlite-database-integration
- * submodule at lib/sqlite-database-integration/. The naive query stream is local
- * to this project.
+ * submodule at lib/sqlite-database-integration/. Its root loader selects the
+ * optional native Rust parser classes when the wp_mysql_parser extension is
+ * loaded and falls back to the pure-PHP parser otherwise. The query streams are
+ * local to this project.
  *
  * If you see "failed to open stream" errors, run:
  *   git submodule update --init
  */
 
-$sdi = null;
+$sdi_loader = null;
 foreach ([
-    dirname(__DIR__, 5) . '/lib/sqlite-database-integration/wp-includes',
-    dirname(__DIR__, 6) . '/lib/sqlite-database-integration/wp-includes',
+    dirname(__DIR__, 5) . '/lib/sqlite-database-integration/wp-pdo-mysql-on-sqlite.php',
+    dirname(__DIR__, 6) . '/lib/sqlite-database-integration/wp-pdo-mysql-on-sqlite.php',
 ] as $candidate) {
-    if (file_exists($candidate . '/parser/class-wp-parser-token.php')) {
-        $sdi = $candidate;
+    if (file_exists($candidate)) {
+        $sdi_loader = $candidate;
         break;
     }
 }
 
-if ($sdi === null) {
+if ($sdi_loader === null) {
     throw new RuntimeException(
         'sqlite-database-integration is missing. Run: git submodule update --init'
     );
 }
 
-// Generic parser framework
-require_once $sdi . '/parser/class-wp-parser-token.php';
-require_once $sdi . '/parser/class-wp-parser-node.php';
-require_once $sdi . '/parser/class-wp-parser-grammar.php';
-require_once $sdi . '/parser/class-wp-parser.php';
-
-// MySQL lexer and parser
-require_once $sdi . '/mysql/mysql-grammar.php';
-require_once $sdi . '/mysql/class-wp-mysql-token.php';
-require_once $sdi . '/mysql/class-wp-mysql-lexer.php';
-require_once $sdi . '/mysql/class-wp-mysql-parser.php';
+require_once $sdi_loader;
 
 // Local: naive query stream (not part of the submodule)
 require_once __DIR__ . '/class-wp-mysql-naive-query-stream.php';

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -17,6 +17,7 @@ parameters:
             - reprint-exporter-wp/wordpress/
             - reprint-exporter-wp/index.php
             - reprint-exporter-wp/vendor/
+            - lib/sqlite-database-integration/packages/mysql-on-sqlite/src/mysql/native/
         analyse:
             - packages/reprint-exporter/src/class-sqlite-driver-pdo.php
             - packages/reprint-importer/src/lib/mysql-query-stream/
@@ -24,7 +25,6 @@ parameters:
     treatPhpDocTypesAsCertain: false
     scanDirectories:
         - packages/reprint-exporter/src
-        - lib/sqlite-database-integration/wp-includes/parser
-        - lib/sqlite-database-integration/wp-includes/mysql
-        - lib/sqlite-database-integration/wp-includes/sqlite
-        - lib/sqlite-database-integration/wp-includes/sqlite-ast
+        - lib/sqlite-database-integration/packages/mysql-on-sqlite/src/parser
+        - lib/sqlite-database-integration/packages/mysql-on-sqlite/src/mysql
+        - lib/sqlite-database-integration/packages/mysql-on-sqlite/src/sqlite

--- a/tests/e2e/benchmark/bench-pull.mjs
+++ b/tests/e2e/benchmark/bench-pull.mjs
@@ -44,7 +44,10 @@ const SEED_POSTMETA = Number(process.env.BENCH_SEED_POSTMETA || 720_015);
 const PHP_BINARY = process.env.PHP_BINARY || 'php';
 const PROJECT_ROOT = join(import.meta.dirname, '..', '..', '..');
 const IMPORTER_PATH = process.env.IMPORTER_PATH || join(PROJECT_ROOT, 'importer', 'import.php');
+const PLAYGROUND_PHP_BINARY = process.env.BENCH_PLAYGROUND_PHP_BINARY || join(PROJECT_ROOT, 'tests', 'e2e', 'ci', 'playground-php.sh');
+const PLAYGROUND_PHP_VERSION = process.env.PLAYGROUND_PHP_VERSION || '8.3';
 const REGISTRY = JSON.parse(readFileSync(join(import.meta.dirname, '..', 'site-registry.json'), 'utf-8'));
+const MYSQL_PARSER_MANIFEST = process.env.WP_MYSQL_PARSER_EXTENSION_MANIFEST || '';
 
 async function seedSourceDb() {
     const dbName = `e2e_${SITE.replace(/-/g, '_')}`;
@@ -132,7 +135,7 @@ async function provisionDatabase() {
     await conn.end();
 }
 
-function runStage(stage, stateDir, extraArgs = [], { includeUrl = true } = {}) {
+function runStage(stage, stateDir, extraArgs = [], { includeUrl = true, phpBinary = PHP_BINARY, env = {} } = {}) {
     const url = `${getSiteUrl(SITE)}&directory=${getSiteDir(SITE)}`;
     const args = [
         IMPORTER_PATH,
@@ -153,11 +156,12 @@ function runStage(stage, stateDir, extraArgs = [], { includeUrl = true } = {}) {
     while (true) {
         attempts += 1;
         try {
-            execFileSync(PHP_BINARY, args, {
+            execFileSync(phpBinary, args, {
                 timeout: 900_000,
                 encoding: 'utf-8',
                 maxBuffer: 64 * 1024 * 1024,
                 stdio: ['ignore', 'pipe', 'pipe'],
+                env: { ...process.env, ...env },
             });
             const elapsedMs = performance.now() - start;
             return { stage, elapsedMs, attempts, ok: true };
@@ -175,6 +179,165 @@ function runStage(stage, stateDir, extraArgs = [], { includeUrl = true } = {}) {
             };
         }
     }
+}
+
+function requireBenchStageOk(result, context) {
+    if (result.ok) {
+        return;
+    }
+
+    throw new Error(
+        `${context} failed with exit ${result.exitCode}\n` +
+        `stderr:\n${result.stderr || ''}\nstdout:\n${result.stdout || ''}`,
+    );
+}
+
+function playgroundPhpEnv() {
+    return {
+        PLAYGROUND_PHP_USE_WASM_RUNNER: '1',
+        PLAYGROUND_PHP_VERSION,
+    };
+}
+
+function runNativeMysqlParserProof({ requireParser }) {
+    if (!MYSQL_PARSER_MANIFEST) {
+        return {
+            ok: true,
+            details: {
+                wp_mysql_parser: 'disabled',
+                native_lexer: 'not requested',
+                native_parser: 'not requested',
+            },
+        };
+    }
+
+    const mode = requireParser ? 'parser' : 'lexer';
+    const verifierPath = join(PROJECT_ROOT, 'tests', 'e2e', 'ci', 'verify-wp-mysql-parser.php');
+
+    try {
+        const stdout = execFileSync(PLAYGROUND_PHP_BINARY, [verifierPath, PROJECT_ROOT, mode], {
+            cwd: PROJECT_ROOT,
+            timeout: 120_000,
+            encoding: 'utf-8',
+            maxBuffer: 16 * 1024 * 1024,
+            stdio: ['ignore', 'pipe', 'pipe'],
+            env: { ...process.env, ...playgroundPhpEnv() },
+        }).trim();
+        return {
+            ok: true,
+            details: stdout ? JSON.parse(stdout) : {},
+        };
+    } catch (e) {
+        return {
+            ok: false,
+            exitCode: e.status === null ? -1 : (e.status || 1),
+            stderr: (e.stderr || '').toString().slice(-4000),
+            stdout: (e.stdout || '').toString().slice(-4000),
+        };
+    }
+}
+
+function proofFailureResult(stage, start, proof, details) {
+    return {
+        stage,
+        elapsedMs: performance.now() - start,
+        attempts: 0,
+        ok: false,
+        exitCode: proof.exitCode || 1,
+        stderr: proof.stderr || '',
+        stdout: proof.stdout || '',
+        details: {
+            ...details,
+            wp_mysql_parser: MYSQL_PARSER_MANIFEST ? 'enabled' : 'disabled',
+            native_parser_proof: 'failed',
+        },
+    };
+}
+
+function runPlaygroundSqliteDbPullBenchmark() {
+    const start = performance.now();
+    const stateDir = join(tmpdir(), `bench-playground-sqlite-db-pull-${Date.now()}`);
+    mkdirSync(stateDir, { recursive: true });
+    mkdirSync(fsRootDir(stateDir), { recursive: true });
+
+    requireBenchStageOk(
+        runStage('preflight', stateDir),
+        'playground sqlite benchmark preflight',
+    );
+    const proof = runNativeMysqlParserProof({ requireParser: false });
+    const baseDetails = {
+        condition: 'db-pull in PHP.wasm',
+        runtime: `php.wasm ${PLAYGROUND_PHP_VERSION}`,
+        wp_mysql_parser: MYSQL_PARSER_MANIFEST ? 'enabled' : 'disabled',
+    };
+    if (!proof.ok) {
+        return proofFailureResult('playground-sqlite-db-pull', start, proof, baseDetails);
+    }
+
+    const result = runStage('db-pull', stateDir, [], {
+        phpBinary: PLAYGROUND_PHP_BINARY,
+        env: playgroundPhpEnv(),
+    });
+
+    return {
+        ...result,
+        stage: 'playground-sqlite-db-pull',
+        details: {
+            ...baseDetails,
+            ...proof.details,
+        },
+    };
+}
+
+function runPlaygroundSqliteDbApplyBenchmark() {
+    const start = performance.now();
+    const stateDir = join(tmpdir(), `bench-playground-sqlite-db-apply-${Date.now()}`);
+    mkdirSync(stateDir, { recursive: true });
+    mkdirSync(fsRootDir(stateDir), { recursive: true });
+
+    requireBenchStageOk(
+        runStage('preflight', stateDir),
+        'playground sqlite benchmark preflight',
+    );
+    requireBenchStageOk(
+        runStage('db-pull', stateDir),
+        'playground sqlite benchmark db-pull',
+    );
+    const proof = runNativeMysqlParserProof({ requireParser: true });
+    const baseDetails = {
+        condition: 'db-apply to SQLite in PHP.wasm',
+        runtime: `php.wasm ${PLAYGROUND_PHP_VERSION}`,
+        wp_mysql_parser: MYSQL_PARSER_MANIFEST ? 'enabled' : 'disabled',
+    };
+    if (!proof.ok) {
+        return proofFailureResult('playground-sqlite-db-apply', start, proof, baseDetails);
+    }
+
+    const sqlitePath = join(
+        fsRootDir(stateDir),
+        getSiteDir(SITE),
+        'wp-content',
+        'database',
+        'bench-playground.sqlite',
+    );
+    const result = runStage('db-apply', stateDir, [
+        '--target-engine=sqlite',
+        `--target-sqlite-path=${sqlitePath}`,
+        '--target-db=playground_sqlite_bench',
+        '--new-site-url=http://localhost:9999',
+    ], {
+        phpBinary: PLAYGROUND_PHP_BINARY,
+        env: playgroundPhpEnv(),
+    });
+
+    return {
+        ...result,
+        stage: 'playground-sqlite-db-apply',
+        details: {
+            ...baseDetails,
+            ...proof.details,
+        },
+    };
 }
 
 function fmtMs(ms) {
@@ -480,6 +643,28 @@ async function main() {
         if (!r.ok) {
             console.error(`   stderr (tail):\n${r.stderr}`);
             console.error(`   stdout (tail):\n${r.stdout}`);
+        }
+    }
+
+    if (shouldRun('playground-sqlite-db-pull')) {
+        console.log('-> playground-sqlite-db-pull');
+        const playgroundSqlitePull = runPlaygroundSqliteDbPullBenchmark();
+        results.push(playgroundSqlitePull);
+        console.log(`   ${playgroundSqlitePull.ok ? 'ok' : 'FAIL'} in ${fmtMs(playgroundSqlitePull.elapsedMs)} (${fmtDetails(playgroundSqlitePull.details)})`);
+        if (!playgroundSqlitePull.ok) {
+            console.error(`   stderr (tail):\n${playgroundSqlitePull.stderr}`);
+            console.error(`   stdout (tail):\n${playgroundSqlitePull.stdout}`);
+        }
+    }
+
+    if (shouldRun('playground-sqlite-db-apply')) {
+        console.log('-> playground-sqlite-db-apply');
+        const playgroundSqliteApply = runPlaygroundSqliteDbApplyBenchmark();
+        results.push(playgroundSqliteApply);
+        console.log(`   ${playgroundSqliteApply.ok ? 'ok' : 'FAIL'} in ${fmtMs(playgroundSqliteApply.elapsedMs)} (${fmtDetails(playgroundSqliteApply.details)})`);
+        if (!playgroundSqliteApply.ok) {
+            console.error(`   stderr (tail):\n${playgroundSqliteApply.stderr}`);
+            console.error(`   stdout (tail):\n${playgroundSqliteApply.stdout}`);
         }
     }
 

--- a/tests/e2e/benchmark/bench-pull.mjs
+++ b/tests/e2e/benchmark/bench-pull.mjs
@@ -44,6 +44,7 @@ const SEED_POSTMETA = Number(process.env.BENCH_SEED_POSTMETA || 720_015);
 const PHP_BINARY = process.env.PHP_BINARY || 'php';
 const PROJECT_ROOT = join(import.meta.dirname, '..', '..', '..');
 const IMPORTER_PATH = process.env.IMPORTER_PATH || join(PROJECT_ROOT, 'importer', 'import.php');
+const PREFLIGHT_IMPORTER_PATH = process.env.BENCH_PREFLIGHT_IMPORTER_PATH || IMPORTER_PATH;
 const PLAYGROUND_PHP_BINARY = process.env.BENCH_PLAYGROUND_PHP_BINARY || join(PROJECT_ROOT, 'tests', 'e2e', 'ci', 'playground-php.sh');
 const PLAYGROUND_PHP_VERSION = process.env.PLAYGROUND_PHP_VERSION || '8.3';
 const REGISTRY = JSON.parse(readFileSync(join(import.meta.dirname, '..', 'site-registry.json'), 'utf-8'));
@@ -137,8 +138,9 @@ async function provisionDatabase() {
 
 function runStage(stage, stateDir, extraArgs = [], { includeUrl = true, phpBinary = PHP_BINARY, env = {} } = {}) {
     const url = `${getSiteUrl(SITE)}&directory=${getSiteDir(SITE)}`;
+    const importerPath = stage === 'preflight' ? PREFLIGHT_IMPORTER_PATH : IMPORTER_PATH;
     const args = [
-        IMPORTER_PATH,
+        importerPath,
         stage,
         ...(includeUrl ? [url] : []),
         `--state-dir=${stateDir}`,
@@ -733,6 +735,7 @@ async function main() {
         seedPostmeta: SEED_POSTMETA,
         phpVersion,
         importer: IMPORTER_PATH,
+        preflightImporter: PREFLIGHT_IMPORTER_PATH,
     };
     const md = renderMarkdown(results, meta);
     console.log('\n' + md);

--- a/tests/e2e/benchmark/focused-stages.txt
+++ b/tests/e2e/benchmark/focused-stages.txt
@@ -3,8 +3,8 @@
 # Both the PR build and the trunk baseline run the same set, so the
 # table shows two like-for-like wall-time numbers per row.
 #
-# This PR streams multipart file bodies directly to disk, so the
-# relevant scenario is a single oversized multipart part — the
-# per-stage details include importer peak memory, which is the
-# real signal for the streaming change.
-files-pull-large-part-peak-memory
+# This PR loads the Rust wp_mysql_parser PHP.wasm extension for the PR side
+# and leaves it disabled for the trunk baseline. Both sides use the same
+# direct PHP.wasm runner so the wall-time delta isolates the extension.
+playground-sqlite-db-pull
+playground-sqlite-db-apply

--- a/tests/e2e/ci/php-wasm-runner.mjs
+++ b/tests/e2e/ci/php-wasm-runner.mjs
@@ -1,0 +1,156 @@
+#!/usr/bin/env node
+import { createNodeFsMountHandler, loadNodeRuntime } from '@php-wasm/node';
+import { PHP } from '@php-wasm/universal';
+import { spawn } from 'node:child_process';
+import { existsSync, statSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+
+const DEFAULT_PHP_VERSION = '8.3';
+const MYSQL_PARSER_MANIFEST_ENV = 'WP_MYSQL_PARSER_EXTENSION_MANIFEST';
+
+function envRecord() {
+    return Object.fromEntries(
+        Object.entries(process.env).filter(([, value]) => typeof value === 'string'),
+    );
+}
+
+function extractAbsolutePaths(arg) {
+    const paths = new Set();
+    if (arg.startsWith('/')) {
+        paths.add(arg);
+    }
+
+    for (const match of arg.matchAll(/(?:^|[=,&])(?<path>\/[^,;&\s]+)/g)) {
+        paths.add(match.groups.path);
+    }
+    return paths;
+}
+
+function existingDirectory(pathCandidate) {
+    let current;
+    try {
+        current = resolve(pathCandidate);
+    } catch {
+        return null;
+    }
+
+    while (!existsSync(current)) {
+        const parent = dirname(current);
+        if (parent === current) {
+            return null;
+        }
+        current = parent;
+    }
+
+    try {
+        const stat = statSync(current);
+        return stat.isDirectory() ? current : dirname(current);
+    } catch {
+        return null;
+    }
+}
+
+function isSameOrChild(child, parent) {
+    return child === parent || child.startsWith(`${parent}/`);
+}
+
+function mountRootFor(pathCandidate) {
+    const existing = existingDirectory(pathCandidate);
+    if (!existing) {
+        return null;
+    }
+
+    for (const root of ['/tmp', '/srv']) {
+        if (isSameOrChild(existing, root) && existsSync(root)) {
+            return root;
+        }
+    }
+
+    const parts = existing.split('/').filter(Boolean);
+    if (parts.length >= 2) {
+        const root = `/${parts[0]}/${parts[1]}`;
+        if (existsSync(root)) {
+            return root;
+        }
+    }
+
+    return existing;
+}
+
+function collectMounts(args) {
+    const candidates = new Set([process.cwd()]);
+    for (const root of ['/tmp', '/srv']) {
+        if (existsSync(root)) {
+            candidates.add(root);
+        }
+    }
+
+    for (const arg of args) {
+        for (const pathCandidate of extractAbsolutePaths(arg)) {
+            candidates.add(pathCandidate);
+        }
+    }
+
+    const roots = [...candidates]
+        .map(mountRootFor)
+        .filter(Boolean)
+        .sort((a, b) => a.length - b.length);
+
+    const mounts = [];
+    for (const root of roots) {
+        if (!mounts.some((parent) => isSameOrChild(root, parent))) {
+            mounts.push(root);
+        }
+    }
+    return mounts;
+}
+
+async function main() {
+    const argv = process.argv.slice(2);
+    const phpVersion = process.env.PLAYGROUND_PHP_VERSION || DEFAULT_PHP_VERSION;
+    const extensions = ['intl'];
+    const manifestUrl = process.env[MYSQL_PARSER_MANIFEST_ENV];
+    if (manifestUrl) {
+        extensions.push({
+            source: {
+                format: 'manifest',
+                manifestUrl,
+            },
+        });
+    }
+
+    const php = new PHP(await loadNodeRuntime(phpVersion, {
+        extensions,
+        emscriptenOptions: {
+            processId: process.pid,
+        },
+    }));
+    for (const mountPath of collectMounts(argv)) {
+        await php.mount(mountPath, createNodeFsMountHandler(mountPath));
+    }
+    php.chdir(process.cwd());
+    await php.setSpawnHandler(spawn);
+
+    const response = await php.cli(['php', ...argv], {
+        cwd: process.cwd(),
+        env: envRecord(),
+    });
+    const [stdoutBytes, stderrText, exitCode] = await Promise.all([
+        response.stdoutBytes,
+        response.stderrText,
+        response.exitCode,
+    ]);
+    if (stdoutBytes.length > 0) {
+        process.stdout.write(Buffer.from(stdoutBytes));
+    }
+    if (stderrText.length > 0) {
+        process.stderr.write(stderrText);
+    }
+    php[Symbol.dispose]?.();
+    process.exitCode = exitCode;
+}
+
+main().catch((error) => {
+    console.error(error?.stack || error);
+    process.exitCode = 1;
+});

--- a/tests/e2e/ci/playground-php.sh
+++ b/tests/e2e/ci/playground-php.sh
@@ -1,12 +1,17 @@
 #!/usr/bin/env bash
-# Wrapper that invokes PHP through WordPress Playground CLI's WASM runtime.
+# Wrapper that invokes PHP through WordPress Playground's WASM runtime.
 # Used by e2e tests when PHP_BINARY points here instead of the system `php`.
 #
-# Mounts the host filesystem paths that the importer needs:
-# - The workspace root (for reprint.phar and project files)
-# - /tmp (for temporary test output)
-# - /srv (for e2e test site data)
+# By default this delegates to @wp-playground/cli php so the CI still covers
+# the public CLI path. When WP_MYSQL_PARSER_EXTENSION_MANIFEST is set, or when
+# PLAYGROUND_PHP_USE_WASM_RUNNER=1 is set, it uses the local @php-wasm/node
+# runner because the CLI does not expose arbitrary external PHP extensions.
 set -euo pipefail
+
+if [ -n "${WP_MYSQL_PARSER_EXTENSION_MANIFEST:-}" ] || [ "${PLAYGROUND_PHP_USE_WASM_RUNNER:-}" = "1" ]; then
+    SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+    exec node --experimental-wasm-jspi "${SCRIPT_DIR}/php-wasm-runner.mjs" "$@"
+fi
 
 MOUNT_ARGS=()
 

--- a/tests/e2e/ci/playground-php.sh
+++ b/tests/e2e/ci/playground-php.sh
@@ -4,13 +4,18 @@
 #
 # By default this delegates to @wp-playground/cli php so the CI still covers
 # the public CLI path. When WP_MYSQL_PARSER_EXTENSION_MANIFEST is set, or when
-# PLAYGROUND_PHP_USE_WASM_RUNNER=1 is set, it uses the local @php-wasm/node
-# runner because the CLI does not expose arbitrary external PHP extensions.
+# PLAYGROUND_PHP_USE_WASM_RUNNER=1 is set, it uses the npm-installed
+# @php-wasm/node runner because the CLI does not expose arbitrary external PHP
+# extensions.
 set -euo pipefail
 
 if [ -n "${WP_MYSQL_PARSER_EXTENSION_MANIFEST:-}" ] || [ "${PLAYGROUND_PHP_USE_WASM_RUNNER:-}" = "1" ]; then
     SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
-    exec node --experimental-wasm-jspi "${SCRIPT_DIR}/php-wasm-runner.mjs" "$@"
+    NODE_CMD=(node)
+    if ! node --experimental-wasm-jspi --input-type=module -e "import { jspi } from 'wasm-feature-detect'; process.exit(await jspi() ? 0 : 1);" >/dev/null 2>&1; then
+        NODE_CMD=(npx --yes node@24)
+    fi
+    exec "${NODE_CMD[@]}" --experimental-wasm-jspi "${SCRIPT_DIR}/php-wasm-runner.mjs" "$@"
 fi
 
 MOUNT_ARGS=()

--- a/tests/e2e/ci/verify-wp-mysql-parser.php
+++ b/tests/e2e/ci/verify-wp-mysql-parser.php
@@ -1,0 +1,123 @@
+<?php
+/**
+ * Verify that the wp_mysql_parser PHP.wasm extension is loaded and actually
+ * selected by the SQLite Integration parser bridge.
+ *
+ * Usage:
+ *   php verify-wp-mysql-parser.php /path/to/reprint [lexer|parser]
+ */
+
+$project_root = $argv[1] ?? dirname(__DIR__, 3);
+$mode = $argv[2] ?? 'parser';
+if (!in_array($mode, array('lexer', 'parser'), true)) {
+    fwrite(STDERR, "Invalid mode: {$mode}\n");
+    exit(2);
+}
+
+$loader = rtrim($project_root, '/') . '/packages/reprint-importer/src/lib/mysql-query-stream/load.php';
+$grammar_path = rtrim($project_root, '/') . '/lib/sqlite-database-integration/packages/mysql-on-sqlite/src/mysql/mysql-grammar.php';
+if (!is_readable($loader)) {
+    fwrite(STDERR, "Cannot read query-stream loader: {$loader}\n");
+    exit(2);
+}
+if (!is_readable($grammar_path)) {
+    fwrite(STDERR, "Cannot read MySQL grammar: {$grammar_path}\n");
+    exit(2);
+}
+
+require $loader;
+
+function reprint_native_parser_fail(string $message): void
+{
+    fwrite(STDERR, $message . "\n");
+    exit(1);
+}
+
+function reprint_assert_native_delegate(WP_MySQL_Parser $parser, string $context): void
+{
+    $reflection = new ReflectionObject($parser);
+    if (!$reflection->hasProperty('native')) {
+        reprint_native_parser_fail($context . ': missing native delegate property');
+    }
+
+    $native_property = $reflection->getProperty('native');
+    $native_property->setAccessible(true);
+    if (!($native_property->getValue($parser) instanceof WP_MySQL_Native_Parser)) {
+        reprint_native_parser_fail($context . ': delegate is not WP_MySQL_Native_Parser');
+    }
+}
+
+$details = array(
+    'mode' => $mode,
+    'wp_mysql_parser' => extension_loaded('wp_mysql_parser') ? 'enabled' : 'missing',
+);
+
+if (!extension_loaded('wp_mysql_parser')) {
+    reprint_native_parser_fail('wp_mysql_parser extension is not loaded');
+}
+
+foreach (
+    array(
+        'WP_MySQL_Native_Lexer',
+        'WP_MySQL_Native_Parser',
+        'WP_MySQL_Native_Parser_Node',
+        'WP_MySQL_Native_Token_Stream',
+    ) as $class
+) {
+    if (!class_exists($class, false)) {
+        reprint_native_parser_fail($class . ' is not declared by the extension/loader');
+    }
+}
+
+if (get_parent_class('WP_MySQL_Lexer') !== 'WP_MySQL_Native_Lexer') {
+    reprint_native_parser_fail('WP_MySQL_Lexer did not resolve to the native lexer');
+}
+
+if (!in_array('WP_MySQL_Native_Parser_Impl', (array) class_uses('WP_MySQL_Parser'), true)) {
+    reprint_native_parser_fail('WP_MySQL_Parser did not resolve to the native parser bridge');
+}
+
+$lexer = new WP_MySQL_Lexer('SELECT ID, post_title FROM wp_posts WHERE ID IN (1, 2, 3);');
+if (!($lexer instanceof WP_MySQL_Native_Lexer)) {
+    reprint_native_parser_fail('Native lexer instance check failed');
+}
+
+$tokens = $lexer->native_token_stream();
+if (!($tokens instanceof WP_MySQL_Native_Token_Stream)) {
+    reprint_native_parser_fail('native_token_stream() did not return WP_MySQL_Native_Token_Stream');
+}
+
+$details['native_lexer'] = 'verified';
+$details['native_token_stream'] = get_class($tokens);
+$details['native_token_count'] = method_exists($tokens, 'count') ? $tokens->count() : null;
+
+if ($mode === 'parser') {
+    $grammar = new WP_Parser_Grammar(require $grammar_path);
+    $parser = new WP_MySQL_Parser($grammar, $tokens);
+    reprint_assert_native_delegate($parser, 'WP_MySQL_Parser');
+
+    $ast = $parser->parse();
+    if (!($ast instanceof WP_MySQL_Native_Parser_Node) || $ast->rule_name !== 'query') {
+        reprint_native_parser_fail('Native parser did not produce a query AST');
+    }
+
+    $driver = new WP_PDO_MySQL_On_SQLite('mysql-on-sqlite:path=:memory:;dbname=wp;');
+    $driver_parser = $driver->create_parser('SELECT 1;');
+    reprint_assert_native_delegate($driver_parser, 'WP_PDO_MySQL_On_SQLite::create_parser');
+    if (!$driver_parser->next_query()) {
+        reprint_native_parser_fail('SQLite driver native parser did not parse a query');
+    }
+
+    $driver_ast = $driver_parser->get_query_ast();
+    if (!($driver_ast instanceof WP_MySQL_Native_Parser_Node)) {
+        reprint_native_parser_fail('SQLite driver did not expose a native-backed AST');
+    }
+
+    $details['native_parser'] = 'verified';
+    $details['native_ast'] = get_class($ast);
+    $details['sqlite_driver_parser'] = 'verified';
+} else {
+    $details['native_parser'] = 'selected';
+}
+
+echo json_encode($details, JSON_UNESCAPED_SLASHES) . "\n";

--- a/tests/e2e/lib/test-helpers.js
+++ b/tests/e2e/lib/test-helpers.js
@@ -452,7 +452,6 @@ export async function createMysqlConnection(dbName = null) {
  */
 export function queryMysqlOnSqlite(sqlitePath, sql, dbName = 'sqlite_database') {
     const script = `
-require_once $argv[1] . '/lib/sqlite-database-integration/php-polyfills.php';
 require_once $argv[1] . '/lib/sqlite-database-integration/wp-pdo-mysql-on-sqlite.php';
 $pdo = new WP_PDO_MySQL_On_SQLite(
     'mysql-on-sqlite:path=' . str_replace(';', ';;', $argv[2]) . ';dbname=' . str_replace(';', ';;', $argv[3]),

--- a/tests/e2e/package-lock.json
+++ b/tests/e2e/package-lock.json
@@ -6,6 +6,8 @@
     "": {
       "name": "e2e-tests",
       "dependencies": {
+        "@php-wasm/node": "3.1.28",
+        "@php-wasm/universal": "3.1.28",
         "mysql2": "^3.9.0"
       },
       "devDependencies": {
@@ -460,6 +462,262 @@
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@php-wasm/cli-util": {
+      "version": "3.1.28",
+      "resolved": "https://registry.npmjs.org/@php-wasm/cli-util/-/cli-util-3.1.28.tgz",
+      "integrity": "sha512-O3lh6DUvIWsQSTJR4y0Taautlon+YirYXeU+Qu/dp3hYhxq8r6Z7zoQIRDAtUzyzLqMiGpbTOgD6WWsN7poVUQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@php-wasm/util": "3.1.28",
+        "fast-xml-parser": "^5.5.1",
+        "jsonc-parser": "3.3.1"
+      },
+      "engines": {
+        "node": ">=20.10.0",
+        "npm": ">=10.2.3"
+      }
+    },
+    "node_modules/@php-wasm/logger": {
+      "version": "3.1.28",
+      "resolved": "https://registry.npmjs.org/@php-wasm/logger/-/logger-3.1.28.tgz",
+      "integrity": "sha512-3rjT7AeZB6/FZSUM0EGb7FxwP0AvYFTweAW+x9JgUBLvN3UTBltz9NWQugGECDioNhnYM/20hcgWdMQdndJ4AQ==",
+      "license": "GPL-2.0-or-later",
+      "engines": {
+        "node": ">=20.10.0",
+        "npm": ">=10.2.3"
+      }
+    },
+    "node_modules/@php-wasm/node": {
+      "version": "3.1.28",
+      "resolved": "https://registry.npmjs.org/@php-wasm/node/-/node-3.1.28.tgz",
+      "integrity": "sha512-VoKAAOmaEFTm61Qttd4pCut9rdOnYeJw2lDhZ+2gsSmfFR41vkLGoESVYRfOmtEtgarpuv215GOPN1M3pzh/8g==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@php-wasm/cli-util": "3.1.28",
+        "@php-wasm/logger": "3.1.28",
+        "@php-wasm/node-5-2": "3.1.28",
+        "@php-wasm/node-7-4": "3.1.28",
+        "@php-wasm/node-8-0": "3.1.28",
+        "@php-wasm/node-8-1": "3.1.28",
+        "@php-wasm/node-8-2": "3.1.28",
+        "@php-wasm/node-8-3": "3.1.28",
+        "@php-wasm/node-8-4": "3.1.28",
+        "@php-wasm/node-8-5": "3.1.28",
+        "@php-wasm/universal": "3.1.28",
+        "@php-wasm/util": "3.1.28",
+        "@wp-playground/common": "3.1.28",
+        "ajv": "8.12.0",
+        "express": "4.22.0",
+        "fast-xml-parser": "^5.5.1",
+        "fs-ext-extra-prebuilt": "2.2.7",
+        "ini": "4.1.2",
+        "jsonc-parser": "3.3.1",
+        "wasm-feature-detect": "1.8.0",
+        "ws": "8.18.0",
+        "yargs": "17.7.2"
+      },
+      "engines": {
+        "node": ">=20.10.0",
+        "npm": ">=10.2.3"
+      }
+    },
+    "node_modules/@php-wasm/node-5-2": {
+      "version": "3.1.28",
+      "resolved": "https://registry.npmjs.org/@php-wasm/node-5-2/-/node-5-2-3.1.28.tgz",
+      "integrity": "sha512-UrrlnattRNkyQyVkp+U6NWS6sU7AYLQZfnkMr6ID2l/Ncc0xqv2aHVaLVXMmjSNvvhgQAhGLz2yy6gO8rNhnXQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@php-wasm/universal": "3.1.28",
+        "ajv": "8.12.0",
+        "ini": "4.1.2",
+        "wasm-feature-detect": "1.8.0",
+        "ws": "8.18.0"
+      },
+      "engines": {
+        "node": ">=20.10.0",
+        "npm": ">=10.2.3"
+      }
+    },
+    "node_modules/@php-wasm/node-7-4": {
+      "version": "3.1.28",
+      "resolved": "https://registry.npmjs.org/@php-wasm/node-7-4/-/node-7-4-3.1.28.tgz",
+      "integrity": "sha512-22SOEXcOb0h5lwpvFxdrMTeNUXh+RjJoyFk04iW1cediviIzIjfGtFokD2tT/e8x7uwJTojcLuH1aSqO3tVpyA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@php-wasm/universal": "3.1.28",
+        "ajv": "8.12.0",
+        "ini": "4.1.2",
+        "wasm-feature-detect": "1.8.0",
+        "ws": "8.18.0"
+      },
+      "engines": {
+        "node": ">=20.10.0",
+        "npm": ">=10.2.3"
+      }
+    },
+    "node_modules/@php-wasm/node-8-0": {
+      "version": "3.1.28",
+      "resolved": "https://registry.npmjs.org/@php-wasm/node-8-0/-/node-8-0-3.1.28.tgz",
+      "integrity": "sha512-s1CziMvw76ZMX2BaTVGUqTN4STPNtw9NGfzOQtmaOAxlPut7DL/QRr+S6kwSptfpklZ795nrFOCmHCWwPxebYw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@php-wasm/universal": "3.1.28",
+        "ajv": "8.12.0",
+        "ini": "4.1.2",
+        "wasm-feature-detect": "1.8.0",
+        "ws": "8.18.0"
+      },
+      "engines": {
+        "node": ">=20.10.0",
+        "npm": ">=10.2.3"
+      }
+    },
+    "node_modules/@php-wasm/node-8-1": {
+      "version": "3.1.28",
+      "resolved": "https://registry.npmjs.org/@php-wasm/node-8-1/-/node-8-1-3.1.28.tgz",
+      "integrity": "sha512-5tkxzs77CZHwZgMdyc5+9ttuuBIj+aKLv30hhygSx8INvUGlWa6DdrXBwikx1XTesabYpcO6Vo/3iTWFGAheDQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@php-wasm/universal": "3.1.28",
+        "ajv": "8.12.0",
+        "ini": "4.1.2",
+        "wasm-feature-detect": "1.8.0",
+        "ws": "8.18.0"
+      },
+      "engines": {
+        "node": ">=20.10.0",
+        "npm": ">=10.2.3"
+      }
+    },
+    "node_modules/@php-wasm/node-8-2": {
+      "version": "3.1.28",
+      "resolved": "https://registry.npmjs.org/@php-wasm/node-8-2/-/node-8-2-3.1.28.tgz",
+      "integrity": "sha512-2N7RWE3FPP8CYnvRcXOfyZ0QZHO/b35GuE9G9TQWlSRL25BUp8UDPgCgRUln8RGTSnOLNL/a+ewno8RcPy8N+Q==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@php-wasm/universal": "3.1.28",
+        "ajv": "8.12.0",
+        "ini": "4.1.2",
+        "wasm-feature-detect": "1.8.0",
+        "ws": "8.18.0"
+      },
+      "engines": {
+        "node": ">=20.10.0",
+        "npm": ">=10.2.3"
+      }
+    },
+    "node_modules/@php-wasm/node-8-3": {
+      "version": "3.1.28",
+      "resolved": "https://registry.npmjs.org/@php-wasm/node-8-3/-/node-8-3-3.1.28.tgz",
+      "integrity": "sha512-njW5RIdBD5kLKGebiGLjcrRXoOegwZZAWs7kaOJ5fHF1c0J+ZcITVq+Itqv+5SEw1GZQfNms69Y5zL7kuvKneA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@php-wasm/universal": "3.1.28",
+        "ajv": "8.12.0",
+        "ini": "4.1.2",
+        "wasm-feature-detect": "1.8.0",
+        "ws": "8.18.0"
+      },
+      "engines": {
+        "node": ">=20.10.0",
+        "npm": ">=10.2.3"
+      }
+    },
+    "node_modules/@php-wasm/node-8-4": {
+      "version": "3.1.28",
+      "resolved": "https://registry.npmjs.org/@php-wasm/node-8-4/-/node-8-4-3.1.28.tgz",
+      "integrity": "sha512-rosFoPifPYwuorrL3sDXMF1GAERxQVQ/b2z2p184kkW8cSHPa90qRKSf0UGwQ4MoKMkAh0F1zTBOFbvgg3I3Yw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@php-wasm/universal": "3.1.28",
+        "ajv": "8.12.0",
+        "ini": "4.1.2",
+        "wasm-feature-detect": "1.8.0",
+        "ws": "8.18.0"
+      },
+      "engines": {
+        "node": ">=20.10.0",
+        "npm": ">=10.2.3"
+      }
+    },
+    "node_modules/@php-wasm/node-8-5": {
+      "version": "3.1.28",
+      "resolved": "https://registry.npmjs.org/@php-wasm/node-8-5/-/node-8-5-3.1.28.tgz",
+      "integrity": "sha512-0ZgtHgLSSsib6HJu6ePW23gTEPleamWj4DGPbFVMJH5X/Js2FLEjW7vxoDl+Wr28Gr0aNRW25akiNK9GOIEqHg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@php-wasm/universal": "3.1.28",
+        "ajv": "8.12.0",
+        "ini": "4.1.2",
+        "wasm-feature-detect": "1.8.0",
+        "ws": "8.18.0"
+      },
+      "engines": {
+        "node": ">=20.10.0",
+        "npm": ">=10.2.3"
+      }
+    },
+    "node_modules/@php-wasm/progress": {
+      "version": "3.1.28",
+      "resolved": "https://registry.npmjs.org/@php-wasm/progress/-/progress-3.1.28.tgz",
+      "integrity": "sha512-Ai9IfqpB2ShJIgc6mc4aHZd/0oqMDmDjfqfIh4GFyN5wG2SKGI/48Z5SIofnj/kQ4vSP3OqW8GXpHR5MWikUhg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@php-wasm/logger": "3.1.28"
+      },
+      "engines": {
+        "node": ">=20.10.0",
+        "npm": ">=10.2.3"
+      }
+    },
+    "node_modules/@php-wasm/stream-compression": {
+      "version": "3.1.28",
+      "resolved": "https://registry.npmjs.org/@php-wasm/stream-compression/-/stream-compression-3.1.28.tgz",
+      "integrity": "sha512-dCWbSuq5UHGz3P4c67jKYHaXnVsQjVp44okxJe/4jxuLSk5kWlJovycOScqTn5SqrqLsBgVudFFhdynpP1aBtw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@php-wasm/util": "3.1.28"
+      }
+    },
+    "node_modules/@php-wasm/universal": {
+      "version": "3.1.28",
+      "resolved": "https://registry.npmjs.org/@php-wasm/universal/-/universal-3.1.28.tgz",
+      "integrity": "sha512-Spep0uCJTg8ZNdcxXyfsaGS+hPdFRpj0NyesVQHYBIWAD5dDnzw3ZLhdW84uUxd7mVVwz1Z6g9gXXBPqsNXspw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@php-wasm/logger": "3.1.28",
+        "@php-wasm/progress": "3.1.28",
+        "@php-wasm/stream-compression": "3.1.28",
+        "@php-wasm/util": "3.1.28",
+        "ajv": "8.12.0",
+        "ini": "4.1.2"
+      },
+      "engines": {
+        "node": ">=20.10.0",
+        "npm": ">=10.2.3"
+      }
+    },
+    "node_modules/@php-wasm/util": {
+      "version": "3.1.28",
+      "resolved": "https://registry.npmjs.org/@php-wasm/util/-/util-3.1.28.tgz",
+      "integrity": "sha512-webbXVqy74mMpDQkvtLOPvRERwLS2+ylRLaY+oDze4MsDdN0QoM3Z8ZaZm9t4oeyX8JEPua87I5NQPcQVDtefw==",
+      "engines": {
+        "node": ">=20.10.0",
+        "npm": ">=10.2.3"
+      }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.57.1",
@@ -954,6 +1212,81 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/@wp-playground/common": {
+      "version": "3.1.28",
+      "resolved": "https://registry.npmjs.org/@wp-playground/common/-/common-3.1.28.tgz",
+      "integrity": "sha512-SMoU5N/idpStRCaCknDDr9fiDNPnHxfgC8P/nBctMsscKMjTUbUtBNV8yURkzLWvxhTNhbuxSH/pe3Ya3E9YBg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@php-wasm/universal": "3.1.28",
+        "@php-wasm/util": "3.1.28",
+        "ajv": "8.12.0",
+        "ini": "4.1.2"
+      },
+      "engines": {
+        "node": ">=20.10.0",
+        "npm": ">=10.2.3"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -973,6 +1306,95 @@
         "node": ">= 6.0.0"
       }
     },
+    "node_modules/body-parser": {
+      "version": "1.20.5",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
+      "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "~1.2.0",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "on-finished": "~2.4.1",
+        "qs": "~6.15.1",
+        "raw-body": "~2.5.3",
+        "type-is": "~1.6.18",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/body-parser/node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/body-parser/node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/chai": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
@@ -981,6 +1403,83 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
       }
     },
     "node_modules/denque": {
@@ -992,12 +1491,96 @@
         "node": ">=0.10"
       }
     },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es-module-lexer": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
       "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.27.3",
@@ -1041,6 +1624,21 @@
         "@esbuild/win32-x64": "0.27.3"
       }
     },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
     "node_modules/estree-walker": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -1051,6 +1649,15 @@
         "@types/estree": "^1.0.0"
       }
     },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -1059,6 +1666,94 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "4.22.0",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.0.tgz",
+      "integrity": "sha512-c2iPh3xp5vvCLgaHK03+mWLFPhox7j1LwyxcZwFVApEv5i0X+IjPpbT50SJJwwLpdBVfp45AkK/v+AFgv/XlfQ==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "~1.20.3",
+        "content-disposition": "~0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "~0.7.1",
+        "cookie-signature": "~1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.3.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "~0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "~6.14.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "~0.19.0",
+        "serve-static": "~1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "~2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-xml-builder": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.8.tgz",
+      "integrity": "sha512-sDVBc2gg8pSKvcbE8rBmOyjSGQf0AdsbqvHeIOv3D/uYNoV4eCReQXyDF8Pdv8+m1FHazACypSz2hR7O2S1LLw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.1.3"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
+      "integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.7",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
       }
     },
     "node_modules/fdir": {
@@ -1079,6 +1774,55 @@
         }
       }
     },
+    "node_modules/finalhandler": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
+      "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "~2.0.2",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fs-ext-extra-prebuilt": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/fs-ext-extra-prebuilt/-/fs-ext-extra-prebuilt-2.2.7.tgz",
+      "integrity": "sha512-Q7rayYRBDIvDF01HWOwSSjoaP+05N1g+o3BXL1Zf8Frw2JkjSmi4EtvCBITuW30l6hB2m2TW1pehdh8wyU/+gw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "nan": "^2.24.0"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -1094,6 +1838,15 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/generate-function": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
@@ -1101,6 +1854,108 @@
       "license": "MIT",
       "dependencies": {
         "is-property": "^1.0.2"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/iconv-lite": {
@@ -1119,10 +1974,55 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.2.tgz",
+      "integrity": "sha512-AMB1mvwR1pyBFY/nSevUX6y8nJWS63/SzUKD3JyQn97s4xgIdgQPT75IRouIiBAN4yLQBUShNYVW0+UG25daCw==",
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-property": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
       "integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/jsonc-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
       "license": "MIT"
     },
     "node_modules/long": {
@@ -1156,6 +2056,81 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
     "node_modules/mysql2": {
       "version": "3.16.3",
       "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.16.3.tgz",
@@ -1188,6 +2163,12 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/nan": {
+      "version": "2.26.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.26.2.tgz",
+      "integrity": "sha512-0tTvBTYkt3tdGw22nrAy50x7gpbGCCFH3AFcyS5WiUu7Eu4vWlri1woE6qHBSfy11vksDqkiwjOnlR7WV8G1Hw==",
+      "license": "MIT"
+    },
     "node_modules/nanoid": {
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
@@ -1207,6 +2188,27 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/obug": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
@@ -1216,6 +2218,48 @@
         "https://github.com/sponsors/sxzz",
         "https://opencollective.com/debug"
       ],
+      "license": "MIT"
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
       "license": "MIT"
     },
     "node_modules/pathe": {
@@ -1274,6 +2318,97 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.14.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
+      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/raw-body/node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/rollup": {
       "version": "4.57.1",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.57.1.tgz",
@@ -1319,16 +2454,159 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
     },
+    "node_modules/send": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
+      "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.1",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "~2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "~2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
     "node_modules/seq-queue": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/seq-queue/-/seq-queue-0.0.5.tgz",
       "integrity": "sha512-hr3Wtp/GZIc/6DAGPDcV4/9WoZhjrkXsi5B/07QgX8tsdc6ilr7BFM6PM6rbdAX1kFSDYeZGLipIZZKyQP0O5Q=="
+    },
+    "node_modules/serve-static": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
+      "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "~0.19.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/siginfo": {
       "version": "2.0.0",
@@ -1363,11 +2641,58 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/std-env": {
       "version": "3.10.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
       "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strnum": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
+      "integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
       "license": "MIT"
     },
     "node_modules/tinybench": {
@@ -1412,6 +2737,64 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/vite": {
@@ -1567,6 +2950,12 @@
         }
       }
     },
+    "node_modules/wasm-feature-detect": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/wasm-feature-detect/-/wasm-feature-detect-1.8.0.tgz",
+      "integrity": "sha512-zksaLKM2fVlnB5jQQDqKXXwYHLQUVH9es+5TOOHwGOVJOCeRBCiPjwSg+3tN2AdTCzjgli4jijCH290kXb/zWQ==",
+      "license": "Apache-2.0"
+    },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -1582,6 +2971,80 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     }
   }

--- a/tests/e2e/package-lock.json
+++ b/tests/e2e/package-lock.json
@@ -6,8 +6,8 @@
     "": {
       "name": "e2e-tests",
       "dependencies": {
-        "@php-wasm/node": "3.1.28",
-        "@php-wasm/universal": "3.1.28",
+        "@php-wasm/node": "3.1.29",
+        "@php-wasm/universal": "3.1.29",
         "mysql2": "^3.9.0"
       },
       "devDependencies": {
@@ -476,12 +476,12 @@
       "license": "MIT"
     },
     "node_modules/@php-wasm/cli-util": {
-      "version": "3.1.28",
-      "resolved": "https://registry.npmjs.org/@php-wasm/cli-util/-/cli-util-3.1.28.tgz",
-      "integrity": "sha512-O3lh6DUvIWsQSTJR4y0Taautlon+YirYXeU+Qu/dp3hYhxq8r6Z7zoQIRDAtUzyzLqMiGpbTOgD6WWsN7poVUQ==",
+      "version": "3.1.29",
+      "resolved": "https://registry.npmjs.org/@php-wasm/cli-util/-/cli-util-3.1.29.tgz",
+      "integrity": "sha512-saVEkjCQGsLBrg0MB6oHF5jZudLK0siKXiCMFkbe99DqRQSckE59PHWh7LJ2nrtTO7rayMqdMe09Pa+5EpSS6Q==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/util": "3.1.28",
+        "@php-wasm/util": "3.1.29",
         "fast-xml-parser": "^5.5.1",
         "jsonc-parser": "3.3.1"
       },
@@ -491,9 +491,9 @@
       }
     },
     "node_modules/@php-wasm/logger": {
-      "version": "3.1.28",
-      "resolved": "https://registry.npmjs.org/@php-wasm/logger/-/logger-3.1.28.tgz",
-      "integrity": "sha512-3rjT7AeZB6/FZSUM0EGb7FxwP0AvYFTweAW+x9JgUBLvN3UTBltz9NWQugGECDioNhnYM/20hcgWdMQdndJ4AQ==",
+      "version": "3.1.29",
+      "resolved": "https://registry.npmjs.org/@php-wasm/logger/-/logger-3.1.29.tgz",
+      "integrity": "sha512-UPm67EQYA4W487HsdSVBzU/QEieXw4MSGBXUmDepqGtn/CXq+1cbvfK/MfgbzDF/M/q7pg5qea0Eb11Guvs8Fg==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=20.10.0",
@@ -501,33 +501,26 @@
       }
     },
     "node_modules/@php-wasm/node": {
-      "version": "3.1.28",
-      "resolved": "https://registry.npmjs.org/@php-wasm/node/-/node-3.1.28.tgz",
-      "integrity": "sha512-VoKAAOmaEFTm61Qttd4pCut9rdOnYeJw2lDhZ+2gsSmfFR41vkLGoESVYRfOmtEtgarpuv215GOPN1M3pzh/8g==",
+      "version": "3.1.29",
+      "resolved": "https://registry.npmjs.org/@php-wasm/node/-/node-3.1.29.tgz",
+      "integrity": "sha512-qsjkAUAr9oUSnPtcILE5KZqQQBF62atEfSfkyqJb8Lf3RdIrorqnx4/GiBu8Qz+uDhQc4GvSUPg2en4wJ1PNpQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/cli-util": "3.1.28",
-        "@php-wasm/logger": "3.1.28",
-        "@php-wasm/node-5-2": "3.1.28",
-        "@php-wasm/node-7-4": "3.1.28",
-        "@php-wasm/node-8-0": "3.1.28",
-        "@php-wasm/node-8-1": "3.1.28",
-        "@php-wasm/node-8-2": "3.1.28",
-        "@php-wasm/node-8-3": "3.1.28",
-        "@php-wasm/node-8-4": "3.1.28",
-        "@php-wasm/node-8-5": "3.1.28",
-        "@php-wasm/universal": "3.1.28",
-        "@php-wasm/util": "3.1.28",
-        "@wp-playground/common": "3.1.28",
-        "ajv": "8.12.0",
-        "express": "4.22.0",
-        "fast-xml-parser": "^5.5.1",
+        "@php-wasm/cli-util": "3.1.29",
+        "@php-wasm/logger": "3.1.29",
+        "@php-wasm/node-5-2": "3.1.29",
+        "@php-wasm/node-7-4": "3.1.29",
+        "@php-wasm/node-8-0": "3.1.29",
+        "@php-wasm/node-8-1": "3.1.29",
+        "@php-wasm/node-8-2": "3.1.29",
+        "@php-wasm/node-8-3": "3.1.29",
+        "@php-wasm/node-8-4": "3.1.29",
+        "@php-wasm/node-8-5": "3.1.29",
+        "@php-wasm/universal": "3.1.29",
+        "@php-wasm/util": "3.1.29",
         "fs-ext-extra-prebuilt": "2.2.7",
-        "ini": "4.1.2",
-        "jsonc-parser": "3.3.1",
         "wasm-feature-detect": "1.8.0",
-        "ws": "8.18.0",
-        "yargs": "17.7.2"
+        "ws": "8.18.0"
       },
       "engines": {
         "node": ">=20.10.0",
@@ -535,16 +528,13 @@
       }
     },
     "node_modules/@php-wasm/node-5-2": {
-      "version": "3.1.28",
-      "resolved": "https://registry.npmjs.org/@php-wasm/node-5-2/-/node-5-2-3.1.28.tgz",
-      "integrity": "sha512-UrrlnattRNkyQyVkp+U6NWS6sU7AYLQZfnkMr6ID2l/Ncc0xqv2aHVaLVXMmjSNvvhgQAhGLz2yy6gO8rNhnXQ==",
+      "version": "3.1.29",
+      "resolved": "https://registry.npmjs.org/@php-wasm/node-5-2/-/node-5-2-3.1.29.tgz",
+      "integrity": "sha512-6giRuYnQkGrpA20sqteq/lHlZrpBw46iIqxDN4+sV5sMODMdIpr6xzSRh3t80xjGGNOkHH4D+FxqwyCvM608Lw==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/universal": "3.1.28",
-        "ajv": "8.12.0",
-        "ini": "4.1.2",
-        "wasm-feature-detect": "1.8.0",
-        "ws": "8.18.0"
+        "@php-wasm/universal": "3.1.29",
+        "wasm-feature-detect": "1.8.0"
       },
       "engines": {
         "node": ">=20.10.0",
@@ -552,16 +542,13 @@
       }
     },
     "node_modules/@php-wasm/node-7-4": {
-      "version": "3.1.28",
-      "resolved": "https://registry.npmjs.org/@php-wasm/node-7-4/-/node-7-4-3.1.28.tgz",
-      "integrity": "sha512-22SOEXcOb0h5lwpvFxdrMTeNUXh+RjJoyFk04iW1cediviIzIjfGtFokD2tT/e8x7uwJTojcLuH1aSqO3tVpyA==",
+      "version": "3.1.29",
+      "resolved": "https://registry.npmjs.org/@php-wasm/node-7-4/-/node-7-4-3.1.29.tgz",
+      "integrity": "sha512-Y17c4bbDyV7M8OkG/dJ7/y36fgHcE9xMXXGHVQRNpFJn0CIJP1unWJWBpkzLTZtliKJv1jvcfmUc+xkGSL1RdQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/universal": "3.1.28",
-        "ajv": "8.12.0",
-        "ini": "4.1.2",
-        "wasm-feature-detect": "1.8.0",
-        "ws": "8.18.0"
+        "@php-wasm/universal": "3.1.29",
+        "wasm-feature-detect": "1.8.0"
       },
       "engines": {
         "node": ">=20.10.0",
@@ -569,16 +556,13 @@
       }
     },
     "node_modules/@php-wasm/node-8-0": {
-      "version": "3.1.28",
-      "resolved": "https://registry.npmjs.org/@php-wasm/node-8-0/-/node-8-0-3.1.28.tgz",
-      "integrity": "sha512-s1CziMvw76ZMX2BaTVGUqTN4STPNtw9NGfzOQtmaOAxlPut7DL/QRr+S6kwSptfpklZ795nrFOCmHCWwPxebYw==",
+      "version": "3.1.29",
+      "resolved": "https://registry.npmjs.org/@php-wasm/node-8-0/-/node-8-0-3.1.29.tgz",
+      "integrity": "sha512-lzVN75ktC36hRqPkvJB6dXoE2h3PQ9hQGvYgus9p0uqEeUaPq7A7gYn6YSLu1iYBvoIvMxdTS7CzV/6e/PG5TQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/universal": "3.1.28",
-        "ajv": "8.12.0",
-        "ini": "4.1.2",
-        "wasm-feature-detect": "1.8.0",
-        "ws": "8.18.0"
+        "@php-wasm/universal": "3.1.29",
+        "wasm-feature-detect": "1.8.0"
       },
       "engines": {
         "node": ">=20.10.0",
@@ -586,16 +570,13 @@
       }
     },
     "node_modules/@php-wasm/node-8-1": {
-      "version": "3.1.28",
-      "resolved": "https://registry.npmjs.org/@php-wasm/node-8-1/-/node-8-1-3.1.28.tgz",
-      "integrity": "sha512-5tkxzs77CZHwZgMdyc5+9ttuuBIj+aKLv30hhygSx8INvUGlWa6DdrXBwikx1XTesabYpcO6Vo/3iTWFGAheDQ==",
+      "version": "3.1.29",
+      "resolved": "https://registry.npmjs.org/@php-wasm/node-8-1/-/node-8-1-3.1.29.tgz",
+      "integrity": "sha512-ZFJzqcFYJ7KEDIj0LStvFri2yYQpxJ9xIBP7dYPP9h1lgVYybRnRFTp4TUwKb5j3FRkcSkSB0oZc0BVpT+8LRg==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/universal": "3.1.28",
-        "ajv": "8.12.0",
-        "ini": "4.1.2",
-        "wasm-feature-detect": "1.8.0",
-        "ws": "8.18.0"
+        "@php-wasm/universal": "3.1.29",
+        "wasm-feature-detect": "1.8.0"
       },
       "engines": {
         "node": ">=20.10.0",
@@ -603,16 +584,13 @@
       }
     },
     "node_modules/@php-wasm/node-8-2": {
-      "version": "3.1.28",
-      "resolved": "https://registry.npmjs.org/@php-wasm/node-8-2/-/node-8-2-3.1.28.tgz",
-      "integrity": "sha512-2N7RWE3FPP8CYnvRcXOfyZ0QZHO/b35GuE9G9TQWlSRL25BUp8UDPgCgRUln8RGTSnOLNL/a+ewno8RcPy8N+Q==",
+      "version": "3.1.29",
+      "resolved": "https://registry.npmjs.org/@php-wasm/node-8-2/-/node-8-2-3.1.29.tgz",
+      "integrity": "sha512-ly62jp97xjTDZYGzoEbJt1tEkZktrKd5RTy1B8awzgPepxb8+F0d7BaIGlIK4EnxI2S/mTw2m5sDhbzAibycqQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/universal": "3.1.28",
-        "ajv": "8.12.0",
-        "ini": "4.1.2",
-        "wasm-feature-detect": "1.8.0",
-        "ws": "8.18.0"
+        "@php-wasm/universal": "3.1.29",
+        "wasm-feature-detect": "1.8.0"
       },
       "engines": {
         "node": ">=20.10.0",
@@ -620,16 +598,13 @@
       }
     },
     "node_modules/@php-wasm/node-8-3": {
-      "version": "3.1.28",
-      "resolved": "https://registry.npmjs.org/@php-wasm/node-8-3/-/node-8-3-3.1.28.tgz",
-      "integrity": "sha512-njW5RIdBD5kLKGebiGLjcrRXoOegwZZAWs7kaOJ5fHF1c0J+ZcITVq+Itqv+5SEw1GZQfNms69Y5zL7kuvKneA==",
+      "version": "3.1.29",
+      "resolved": "https://registry.npmjs.org/@php-wasm/node-8-3/-/node-8-3-3.1.29.tgz",
+      "integrity": "sha512-pKV0MoXNvXFEs5mZ/oCPUDNxCtSxIGjGov89fohyjCPUjTmBQUXkkDMsneCgipUubc/Ysbm/hVPWB+VuhWElPg==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/universal": "3.1.28",
-        "ajv": "8.12.0",
-        "ini": "4.1.2",
-        "wasm-feature-detect": "1.8.0",
-        "ws": "8.18.0"
+        "@php-wasm/universal": "3.1.29",
+        "wasm-feature-detect": "1.8.0"
       },
       "engines": {
         "node": ">=20.10.0",
@@ -637,16 +612,13 @@
       }
     },
     "node_modules/@php-wasm/node-8-4": {
-      "version": "3.1.28",
-      "resolved": "https://registry.npmjs.org/@php-wasm/node-8-4/-/node-8-4-3.1.28.tgz",
-      "integrity": "sha512-rosFoPifPYwuorrL3sDXMF1GAERxQVQ/b2z2p184kkW8cSHPa90qRKSf0UGwQ4MoKMkAh0F1zTBOFbvgg3I3Yw==",
+      "version": "3.1.29",
+      "resolved": "https://registry.npmjs.org/@php-wasm/node-8-4/-/node-8-4-3.1.29.tgz",
+      "integrity": "sha512-HXJ8GzqNaYPjN/V4RC77lCJUd7YYRlQtV7JTdKhRdq56e8CezbaFu25mUtpJGeXaJ0CNTu7e0SxQ6lGTq2spIg==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/universal": "3.1.28",
-        "ajv": "8.12.0",
-        "ini": "4.1.2",
-        "wasm-feature-detect": "1.8.0",
-        "ws": "8.18.0"
+        "@php-wasm/universal": "3.1.29",
+        "wasm-feature-detect": "1.8.0"
       },
       "engines": {
         "node": ">=20.10.0",
@@ -654,16 +626,13 @@
       }
     },
     "node_modules/@php-wasm/node-8-5": {
-      "version": "3.1.28",
-      "resolved": "https://registry.npmjs.org/@php-wasm/node-8-5/-/node-8-5-3.1.28.tgz",
-      "integrity": "sha512-0ZgtHgLSSsib6HJu6ePW23gTEPleamWj4DGPbFVMJH5X/Js2FLEjW7vxoDl+Wr28Gr0aNRW25akiNK9GOIEqHg==",
+      "version": "3.1.29",
+      "resolved": "https://registry.npmjs.org/@php-wasm/node-8-5/-/node-8-5-3.1.29.tgz",
+      "integrity": "sha512-5dQqlD4GgPzH8cAehShyU7+QgVr02ChvRIu1COhWhGDsv/a5tzAj8rXpnB79Xn6+BUeVAXJ4THx9kMttsuLjhA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/universal": "3.1.28",
-        "ajv": "8.12.0",
-        "ini": "4.1.2",
-        "wasm-feature-detect": "1.8.0",
-        "ws": "8.18.0"
+        "@php-wasm/universal": "3.1.29",
+        "wasm-feature-detect": "1.8.0"
       },
       "engines": {
         "node": ">=20.10.0",
@@ -671,12 +640,12 @@
       }
     },
     "node_modules/@php-wasm/progress": {
-      "version": "3.1.28",
-      "resolved": "https://registry.npmjs.org/@php-wasm/progress/-/progress-3.1.28.tgz",
-      "integrity": "sha512-Ai9IfqpB2ShJIgc6mc4aHZd/0oqMDmDjfqfIh4GFyN5wG2SKGI/48Z5SIofnj/kQ4vSP3OqW8GXpHR5MWikUhg==",
+      "version": "3.1.29",
+      "resolved": "https://registry.npmjs.org/@php-wasm/progress/-/progress-3.1.29.tgz",
+      "integrity": "sha512-I2Outwb6VzdzNLYzvr+3vrF7DnkbD+TNS9Hefo/3rcp8KWtaA8OBa+3SvZ6K/nTDAk3KphpHMlm2F4DQNkC+ug==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/logger": "3.1.28"
+        "@php-wasm/logger": "3.1.29"
       },
       "engines": {
         "node": ">=20.10.0",
@@ -684,25 +653,24 @@
       }
     },
     "node_modules/@php-wasm/stream-compression": {
-      "version": "3.1.28",
-      "resolved": "https://registry.npmjs.org/@php-wasm/stream-compression/-/stream-compression-3.1.28.tgz",
-      "integrity": "sha512-dCWbSuq5UHGz3P4c67jKYHaXnVsQjVp44okxJe/4jxuLSk5kWlJovycOScqTn5SqrqLsBgVudFFhdynpP1aBtw==",
+      "version": "3.1.29",
+      "resolved": "https://registry.npmjs.org/@php-wasm/stream-compression/-/stream-compression-3.1.29.tgz",
+      "integrity": "sha512-oAgV8WkbWJ6j3ZhWoRjJivyuYdTKodtLjExEQ49VTGRVvyQgjNKz3CIO39Pnnt5KrYFmj1+YnEPjzNAfRMUjUQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/util": "3.1.28"
+        "@php-wasm/util": "3.1.29"
       }
     },
     "node_modules/@php-wasm/universal": {
-      "version": "3.1.28",
-      "resolved": "https://registry.npmjs.org/@php-wasm/universal/-/universal-3.1.28.tgz",
-      "integrity": "sha512-Spep0uCJTg8ZNdcxXyfsaGS+hPdFRpj0NyesVQHYBIWAD5dDnzw3ZLhdW84uUxd7mVVwz1Z6g9gXXBPqsNXspw==",
+      "version": "3.1.29",
+      "resolved": "https://registry.npmjs.org/@php-wasm/universal/-/universal-3.1.29.tgz",
+      "integrity": "sha512-RsvMUNh8YUE+ub5FjEYzK/NkUDe+qFDarhnHs+Xa6VISC6IT/zfbzzAouxq55zfTBBq3OoAAfNIr/5hvUL69BQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/logger": "3.1.28",
-        "@php-wasm/progress": "3.1.28",
-        "@php-wasm/stream-compression": "3.1.28",
-        "@php-wasm/util": "3.1.28",
-        "ajv": "8.12.0",
+        "@php-wasm/logger": "3.1.29",
+        "@php-wasm/progress": "3.1.29",
+        "@php-wasm/stream-compression": "3.1.29",
+        "@php-wasm/util": "3.1.29",
         "ini": "4.1.2"
       },
       "engines": {
@@ -711,9 +679,9 @@
       }
     },
     "node_modules/@php-wasm/util": {
-      "version": "3.1.28",
-      "resolved": "https://registry.npmjs.org/@php-wasm/util/-/util-3.1.28.tgz",
-      "integrity": "sha512-webbXVqy74mMpDQkvtLOPvRERwLS2+ylRLaY+oDze4MsDdN0QoM3Z8ZaZm9t4oeyX8JEPua87I5NQPcQVDtefw==",
+      "version": "3.1.29",
+      "resolved": "https://registry.npmjs.org/@php-wasm/util/-/util-3.1.29.tgz",
+      "integrity": "sha512-k7ZIbibADTK0B/hsgFZ4RDPnIKZ1p37c2qAjZts9nl5C4zCzGO9giLA16wBV/+78vL8hkLkNQSQpkQlBZVxn3g==",
       "engines": {
         "node": ">=20.10.0",
         "npm": ">=10.2.3"
@@ -1212,81 +1180,6 @@
         "url": "https://opencollective.com/vitest"
       }
     },
-    "node_modules/@wp-playground/common": {
-      "version": "3.1.28",
-      "resolved": "https://registry.npmjs.org/@wp-playground/common/-/common-3.1.28.tgz",
-      "integrity": "sha512-SMoU5N/idpStRCaCknDDr9fiDNPnHxfgC8P/nBctMsscKMjTUbUtBNV8yURkzLWvxhTNhbuxSH/pe3Ya3E9YBg==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@php-wasm/universal": "3.1.28",
-        "@php-wasm/util": "3.1.28",
-        "ajv": "8.12.0",
-        "ini": "4.1.2"
-      },
-      "engines": {
-        "node": ">=20.10.0",
-        "npm": ">=10.2.3"
-      }
-    },
-    "node_modules/accepts": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
-      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-types": "~2.1.34",
-        "negotiator": "0.6.3"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/ajv": {
-      "version": "8.12.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
-      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/array-flatten": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
-      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
-      "license": "MIT"
-    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -1306,95 +1199,6 @@
         "node": ">= 6.0.0"
       }
     },
-    "node_modules/body-parser": {
-      "version": "1.20.5",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
-      "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
-      "license": "MIT",
-      "dependencies": {
-        "bytes": "~3.1.2",
-        "content-type": "~1.0.5",
-        "debug": "2.6.9",
-        "depd": "2.0.0",
-        "destroy": "~1.2.0",
-        "http-errors": "~2.0.1",
-        "iconv-lite": "~0.4.24",
-        "on-finished": "~2.4.1",
-        "qs": "~6.15.1",
-        "raw-body": "~2.5.3",
-        "type-is": "~1.6.18",
-        "unpipe": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8",
-        "npm": "1.2.8000 || >= 1.4.16"
-      }
-    },
-    "node_modules/body-parser/node_modules/iconv-lite": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/body-parser/node_modules/qs": {
-      "version": "6.15.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
-      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "side-channel": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/bytes": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
-      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/call-bind-apply-helpers": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
-      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/call-bound": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
-      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.2",
-        "get-intrinsic": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/chai": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
@@ -1403,83 +1207,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/cliui": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.1",
-        "wrap-ansi": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "license": "MIT"
-    },
-    "node_modules/content-disposition": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
-      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "5.2.1"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/content-type": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
-      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/cookie": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
-      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/cookie-signature": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
-      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
-      "license": "MIT"
-    },
-    "node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.0.0"
       }
     },
     "node_modules/denque": {
@@ -1491,96 +1218,12 @@
         "node": ">=0.10"
       }
     },
-    "node_modules/depd": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
-      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/destroy": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
-      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8",
-        "npm": "1.2.8000 || >= 1.4.16"
-      }
-    },
-    "node_modules/dunder-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
-      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "gopd": "^1.2.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/ee-first": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
-      "license": "MIT"
-    },
-    "node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "license": "MIT"
-    },
-    "node_modules/encodeurl": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
-      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/es-define-property": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
-      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-errors": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
-      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/es-module-lexer": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
       "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
     },
     "node_modules/esbuild": {
       "version": "0.27.3",
@@ -1624,21 +1267,6 @@
         "@esbuild/win32-x64": "0.27.3"
       }
     },
-    "node_modules/escalade": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
-      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/escape-html": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
-      "license": "MIT"
-    },
     "node_modules/estree-walker": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -1647,15 +1275,6 @@
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"
-      }
-    },
-    "node_modules/etag": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/expect-type": {
@@ -1668,62 +1287,10 @@
         "node": ">=12.0.0"
       }
     },
-    "node_modules/express": {
-      "version": "4.22.0",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.22.0.tgz",
-      "integrity": "sha512-c2iPh3xp5vvCLgaHK03+mWLFPhox7j1LwyxcZwFVApEv5i0X+IjPpbT50SJJwwLpdBVfp45AkK/v+AFgv/XlfQ==",
-      "license": "MIT",
-      "dependencies": {
-        "accepts": "~1.3.8",
-        "array-flatten": "1.1.1",
-        "body-parser": "~1.20.3",
-        "content-disposition": "~0.5.4",
-        "content-type": "~1.0.4",
-        "cookie": "~0.7.1",
-        "cookie-signature": "~1.0.6",
-        "debug": "2.6.9",
-        "depd": "2.0.0",
-        "encodeurl": "~2.0.0",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
-        "finalhandler": "~1.3.1",
-        "fresh": "~0.5.2",
-        "http-errors": "~2.0.0",
-        "merge-descriptors": "1.0.3",
-        "methods": "~1.1.2",
-        "on-finished": "~2.4.1",
-        "parseurl": "~1.3.3",
-        "path-to-regexp": "~0.1.12",
-        "proxy-addr": "~2.0.7",
-        "qs": "~6.14.0",
-        "range-parser": "~1.2.1",
-        "safe-buffer": "5.2.1",
-        "send": "~0.19.0",
-        "serve-static": "~1.16.2",
-        "setprototypeof": "1.2.0",
-        "statuses": "~2.0.1",
-        "type-is": "~1.6.18",
-        "utils-merge": "1.0.1",
-        "vary": "~1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.10.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/fast-deep-equal": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "license": "MIT"
-    },
     "node_modules/fast-xml-builder": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.8.tgz",
-      "integrity": "sha512-sDVBc2gg8pSKvcbE8rBmOyjSGQf0AdsbqvHeIOv3D/uYNoV4eCReQXyDF8Pdv8+m1FHazACypSz2hR7O2S1LLw==",
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.9.tgz",
+      "integrity": "sha512-jcyKVSEX13iseJqg7n/KWw+xnu/7fdrZ333Fac54KjHDIELVCfDDJXYIm6DTJ0Su4gSzrhqiK0DzY/wZbF40mw==",
       "funding": [
         {
           "type": "github",
@@ -1774,42 +1341,6 @@
         }
       }
     },
-    "node_modules/finalhandler": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
-      "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "2.6.9",
-        "encodeurl": "~2.0.0",
-        "escape-html": "~1.0.3",
-        "on-finished": "~2.4.1",
-        "parseurl": "~1.3.3",
-        "statuses": "~2.0.2",
-        "unpipe": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/forwarded": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
-      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/fresh": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/fs-ext-extra-prebuilt": {
       "version": "2.2.7",
       "resolved": "https://registry.npmjs.org/fs-ext-extra-prebuilt/-/fs-ext-extra-prebuilt-2.2.7.tgz",
@@ -1838,15 +1369,6 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
-    "node_modules/function-bind": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/generate-function": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
@@ -1854,108 +1376,6 @@
       "license": "MIT",
       "dependencies": {
         "is-property": "^1.0.2"
-      }
-    },
-    "node_modules/get-caller-file": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "license": "ISC",
-      "engines": {
-        "node": "6.* || 8.* || >= 10.*"
-      }
-    },
-    "node_modules/get-intrinsic": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
-      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.2",
-        "es-define-property": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.1.1",
-        "function-bind": "^1.1.2",
-        "get-proto": "^1.0.1",
-        "gopd": "^1.2.0",
-        "has-symbols": "^1.1.0",
-        "hasown": "^2.0.2",
-        "math-intrinsics": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/get-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
-      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "license": "MIT",
-      "dependencies": {
-        "dunder-proto": "^1.0.1",
-        "es-object-atoms": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/gopd": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
-      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-symbols": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
-      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/hasown": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
-      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
-      "license": "MIT",
-      "dependencies": {
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/http-errors": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
-      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
-      "license": "MIT",
-      "dependencies": {
-        "depd": "~2.0.0",
-        "inherits": "~2.0.4",
-        "setprototypeof": "~1.2.0",
-        "statuses": "~2.0.2",
-        "toidentifier": "~1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/iconv-lite": {
@@ -1974,12 +1394,6 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/inherits": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "license": "ISC"
-    },
     "node_modules/ini": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.2.tgz",
@@ -1989,34 +1403,10 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
-    "node_modules/ipaddr.js": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
-      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
-    "node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/is-property": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
       "integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==",
-      "license": "MIT"
-    },
-    "node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
     },
     "node_modules/jsonc-parser": {
@@ -2055,81 +1445,6 @@
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
-    },
-    "node_modules/math-intrinsics": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
-      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/media-typer": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/merge-descriptors": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
-      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/methods": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
-      "license": "MIT",
-      "bin": {
-        "mime": "cli.js"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "license": "MIT"
     },
     "node_modules/mysql2": {
       "version": "3.16.3",
@@ -2188,27 +1503,6 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
-    "node_modules/negotiator": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
-      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/object-inspect": {
-      "version": "1.13.4",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
-      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/obug": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
@@ -2219,27 +1513,6 @@
         "https://opencollective.com/debug"
       ],
       "license": "MIT"
-    },
-    "node_modules/on-finished": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
-      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
-      "license": "MIT",
-      "dependencies": {
-        "ee-first": "1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/parseurl": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
-      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
     },
     "node_modules/path-expression-matcher": {
       "version": "1.5.0",
@@ -2255,12 +1528,6 @@
       "engines": {
         "node": ">=14.0.0"
       }
-    },
-    "node_modules/path-to-regexp": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
-      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
-      "license": "MIT"
     },
     "node_modules/pathe": {
       "version": "2.0.3",
@@ -2318,97 +1585,6 @@
         "node": "^10 || ^12 || >=14"
       }
     },
-    "node_modules/proxy-addr": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
-      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
-      "license": "MIT",
-      "dependencies": {
-        "forwarded": "0.2.0",
-        "ipaddr.js": "1.9.1"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
-    "node_modules/punycode": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
-      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/qs": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "side-channel": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/range-parser": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
-      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/raw-body": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
-      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
-      "license": "MIT",
-      "dependencies": {
-        "bytes": "~3.1.2",
-        "http-errors": "~2.0.1",
-        "iconv-lite": "~0.4.24",
-        "unpipe": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/raw-body/node_modules/iconv-lite": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/require-directory": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/require-from-string": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/rollup": {
       "version": "4.57.1",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.57.1.tgz",
@@ -2454,159 +1630,16 @@
         "fsevents": "~2.3.2"
       }
     },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
     },
-    "node_modules/send": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
-      "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "2.6.9",
-        "depd": "2.0.0",
-        "destroy": "1.2.0",
-        "encodeurl": "~2.0.0",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
-        "fresh": "~0.5.2",
-        "http-errors": "~2.0.1",
-        "mime": "1.6.0",
-        "ms": "2.1.3",
-        "on-finished": "~2.4.1",
-        "range-parser": "~1.2.1",
-        "statuses": "~2.0.2"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/send/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
-    },
     "node_modules/seq-queue": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/seq-queue/-/seq-queue-0.0.5.tgz",
       "integrity": "sha512-hr3Wtp/GZIc/6DAGPDcV4/9WoZhjrkXsi5B/07QgX8tsdc6ilr7BFM6PM6rbdAX1kFSDYeZGLipIZZKyQP0O5Q=="
-    },
-    "node_modules/serve-static": {
-      "version": "1.16.3",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
-      "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
-      "license": "MIT",
-      "dependencies": {
-        "encodeurl": "~2.0.0",
-        "escape-html": "~1.0.3",
-        "parseurl": "~1.3.3",
-        "send": "~0.19.1"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/setprototypeof": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
-      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
-      "license": "ISC"
-    },
-    "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
-        "side-channel-map": "^1.0.1",
-        "side-channel-weakmap": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/side-channel-list": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
-      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.4"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/side-channel-map": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
-      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.5",
-        "object-inspect": "^1.13.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/side-channel-weakmap": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
-      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.5",
-        "object-inspect": "^1.13.3",
-        "side-channel-map": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
     },
     "node_modules/siginfo": {
       "version": "2.0.0",
@@ -2641,15 +1674,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/statuses": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
-      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/std-env": {
       "version": "3.10.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
@@ -2657,36 +1681,10 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/strnum": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
-      "integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
       "funding": [
         {
           "type": "github",
@@ -2737,64 +1735,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
-      }
-    },
-    "node_modules/toidentifier": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
-      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.6"
-      }
-    },
-    "node_modules/type-is": {
-      "version": "1.6.18",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
-      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
-      "license": "MIT",
-      "dependencies": {
-        "media-typer": "0.3.0",
-        "mime-types": "~2.1.24"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/unpipe": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/uri-js": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
-      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "punycode": "^2.1.0"
-      }
-    },
-    "node_modules/utils-merge": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
-      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4.0"
-      }
-    },
-    "node_modules/vary": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
-      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
       }
     },
     "node_modules/vite": {
@@ -2973,23 +1913,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/wrap-ansi": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
     "node_modules/ws": {
       "version": "8.18.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
@@ -3009,42 +1932,6 @@
         "utf-8-validate": {
           "optional": true
         }
-      }
-    },
-    "node_modules/y18n": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/yargs": {
-      "version": "17.7.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-      "license": "MIT",
-      "dependencies": {
-        "cliui": "^8.0.1",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.3",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^21.1.1"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/yargs-parser": {
-      "version": "21.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
       }
     }
   }

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -7,8 +7,8 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@php-wasm/node": "3.1.28",
-    "@php-wasm/universal": "3.1.28",
+    "@php-wasm/node": "3.1.29",
+    "@php-wasm/universal": "3.1.29",
     "mysql2": "^3.9.0"
   },
   "devDependencies": {

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -7,6 +7,8 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@php-wasm/node": "3.1.28",
+    "@php-wasm/universal": "3.1.28",
     "mysql2": "^3.9.0"
   },
   "devDependencies": {

--- a/tests/e2e/tests/import-41-playground-cli-runtime.test.js
+++ b/tests/e2e/tests/import-41-playground-cli-runtime.test.js
@@ -21,6 +21,7 @@ import { ensureSite } from '../lib/site-setup.js';
 
 const PROJECT_ROOT = join(import.meta.dirname, '..', '..', '..');
 const IMPORTER_PATH = process.env.IMPORTER_PATH || join(PROJECT_ROOT, 'importer', 'import.php');
+const itWhenRustExtensionConfigured = process.env.WP_MYSQL_PARSER_EXTENSION_MANIFEST ? it : it.skip;
 
 describe('Import: Playground CLI runtime', () => {
     const site = 'basic';
@@ -45,6 +46,23 @@ describe('Import: Playground CLI runtime', () => {
     function importUrl() {
         return `${getSiteUrl(site)}&directory=${getSiteDir(site)}`;
     }
+
+    itWhenRustExtensionConfigured('loads and selects the Rust wp_mysql_parser extension in Playground PHP', () => {
+        const output = execFileSync(PHP_BINARY, [
+            join(PROJECT_ROOT, 'tests', 'e2e', 'ci', 'verify-wp-mysql-parser.php'),
+            PROJECT_ROOT,
+            'parser',
+        ], {
+            encoding: 'utf-8',
+            timeout: 120000,
+        }).trim();
+        const details = JSON.parse(output);
+
+        assert.equal(details.wp_mysql_parser, 'enabled');
+        assert.equal(details.native_lexer, 'verified');
+        assert.equal(details.native_parser, 'verified');
+        assert.equal(details.sqlite_driver_parser, 'verified');
+    });
 
     it('files-sync downloads the site', () => {
         const result = runImporter(importUrl(), tempDir, 'files-sync', {


### PR DESCRIPTION
## What it does

Runs the Playground CLI E2E importer with the SQLite Integration plugin's published Rust `wp_mysql_parser` PHP.wasm extension and verifies that the native parser path is selected before timing any Playground SQLite work.

The focused performance report now measures both stages:

- `playground-sqlite-db-pull`
- `playground-sqlite-db-apply`

The PR side loads `wp_mysql_parser`; the trunk baseline runs the trunk `reprint.phar` through the same PHP.wasm runner with the extension disabled.

## Rationale

The earlier timings could not prove the parser extension was actually loaded. This PR now fails fast unless PHP.wasm reports the native lexer, native token stream, native parser bridge, and SQLite driver's native-backed parser.

The tests now use the released npm packages directly:

```json
"@php-wasm/node": "3.1.29",
"@php-wasm/universal": "3.1.29"
```

There is no local WordPress Playground checkout or copied `packages/php-wasm` tree in the Reprint test path.

## Implementation

Adds a PHP.wasm runner for the external extension path because `@wp-playground/cli php` does not expose arbitrary external PHP extensions yet. The runner loads the extension from `WP_MYSQL_PARSER_EXTENSION_MANIFEST` and runs the existing importer under PHP.wasm.

Adds `tests/e2e/ci/verify-wp-mysql-parser.php`, which checks more than `extension_loaded()`:

- `WP_MySQL_Lexer` resolves to `WP_MySQL_Native_Lexer`
- `native_token_stream()` returns `WP_MySQL_Native_Token_Stream`
- `WP_MySQL_Parser` resolves to the native parser bridge
- `WP_PDO_MySQL_On_SQLite::create_parser()` creates a native-backed parser and AST

The wrapper still delegates to `@wp-playground/cli php` for the regular Playground CLI path. When the external parser extension is configured, it uses the npm-installed `@php-wasm/node` runtime. Local Node builds without working JSPI fall back to `npx node@24` for that path.

The perf workflow compares the PR PHAR against the trunk PHAR on the same benchmark source site. Setup preflight uses the PR PHAR for both sides so a trunk source preflight timeout cannot hide the measured PHP.wasm `db-pull` and `db-apply` numbers.

## Performance result

Latest CI result on `large-directory` with 10,000 posts and 25,000 postmeta:

| Stage | PR | trunk | Change |
|---|---:|---:|---:|
| `playground-sqlite-db-pull` | 9.15 s | 12.79 s | -3.63 s (-28.4%) |
| `playground-sqlite-db-apply` | 20.64 s | 51.54 s | -30.90 s (-60.0%) |
| **Total** | **29.79 s** | **64.33 s** | **-34.53 s (-53.7%)** |

The PR details show `wp_mysql_parser=enabled`, `native_parser=verified`, and `sqlite_driver_parser=verified` for `db-apply`. The trunk details show `wp_mysql_parser=disabled`.

## Testing instructions

Validated locally:

```bash
npm ci --prefix tests/e2e
bash -n tests/e2e/ci/playground-php.sh
node --check tests/e2e/benchmark/bench-pull.mjs
```

Verified the published npm PHP.wasm packages load the native parser extension for all supported JSPI PHP versions:

```bash
cd tests/e2e
manifest='https://wordpress.github.io/sqlite-database-integration/wp_mysql_parser-wasm-extension/latest/manifest.json'
for version in 8.5 8.4 8.3 8.2 8.1 8.0; do
  PLAYGROUND_PHP_VERSION="$version" \
  WP_MYSQL_PARSER_EXTENSION_MANIFEST="$manifest" \
  ci/playground-php.sh ci/verify-wp-mysql-parser.php "$(git rev-parse --show-toplevel)" parser
done
```

Each version prints JSON with `wp_mysql_parser: "enabled"`, `native_lexer: "verified"`, `native_parser: "verified"`, and `sqlite_driver_parser: "verified"`.