### PR TITLE
[codex] Add per-part gzip for mixed file fetches

### DIFF
--- a/packages/reprint-exporter/src/class-http-server.php
+++ b/packages/reprint-exporter/src/class-http-server.php
@@ -171,7 +171,7 @@ final class Site_Export_HTTP_Server {
                 $value = (int) $value;
             } elseif (in_array($key, ['memory_threshold'], true)) {
                 $value = (float) $value;
-            } elseif (in_array($key, ['create_table_query', 'db_unbuffered', 'follow_symlinks'], true)) {
+            } elseif (in_array($key, ['create_table_query', 'db_unbuffered', 'follow_symlinks', 'file_part_gzip'], true)) {
                 $value = filter_var($value, FILTER_VALIDATE_BOOLEAN);
             } elseif ($key === 'paths' && is_string($value)) {
                 $decoded = json_decode($value, true);

--- a/packages/reprint-exporter/src/export.php
+++ b/packages/reprint-exporter/src/export.php
@@ -3399,7 +3399,11 @@ function endpoint_file_fetch(
         $producer,
         $budget,
         $config,
-        file_fetch_compression_mode($paths, !empty($config["file_part_gzip"])),
+        file_fetch_compression_mode(
+            $paths,
+            !empty($config["file_part_gzip"]),
+            $directories
+        ),
     );
 }
 
