### PR TITLE
Use parser extension in performance history

### DIFF
--- a/.github/workflows/perf-history.yml
+++ b/.github/workflows/perf-history.yml
@@ -96,6 +96,10 @@ jobs:
           BENCH_LABEL: trunk
           BENCH_JSON_OUT: bench-trunk.json
           BENCH_MD_OUT: bench-trunk.md
+          BENCH_PLAYGROUND_PHP_BINARY: ${{ github.workspace }}/tests/e2e/ci/playground-php.sh
+          PLAYGROUND_PHP_USE_WASM_RUNNER: '1'
+          PLAYGROUND_PHP_VERSION: '8.3'
+          WP_MYSQL_PARSER_EXTENSION_MANIFEST: https://wordpress.github.io/sqlite-database-integration/wp_mysql_parser-wasm-extension/latest/manifest.json
         run: node benchmark/bench-pull.mjs
 
       - name: Capture commit metadata


### PR DESCRIPTION
## What changed

Updates the trunk Performance History workflow so the Playground SQLite benchmark uses the PHP.wasm runner and the published `wp_mysql_parser` extension manifest.

## Why

The merged benchmark now includes Playground SQLite stages by default. On trunk, the history workflow was still running those stages without the parser extension on the full history dataset, and `playground-sqlite-db-apply` timed out after 900 seconds.

## Validation

- `actionlint .github/workflows/perf-history.yml`
- `git diff --check`