### PR TITLE
ci: match Rust MySQL parser between PR and trunk in perf-report

### DIFF
--- a/.github/workflows/perf-report.yml
+++ b/.github/workflows/perf-report.yml
@@ -157,6 +157,14 @@ jobs:
           BENCH_PLAYGROUND_PHP_BINARY: ${{ github.workspace }}/tests/e2e/ci/playground-php.sh
           PLAYGROUND_PHP_USE_WASM_RUNNER: '1'
           PLAYGROUND_PHP_VERSION: '8.3'
+          # Match the PR side. Without this, the Playground SQLite db-pull
+          # / db-apply scenarios run on trunk WITHOUT the Rust MySQL parser
+          # extension (because the parser is loaded only when the manifest
+          # URL is set), while the PR side runs WITH it. The resulting
+          # comparison shows a constant ~10× "improvement" attributable to
+          # the parser, on every PR — which has nothing to do with what
+          # the PR actually changes. Keep both sides on the same parser.
+          WP_MYSQL_PARSER_EXTENSION_MANIFEST: https://wordpress.github.io/sqlite-database-integration/wp_mysql_parser-wasm-extension/latest/manifest.json
         # Don't fail the whole job if trunk's bench fails — we still want
         # to publish the PR's numbers.
         continue-on-error: true


### PR DESCRIPTION
## What was wrong

The PR-side bench in `.github/workflows/perf-report.yml` sets `WP_MYSQL_PARSER_EXTENSION_MANIFEST`, which makes the Playground SQLite scenarios (`playground-sqlite-db-pull`, `playground-sqlite-db-apply`) run with the Rust MySQL parser extension. The trunk-side bench step doesn't set the manifest, so the parser is off there.

Net effect: every PR's sticky \"Pull pipeline performance\" comment shows a near-constant ~10× speedup on those two stages that's actually just the parser being on for the PR and off for the baseline. The comparison has nothing to do with what the PR actually changes.

## Fix

Set the same `WP_MYSQL_PARSER_EXTENSION_MANIFEST` on the trunk bench step. Both sides now exercise the parser identically and the diff reflects only the PR's contribution.

This mirrors what `perf-history.yml` already does for the trunk-only history pipeline (#203).

## Verifying after merge

After this lands on trunk, any open PR's sticky perf comment will refresh with the corrected baseline on its next workflow run (push a commit, or kick the workflow manually).

## Test plan

- [ ] Merge to trunk
- [ ] Re-trigger the perf workflow on PR #205 (and any other open PR) and confirm the playground-sqlite-* rows no longer show a phantom ~10× improvement
- [ ] Spot-check that all-stage runs (no `BENCH_STAGES` filter) still complete within the 60-min job timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)