@@ -3427,22 +3431,41 @@ function endpoint_file_fetch(
  *   - mixed without that capability: fall back to response gzip so older
  *     importers never receive encoded file parts they cannot decode.
  */
-function file_fetch_compression_mode(array $paths, bool $allow_file_parts = false): string
+function file_fetch_compression_mode(
+    array $paths,
+    bool $allow_file_parts = false,
+    array $directories = []
+): string
 {
     if ($paths === []) {
         return 'identity';
     }
     $any_compressible = false;
     $any_incompressible = false;
+    $compressible_bytes = 0;
+    $incompressible_bytes = 0;
+    $compressible_count = 0;
+    $incompressible_count = 0;
+    $unknown_size_count = 0;
+
     foreach ($paths as $path) {
         if (!is_string($path)) {
             // Defensive: an unexpected non-string entry is a bad input we
             // shouldn't compress around. Treat as a hard reject.
             return 'identity';
         }
+        $resolved_path = resolve_file_fetch_heuristic_path($path, $directories);
+        $size = file_fetch_heuristic_file_size($resolved_path);
+
         $ext = path_extension_compressibility($path);
         if ($ext === 'yes') {
             $any_compressible = true;
+            $compressible_count++;
+            if ($size === null) {
+                $unknown_size_count++;
+            } else {
+                $compressible_bytes += $size;
+            }
             continue;
         }
         if ($ext === 'unknown') {
@@ -3450,23 +3473,158 @@ function file_fetch_compression_mode(array $paths, bool $allow_file_parts = fals
             // at the first 64 bytes and let the bytes decide. Cheap (one
             // open/read/close per file) and means we don't have to grow the
             // whitelist every time a plugin invents a new template suffix.
-            if (path_head_looks_like_text($path)) {
+            if (path_head_looks_like_text($resolved_path ?? $path)) {
                 $any_compressible = true;
+                $compressible_count++;
+                if ($size === null) {
+                    $unknown_size_count++;
+                } else {
+                    $compressible_bytes += $size;
+                }
             } else {
                 $any_incompressible = true;
+                $incompressible_count++;
+                if ($size === null) {
+                    $unknown_size_count++;
+                } else {
+                    $incompressible_bytes += $size;
+                }
             }
             continue;
         }
         // 'no' — known binary.
         $any_incompressible = true;
+        $incompressible_count++;
+        if ($size === null) {
+            $unknown_size_count++;
+        } else {
+            $incompressible_bytes += $size;
+        }
     }
     if ($any_compressible && $any_incompressible) {
-        return $allow_file_parts ? 'file-parts' : 'response-gzip';
+        if (!$allow_file_parts) {
+            return 'response-gzip';
+        }
+        return file_fetch_mixed_batch_prefers_file_parts([
+            'compressible_bytes' => $compressible_bytes,
+            'incompressible_bytes' => $incompressible_bytes,
+            'compressible_count' => $compressible_count,
+            'incompressible_count' => $incompressible_count,
+            'unknown_size_count' => $unknown_size_count,
+        ]) ? 'file-parts' : 'response-gzip';
     }
     if ($any_compressible) {
         return 'response-gzip';
     }
     return 'identity';
+}
+
+/**
+ * Resolves a file_fetch path for compression heuristics only.
+ *
+ * FileTreeProducer still performs the authoritative path resolution later.
+ * This helper just lets the compression decision use file sizes and byte
+ * sniffing for relative path lists too.
+ */
+function resolve_file_fetch_heuristic_path(string $path, array $directories = []): ?string
+{
+    if ($path === '') {
+        return null;
+    }
+
+    clearstatcache(true, $path);
+    if ($path[0] === '/' && (is_file($path) || is_link($path))) {
+        return $path;
+    }
+
+    foreach ($directories as $directory) {
+        if (!is_string($directory) || $directory === '') {
+            continue;
+        }
+        $candidate = rtrim($directory, '/') . '/' . ltrim($path, '/');
+        clearstatcache(true, $candidate);
+        if (is_file($candidate) || is_link($candidate)) {
+            return $candidate;
+        }
+    }
+
+    if ($path[0] !== '/') {
+        clearstatcache(true, $path);
+        if (is_file($path) || is_link($path)) {
+            return $path;
+        }
+    }
+
+    return null;
+}
+
+function file_fetch_heuristic_file_size(?string $path): ?int
+{
+    if ($path === null || !is_file($path)) {
+        return null;
+    }
+
+    $size = @filesize($path);
+    return $size === false ? null : (int) $size;
+}
+
+/**
+ * Decide whether a mixed batch is worth splitting into per-file gzip bodies.
+ *
+ * Whole-response gzip is still better for batches dominated by many tiny text
+ * files: one stream shares a dictionary across part boundaries and avoids
+ * thousands of tiny gzip members. Per-part gzip wins when enough bytes are
+ * already-compressed media/archive data that response gzip would burn CPU
+ * deflating bytes it cannot shrink.
+ *
+ * @param array{compressible_bytes:int,incompressible_bytes:int,compressible_count:int,incompressible_count:int,unknown_size_count:int} $summary
+ */
+function file_fetch_mixed_batch_prefers_file_parts(array $summary): bool
+{
+    if ($summary['unknown_size_count'] > 0) {
+        // Preserve the old mixed-batch behavior when we cannot size the
+        // entries. endpoint_file_fetch passes directories, so production
+        // requests normally take the measured path.
+        return true;
+    }
+
+    $compressible_bytes = $summary['compressible_bytes'];
+    $incompressible_bytes = $summary['incompressible_bytes'];
+    $total_bytes = $compressible_bytes + $incompressible_bytes;
+    if ($total_bytes <= 0 || $incompressible_bytes <= 0) {
+        return false;
+    }
+
+    // If the binary side is tiny, response gzip's shared dictionary is worth
+    // more than avoiding a negligible amount of binary deflate work.
+    if ($incompressible_bytes < 1024 * 1024) {
+        return false;
+    }
+
+    if (($incompressible_bytes / $total_bytes) < 0.10) {
+        return false;
+    }
+
+    // Many tiny text files are the specific bad case for per-part gzip: each
+    // file pays its own gzip header/trailer and cannot reuse a dictionary from
+    // neighboring parts. Keep response gzip until the binary side is large
+    // enough to dominate both CPU and wire size.
+    if ($summary['compressible_count'] >= 128) {
+        $average_compressible_size = $compressible_bytes > 0
+            ? $compressible_bytes / $summary['compressible_count']
+            : 0;
+        if (
+            $average_compressible_size <= 16 * 1024 &&
+            (
+                $incompressible_bytes < 8 * 1024 * 1024 ||
+                $incompressible_bytes < $compressible_bytes
+            )
+        ) {
+            return false;
+        }
+    }
+
+    return true;
 }
 
 /**

--- a/packages/reprint-exporter/src/export.php
+++ b/packages/reprint-exporter/src/export.php
@@ -2181,11 +2181,20 @@ function stream_file_producer(
     $producer,
     ResourceBudget $budget,
     array $config = [],
-    bool $gzip = false
+    $compression_mode = 'identity'
 ): array {
     prepare_streaming_response();
 
-    ['gz' => $gz, 'boundary' => $boundary] = begin_multipart_stream(false, $gzip);
+    if ($compression_mode === true) {
+        $compression_mode = 'response-gzip';
+    } elseif ($compression_mode === false || !is_string($compression_mode)) {
+        $compression_mode = 'identity';
+    }
+
+    $response_gzip = $compression_mode === 'response-gzip';
+    $gzip_file_parts = $compression_mode === 'file-parts';
+
+    ['gz' => $gz, 'boundary' => $boundary] = begin_multipart_stream(false, $response_gzip);
 
     // E2E test hook: after gzip stream initialization (file producer)
     if (getenv('SITE_EXPORT_TEST_MODE')) {
@@ -2376,7 +2385,18 @@ function stream_file_producer(
                     $files_completed++;
                 }
 
+                $decoded_size = strlen($chunk["data"]);
                 $data = $chunk["data"];
+                $body_encoding_headers = "";
+                if ($gzip_file_parts && file_part_body_should_gzip($chunk["path"], $data)) {
+                    $encoded = gzencode($data, 6);
+                    if ($encoded !== false && strlen($encoded) < $decoded_size) {
+                        $data = $encoded;
+                        $body_encoding_headers =
+                            "X-Body-Encoding: gzip\r\n" .
+                            "X-Decoded-Content-Length: " . $decoded_size . "\r\n";
+                    }
+                }
 
                 $headers =
                     "--{$boundary}\r\n" .
@@ -2388,9 +2408,10 @@ function stream_file_producer(
                     "X-File-Size: " . $chunk["size"] . "\r\n" .
                     "X-File-Ctime: " . $chunk["ctime"] . "\r\n" .
                     "X-Chunk-Offset: " . $chunk["offset"] . "\r\n" .
-                    "X-Chunk-Size: " . strlen($data) . "\r\n" .
+                    "X-Chunk-Size: " . $decoded_size . "\r\n" .
                     "X-First-Chunk: " . ($chunk["is_first_chunk"] ? "1" : "0") . "\r\n" .
-                    "X-Last-Chunk: " . ($chunk["is_last_chunk"] ? "1" : "0") . "\r\n";
+                    "X-Last-Chunk: " . ($chunk["is_last_chunk"] ? "1" : "0") . "\r\n" .
+                    $body_encoding_headers;
                 if (!empty($chunk["file_changed"])) {
                     $headers .= "X-File-Changed: 1\r\n";
                     if ($chunk["change_ctime"] !== null) {
@@ -3378,16 +3399,16 @@ function endpoint_file_fetch(
         $producer,
         $budget,
         $config,
-        file_fetch_paths_should_gzip($paths),
+        file_fetch_compression_mode($paths, !empty($config["file_part_gzip"])),
     );
 }
 
 /**
- * Decides whether to gzip a file_fetch multipart response based on the path
+ * Decides how to compress a file_fetch multipart response based on the path
  * list it will carry.
  *
  * Encoding is set per response (Content-Encoding is a response-level header),
- * so we have to commit before any byte is sent. The trade-off:
+ * so whole-response gzip is still all-or-nothing. The trade-off:
  *   - Text-y bodies (PHP/JS/CSS/JSON/SQL/HTML/etc.) compress 5–60×. Gzip is
  *     a clear win on wire size and total wall time.
  *   - Image/video/audio/font/archive bodies are already compressed; passing
@@ -3396,28 +3417,28 @@ function endpoint_file_fetch(
  *     input). Negligible per individual file, but unbounded if the batch is
  *     all-binary multiplied by request volume.
  *
- * Rule: gzip the response if **any** file in the batch is compressible.
- *
- * The previous all-or-nothing rule ("gzip only if every file is compressible")
- * was over-conservative — a single PNG in a 200-CSS batch flipped the whole
- * response to identity, losing ~50 % of wire size that would have compressed.
- * The wasted CPU on the small binary portion of mixed batches is bounded by
- * request size (capped server-side), so this trade-off favors smaller wire
- * bytes on the common WordPress mixed batch (theme dirs, wp-content/uploads
- * mixed with plugin assets) without harming the all-binary uploads case
- * (which has zero compressible files and stays identity).
+ * Rule:
+ *   - all text-y: gzip the whole response, which is best for many small files
+ *     because one stream can share a compression dictionary across parts.
+ *   - all binary: keep the response identity.
+ *   - mixed with file_part_gzip client capability: keep the response identity
+ *     and gzip only compressible file parts. This preserves the text win
+ *     without spending CPU deflating media bytes.
+ *   - mixed without that capability: fall back to response gzip so older
+ *     importers never receive encoded file parts they cannot decode.
  */
-function file_fetch_paths_should_gzip(array $paths): bool
+function file_fetch_compression_mode(array $paths, bool $allow_file_parts = false): string
 {
     if ($paths === []) {
-        return false;
+        return 'identity';
     }
     $any_compressible = false;
+    $any_incompressible = false;
     foreach ($paths as $path) {
         if (!is_string($path)) {
             // Defensive: an unexpected non-string entry is a bad input we
             // shouldn't compress around. Treat as a hard reject.
-            return false;
+            return 'identity';
         }
         $ext = path_extension_compressibility($path);
         if ($ext === 'yes') {
@@ -3431,12 +3452,29 @@ function file_fetch_paths_should_gzip(array $paths): bool
             // whitelist every time a plugin invents a new template suffix.
             if (path_head_looks_like_text($path)) {
                 $any_compressible = true;
+            } else {
+                $any_incompressible = true;
             }
             continue;
         }
-        // 'no' — known binary. Skip; doesn't disqualify the batch.
+        // 'no' — known binary.
+        $any_incompressible = true;
     }
-    return $any_compressible;
+    if ($any_compressible && $any_incompressible) {
+        return $allow_file_parts ? 'file-parts' : 'response-gzip';
+    }
+    if ($any_compressible) {
+        return 'response-gzip';
+    }
+    return 'identity';
+}
+
+/**
+ * Back-compat helper for callers/tests that only care about response-level gzip.
+ */
+function file_fetch_paths_should_gzip(array $paths): bool
+{
+    return file_fetch_compression_mode($paths) === 'response-gzip';
 }
 
 /**
@@ -3558,6 +3596,36 @@ function path_head_looks_like_text(string $path): bool
     // a multi-byte sequence is sliced by our 64-byte window: it returns false,
     // which we treat as "not obviously text" — biased toward identity, which
     // is the safe direction.
+    if (function_exists('mb_check_encoding') && !mb_check_encoding($head, 'UTF-8')) {
+        return false;
+    }
+    return true;
+}
+
+function file_part_body_should_gzip(string $path, string $body): bool
+{
+    $ext = path_extension_compressibility($path);
+    if ($ext === 'yes') {
+        return true;
+    }
+    if ($ext === 'no') {
+        return false;
+    }
+    return body_head_looks_like_text($body);
+}
+
+function body_head_looks_like_text(string $body): bool
+{
+    $head = substr($body, 0, 64);
+    if ($head === '') {
+        return false;
+    }
+    if (strpos($head, "\x00") !== false) {
+        return false;
+    }
+    if (preg_match('/[\x01-\x08\x0B\x0E-\x1F\x7F]/', $head)) {
+        return false;
+    }
     if (function_exists('mb_check_encoding') && !mb_check_encoding($head, 'UTF-8')) {
         return false;
     }

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -8382,6 +8382,11 @@ class ImportClient
                 : 0;
 
             $file_changed = ($headers["x-file-changed"] ?? "0") === "1";
+            if (!$file_changed && $final_size !== $file_size) {
+                throw new RuntimeException(
+                    "Downloaded file size mismatch for {$path}: expected {$file_size}, wrote {$final_size}"
+                );
+            }
 
             if ($context->file_ctime && !$file_changed) {
                 $this->upsert_index_entry(

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -5683,6 +5683,7 @@ class ImportClient
         }
 
         $params = $this->get_tuned_params("file_fetch");
+        $params["file_part_gzip"] = "1";
         // Always send directory[] – see comment in download_remote_index().
         $export_dirs = $this->get_export_directories();
         if (!empty($export_dirs)) {
@@ -9299,6 +9300,34 @@ class ImportClient
         ];
     }
 
+    private function decode_file_part_body(array $headers, string $body): string
+    {
+        $encoding = strtolower(trim($headers["x-body-encoding"] ?? ""));
+        if ($encoding === "" || $encoding === "identity") {
+            return $body;
+        }
+        if ($encoding !== "gzip") {
+            throw new RuntimeException("Unsupported file part body encoding: {$encoding}");
+        }
+
+        $decoded = gzdecode($body);
+        if ($decoded === false) {
+            throw new RuntimeException("Failed to decode gzip file part body");
+        }
+
+        if (isset($headers["x-decoded-content-length"])) {
+            $expected_length = (int) $headers["x-decoded-content-length"];
+            $actual_length = strlen($decoded);
+            if ($actual_length !== $expected_length) {
+                throw new RuntimeException(
+                    "Decoded gzip file part length mismatch: expected {$expected_length}, got {$actual_length}"
+                );
+            }
+        }
+
+        return $decoded;
+    }
+
     /**
      * Build the multipart chunk handler callback shared by both parser
      * creation sites inside fetch_streaming.
@@ -9316,6 +9345,21 @@ class ImportClient
                 $headers = $event["headers"];
                 $chunk_type = $headers["x-chunk-type"] ?? "";
                 if ($chunk_type === "file") {
+                    $body_encoding = strtolower(trim($headers["x-body-encoding"] ?? ""));
+                    if ($body_encoding === "gzip") {
+                        if (!$current_chunk) {
+                            $current_chunk = [
+                                "headers" => $headers,
+                                "body" => "",
+                                "compressed_file_part" => true,
+                            ];
+                        }
+                        $current_chunk["body"] =
+                            ($current_chunk["body"] ?? "") .
+                            $event["data"];
+                        return;
+                    }
+
                     if (!$current_chunk) {
                         $current_chunk = [
                             "headers" => $headers,
@@ -9357,7 +9401,29 @@ class ImportClient
             } elseif ($event["type"] === "complete") {
                 $headers = $event["headers"];
                 $chunk_type = $headers["x-chunk-type"] ?? "";
-                if ($chunk_type === "file" && !empty($current_chunk["body_streamed"])) {
+                if ($chunk_type === "file" && !empty($current_chunk["compressed_file_part"])) {
+                    if ($context->on_chunk) {
+                        $decoded_body = $this->decode_file_part_body(
+                            $headers,
+                            (string) ($current_chunk["body"] ?? ""),
+                        );
+                        $stream_headers = $headers;
+                        $stream_headers["x-last-chunk"] = "0";
+                        ($context->on_chunk)([
+                            "headers" => $stream_headers,
+                            "body" => $decoded_body,
+                            "is_streaming_body" => true,
+                        ]);
+
+                        $close_headers = $headers;
+                        $close_headers["x-first-chunk"] = "0";
+                        ($context->on_chunk)([
+                            "headers" => $close_headers,
+                            "body" => "",
+                            "is_streaming_close" => true,
+                        ]);
+                    }
+                } elseif ($chunk_type === "file" && !empty($current_chunk["body_streamed"])) {
                     if ($context->on_chunk) {
                         $close_headers = $headers;
                         $close_headers["x-first-chunk"] = "0";

--- a/tests/FileFetchCompressionTest.php
+++ b/tests/FileFetchCompressionTest.php
@@ -55,16 +55,11 @@ final class FileFetchCompressionTest extends TestCase
         $this->assertStringContainsString('body { color: red; }', $decoded);
     }
 
-    public function testFileFetchGzipsMixedBatchesIfAnyFileIsCompressible(): void
+    public function testFileFetchUsesPerPartGzipForMixedBatches(): void
     {
-        // A mixed batch (some text + some binary) gets gzipped at the
-        // response level. The binary portion passes through deflate as
-        // literal stored blocks (~0 % size change, ~4 ms CPU per 200 KB);
-        // the text portion compresses 5–60×. Net: a ~50 % wire reduction
-        // on a typical wp-content batch with mostly assets.
-        //
-        // The previous behaviour (fall back to identity if any binary)
-        // sacrificed all gzip benefit on these batches.
+        // Mixed batches keep the HTTP response identity, but gzip the
+        // compressible file part body. That avoids spending CPU deflating
+        // already-compressed media while preserving the text-file wire win.
         $siteDir = $this->tempDir . '/site';
         mkdir($siteDir, 0755, true);
         $textPath = $siteDir . '/style.css';
@@ -74,11 +69,35 @@ final class FileFetchCompressionTest extends TestCase
 
         $stdout = $this->runFileFetch($siteDir, [$textPath, $binaryPath]);
 
-        $this->assertSame("\x1f\x8b", substr($stdout, 0, 2), 'mixed batch should be gzip framed');
+        $this->assertStringStartsWith('--boundary-', $stdout);
+        $this->assertFalse(@gzdecode($stdout), 'mixed file_fetch should not use response-level gzip');
+
+        $textPart = $this->findFilePart($stdout, $textPath);
+        $this->assertSame('gzip', $textPart['headers']['x-body-encoding'] ?? null);
+        $this->assertSame('body { color: red; }', substr((string) gzdecode($textPart['body']), 0, 20));
+
+        $binaryPart = $this->findFilePart($stdout, $binaryPath);
+        $this->assertArrayNotHasKey('x-body-encoding', $binaryPart['headers']);
+        $this->assertSame('pretend-jpeg-bytes', $binaryPart['body']);
+    }
+
+    public function testFileFetchKeepsResponseGzipForMixedBatchesWithoutCapability(): void
+    {
+        $siteDir = $this->tempDir . '/site';
+        mkdir($siteDir, 0755, true);
+        $textPath = $siteDir . '/style.css';
+        $binaryPath = $siteDir . '/photo.jpg';
+        file_put_contents($textPath, str_repeat("body { color: red; }\n", 200));
+        file_put_contents($binaryPath, 'pretend-jpeg-bytes');
+
+        $stdout = $this->runFileFetch($siteDir, [$textPath, $binaryPath], false);
+
+        $this->assertSame("\x1f\x8b", substr($stdout, 0, 2));
         $decoded = gzdecode($stdout);
-        $this->assertNotFalse($decoded, 'gzip body should decode');
+        $this->assertNotFalse($decoded);
         $this->assertStringContainsString('body { color: red; }', $decoded);
         $this->assertStringContainsString('pretend-jpeg-bytes', $decoded);
+        $this->assertStringNotContainsString('X-Body-Encoding: gzip', $decoded);
     }
 
     public function testFileFetchKeepsIdentityWhenAllPathsAreBinary(): void
@@ -104,14 +123,10 @@ final class FileFetchCompressionTest extends TestCase
         $this->assertStringContainsString('mp4-blob', $stdout);
     }
 
-    public function testFileFetchGzipsBatchWhereOnlyOneFileIsCompressible(): void
+    public function testFileFetchUsesPerPartGzipWhenOnlyOneFileIsCompressible(): void
     {
-        // Edge case: 99 binary files + 1 readme. The single text file
-        // alone is enough to flip the response to gzip. The 99 binaries
-        // ride through deflate as stored blocks (no inflation). This
-        // codifies the "any compressible → gzip" rule on a slightly
-        // pathological mix — we accept the CPU cost on the binary
-        // majority because per-request total size is bounded server-side.
+        // Edge case: many binary files + one readme. Only the readme part
+        // should be encoded; media parts stay raw.
         $siteDir = $this->tempDir . '/site';
         mkdir($siteDir, 0755, true);
         $paths = [];
@@ -125,19 +140,18 @@ final class FileFetchCompressionTest extends TestCase
         $paths[] = $readme;
 
         $stdout = $this->runFileFetch($siteDir, $paths);
-        $this->assertSame("\x1f\x8b", substr($stdout, 0, 2), 'one compressible file flips the batch to gzip');
-        $decoded = gzdecode($stdout);
-        $this->assertNotFalse($decoded);
-        $this->assertStringContainsString('Welcome to the plugin.', $decoded);
-        $this->assertStringContainsString('binary-0', $decoded);
-        $this->assertStringContainsString('binary-7', $decoded);
+        $this->assertStringStartsWith('--boundary-', $stdout);
+        $readmePart = $this->findFilePart($stdout, $readme);
+        $this->assertSame('gzip', $readmePart['headers']['x-body-encoding'] ?? null);
+        $this->assertStringContainsString('Welcome to the plugin.', (string) gzdecode($readmePart['body']));
+        $this->assertSame('binary-0', $this->findFilePart($stdout, $paths[0])['body']);
+        $this->assertSame('binary-7', $this->findFilePart($stdout, $paths[7])['body']);
     }
 
-    public function testFileFetchGzipsBatchWithUnknownTextAndKnownBinary(): void
+    public function testFileFetchUsesPerPartGzipWithUnknownTextAndKnownBinary(): void
     {
         // Mixed: an unknown-extension file with text bytes (sniffer says
-        // text) plus a known-binary jpeg. The unknown-text contributes a
-        // 'yes' classification → response gzipped.
+        // text) plus a known-binary jpeg. The unknown-text part gets gzip.
         $siteDir = $this->tempDir . '/site';
         mkdir($siteDir, 0755, true);
         $unknownText = $siteDir . '/config.neon';
@@ -146,11 +160,11 @@ final class FileFetchCompressionTest extends TestCase
         file_put_contents($jpg, 'jpeg-blob');
 
         $stdout = $this->runFileFetch($siteDir, [$unknownText, $jpg]);
-        $this->assertSame("\x1f\x8b", substr($stdout, 0, 2));
-        $decoded = gzdecode($stdout);
-        $this->assertNotFalse($decoded);
-        $this->assertStringContainsString('services:', $decoded);
-        $this->assertStringContainsString('jpeg-blob', $decoded);
+        $this->assertStringStartsWith('--boundary-', $stdout);
+        $unknownTextPart = $this->findFilePart($stdout, $unknownText);
+        $this->assertSame('gzip', $unknownTextPart['headers']['x-body-encoding'] ?? null);
+        $this->assertStringContainsString('services:', (string) gzdecode($unknownTextPart['body']));
+        $this->assertSame('jpeg-blob', $this->findFilePart($stdout, $jpg)['body']);
     }
 
     public function testFileFetchKeepsIdentityWithUnknownBinaryAndKnownBinary(): void
@@ -169,10 +183,10 @@ final class FileFetchCompressionTest extends TestCase
         $this->assertFalse(@gzdecode($stdout), 'no compressible file → identity');
     }
 
-    public function testFileFetchGzipsBatchWithExtensionlessTextAndImage(): void
+    public function testFileFetchUsesPerPartGzipWithExtensionlessTextAndImage(): void
     {
-        // .htaccess + a screenshot — the canonical "theme/plugin
-        // distribution" shape. Pre-PR this was identity; now it gzips.
+        // .htaccess + a screenshot — common theme/plugin distribution shape.
+        // Only the text part should be gzip encoded.
         $siteDir = $this->tempDir . '/site';
         mkdir($siteDir, 0755, true);
         $ht = $siteDir . '/.htaccess';
@@ -181,11 +195,11 @@ final class FileFetchCompressionTest extends TestCase
         file_put_contents($png, 'pretend-png-bytes');
 
         $stdout = $this->runFileFetch($siteDir, [$ht, $png]);
-        $this->assertSame("\x1f\x8b", substr($stdout, 0, 2));
-        $decoded = gzdecode($stdout);
-        $this->assertNotFalse($decoded);
-        $this->assertStringContainsString('RewriteRule', $decoded);
-        $this->assertStringContainsString('pretend-png-bytes', $decoded);
+        $this->assertStringStartsWith('--boundary-', $stdout);
+        $htPart = $this->findFilePart($stdout, $ht);
+        $this->assertSame('gzip', $htPart['headers']['x-body-encoding'] ?? null);
+        $this->assertStringContainsString('RewriteRule', (string) gzdecode($htPart['body']));
+        $this->assertSame('pretend-png-bytes', $this->findFilePart($stdout, $png)['body']);
     }
 
     public function testFileFetchEmptyListStaysIdentity(): void
@@ -209,10 +223,15 @@ final class FileFetchCompressionTest extends TestCase
         $this->assertFalse(file_fetch_paths_should_gzip(['photo.jpg']),                'single binary');
         $this->assertTrue(file_fetch_paths_should_gzip(['.htaccess']),                 'single extensionless');
 
-        // Multi-file: any-compressible flips on.
+        // Multi-file without file-part capability keeps old response-gzip behavior.
         $this->assertTrue(file_fetch_paths_should_gzip(['a.php', 'b.jpg']),            'text + binary');
         $this->assertTrue(file_fetch_paths_should_gzip(['a.jpg', 'b.css', 'c.mp4']),   'majority binary, one text');
         $this->assertFalse(file_fetch_paths_should_gzip(['a.jpg', 'b.png', 'c.mp4']),  'all binary');
+
+        $this->assertSame('response-gzip', file_fetch_compression_mode(['a.php', 'b.css']));
+        $this->assertSame('response-gzip', file_fetch_compression_mode(['a.php', 'b.jpg']));
+        $this->assertSame('file-parts', file_fetch_compression_mode(['a.php', 'b.jpg'], true));
+        $this->assertSame('identity', file_fetch_compression_mode(['a.jpg', 'b.png']));
 
         // Bad input — defensive.
         $this->assertFalse(file_fetch_paths_should_gzip([null]),                       /** @phpstan-ignore-line */
@@ -310,7 +329,60 @@ final class FileFetchCompressionTest extends TestCase
         ];
     }
 
-    private function runFileFetch(string $siteDir, array $paths): string
+    private function findFilePart(string $multipart, string $path): array
+    {
+        foreach ($this->parseMultipart($multipart) as $part) {
+            if (($part['headers']['x-chunk-type'] ?? '') !== 'file') {
+                continue;
+            }
+            $partPath = base64_decode($part['headers']['x-file-path'] ?? '', true);
+            if ($partPath === $path) {
+                return $part;
+            }
+        }
+        $this->fail("File part not found for {$path}");
+    }
+
+    private function parseMultipart(string $multipart): array
+    {
+        $lineEnd = strpos($multipart, "\n");
+        $this->assertNotFalse($lineEnd, 'multipart response should start with a boundary line');
+        $boundaryLine = rtrim(substr($multipart, 0, $lineEnd), "\r\n");
+        $this->assertStringStartsWith('--boundary-', $boundaryLine);
+
+        $boundary = substr($boundaryLine, 2);
+        $parts = [];
+        foreach (explode('--' . $boundary, $multipart) as $segment) {
+            $segment = ltrim($segment, "\r\n");
+            if ($segment === '' || strncmp($segment, '--', 2) === 0) {
+                continue;
+            }
+            $headerEnd = strpos($segment, "\r\n\r\n");
+            $this->assertNotFalse($headerEnd, 'multipart part should contain a header/body separator');
+            $headerBlock = substr($segment, 0, $headerEnd);
+            $body = substr($segment, $headerEnd + 4);
+            if (substr($body, -2) === "\r\n") {
+                $body = substr($body, 0, -2);
+            }
+
+            $headers = [];
+            foreach (explode("\r\n", $headerBlock) as $line) {
+                $colon = strpos($line, ':');
+                if ($colon === false) {
+                    continue;
+                }
+                $headers[strtolower(substr($line, 0, $colon))] = ltrim(substr($line, $colon + 1));
+            }
+            $parts[] = [
+                'headers' => $headers,
+                'body' => $body,
+            ];
+        }
+
+        return $parts;
+    }
+
+    private function runFileFetch(string $siteDir, array $paths, bool $filePartGzip = true): string
     {
         $listPath = $this->tempDir . '/file-list.json';
         file_put_contents($listPath, json_encode($paths, JSON_THROW_ON_ERROR));
@@ -319,6 +391,7 @@ final class FileFetchCompressionTest extends TestCase
         file_put_contents($configPath, json_encode([
             'directory' => $siteDir,
             'file_list_path' => $listPath,
+            'file_part_gzip' => $filePartGzip,
         ], JSON_THROW_ON_ERROR));
 
         $scriptPath = $this->tempDir . '/run-file-fetch.php';

--- a/tests/FileFetchCompressionTest.php
+++ b/tests/FileFetchCompressionTest.php
@@ -65,7 +65,7 @@ final class FileFetchCompressionTest extends TestCase
         $textPath = $siteDir . '/style.css';
         $binaryPath = $siteDir . '/photo.jpg';
         file_put_contents($textPath, str_repeat("body { color: red; }\n", 200));
-        file_put_contents($binaryPath, 'pretend-jpeg-bytes');
+        file_put_contents($binaryPath, str_repeat('pretend-jpeg-bytes', 128 * 1024));
 
         $stdout = $this->runFileFetch($siteDir, [$textPath, $binaryPath]);
 
@@ -78,7 +78,7 @@ final class FileFetchCompressionTest extends TestCase
 
         $binaryPart = $this->findFilePart($stdout, $binaryPath);
         $this->assertArrayNotHasKey('x-body-encoding', $binaryPart['headers']);
-        $this->assertSame('pretend-jpeg-bytes', $binaryPart['body']);
+        $this->assertStringStartsWith('pretend-jpeg-bytes', $binaryPart['body']);
     }
 
     public function testFileFetchKeepsResponseGzipForMixedBatchesWithoutCapability(): void
@@ -132,7 +132,7 @@ final class FileFetchCompressionTest extends TestCase
         $paths = [];
         for ($i = 0; $i < 8; $i++) {
             $p = $siteDir . sprintf('/blob-%d.jpg', $i);
-            file_put_contents($p, 'binary-' . $i);
+            file_put_contents($p, str_repeat('binary-' . $i, 32 * 1024));
             $paths[] = $p;
         }
         $readme = $siteDir . '/README';
@@ -144,8 +144,8 @@ final class FileFetchCompressionTest extends TestCase
         $readmePart = $this->findFilePart($stdout, $readme);
         $this->assertSame('gzip', $readmePart['headers']['x-body-encoding'] ?? null);
         $this->assertStringContainsString('Welcome to the plugin.', (string) gzdecode($readmePart['body']));
-        $this->assertSame('binary-0', $this->findFilePart($stdout, $paths[0])['body']);
-        $this->assertSame('binary-7', $this->findFilePart($stdout, $paths[7])['body']);
+        $this->assertStringStartsWith('binary-0', $this->findFilePart($stdout, $paths[0])['body']);
+        $this->assertStringStartsWith('binary-7', $this->findFilePart($stdout, $paths[7])['body']);
     }
 
     public function testFileFetchUsesPerPartGzipWithUnknownTextAndKnownBinary(): void
