### PR TITLE
[codex] Add aggressive transfer profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,17 @@ The command returns one of three exit codes:
 
 Which is to say, you'll need to wrap it in a loop that runs until failure or full completion.
 
+**Transfer profile**
+
+By default, RePrint uses the `balanced` transfer profile: short requests with an intentional duty-cycle pause between partial requests. On trusted sources that can tolerate sustained sequential transfer load, use `--transfer-profile=aggressive` to remove the duty-cycle pause and use larger request budgets:
+
+```bash
+php reprint.phar files-pull "$URL" --state-dir="$STATE_DIR" --fs-root="$FS_ROOT" --secret="$SECRET" \
+    --transfer-profile=aggressive
+```
+
+The aggressive profile keeps transfers sequential. It raises the per-request execution budget, starts file chunks at 16 MiB, and uses larger file-index batches.
+
 **Non-empty local fs-root**
 
 By default, `files-pull` refuses to start if `--fs-root` is non-empty. If you need to use a non-empty local fs-root,

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -959,6 +959,46 @@ class ImportClient
 
     private const SAVE_STATE_EVERY_N_CHUNKS = 50;
     private const STATE_PATH_ENCODING_PREFIX = "base64:";
+    private const DEFAULT_FILE_CHUNK_SIZE = 5 * 1024 * 1024;
+    private const MAX_FILE_CHUNK_SIZE = 16 * 1024 * 1024;
+    private const DEFAULT_INDEX_BATCH_SIZE = 5000;
+    private const MAX_INDEX_BATCH_SIZE = 50000;
+    private const DEFAULT_SQL_FRAGMENTS_PER_BATCH = 1000;
+    private const MAX_SQL_FRAGMENTS_PER_BATCH = 5000;
+
+    private const TRANSFER_PROFILES = [
+        "balanced" => [
+            "max_execution_time" => 5,
+            "duty" => 0.5,
+            "duty_min" => 0.35,
+            "duty_max" => 1.0,
+            "file_chunk_start" => self::DEFAULT_FILE_CHUNK_SIZE,
+            "file_chunk_max" => self::MAX_FILE_CHUNK_SIZE,
+            "index_batch_start" => self::DEFAULT_INDEX_BATCH_SIZE,
+            "index_batch_max" => self::MAX_INDEX_BATCH_SIZE,
+            "sql_fragments_start" => self::DEFAULT_SQL_FRAGMENTS_PER_BATCH,
+            "sql_fragments_max" => self::MAX_SQL_FRAGMENTS_PER_BATCH,
+        ],
+        "aggressive" => [
+            "max_execution_time" => 30,
+            "duty" => 1.0,
+            "duty_min" => 1.0,
+            "duty_max" => 1.0,
+            "file_chunk_start" => self::MAX_FILE_CHUNK_SIZE,
+            "file_chunk_max" => self::MAX_FILE_CHUNK_SIZE,
+            "index_batch_start" => self::MAX_INDEX_BATCH_SIZE,
+            "index_batch_max" => self::MAX_INDEX_BATCH_SIZE,
+            "sql_fragments_start" => self::MAX_SQL_FRAGMENTS_PER_BATCH,
+            "sql_fragments_max" => self::MAX_SQL_FRAGMENTS_PER_BATCH,
+        ],
+    ];
+
+    private const TUNING_STATE_OVERRIDES = [
+        "duty" => "duty",
+        "file_chunk_start" => "file_chunk_size",
+        "index_batch_start" => "index_batch_size",
+        "sql_fragments_start" => "sql_fragments_per_batch",
+    ];
 
     /**
      * Maximum number of consecutive cURL timeouts with no cursor progress
@@ -1702,6 +1742,7 @@ class ImportClient
             );
         }
 
+        $options = $this->apply_transfer_profile_options($options);
         $this->initialize_tuner($options);
 
         // Initialize HMAC authentication if a shared secret was provided.
@@ -1993,6 +2034,7 @@ class ImportClient
         $cli_config = $options["tuning_config"] ?? [];
 
         $config = array_merge($config, $cli_config);
+        $state = $this->apply_tuning_state_overrides($state, $cli_config);
 
         $this->tuner = new AdaptiveTuner($config, $state);
         $this->state["tuning"] = [
@@ -2004,6 +2046,49 @@ class ImportClient
             "TUNER CONFIG | " . json_encode($this->state["tuning"]["config"]),
             false,
         );
+    }
+
+    /**
+     * Expand a named transfer profile into explicit tuning options.
+     *
+     * Profiles are intentionally opt-in. Any lower-level tuning flag passed
+     * alongside the profile wins, so operators can use a profile as a base
+     * and still adjust one budget or chunk size for a specific host.
+     */
+    private function apply_transfer_profile_options(array $options): array
+    {
+        $profile = $options["transfer_profile"] ?? null;
+        if ($profile === null) {
+            return $options;
+        }
+
+        if (!isset(self::TRANSFER_PROFILES[$profile])) {
+            throw new InvalidArgumentException(
+                "Invalid --transfer-profile value: {$profile}. Valid values: " .
+                    implode(", ", array_keys(self::TRANSFER_PROFILES)),
+            );
+        }
+
+        $options["tuning_config"] = array_merge(
+            self::TRANSFER_PROFILES[$profile],
+            $options["tuning_config"] ?? [],
+        );
+        return $options;
+    }
+
+    /**
+     * Treat explicit CLI/profile start values as new tuner state, not just
+     * config. Without this, a resumed state seeded by preflight could keep an
+     * old duty cycle or chunk size even after the caller supplied overrides.
+     */
+    private function apply_tuning_state_overrides(array $state, array $cli_config): array
+    {
+        foreach (self::TUNING_STATE_OVERRIDES as $config_key => $state_key) {
+            if (array_key_exists($config_key, $cli_config)) {
+                $state[$state_key] = $cli_config[$config_key];
+            }
+        }
+        return $state;
     }
 
     /**
@@ -10965,6 +11050,16 @@ if (
             'help' => 'Include generated caches, VCS metadata, OS junk and editor scratch files (skipped by default)',
             'help_section' => 'global',
             'commands' => ['pull', 'files-pull', 'files-index'],
+        ],
+        [
+            'name' => 'transfer-profile',
+            'type' => 'value',
+            'target' => 'transfer_profile',
+            'placeholder' => 'PROFILE',
+            'valid_values' => ['balanced', 'aggressive'],
+            'help' => 'Transfer tuning profile (balanced|aggressive)',
+            'help_section' => 'global',
+            'commands' => ['pull', 'files-pull', 'files-index', 'db-pull', 'db-index', 'preflight', 'preflight-assert'],
         ],
         [
             'name' => 'adaptive',

--- a/tests/Import/AdaptiveTunerTest.php
+++ b/tests/Import/AdaptiveTunerTest.php
@@ -91,6 +91,74 @@ class AdaptiveTunerTest extends TestCase
         $this->assertSame(1000, $tuner2->get_state()["file_chunk_size"]);
     }
 
+    public function testTransferProfileOverridesPersistedTunerState(): void
+    {
+        $tempDir = sys_get_temp_dir() . '/transfer-profile-test-' . uniqid('', true);
+        $stateDir = $tempDir . '/state';
+        $fsRoot = $tempDir . '/fs-root';
+
+        try {
+            $client = new \ImportClient('http://example.invalid', $stateDir, $fsRoot);
+            $client->state = [
+                "tuning" => [
+                    "config" => [
+                        "duty" => 0.5,
+                        "file_chunk_start" => 5 * 1024 * 1024,
+                        "index_batch_start" => 5000,
+                        "sql_fragments_start" => 1000,
+                    ],
+                    "state" => [
+                        "duty" => 0.5,
+                        "file_chunk_size" => 5 * 1024 * 1024,
+                        "index_batch_size" => 5000,
+                        "sql_fragments_per_batch" => 1000,
+                    ],
+                ],
+            ];
+
+            $applyProfile = new \ReflectionMethod(\ImportClient::class, 'apply_transfer_profile_options');
+            $applyProfile->setAccessible(true);
+            $initialize = new \ReflectionMethod(\ImportClient::class, 'initialize_tuner');
+            $initialize->setAccessible(true);
+
+            $options = $applyProfile->invoke($client, [
+                "transfer_profile" => "aggressive",
+            ]);
+            $initialize->invoke($client, $options);
+
+            $config = $client->state["tuning"]["config"];
+            $state = $client->state["tuning"]["state"];
+
+            $this->assertSame(30, $config["max_execution_time"]);
+            $this->assertSame(1.0, $config["duty"]);
+            $this->assertSame(1.0, $state["duty"]);
+            $this->assertSame(16 * 1024 * 1024, $state["file_chunk_size"]);
+            $this->assertSame(50000, $state["index_batch_size"]);
+            $this->assertSame(5000, $state["sql_fragments_per_batch"]);
+        } finally {
+            $this->recursiveDelete($tempDir);
+        }
+    }
+
+    private function recursiveDelete(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        foreach (scandir($dir) as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $path = $dir . '/' . $item;
+            if (is_dir($path) && !is_link($path)) {
+                $this->recursiveDelete($path);
+            } else {
+                unlink($path);
+            }
+        }
+        rmdir($dir);
+    }
+
     // ---------------------------------------------------------------
     // Request params
     // ---------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds an opt-in `--transfer-profile=aggressive` mode for sustained sequential transfers and fixes tuner state overrides so explicit CLI/profile start values replace persisted preflight state.

The aggressive profile:

- removes intentional duty-cycle sleep (`duty=1`)
- raises the per-request execution budget to 30s
- starts file chunks at 16 MiB
- starts file-index batches at 50k entries

Default behavior remains the current balanced profile.

## Benchmarks

Local e2e source, PHP 8.2.29, file transfer only. Each row runs default preflight, then times `files-pull`.

| Dataset | Default | Aggressive profile | Delta | Notes |
|---|---:|---:|---:|---|
| Favorable: `large-directory` expanded to 220 MiB so default hits a partial response | 11.741s, 2 attempts, 5.000s tuner sleep | 9.252s, 1 attempt, 0s sleep | 1.27x faster | profile avoids the forced second request and duty sleep |
| Unfavorable: existing 92 MiB `large-directory`, completes in one default request | 5.673s, 1 attempt, 0s sleep | 6.385s, 1 attempt, 0s sleep | 12.6% slower | no sleep to remove; larger chunk framing is not beneficial here |

## Validation

- `php -l packages/reprint-importer/src/import.php`
- `php -l tests/Import/AdaptiveTunerTest.php`
- `vendor/bin/phpunit tests/Import/AdaptiveTunerTest.php --colors=never`
