### PR TITLE
[codex] Batch file fetch state saves

### DIFF
--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -1052,6 +1052,9 @@ class ImportClient
     /** @var int Running count of files imported in the current invocation. */
     private $files_imported = 0;
 
+    /** @var int|null Cached index count for repeated save-state audit logs. */
+    private $save_state_index_count = null;
+
     /** @var int|null Total entries in the current download list.  Set once
      *  at the start of download_files_from_list() by counting newlines. */
     private $download_list_total = null;
@@ -5741,7 +5744,7 @@ class ImportClient
             $is_streaming_close = !empty($chunk["is_streaming_close"]);
             if (!$is_streaming_body) {
                 $chunks_since_save++;
-                $force_save = $is_streaming_close;
+                $force_save = $this->should_force_file_fetch_checkpoint($chunk);
                 if ($force_save || $chunks_since_save >= self::SAVE_STATE_EVERY_N_CHUNKS) {
                     $this->state[$state_key]["cursor"] = $cursor;
                     // Track current file for crash recovery
@@ -5869,6 +5872,26 @@ class ImportClient
         $this->save_state($this->state);
 
         return $complete;
+    }
+
+    /**
+     * Force checkpoints only for unfinished file parts.
+     *
+     * Completed small files are cheap to replay on crash, so batching their
+     * checkpoints avoids thousands of state writes on many-small-file sites.
+     * Unfinished file parts still checkpoint immediately so mid-file resume
+     * has the byte count it needs to append safely.
+     */
+    private function should_force_file_fetch_checkpoint(array $chunk): bool
+    {
+        if (empty($chunk["is_streaming_close"])) {
+            return false;
+        }
+        $headers = $chunk["headers"] ?? [];
+        if (($headers["x-chunk-type"] ?? "") !== "file") {
+            return false;
+        }
+        return ($headers["x-last-chunk"] ?? "0") !== "1";
     }
 
     /**
@@ -6950,6 +6973,7 @@ class ImportClient
         if (!rename($new_index, $this->index_file)) {
             throw new RuntimeException("Failed to replace index file");
         }
+        $this->invalidate_save_state_index_count();
         $this->audit_log("INDEX MERGE COMPLETE | {$this->index_file} updated");
 
         @unlink($updates_path);
@@ -10588,7 +10612,7 @@ class ImportClient
             throw new RuntimeException("Failed to rename state file: $tmp_file -> {$this->state_file}");
         }
 
-        $indexed = $this->index_count();
+        $indexed = $this->get_save_state_index_count();
         $files_imported = $this->files_imported; // Completed in this run
         $has_cursor =
             !empty($state["cursor"] ?? null) ||
@@ -10607,6 +10631,19 @@ class ImportClient
         );
 
         $this->write_status_file();
+    }
+
+    private function get_save_state_index_count(): int
+    {
+        if ($this->save_state_index_count === null) {
+            $this->save_state_index_count = $this->index_count();
+        }
+        return $this->save_state_index_count;
+    }
+
+    private function invalidate_save_state_index_count(): void
+    {
+        $this->save_state_index_count = null;
     }
 
     /**

--- a/tests/Import/FileBodyStreamingTest.php
+++ b/tests/Import/FileBodyStreamingTest.php
@@ -210,6 +210,33 @@ class FileBodyStreamingTest extends TestCase
             'Final file must be byte-identical to source after mid-file resume.');
     }
 
+    public function testFileFetchCheckpointPolicyBatchesCompletedFiles(): void
+    {
+        $client = new \ImportClient(
+            'http://fake.url',
+            $this->tempDir . '/state',
+            $this->tempDir . '/fs-root',
+        );
+        $reflection = new \ReflectionClass($client);
+        $shouldForceCheckpoint = $reflection->getMethod('should_force_file_fetch_checkpoint');
+
+        $this->assertFalse($shouldForceCheckpoint->invoke($client, [
+            'is_streaming_close' => true,
+            'headers' => [
+                'x-chunk-type' => 'file',
+                'x-last-chunk' => '1',
+            ],
+        ]), 'A complete file part should be batched instead of forcing a state write.');
+
+        $this->assertTrue($shouldForceCheckpoint->invoke($client, [
+            'is_streaming_close' => true,
+            'headers' => [
+                'x-chunk-type' => 'file',
+                'x-last-chunk' => '0',
+            ],
+        ]), 'An unfinished file part must checkpoint immediately for mid-file resume.');
+    }
+
     private function buildMultipart(string $boundary, array $parts): string
     {
         $out = '';


### PR DESCRIPTION
## Summary

Reduces hot-path state persistence during `files-pull`:

- completed file parts are checkpointed in batches instead of forcing one state write per file
- unfinished file parts still checkpoint immediately so mid-file resume keeps its byte counter
- the index count used only for `SAVE CURSOR` audit logging is cached per index version, avoiding repeated full reads of `.import-index.jsonl`

This keeps the transfer sequential and preserves the existing periodic checkpoint behavior.

## Benchmarks

Local e2e source, PHP 8.2.29, `files-pull` only. Both trunk and this branch used the same high-throughput tuning flags to isolate state-save overhead:

`--duty=1 --max-exec=60 --file-chunk-start=16777216 --file-chunk-max=16777216 --index-batch-start=50000 --index-batch-max=50000`

| Dataset | Trunk | This branch | Delta | State writes |
|---|---:|---:|---:|---:|
| Less favorable mixed fixture: 5,638 files, 220 MiB | 5.740s | 3.262s | 1.76x faster | 5,687 -> 173 |
| Favorable many-small-file fixture: 25,638 files, 299 MiB on disk | 26.344s | 11.013s | 2.39x faster | 25,787 -> 673 |

## Validation

- `php -l packages/reprint-importer/src/import.php`
- `php -l tests/Import/FileBodyStreamingTest.php`
- `vendor/bin/phpunit tests/Import/FileBodyStreamingTest.php --colors=never`

I also tried the targeted e2e mid-file-resume test locally, but that run was not usable as validation because the test hook crash left the local source server unreachable before the resume assertions.