@@ -157,14 +157,14 @@ final class FileFetchCompressionTest extends TestCase
         $unknownText = $siteDir . '/config.neon';
         file_put_contents($unknownText, str_repeat("services: { foo: Foo\\Bar }\n", 100));
         $jpg = $siteDir . '/photo.jpg';
-        file_put_contents($jpg, 'jpeg-blob');
+        file_put_contents($jpg, str_repeat('jpeg-blob', 128 * 1024));
 
         $stdout = $this->runFileFetch($siteDir, [$unknownText, $jpg]);
         $this->assertStringStartsWith('--boundary-', $stdout);
         $unknownTextPart = $this->findFilePart($stdout, $unknownText);
         $this->assertSame('gzip', $unknownTextPart['headers']['x-body-encoding'] ?? null);
         $this->assertStringContainsString('services:', (string) gzdecode($unknownTextPart['body']));
-        $this->assertSame('jpeg-blob', $this->findFilePart($stdout, $jpg)['body']);
+        $this->assertStringStartsWith('jpeg-blob', $this->findFilePart($stdout, $jpg)['body']);
     }
 
     public function testFileFetchKeepsIdentityWithUnknownBinaryAndKnownBinary(): void
@@ -192,14 +192,40 @@ final class FileFetchCompressionTest extends TestCase
         $ht = $siteDir . '/.htaccess';
         file_put_contents($ht, str_repeat("RewriteRule ^index\\.php$ - [L]\n", 200));
         $png = $siteDir . '/screenshot.png';
-        file_put_contents($png, 'pretend-png-bytes');
+        file_put_contents($png, str_repeat('pretend-png-bytes', 128 * 1024));
 
         $stdout = $this->runFileFetch($siteDir, [$ht, $png]);
         $this->assertStringStartsWith('--boundary-', $stdout);
         $htPart = $this->findFilePart($stdout, $ht);
         $this->assertSame('gzip', $htPart['headers']['x-body-encoding'] ?? null);
         $this->assertStringContainsString('RewriteRule', (string) gzdecode($htPart['body']));
-        $this->assertSame('pretend-png-bytes', $this->findFilePart($stdout, $png)['body']);
+        $this->assertStringStartsWith('pretend-png-bytes', $this->findFilePart($stdout, $png)['body']);
+    }
+
+    public function testFileFetchKeepsResponseGzipForTextHeavySmallMixedBatches(): void
+    {
+        // Many small text files plus a tiny binary file are better as one gzip
+        // response: the shared dictionary beats thousands of isolated gzip
+        // members, and the binary side is too small to matter.
+        $siteDir = $this->tempDir . '/site';
+        mkdir($siteDir, 0755, true);
+        $paths = [];
+        for ($i = 0; $i < 200; $i++) {
+            $p = $siteDir . sprintf('/snippet-%03d.php', $i);
+            file_put_contents($p, str_repeat("<?php echo 'hello';\n", 100));
+            $paths[] = $p;
+        }
+        $tinyBinary = $siteDir . '/tiny-logo.jpg';
+        file_put_contents($tinyBinary, str_repeat('tiny-jpeg', 1024));
+        $paths[] = $tinyBinary;
+
+        $stdout = $this->runFileFetch($siteDir, $paths);
+
+        $this->assertSame("\x1f\x8b", substr($stdout, 0, 2));
+        $decoded = gzdecode($stdout);
+        $this->assertNotFalse($decoded);
+        $this->assertStringContainsString("<?php echo 'hello';", $decoded);
+        $this->assertStringNotContainsString('X-Body-Encoding: gzip', $decoded);
     }
 
     public function testFileFetchEmptyListStaysIdentity(): void
@@ -238,6 +264,30 @@ final class FileFetchCompressionTest extends TestCase
             'non-string entry rejects the batch');
         $this->assertFalse(file_fetch_paths_should_gzip([42]),                         /** @phpstan-ignore-line */
             'numeric entry rejects the batch');
+    }
+
+    public function testMixedBatchHeuristicUsesMeasuredSizesWhenDirectoriesAreKnown(): void
+    {
+        require_once __DIR__ . '/../packages/reprint-exporter/src/export.php';
+
+        $siteDir = $this->tempDir . '/site';
+        mkdir($siteDir, 0755, true);
+
+        $largeText = $siteDir . '/large.css';
+        $largeBinary = $siteDir . '/large.jpg';
+        file_put_contents($largeText, str_repeat('body { color: red; }', 64 * 1024));
+        file_put_contents($largeBinary, str_repeat('jpeg-blob', 256 * 1024));
+        $this->assertSame(
+            'file-parts',
+            file_fetch_compression_mode(['large.css', 'large.jpg'], true, [$siteDir])
+        );
+
+        $smallBinary = $siteDir . '/small.jpg';
+        file_put_contents($smallBinary, str_repeat('jpeg-blob', 1024));
+        $this->assertSame(
+            'response-gzip',
+            file_fetch_compression_mode(['large.css', 'small.jpg'], true, [$siteDir])
+        );
     }
 
     public function testUnknownExtensionWithTextContentGetsGzipped(): void

--- a/tests/Import/FileBodyStreamingTest.php
+++ b/tests/Import/FileBodyStreamingTest.php
@@ -85,6 +85,72 @@ class FileBodyStreamingTest extends TestCase
         $this->assertLessThan(strlen($body), max($nonEmptyBodies));
     }
 
+    public function testGzipEncodedFilePartBodyIsDecodedBeforeWriting(): void
+    {
+        $client = new \ImportClient(
+            'http://fake.url',
+            $this->tempDir . '/state',
+            $this->tempDir . '/fs-root',
+        );
+        $reflection = new \ReflectionClass($client);
+        $reflection->getProperty('is_tty')->setValue($client, true);
+        $reflection->getProperty('state')->setValue($client, []);
+
+        $handleFileChunk = $reflection->getMethod('handle_file_chunk');
+        $context = new \StreamingContext();
+        $events = [];
+        $context->on_chunk = function (array $chunk) use ($client, $handleFileChunk, $context, &$events): void {
+            if (($chunk['headers']['x-chunk-type'] ?? '') === 'file') {
+                $events[] = [
+                    'body' => $chunk['body'] ?? '',
+                    'is_streaming_body' => !empty($chunk['is_streaming_body']),
+                    'is_streaming_close' => !empty($chunk['is_streaming_close']),
+                ];
+            }
+            $handleFileChunk->invoke($client, $chunk, $context);
+        };
+
+        $currentChunk = null;
+        $makeHandler = $reflection->getMethod('make_chunk_handler');
+        $handler = $makeHandler->invokeArgs($client, [$context, &$currentChunk]);
+        $parser = new \MultipartStreamParser('BOUNDARY', $handler);
+
+        $body = str_repeat("body { color: red; }\n", 1024);
+        $encodedBody = gzencode($body);
+        $this->assertNotFalse($encodedBody);
+        $multipart = $this->buildMultipart('BOUNDARY', [
+            [
+                'headers' => [
+                    'Content-Type' => 'application/octet-stream',
+                    'Content-Length' => (string) strlen($encodedBody),
+                    'X-Chunk-Type' => 'file',
+                    'X-Body-Encoding' => 'gzip',
+                    'X-Decoded-Content-Length' => (string) strlen($body),
+                    'X-File-Path' => base64_encode('/themes/style.css'),
+                    'X-File-Size' => (string) strlen($body),
+                    'X-File-Ctime' => '1234567890',
+                    'X-Chunk-Offset' => '0',
+                    'X-Chunk-Size' => (string) strlen($body),
+                    'X-First-Chunk' => '1',
+                    'X-Last-Chunk' => '1',
+                ],
+                'body' => $encodedBody,
+            ],
+        ]);
+
+        for ($offset = 0; $offset < strlen($multipart); $offset += 257) {
+            $parser->feed(substr($multipart, $offset, 257));
+        }
+
+        $target = $this->tempDir . '/fs-root/themes/style.css';
+        $this->assertSame($body, file_get_contents($target));
+        $this->assertCount(2, $events);
+        $this->assertTrue($events[0]['is_streaming_body']);
+        $this->assertSame($body, $events[0]['body']);
+        $this->assertTrue($events[1]['is_streaming_close']);
+        $this->assertSame('', $events[1]['body']);
+    }
+
     /**
      * The PR's whole point is partial on-disk writes before a part completes.
      * That means a request cut mid-body now leaves bytes already written —

--- a/tests/Import/FileBodyStreamingTest.php
+++ b/tests/Import/FileBodyStreamingTest.php
@@ -151,6 +151,59 @@ class FileBodyStreamingTest extends TestCase
         $this->assertSame('', $events[1]['body']);
     }
 
+    public function testEncodedFilePartWithoutEncodingHeaderFailsSizeCheck(): void
+    {
+        $client = new \ImportClient(
+            'http://fake.url',
+            $this->tempDir . '/state',
+            $this->tempDir . '/fs-root',
+        );
+        $reflection = new \ReflectionClass($client);
+        $reflection->getProperty('is_tty')->setValue($client, true);
+        $reflection->getProperty('state')->setValue($client, []);
+
+        $handleFileChunk = $reflection->getMethod('handle_file_chunk');
+        $context = new \StreamingContext();
+        $context->on_chunk = function (array $chunk) use ($client, $handleFileChunk, $context): void {
+            $handleFileChunk->invoke($client, $chunk, $context);
+        };
+
+        $currentChunk = null;
+        $makeHandler = $reflection->getMethod('make_chunk_handler');
+        $handler = $makeHandler->invokeArgs($client, [$context, &$currentChunk]);
+        $parser = new \MultipartStreamParser('BOUNDARY', $handler);
+
+        $body = str_repeat("body { color: red; }\n", 1024);
+        $encodedBody = gzencode($body);
+        $this->assertNotFalse($encodedBody);
+        $multipart = $this->buildMultipart('BOUNDARY', [
+            [
+                'headers' => [
+                    'Content-Type' => 'application/octet-stream',
+                    'Content-Length' => (string) strlen($encodedBody),
+                    'X-Chunk-Type' => 'file',
+                    // Simulates a body-inspecting wrapper that strips the new
+                    // X-Body-Encoding header but leaves the compressed bytes.
+                    'X-File-Path' => base64_encode('/themes/style.css'),
+                    'X-File-Size' => (string) strlen($body),
+                    'X-File-Ctime' => '1234567890',
+                    'X-Chunk-Offset' => '0',
+                    'X-Chunk-Size' => (string) strlen($body),
+                    'X-First-Chunk' => '1',
+                    'X-Last-Chunk' => '1',
+                ],
+                'body' => $encodedBody,
+            ],
+        ]);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Downloaded file size mismatch');
+
+        for ($offset = 0; $offset < strlen($multipart); $offset += 257) {
+            $parser->feed(substr($multipart, $offset, 257));
+        }
+    }
+
     /**
      * The PR's whole point is partial on-disk writes before a part completes.
      * That means a request cut mid-body now leaves bytes already written —

--- a/tests/e2e/benchmark/bench-file-fetch-wrappers.mjs
+++ b/tests/e2e/benchmark/bench-file-fetch-wrappers.mjs
@@ -1,0 +1,938 @@
+/**
+ * HTTP-level benchmark for file_fetch compression behavior.
+ *
+ * This intentionally avoids the full e2e site registry. It starts the real
+ * exporter endpoint behind PHP's built-in server, wraps it with several local
+ * reverse-proxy modes, and verifies the multipart payload byte-for-byte.
+ *
+ * Compared modes:
+ *   - old: no file_part_gzip request flag (mixed batches use response gzip)
+ *   - new: file_part_gzip=1 (mixed batches may gzip selected file parts)
+ *
+ * Useful environment variables:
+ *   BENCH_REPS=5
+ *   BENCH_DATASETS=mixed-binary-heavy,text-heavy-many-small-mixed
+ *   BENCH_WRAPPERS=php-default,proxy-pass
+ *   BENCH_CHUNK_SIZE=8388608
+ *   BENCH_OUT=/tmp/reprint-file-fetch-wrappers.json
+ *   BENCH_KEEP_TMP=1
+ */
+import { spawn } from 'node:child_process';
+import { createHash, randomBytes } from 'node:crypto';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync, statSync, readFileSync } from 'node:fs';
+import { request, createServer } from 'node:http';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { performance } from 'node:perf_hooks';
+import { gzipSync, gunzipSync } from 'node:zlib';
+import net from 'node:net';
+
+const PROJECT_ROOT = resolve(join(import.meta.dirname, '..', '..', '..'));
+const PHP_BINARY = process.env.PHP_BINARY || 'php';
+const REPS = Number(process.env.BENCH_REPS || 5);
+const CHUNK_SIZE = Number(process.env.BENCH_CHUNK_SIZE || 8 * 1024 * 1024);
+const OUTPUT_PATH = process.env.BENCH_OUT || '';
+const KEEP_TMP = process.env.BENCH_KEEP_TMP === '1';
+const MIB = 1024 * 1024;
+const KIB = 1024;
+
+const PERF_WRAPPERS = [
+    'php-default',
+    'php-zlib-buffering',
+    'proxy-pass',
+    'proxy-buffer',
+    'proxy-gzip-identity',
+];
+
+const BREAK_WRAPPERS = [
+    'proxy-strip-http-content-encoding',
+    'proxy-strip-part-encoding',
+];
+
+const DEFAULT_DATASETS = [
+    'all-binary',
+    'all-text-many-small',
+    'balanced-mixed',
+    'mixed-binary-heavy',
+    'text-heavy-many-small-mixed',
+];
+
+function requestedList(envName, defaults) {
+    const raw = process.env[envName] || '';
+    return raw
+        ? raw.split(',').map((s) => s.trim()).filter(Boolean)
+        : defaults;
+}
+
+const DATASET_FILTER = requestedList('BENCH_DATASETS', DEFAULT_DATASETS);
+const WRAPPER_FILTER = requestedList('BENCH_WRAPPERS', PERF_WRAPPERS);
+
+function fmtBytes(bytes) {
+    if (!Number.isFinite(bytes)) return '';
+    if (bytes < KIB) return `${bytes} B`;
+    if (bytes < MIB) return `${(bytes / KIB).toFixed(1)} KiB`;
+    return `${(bytes / MIB).toFixed(1)} MiB`;
+}
+
+function fmtMs(ms) {
+    return ms < 1000 ? `${ms.toFixed(0)} ms` : `${(ms / 1000).toFixed(2)} s`;
+}
+
+function median(values) {
+    if (values.length === 0) return NaN;
+    const sorted = [...values].sort((a, b) => a - b);
+    const mid = Math.floor(sorted.length / 2);
+    return sorted.length % 2 === 0
+        ? (sorted[mid - 1] + sorted[mid]) / 2
+        : sorted[mid];
+}
+
+function pctDelta(newValue, oldValue) {
+    if (!Number.isFinite(newValue) || !Number.isFinite(oldValue) || oldValue === 0) {
+        return NaN;
+    }
+    return ((newValue - oldValue) / oldValue) * 100;
+}
+
+function ensureDir(path) {
+    mkdirSync(path, { recursive: true });
+}
+
+function repeatedBuffer(size, seed) {
+    const line = Buffer.from(
+        `<?php /* ${seed} */ function bench_${seed.replace(/[^a-z0-9]/gi, '_')}() { return "lorem ipsum dolor sit amet"; }\n`,
+    );
+    const out = Buffer.allocUnsafe(size);
+    for (let offset = 0; offset < size; offset += line.length) {
+        line.copy(out, offset, 0, Math.min(line.length, size - offset));
+    }
+    return out;
+}
+
+function writeTextFile(path, size, seed) {
+    ensureDir(dirname(path));
+    writeFileSync(path, repeatedBuffer(size, seed));
+}
+
+function writeRandomFile(path, size) {
+    ensureDir(dirname(path));
+    const chunks = [];
+    let remaining = size;
+    while (remaining > 0) {
+        const n = Math.min(remaining, MIB);
+        chunks.push(randomBytes(n));
+        remaining -= n;
+    }
+    writeFileSync(path, Buffer.concat(chunks));
+}
+
+function sha256File(path) {
+    const hash = createHash('sha256');
+    const data = readFileSync(path);
+    hash.update(data);
+    return hash.digest('hex');
+}
+
+function fileRecord(path) {
+    return {
+        path,
+        size: statSync(path).size,
+        sha256: sha256File(path),
+    };
+}
+
+function buildDatasets(root) {
+    const siteDir = join(root, 'site');
+    ensureDir(siteDir);
+    const datasets = new Map();
+
+    const binaryOnly = [];
+    for (let i = 0; i < 4; i++) {
+        const path = join(siteDir, 'all-binary', `image-${i}.jpg`);
+        writeRandomFile(path, 8 * MIB);
+        binaryOnly.push(fileRecord(path));
+    }
+    datasets.set('all-binary', {
+        name: 'all-binary',
+        description: '32 MiB random binary; should stay identity in both modes',
+        files: binaryOnly,
+    });
+
+    const textOnly = [];
+    for (let i = 0; i < 2000; i++) {
+        const path = join(siteDir, 'all-text-many-small', `file-${String(i).padStart(4, '0')}.php`);
+        writeTextFile(path, 2 * KIB, `all-text-${i}`);
+        textOnly.push(fileRecord(path));
+    }
+    datasets.set('all-text-many-small', {
+        name: 'all-text-many-small',
+        description: '2000 small PHP files; should keep one response-gzip stream',
+        files: textOnly,
+    });
+
+    const balanced = [];
+    const balancedText = join(siteDir, 'balanced-mixed', 'theme.css');
+    const balancedBinary = join(siteDir, 'balanced-mixed', 'hero.jpg');
+    writeTextFile(balancedText, 8 * MIB, 'balanced-text');
+    writeRandomFile(balancedBinary, 8 * MIB);
+    balanced.push(fileRecord(balancedText), fileRecord(balancedBinary));
+    datasets.set('balanced-mixed', {
+        name: 'balanced-mixed',
+        description: '8 MiB text + 8 MiB random binary',
+        files: balanced,
+    });
+
+    const binaryHeavy = [];
+    const readme = join(siteDir, 'mixed-binary-heavy', 'README.md');
+    writeTextFile(readme, 8 * MIB, 'binary-heavy-readme');
+    binaryHeavy.push(fileRecord(readme));
+    for (let i = 0; i < 3; i++) {
+        const path = join(siteDir, 'mixed-binary-heavy', `media-${i}.jpg`);
+        writeRandomFile(path, 8 * MIB);
+        binaryHeavy.push(fileRecord(path));
+    }
+    datasets.set('mixed-binary-heavy', {
+        name: 'mixed-binary-heavy',
+        description: '8 MiB text + 24 MiB random binary; favorable for per-part gzip',
+        files: binaryHeavy,
+    });
+
+    const textHeavyMixed = [];
+    for (let i = 0; i < 2000; i++) {
+        const path = join(siteDir, 'text-heavy-many-small-mixed', `snippet-${String(i).padStart(4, '0')}.php`);
+        writeTextFile(path, 2 * KIB, `mixed-small-${i}`);
+        textHeavyMixed.push(fileRecord(path));
+    }
+    const tinyBinary = join(siteDir, 'text-heavy-many-small-mixed', 'tiny-logo.jpg');
+    writeRandomFile(tinyBinary, 64 * KIB);
+    textHeavyMixed.push(fileRecord(tinyBinary));
+    datasets.set('text-heavy-many-small-mixed', {
+        name: 'text-heavy-many-small-mixed',
+        description: '2000 small text files + one tiny binary; unfavorable for per-part gzip',
+        files: textHeavyMixed,
+    });
+
+    const largeTextPart = [];
+    const largeText = join(siteDir, 'large-text-part-mixed', 'large-style.css');
+    const largeBin = join(siteDir, 'large-text-part-mixed', 'small-image.jpg');
+    writeTextFile(largeText, 24 * MIB, 'large-text-part');
+    writeRandomFile(largeBin, MIB);
+    largeTextPart.push(fileRecord(largeText), fileRecord(largeBin));
+    datasets.set('large-text-part-mixed', {
+        name: 'large-text-part-mixed',
+        description: '24 MiB text file + 1 MiB random binary; probes memory pressure',
+        files: largeTextPart,
+    });
+
+    for (const dataset of datasets.values()) {
+        const listPath = join(root, `${dataset.name}.file-list.json`);
+        writeFileSync(listPath, JSON.stringify(dataset.files.map((file) => file.path)));
+        dataset.siteDir = siteDir;
+        dataset.listPath = listPath;
+        dataset.totalBytes = dataset.files.reduce((sum, file) => sum + file.size, 0);
+    }
+
+    return datasets;
+}
+
+function getFreePort() {
+    return new Promise((resolvePort, reject) => {
+        const server = net.createServer();
+        server.listen(0, '127.0.0.1', () => {
+            const address = server.address();
+            const port = typeof address === 'object' && address ? address.port : 0;
+            server.close(() => resolvePort(port));
+        });
+        server.on('error', reject);
+    });
+}
+
+function waitForTcp(port, timeoutMs = 10000) {
+    const start = performance.now();
+    return new Promise((resolveReady, reject) => {
+        const attempt = () => {
+            const socket = net.createConnection({ port, host: '127.0.0.1' });
+            socket.once('connect', () => {
+                socket.end();
+                resolveReady();
+            });
+            socket.once('error', (error) => {
+                socket.destroy();
+                if (performance.now() - start > timeoutMs) {
+                    reject(error);
+                } else {
+                    setTimeout(attempt, 50);
+                }
+            });
+        };
+        attempt();
+    });
+}
+
+async function startPhpServer(root, label, iniArgs = []) {
+    const port = await getFreePort();
+    const routerPath = join(root, `${label}.router.php`);
+    writeFileSync(routerPath, `<?php
+chdir(${JSON.stringify(PROJECT_ROOT)});
+require_once ${JSON.stringify(join(PROJECT_ROOT, 'packages/reprint-exporter/src/class-http-server.php'))};
+try {
+    Site_Export_HTTP_Server::serve();
+} catch (Throwable $e) {
+    http_response_code(500);
+    header('Content-Type: application/json');
+    echo json_encode([
+        'error' => $e->getMessage(),
+        'file' => $e->getFile(),
+        'line' => $e->getLine(),
+    ]);
+}
+`);
+
+    const child = spawn(PHP_BINARY, [
+        ...iniArgs,
+        '-S',
+        `127.0.0.1:${port}`,
+        routerPath,
+    ], {
+        cwd: PROJECT_ROOT,
+        stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    let stderr = '';
+    child.stderr.on('data', (chunk) => {
+        stderr += chunk.toString();
+        if (stderr.length > 16000) stderr = stderr.slice(-16000);
+    });
+
+    child.stdout.resume();
+    await waitForTcp(port);
+
+    return {
+        name: label,
+        baseUrl: `http://127.0.0.1:${port}`,
+        close: async () => {
+            child.kill('SIGTERM');
+            await new Promise((resolveClose) => child.once('close', resolveClose));
+        },
+        stderr: () => stderr,
+    };
+}
+
+function copyHeaders(headers) {
+    const out = { ...headers };
+    delete out['connection'];
+    delete out['keep-alive'];
+    delete out['proxy-authenticate'];
+    delete out['proxy-authorization'];
+    delete out['te'];
+    delete out['trailer'];
+    delete out['transfer-encoding'];
+    delete out['upgrade'];
+    delete out['content-length'];
+    return out;
+}
+
+function collectStream(stream) {
+    return new Promise((resolveBody, reject) => {
+        const chunks = [];
+        stream.on('data', (chunk) => chunks.push(chunk));
+        stream.on('end', () => resolveBody(Buffer.concat(chunks)));
+        stream.on('error', reject);
+    });
+}
+
+async function startProxy(targetBaseUrl, mode) {
+    const target = new URL(targetBaseUrl);
+    const server = createServer((clientReq, clientRes) => {
+        const upstreamReq = request({
+            hostname: target.hostname,
+            port: target.port,
+            method: clientReq.method,
+            path: clientReq.url,
+            headers: clientReq.headers,
+        }, async (upstreamRes) => {
+            try {
+                if (mode === 'proxy-pass') {
+                    clientRes.writeHead(upstreamRes.statusCode || 502, copyHeaders(upstreamRes.headers));
+                    upstreamRes.pipe(clientRes);
+                    return;
+                }
+
+                let body = await collectStream(upstreamRes);
+                let headers = copyHeaders(upstreamRes.headers);
+
+                if (mode === 'proxy-gzip-identity' && !headers['content-encoding']) {
+                    body = gzipSync(body, { level: 6 });
+                    headers = {
+                        ...headers,
+                        'content-encoding': 'gzip',
+                    };
+                } else if (mode === 'proxy-strip-http-content-encoding') {
+                    delete headers['content-encoding'];
+                } else if (
+                    mode === 'proxy-strip-part-encoding' &&
+                    !headers['content-encoding']
+                ) {
+                    body = Buffer.from(
+                        body
+                            .toString('binary')
+                            .replace(/\r?\nX-Body-Encoding: gzip\r?\n/gi, '\r\n')
+                            .replace(/\r?\nX-Decoded-Content-Length: [0-9]+\r?\n/gi, '\r\n'),
+                        'binary',
+                    );
+                }
+
+                clientRes.writeHead(upstreamRes.statusCode || 502, headers);
+                clientRes.end(body);
+            } catch (error) {
+                clientRes.writeHead(502, { 'content-type': 'text/plain' });
+                clientRes.end(String(error && error.stack ? error.stack : error));
+            }
+        });
+
+        upstreamReq.on('error', (error) => {
+            clientRes.writeHead(502, { 'content-type': 'text/plain' });
+            clientRes.end(String(error.message || error));
+        });
+        clientReq.pipe(upstreamReq);
+    });
+
+    const port = await getFreePort();
+    await new Promise((resolveListen) => server.listen(port, '127.0.0.1', resolveListen));
+
+    return {
+        name: mode,
+        baseUrl: `http://127.0.0.1:${port}`,
+        close: async () => new Promise((resolveClose) => server.close(resolveClose)),
+    };
+}
+
+async function createWrapper(root, name, basePhpServer) {
+    if (name === 'php-default') {
+        return basePhpServer;
+    }
+    if (name === 'php-zlib-buffering') {
+        return startPhpServer(root, name, [
+            '-d', 'zlib.output_compression=1',
+            '-d', 'output_buffering=4096',
+        ]);
+    }
+    if (name.startsWith('proxy-')) {
+        return startProxy(basePhpServer.baseUrl, name);
+    }
+    throw new Error(`Unknown wrapper: ${name}`);
+}
+
+function requestFileFetch(wrapper, dataset, mode, chunkSize = CHUNK_SIZE) {
+    const url = new URL(wrapper.baseUrl);
+    url.searchParams.set('endpoint', 'file_fetch');
+    url.searchParams.set('directory', dataset.siteDir);
+    url.searchParams.set('file_list_path', dataset.listPath);
+    url.searchParams.set('chunk_size', String(chunkSize));
+    if (mode === 'new') {
+        url.searchParams.set('file_part_gzip', '1');
+    }
+
+    const start = performance.now();
+    return new Promise((resolveResult) => {
+        const req = request({
+            hostname: url.hostname,
+            port: url.port,
+            path: `${url.pathname}${url.search}`,
+            method: 'GET',
+            headers: {
+                'accept': 'multipart/mixed,*/*',
+                'accept-encoding': 'gzip, deflate',
+                'user-agent': 'ReprintFileFetchBench/1.0',
+            },
+        }, async (res) => {
+            try {
+                const wireBody = await collectStream(res);
+                const elapsedMs = performance.now() - start;
+                const httpEncoding = String(res.headers['content-encoding'] || 'identity').toLowerCase();
+                let decodedBody = wireBody;
+                if (httpEncoding === 'gzip') {
+                    decodedBody = gunzipSync(wireBody);
+                } else if (httpEncoding !== 'identity' && httpEncoding !== '') {
+                    throw new Error(`Unsupported response content-encoding: ${httpEncoding}`);
+                }
+
+                const verification = verifyMultipart(decodedBody, res.headers, dataset);
+                resolveResult({
+                    ok: res.statusCode === 200 && verification.ok,
+                    statusCode: res.statusCode,
+                    elapsedMs,
+                    wallMs: elapsedMs,
+                    wireBytes: wireBody.length,
+                    decodedHttpBytes: decodedBody.length,
+                    httpEncoding,
+                    ...verification,
+                });
+            } catch (error) {
+                resolveResult({
+                    ok: false,
+                    statusCode: res.statusCode,
+                    elapsedMs: performance.now() - start,
+                    wireBytes: 0,
+                    decodedHttpBytes: 0,
+                    httpEncoding: String(res.headers['content-encoding'] || 'identity').toLowerCase(),
+                    error: String(error && error.message ? error.message : error),
+                });
+            }
+        });
+        req.on('error', (error) => {
+            resolveResult({
+                ok: false,
+                statusCode: 0,
+                elapsedMs: performance.now() - start,
+                wireBytes: 0,
+                decodedHttpBytes: 0,
+                httpEncoding: 'identity',
+                error: String(error.message || error),
+            });
+        });
+        req.end();
+    });
+}
+
+function findHeaderEnd(buffer, start) {
+    const crlf = Buffer.from('\r\n\r\n');
+    const lf = Buffer.from('\n\n');
+    const crlfPos = buffer.indexOf(crlf, start);
+    const lfPos = buffer.indexOf(lf, start);
+    if (crlfPos === -1) {
+        return lfPos === -1 ? null : { pos: lfPos, length: 2 };
+    }
+    if (lfPos === -1 || crlfPos < lfPos) {
+        return { pos: crlfPos, length: 4 };
+    }
+    return { pos: lfPos, length: 2 };
+}
+
+function findLineEnd(buffer, start) {
+    const lf = buffer.indexOf(0x0a, start);
+    if (lf === -1) return -1;
+    return lf + 1;
+}
+
+function parsePartHeaders(headerBlock) {
+    const headers = {};
+    for (const rawLine of headerBlock.split(/\r?\n/)) {
+        const idx = rawLine.indexOf(':');
+        if (idx === -1) continue;
+        headers[rawLine.slice(0, idx).trim().toLowerCase()] = rawLine.slice(idx + 1).trimStart();
+    }
+    return headers;
+}
+
+function parseMultipart(body, boundary) {
+    const delimiter = Buffer.from(`--${boundary}`);
+    const parts = [];
+    let pos = body.indexOf(delimiter);
+    if (pos === -1) {
+        throw new Error('multipart boundary not found in decoded HTTP body');
+    }
+
+    while (pos !== -1) {
+        const afterDelimiter = pos + delimiter.length;
+        if (body.subarray(afterDelimiter, afterDelimiter + 2).toString('latin1') === '--') {
+            return parts;
+        }
+
+        const headersStart = findLineEnd(body, afterDelimiter);
+        if (headersStart === -1) {
+            throw new Error('unterminated multipart boundary line');
+        }
+
+        const headerEnd = findHeaderEnd(body, headersStart);
+        if (headerEnd === null) {
+            throw new Error('unterminated multipart headers');
+        }
+
+        const headerText = body.subarray(headersStart, headerEnd.pos).toString('latin1');
+        const headers = parsePartHeaders(headerText);
+        const bodyStart = headerEnd.pos + headerEnd.length;
+        const contentLength = Number(headers['content-length']);
+        if (!Number.isInteger(contentLength) || contentLength < 0) {
+            throw new Error('multipart part missing valid content-length');
+        }
+        const bodyEnd = bodyStart + contentLength;
+        if (bodyEnd > body.length) {
+            throw new Error(`multipart body truncated: expected ${contentLength} bytes`);
+        }
+
+        parts.push({
+            headers,
+            body: body.subarray(bodyStart, bodyEnd),
+        });
+
+        pos = bodyEnd;
+        if (body[pos] === 0x0d && body[pos + 1] === 0x0a) {
+            pos += 2;
+        } else if (body[pos] === 0x0a) {
+            pos += 1;
+        }
+        pos = body.indexOf(delimiter, pos);
+    }
+
+    throw new Error('closing multipart boundary not found');
+}
+
+function decodeBase64Header(value) {
+    if (!value) return '';
+    return Buffer.from(value, 'base64').toString();
+}
+
+function verifyMultipart(body, responseHeaders, dataset) {
+    const contentType = String(responseHeaders['content-type'] || '');
+    const match = contentType.match(/boundary="?([^";\s]+)"?/i);
+    if (!match) {
+        throw new Error(`missing multipart boundary header; content-type=${contentType || '<none>'}`);
+    }
+
+    const parts = parseMultipart(body, match[1]);
+    const expectedByPath = new Map(dataset.files.map((file) => [file.path, file]));
+    const buffersByPath = new Map();
+    let fileParts = 0;
+    let gzipFileParts = 0;
+    let completionStatus = '';
+    let serverTimeSeconds = null;
+
+    for (const part of parts) {
+        const chunkType = part.headers['x-chunk-type'] || '';
+        if (chunkType === 'completion') {
+            completionStatus = part.headers['x-status'] || '';
+            if (part.headers['x-time-elapsed']) {
+                serverTimeSeconds = Number(part.headers['x-time-elapsed']);
+            }
+            continue;
+        }
+        if (chunkType !== 'file') {
+            continue;
+        }
+
+        fileParts++;
+        const path = decodeBase64Header(part.headers['x-file-path']);
+        if (!expectedByPath.has(path)) {
+            throw new Error(`unexpected file part path: ${path}`);
+        }
+
+        let data = part.body;
+        const bodyEncoding = String(part.headers['x-body-encoding'] || '').toLowerCase();
+        if (bodyEncoding === 'gzip') {
+            gzipFileParts++;
+            data = gunzipSync(data);
+            const expectedDecodedLength = Number(part.headers['x-decoded-content-length'] || -1);
+            if (expectedDecodedLength !== data.length) {
+                throw new Error(`decoded length mismatch for ${path}: expected ${expectedDecodedLength}, got ${data.length}`);
+            }
+        } else if (bodyEncoding && bodyEncoding !== 'identity') {
+            throw new Error(`unsupported part body encoding for ${path}: ${bodyEncoding}`);
+        }
+
+        const expectedChunkSize = Number(part.headers['x-chunk-size'] || -1);
+        if (expectedChunkSize !== data.length) {
+            throw new Error(`chunk size mismatch for ${path}: expected ${expectedChunkSize}, got ${data.length}`);
+        }
+
+        const offset = Number(part.headers['x-chunk-offset'] || 0);
+        const existing = buffersByPath.get(path) || Buffer.alloc(0);
+        if (existing.length !== offset) {
+            throw new Error(`chunk offset mismatch for ${path}: expected offset ${existing.length}, got ${offset}`);
+        }
+        buffersByPath.set(path, Buffer.concat([existing, data]));
+    }
+
+    if (completionStatus !== 'complete') {
+        throw new Error(`missing complete status; status=${completionStatus || '<none>'}`);
+    }
+
+    for (const expected of dataset.files) {
+        const actual = buffersByPath.get(expected.path);
+        if (!actual) {
+            throw new Error(`missing file in response: ${expected.path}`);
+        }
+        if (actual.length !== expected.size) {
+            throw new Error(`file size mismatch for ${expected.path}: expected ${expected.size}, got ${actual.length}`);
+        }
+        const hash = createHash('sha256').update(actual).digest('hex');
+        if (hash !== expected.sha256) {
+            throw new Error(`file hash mismatch for ${expected.path}`);
+        }
+    }
+
+    return {
+        ok: true,
+        parts: parts.length,
+        fileParts,
+        gzipFileParts,
+        serverTimeSeconds,
+    };
+}
+
+async function runScenario(wrapper, dataset, mode, reps = REPS, chunkSize = CHUNK_SIZE) {
+    const warmup = await requestFileFetch(wrapper, dataset, mode, chunkSize);
+    if (!warmup.ok) {
+        return {
+            wrapper: wrapper.name,
+            dataset: dataset.name,
+            mode,
+            ok: false,
+            runs: [warmup],
+            error: warmup.error || `HTTP ${warmup.statusCode}`,
+        };
+    }
+
+    const runs = [];
+    for (let i = 0; i < reps; i++) {
+        const run = await requestFileFetch(wrapper, dataset, mode, chunkSize);
+        runs.push(run);
+        if (!run.ok) {
+            return {
+                wrapper: wrapper.name,
+                dataset: dataset.name,
+                mode,
+                ok: false,
+                runs,
+                error: run.error || `HTTP ${run.statusCode}`,
+            };
+        }
+    }
+
+    return summarizeScenario(wrapper.name, dataset.name, mode, runs);
+}
+
+function summarizeScenario(wrapperName, datasetName, mode, runs) {
+    return {
+        wrapper: wrapperName,
+        dataset: datasetName,
+        mode,
+        ok: runs.every((run) => run.ok),
+        reps: runs.length,
+        wallMsMedian: median(runs.map((run) => run.wallMs)),
+        wallMsMin: Math.min(...runs.map((run) => run.wallMs)),
+        wallMsMax: Math.max(...runs.map((run) => run.wallMs)),
+        serverMsMedian: median(runs.map((run) => run.serverTimeSeconds * 1000).filter(Number.isFinite)),
+        wireBytesMedian: median(runs.map((run) => run.wireBytes)),
+        decodedHttpBytesMedian: median(runs.map((run) => run.decodedHttpBytes)),
+        filePartsMedian: median(runs.map((run) => run.fileParts)),
+        gzipFilePartsMedian: median(runs.map((run) => run.gzipFileParts)),
+        httpEncoding: runs[0]?.httpEncoding || '',
+        runs,
+    };
+}
+
+async function runPerformanceMatrix(root, datasets, basePhpServer) {
+    const results = [];
+    for (const wrapperName of WRAPPER_FILTER) {
+        console.log(`wrapper=${wrapperName}`);
+        const wrapper = await createWrapper(root, wrapperName, basePhpServer);
+        try {
+            for (const datasetName of DATASET_FILTER) {
+                const dataset = datasets.get(datasetName);
+                if (!dataset) {
+                    throw new Error(`Unknown dataset requested: ${datasetName}`);
+                }
+                console.log(`  dataset=${datasetName} total=${fmtBytes(dataset.totalBytes)} files=${dataset.files.length}`);
+                for (const mode of ['old', 'new']) {
+                    const result = await runScenario(wrapper, dataset, mode);
+                    results.push(result);
+                    const label = result.ok
+                        ? `${fmtMs(result.wallMsMedian)} wire=${fmtBytes(result.wireBytesMedian)} gzipParts=${result.gzipFilePartsMedian}`
+                        : `FAIL ${result.error}`;
+                    console.log(`    ${mode}: ${label}`);
+                }
+            }
+        } finally {
+            if (wrapper !== basePhpServer) {
+                await wrapper.close();
+            }
+        }
+    }
+    return results;
+}
+
+async function runBreakageProbes(root, datasets, basePhpServer) {
+    const probes = [];
+
+    for (const wrapperName of BREAK_WRAPPERS) {
+        const wrapper = await createWrapper(root, wrapperName, basePhpServer);
+        try {
+            const dataset = wrapperName === 'proxy-strip-http-content-encoding'
+                ? datasets.get('all-text-many-small')
+                : datasets.get('mixed-binary-heavy');
+            for (const mode of ['old', 'new']) {
+                const run = await requestFileFetch(wrapper, dataset, mode);
+                probes.push({
+                    probe: wrapperName,
+                    dataset: dataset.name,
+                    mode,
+                    ok: run.ok,
+                    statusCode: run.statusCode,
+                    error: run.error || '',
+                    wireBytes: run.wireBytes,
+                    decodedHttpBytes: run.decodedHttpBytes,
+                });
+            }
+        } finally {
+            await wrapper.close();
+        }
+    }
+
+    for (const memoryLimit of ['32M', '48M', '64M', '96M']) {
+        const php = await startPhpServer(root, `php-memory-${memoryLimit.toLowerCase()}`, [
+            '-d', `memory_limit=${memoryLimit}`,
+            '-d', 'output_buffering=0',
+            '-d', 'zlib.output_compression=0',
+        ]);
+        try {
+            const dataset = datasets.get('large-text-part-mixed');
+            for (const mode of ['old', 'new']) {
+                const run = await requestFileFetch(php, dataset, mode, 32 * MIB);
+                probes.push({
+                    probe: `memory_limit=${memoryLimit}`,
+                    dataset: dataset.name,
+                    mode,
+                    ok: run.ok,
+                    statusCode: run.statusCode,
+                    error: run.error || '',
+                    wireBytes: run.wireBytes,
+                    decodedHttpBytes: run.decodedHttpBytes,
+                    phpStderrTail: php.stderr ? php.stderr().slice(-1000) : '',
+                });
+            }
+        } finally {
+            await php.close();
+        }
+    }
+
+    return probes;
+}
+
+function renderPerformanceMarkdown(results, datasets) {
+    const byKey = new Map();
+    for (const result of results) {
+        byKey.set(`${result.wrapper}/${result.dataset}/${result.mode}`, result);
+    }
+
+    const lines = [];
+    lines.push(`## file_fetch HTTP wrapper benchmark`);
+    lines.push('');
+    lines.push(`Reps: ${REPS} recorded + 1 warmup per scenario. Chunk size: ${fmtBytes(CHUNK_SIZE)}.`);
+    lines.push('');
+    lines.push('| Dataset | Wrapper | Old median | New median | New vs old | Old wire | New wire | Wire delta | Encodings |');
+    lines.push('|---|---|---:|---:|---:|---:|---:|---:|---|');
+
+    for (const wrapper of WRAPPER_FILTER) {
+        for (const dataset of DATASET_FILTER) {
+            const oldResult = byKey.get(`${wrapper}/${dataset}/old`);
+            const newResult = byKey.get(`${wrapper}/${dataset}/new`);
+            if (!oldResult || !newResult) continue;
+            if (!oldResult.ok || !newResult.ok) {
+                lines.push(`| ${dataset} | ${wrapper} | ${oldResult.ok ? fmtMs(oldResult.wallMsMedian) : 'FAIL'} | ${newResult.ok ? fmtMs(newResult.wallMsMedian) : 'FAIL'} | | | | | ${oldResult.error || newResult.error || ''} |`);
+                continue;
+            }
+            const timeDelta = pctDelta(newResult.wallMsMedian, oldResult.wallMsMedian);
+            const wireDelta = pctDelta(newResult.wireBytesMedian, oldResult.wireBytesMedian);
+            lines.push([
+                dataset,
+                wrapper,
+                fmtMs(oldResult.wallMsMedian),
+                fmtMs(newResult.wallMsMedian),
+                `${timeDelta > 0 ? '+' : ''}${timeDelta.toFixed(1)}%`,
+                fmtBytes(oldResult.wireBytesMedian),
+                fmtBytes(newResult.wireBytesMedian),
+                `${wireDelta > 0 ? '+' : ''}${wireDelta.toFixed(1)}%`,
+                `${oldResult.httpEncoding}->${newResult.httpEncoding}; parts ${oldResult.gzipFilePartsMedian}->${newResult.gzipFilePartsMedian}`,
+            ].map((value) => String(value).replaceAll('|', '/')).join(' | ').replace(/^/, '| ').replace(/$/, ' |'));
+        }
+    }
+
+    lines.push('');
+    lines.push('### Datasets');
+    lines.push('');
+    for (const name of DATASET_FILTER) {
+        const dataset = datasets.get(name);
+        if (!dataset) continue;
+        lines.push(`- ${name}: ${dataset.description}; ${dataset.files.length} files; ${fmtBytes(dataset.totalBytes)}`);
+    }
+    lines.push('');
+    return lines.join('\n');
+}
+
+function renderBreakageMarkdown(probes) {
+    const lines = [];
+    lines.push('## Breakage probes');
+    lines.push('');
+    lines.push('| Probe | Dataset | Mode | Result | Error |');
+    lines.push('|---|---|---|---|---|');
+    for (const probe of probes) {
+        const error = (probe.error || '')
+            .replace(/\s+/g, ' ')
+            .slice(0, 140)
+            .replaceAll('|', '/');
+        lines.push(`| ${probe.probe} | ${probe.dataset} | ${probe.mode} | ${probe.ok ? 'ok' : `FAIL HTTP ${probe.statusCode}`} | ${error} |`);
+    }
+    lines.push('');
+    return lines.join('\n');
+}
+
+async function main() {
+    const root = mkdtempSync(join(tmpdir(), 'reprint-file-fetch-wrappers-'));
+    console.log(`tmp=${root}`);
+    console.log(`project=${PROJECT_ROOT}`);
+    console.log(`reps=${REPS} chunk=${fmtBytes(CHUNK_SIZE)}`);
+
+    let basePhpServer = null;
+    try {
+        const datasets = buildDatasets(root);
+        basePhpServer = await startPhpServer(root, 'php-default');
+        const performanceResults = await runPerformanceMatrix(root, datasets, basePhpServer);
+        const breakageProbes = await runBreakageProbes(root, datasets, basePhpServer);
+
+        const markdown =
+            renderPerformanceMarkdown(performanceResults, datasets) +
+            renderBreakageMarkdown(breakageProbes);
+        console.log('\n' + markdown);
+
+        const payload = {
+            meta: {
+                projectRoot: PROJECT_ROOT,
+                reps: REPS,
+                chunkSize: CHUNK_SIZE,
+                tmp: root,
+                wrappers: WRAPPER_FILTER,
+                datasets: DATASET_FILTER,
+            },
+            performanceResults,
+            breakageProbes,
+            markdown,
+        };
+
+        if (OUTPUT_PATH) {
+            writeFileSync(OUTPUT_PATH, JSON.stringify(payload, null, 2));
+            console.log(`wrote ${OUTPUT_PATH}`);
+        }
+
+        if (
+            performanceResults.some((result) => !result.ok) ||
+            breakageProbes.some((probe) => !probe.ok && probe.probe.startsWith('memory_limit=96M'))
+        ) {
+            process.exitCode = 1;
+        }
+    } finally {
+        if (basePhpServer) {
+            await basePhpServer.close();
+        }
+        if (!KEEP_TMP) {
+            rmSync(root, { recursive: true, force: true });
+        } else {
+            console.log(`kept ${root}`);
+        }
+    }
+}
+
+main().catch((error) => {
+    console.error(error && error.stack ? error.stack : error);
+    process.exit(1);
+});


### PR DESCRIPTION
## What it does

Adds an opt-in `file_part_gzip` capability for `file_fetch` mixed batches. When the importer sends the capability, the exporter keeps the HTTP response identity and gzip-encodes only compressible file-part bodies with `X-Body-Encoding: gzip`.

Text-only batches still use response-level gzip. Binary-only batches stay identity. Mixed batches without the capability keep the old response-level gzip behavior for older importers.

## Rationale

Response-level gzip is all-or-nothing. In mixed media/text batches it preserves wire size, but it burns exporter CPU deflating already-compressed media bytes. Per-part gzip keeps one sequential request while avoiding that binary CPU cost.

Benchmark, PHP 8.2, gzip level 6, median of 5 synthetic runs:

| Dataset | Old response gzip encode+decode | Hybrid encode+decode | Wire size |
| --- | ---: | ---: | --- |
| 4 MiB text + 28 MiB binary | 1311.6 ms | 409.5 ms | 87.55% vs 87.57% of identity |
| 28 MiB text + 4 MiB binary | 527.7 ms | 299.9 ms | 12.83% vs 12.81% of identity |
| 2000 small text files | 52.6 ms | 52.6 ms | unchanged; still response gzip |
| 32 MiB binary | identity | identity | unchanged |

## Implementation

- Adds `file_fetch_compression_mode()` with three modes: `identity`, `response-gzip`, and `file-parts`.
- Sends `file_part_gzip=1` from the importer for `file_fetch` requests.
- Parses `file_part_gzip` as a boolean in the exporter HTTP server.
- Buffers gzip-encoded file parts in the importer, decodes them, then emits the same streaming body + streaming close events as raw file parts so checkpoint behavior stays aligned.
- Leaves old importers compatible: no capability means mixed batches still use response-level gzip.

## Testing instructions

Passed:

```bash
php -l packages/reprint-exporter/src/class-http-server.php
php -l packages/reprint-exporter/src/export.php
php -l packages/reprint-importer/src/import.php
php -l tests/FileFetchCompressionTest.php
php -l tests/Import/FileBodyStreamingTest.php
vendor/bin/phpunit -c tests/phpunit.xml tests/FileFetchCompressionTest.php tests/Import/FileBodyStreamingTest.php tests/Import/MultipartStreamParserTest.php tests/Import/CurlTimeoutRecoveryTest.php tests/ExportHttpServerTest.php
php -r 'require "packages/reprint-exporter/src/class-http-server.php"; $s=new Site_Export_HTTP_Server(); $config=$s->parse_http_config(["file-part-gzip"=>"1"],[],[],""); if (($config["file_part_gzip"] ?? null) !== true) exit(1);'
composer run-script analyze
```

Also ran full `vendor/bin/phpunit -c tests/phpunit.xml`; it still fails in this environment because MySQL dump tests cannot authenticate as local `root`. `composer run-script compat` still reports existing PHPCompatibility findings under vendored `data-liberation/vendor-patched` code.