### PR TITLE
Measure native batch URL rewrite impact

### DIFF
--- a/.github/workflows/perf-report.yml
+++ b/.github/workflows/perf-report.yml
@@ -7,9 +7,15 @@ permissions:
   contents: read
   pull-requests: write
 
+env:
+  PHP_VERSION: '8.3'
+  WASM_PHP_VERSION: '8.4'
+  PHP_TOOLKIT_NATIVE_REF: codex-native-structured-rewrite
+  WP_MYSQL_PARSER_EXTENSION_MANIFEST_URL: https://wordpress.github.io/sqlite-database-integration/wp_mysql_parser-wasm-extension/latest/manifest.json
+
 jobs:
   build-pr-phar:
-    name: Build reprint.phar (PR)
+    name: Build reprint.phar
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -18,7 +24,7 @@ jobs:
 
       - uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.5'
+          php-version: ${{ env.PHP_VERSION }}
           extensions: pdo, pdo_mysql, json, hash, zlib, mbstring
 
       - run: composer install --no-dev --no-interaction --prefer-dist
@@ -29,52 +35,26 @@ jobs:
           name: importer-phar-pr
           path: reprint.phar
 
-  build-trunk-phar:
-    name: Build reprint.phar (trunk)
+  bench-php:
+    name: Host PHP native rewrite vs userland
+    needs: build-pr-phar
     runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v5
-        with:
-          ref: trunk
-          submodules: true
-
-      - uses: shivammathur/setup-php@v2
-        with:
-          php-version: '8.5'
-          extensions: pdo, pdo_mysql, json, hash, zlib, mbstring
-
-      - run: composer install --no-dev --no-interaction --prefer-dist
-      - run: ./bin/build-reprint-phar.sh
-
-      - uses: actions/upload-artifact@v4
-        with:
-          name: importer-phar-trunk
-          path: reprint.phar
-
-  bench:
-    name: Pull pipeline benchmark
-    needs: [build-pr-phar, build-trunk-phar]
-    runs-on: ubuntu-22.04
     timeout-minutes: 60
     env:
-      PHP_VERSION: '8.5'
+      PHP_BENCH_STAGES: structured-text-url-rewrite
+      BENCH_SEED_POSTS: '10000'
+      BENCH_SEED_POSTMETA: '25000'
 
     steps:
       - uses: actions/checkout@v5
         with:
           submodules: true
 
-      - name: Resolve focused bench stages
-        id: stages
-        run: |
-          file="tests/e2e/benchmark/focused-stages.txt"
-          if [ -f "$file" ]; then
-            stages="$(grep -v '^[[:space:]]*$' "$file" | grep -v '^[[:space:]]*#' | paste -sd, -)"
-          else
-            stages=""
-          fi
-          echo "stages=$stages" >> "$GITHUB_OUTPUT"
-          echo "Focused stages: $stages"
+      - uses: actions/checkout@v5
+        with:
+          repository: WordPress/php-toolkit
+          ref: ${{ env.PHP_TOOLKIT_NATIVE_REF }}
+          path: php-toolkit-native
 
       - name: Download PR phar
         uses: actions/download-artifact@v4
@@ -82,124 +62,251 @@ jobs:
           name: importer-phar-pr
           path: phars/pr
 
-      - name: Download trunk phar
-        uses: actions/download-artifact@v4
-        with:
-          name: importer-phar-trunk
-          path: phars/trunk
-
       - uses: actions/setup-node@v4
         with:
           node-version: '24'
 
-      # PHP comes from the runner's pre-cached toolcache via this
-      # action; we don't try to apt-install ondrej/php ourselves
-      # because every Launchpad endpoint flakes regularly.
       - uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ env.PHP_VERSION }}
           extensions: pdo, pdo_mysql, json, hash, zlib, mbstring, curl, xml, sqlite3
           coverage: none
 
-      - name: Setup infrastructure
-        run: tests/e2e/ci/setup-infrastructure.sh "${{ env.PHP_VERSION }}"
+      - uses: dtolnay/rust-toolchain@stable
 
-      - name: Setup test sites
-        run: tests/e2e/setup.sh
+      - name: Install native extension build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang libclang-dev
+
+      - name: Build wp_native_apis for host PHP
+        run: php-toolkit-native/extensions/native-apis/build-extension.sh
+
+      - run: composer install --no-dev --no-interaction --prefer-dist
 
       - name: Install e2e dependencies
         working-directory: tests/e2e
         run: npm install
 
-      - name: Download wp-cli
-        run: |
-          if [ ! -f /tmp/wp-cli.phar ]; then
-            curl -sfL "https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar" -o /tmp/wp-cli.phar
-            chmod +x /tmp/wp-cli.phar
-          fi
-
-      - name: Bench PR
+      - name: Bench host PHP userland
         working-directory: tests/e2e
         env:
           IMPORTER_PATH: ${{ github.workspace }}/phars/pr/reprint.phar
-          BENCH_LABEL: pr
-          BENCH_JSON_OUT: bench-pr.json
-          BENCH_MD_OUT: bench-pr.md
-          BENCH_STAGES: ${{ steps.stages.outputs.stages }}
+          BENCH_LABEL: host-php-userland
+          BENCH_JSON_OUT: bench-php-userland.json
+          BENCH_MD_OUT: bench-php-userland.md
+          BENCH_STAGES: ${{ env.PHP_BENCH_STAGES }}
           E2E_EXPORTER_PROJECT_ROOT: ${{ github.workspace }}
-          # Keep the PHP.wasm SQLite benchmark large enough to exercise the
-          # parser without pushing a PR check into the workflow timeout.
-          BENCH_SEED_POSTS: '10000'
-          BENCH_SEED_POSTMETA: '25000'
-          BENCH_PLAYGROUND_PHP_BINARY: ${{ github.workspace }}/tests/e2e/ci/playground-php.sh
-          PLAYGROUND_PHP_USE_WASM_RUNNER: '1'
-          PLAYGROUND_PHP_VERSION: '8.3'
-          WP_MYSQL_PARSER_EXTENSION_MANIFEST: https://wordpress.github.io/sqlite-database-integration/wp_mysql_parser-wasm-extension/latest/manifest.json
+          BENCH_SEED_POSTS: ${{ env.BENCH_SEED_POSTS }}
+          BENCH_SEED_POSTMETA: ${{ env.BENCH_SEED_POSTMETA }}
         run: node benchmark/bench-pull.mjs
 
-      - name: Reset benchmark sites before trunk
+      - name: Reset benchmark sites before native host PHP
         run: |
           sudo rm -rf /srv/e2e-sites/large-directory /srv/e2e-sites/large-single-file
           sudo rm -f /tmp/e2e-site-large-directory.lock /tmp/e2e-site-large-single-file.lock
 
-      - name: Bench trunk
+      - name: Bench host PHP native extension
         working-directory: tests/e2e
         env:
-          IMPORTER_PATH: ${{ github.workspace }}/phars/trunk/reprint.phar
-          BENCH_LABEL: trunk
-          BENCH_JSON_OUT: bench-trunk.json
-          BENCH_MD_OUT: bench-trunk.md
-          BENCH_STAGES: ${{ steps.stages.outputs.stages }}
+          IMPORTER_PATH: ${{ github.workspace }}/phars/pr/reprint.phar
+          BENCH_LABEL: host-php-native
+          BENCH_JSON_OUT: bench-php-native.json
+          BENCH_MD_OUT: bench-php-native.md
+          BENCH_STAGES: ${{ env.PHP_BENCH_STAGES }}
           E2E_EXPORTER_PROJECT_ROOT: ${{ github.workspace }}
-          BENCH_SEED_POSTS: '10000'
-          BENCH_SEED_POSTMETA: '25000'
-          BENCH_PREFLIGHT_IMPORTER_PATH: ${{ github.workspace }}/phars/pr/reprint.phar
-          BENCH_PLAYGROUND_PHP_BINARY: ${{ github.workspace }}/tests/e2e/ci/playground-php.sh
-          PLAYGROUND_PHP_USE_WASM_RUNNER: '1'
-          PLAYGROUND_PHP_VERSION: '8.3'
-          # Match the PR side. Without this, the Playground SQLite db-pull
-          # / db-apply scenarios run on trunk WITHOUT the Rust MySQL parser
-          # extension (because the parser is loaded only when the manifest
-          # URL is set), while the PR side runs WITH it. The resulting
-          # comparison shows a constant ~10× "improvement" attributable to
-          # the parser, on every PR — which has nothing to do with what
-          # the PR actually changes. Keep both sides on the same parser.
-          WP_MYSQL_PARSER_EXTENSION_MANIFEST: https://wordpress.github.io/sqlite-database-integration/wp_mysql_parser-wasm-extension/latest/manifest.json
-        # Don't fail the whole job if trunk's bench fails — we still want
-        # to publish the PR's numbers.
-        continue-on-error: true
+          BENCH_SEED_POSTS: ${{ env.BENCH_SEED_POSTS }}
+          BENCH_SEED_POSTMETA: ${{ env.BENCH_SEED_POSTMETA }}
+          PHP_BINARY: ${{ github.workspace }}/tests/e2e/ci/native-php.sh
+          WP_NATIVE_APIS_EXTENSION_SO: ${{ github.workspace }}/php-toolkit-native/extensions/native-apis/target/release/libwp_native_apis.so
         run: node benchmark/bench-pull.mjs
 
-      - name: Render PR vs. trunk diff
+      - name: Render host PHP native delta
         working-directory: tests/e2e
         env:
-          BASELINE_LABEL: trunk
+          PR_JSON: bench-php-native.json
+          TRUNK_JSON: bench-php-userland.json
+          OUT_MD: bench-php-results.md
+          RESULT_LABEL: native extension
+          BASELINE_LABEL: userland
         run: node benchmark/render-diff.mjs
 
-      - name: Upload benchmark artifacts
+      - name: Upload host PHP benchmark artifacts
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: pull-pipeline-bench
+          name: pull-pipeline-bench-php
           path: |
-            tests/e2e/bench-pr.json
-            tests/e2e/bench-trunk.json
-            tests/e2e/bench-results.md
+            tests/e2e/bench-php-userland.json
+            tests/e2e/bench-php-native.json
+            tests/e2e/bench-php-results.md
           if-no-files-found: ignore
 
-      - name: Check bench-results.md exists
-        id: check_md
-        if: always()
+  bench-wasm:
+    name: PHP.wasm native rewrite vs userland
+    needs: build-pr-phar
+    runs-on: ubuntu-22.04
+    timeout-minutes: 90
+    env:
+      WASM_BENCH_STAGES: structured-text-url-rewrite
+      BENCH_SEED_POSTS: '10000'
+      BENCH_SEED_POSTMETA: '25000'
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          submodules: true
+
+      - uses: actions/checkout@v5
+        with:
+          repository: WordPress/php-toolkit
+          ref: ${{ env.PHP_TOOLKIT_NATIVE_REF }}
+          path: php-toolkit-native
+
+      - name: Download PR phar
+        uses: actions/download-artifact@v4
+        with:
+          name: importer-phar-pr
+          path: phars/pr
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ env.PHP_VERSION }}
+          extensions: pdo, pdo_mysql, json, hash, zlib, mbstring, curl, xml, sqlite3
+          coverage: none
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - run: composer install --no-dev --no-interaction --prefer-dist
+
+      - name: Build wp_native_apis for PHP.wasm
+        run: php-toolkit-native/extensions/native-apis/build-playground-extension.sh "${{ github.workspace }}/wp-native-apis-wasm"
+
+      - name: Serve local wp_native_apis manifest
         run: |
-          if [ -f tests/e2e/bench-results.md ]; then
+          python3 -m http.server 8899 --bind 127.0.0.1 --directory "${{ github.workspace }}/wp-native-apis-wasm" >/tmp/wp-native-apis-http.log 2>&1 &
+          echo $! > /tmp/wp-native-apis-http.pid
+          for i in $(seq 1 20); do
+            if curl -sf http://127.0.0.1:8899/manifest.json >/dev/null; then
+              exit 0
+            fi
+            sleep 0.5
+          done
+          cat /tmp/wp-native-apis-http.log
+          exit 1
+
+      - name: Install e2e dependencies
+        working-directory: tests/e2e
+        run: npm install
+
+      - name: Bench PHP.wasm userland
+        working-directory: tests/e2e
+        env:
+          IMPORTER_PATH: ${{ github.workspace }}/phars/pr/reprint.phar
+          BENCH_LABEL: php-wasm-userland
+          BENCH_JSON_OUT: bench-wasm-userland.json
+          BENCH_MD_OUT: bench-wasm-userland.md
+          BENCH_STAGES: ${{ env.WASM_BENCH_STAGES }}
+          E2E_EXPORTER_PROJECT_ROOT: ${{ github.workspace }}
+          BENCH_SEED_POSTS: ${{ env.BENCH_SEED_POSTS }}
+          BENCH_SEED_POSTMETA: ${{ env.BENCH_SEED_POSTMETA }}
+          BENCH_STRUCTURED_REWRITE_PHP_BINARY: ${{ github.workspace }}/tests/e2e/ci/playground-php.sh
+          BENCH_PLAYGROUND_PHP_BINARY: ${{ github.workspace }}/tests/e2e/ci/playground-php.sh
+          PLAYGROUND_PHP_USE_WASM_RUNNER: '1'
+          PLAYGROUND_PHP_VERSION: ${{ env.WASM_PHP_VERSION }}
+          WP_MYSQL_PARSER_EXTENSION_MANIFEST: ${{ env.WP_MYSQL_PARSER_EXTENSION_MANIFEST_URL }}
+        run: node benchmark/bench-pull.mjs
+
+      - name: Reset benchmark sites before native PHP.wasm
+        run: |
+          sudo rm -rf /srv/e2e-sites/large-directory /srv/e2e-sites/large-single-file
+          sudo rm -f /tmp/e2e-site-large-directory.lock /tmp/e2e-site-large-single-file.lock
+
+      - name: Bench PHP.wasm native extension
+        working-directory: tests/e2e
+        env:
+          IMPORTER_PATH: ${{ github.workspace }}/phars/pr/reprint.phar
+          BENCH_LABEL: php-wasm-native
+          BENCH_JSON_OUT: bench-wasm-native.json
+          BENCH_MD_OUT: bench-wasm-native.md
+          BENCH_STAGES: ${{ env.WASM_BENCH_STAGES }}
+          E2E_EXPORTER_PROJECT_ROOT: ${{ github.workspace }}
+          BENCH_SEED_POSTS: ${{ env.BENCH_SEED_POSTS }}
+          BENCH_SEED_POSTMETA: ${{ env.BENCH_SEED_POSTMETA }}
+          BENCH_STRUCTURED_REWRITE_PHP_BINARY: ${{ github.workspace }}/tests/e2e/ci/playground-php.sh
+          BENCH_PLAYGROUND_PHP_BINARY: ${{ github.workspace }}/tests/e2e/ci/playground-php.sh
+          PLAYGROUND_PHP_USE_WASM_RUNNER: '1'
+          PLAYGROUND_PHP_VERSION: ${{ env.WASM_PHP_VERSION }}
+          WP_MYSQL_PARSER_EXTENSION_MANIFEST: ${{ env.WP_MYSQL_PARSER_EXTENSION_MANIFEST_URL }}
+          WP_NATIVE_APIS_EXTENSION_MANIFEST: http://127.0.0.1:8899/manifest.json
+        run: node benchmark/bench-pull.mjs
+
+      - name: Render PHP.wasm native delta
+        working-directory: tests/e2e
+        env:
+          PR_JSON: bench-wasm-native.json
+          TRUNK_JSON: bench-wasm-userland.json
+          OUT_MD: bench-wasm-results.md
+          RESULT_LABEL: native extension
+          BASELINE_LABEL: userland
+        run: node benchmark/render-diff.mjs
+
+      - name: Upload PHP.wasm benchmark artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pull-pipeline-bench-wasm
+          path: |
+            tests/e2e/bench-wasm-userland.json
+            tests/e2e/bench-wasm-native.json
+            tests/e2e/bench-wasm-results.md
+          if-no-files-found: ignore
+
+  report:
+    name: Post performance report
+    needs: [bench-php, bench-wasm]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download benchmark artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          pattern: pull-pipeline-bench-*
+
+      - name: Combine benchmark reports
+        id: combine
+        run: |
+          report="bench-results.md"
+          : > "$report"
+          for file in artifacts/pull-pipeline-bench-php/bench-php-results.md artifacts/pull-pipeline-bench-wasm/bench-wasm-results.md; do
+            if [ -f "$file" ]; then
+              if [ -s "$report" ]; then
+                printf '\n---\n\n' >> "$report"
+              fi
+              cat "$file" >> "$report"
+            fi
+          done
+          if [ -s "$report" ]; then
             echo "exists=true" >> "$GITHUB_OUTPUT"
           else
             echo "exists=false" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Upload combined benchmark report
+        if: always() && steps.combine.outputs.exists == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: pull-pipeline-bench
+          path: bench-results.md
+
       - name: Post sticky PR comment
-        if: always() && github.event_name == 'pull_request' && steps.check_md.outputs.exists == 'true'
+        if: always() && github.event_name == 'pull_request' && steps.combine.outputs.exists == 'true'
         uses: marocchino/sticky-pull-request-comment@v2
         with:
-          header: pull-pipeline-perf
-          path: tests/e2e/bench-results.md
+          header: pull-pipeline-native-rewrite-perf
+          path: bench-results.md

--- a/packages/reprint-importer/src/lib/url-rewrite/class-structured-data-url-rewriter.php
+++ b/packages/reprint-importer/src/lib/url-rewrite/class-structured-data-url-rewriter.php
@@ -57,6 +57,9 @@ class StructuredDataUrlRewriter
     /** @var string Default base_url used by the URL processors (first from-url). */
     private string $base_url;
 
+    /** @var string Compact URL mapping passed to the native batch text rewriter. */
+    private string $native_compact_mapping = '';
+
     /**
      * @param array<string, string> $url_mapping Source URL => target URL mapping.
      */
@@ -76,12 +79,18 @@ class StructuredDataUrlRewriter
         // (scheme/host/path tokenisation, punycode, etc.) and used to be
         // repeated on every leaf we rewrote.
         $this->parsed_mapping = [];
+        $native_mapping_rows = [];
         foreach ($url_mapping as $from_url_string => $to_url_string) {
             $this->parsed_mapping[] = [
                 'from_url' => WPURL::parse($from_url_string),
                 'to_url'   => WPURL::parse($to_url_string),
             ];
+
+            if (strpbrk($from_url_string . $to_url_string, "\x1e\x1f") === false) {
+                $native_mapping_rows[] = $from_url_string . "\x1f" . $to_url_string;
+            }
         }
+        $this->native_compact_mapping = implode("\x1e", $native_mapping_rows);
 
         // Default base_url: first from-url in the mapping. Preserves the
         // behaviour of the previous per-call default so outputs are unchanged.
@@ -177,6 +186,30 @@ class StructuredDataUrlRewriter
     }
 
     /**
+     * Rewrite plain text URLs with the native extension when it is available.
+     *
+     * The native function accepts the whole value and the whole URL mapping at
+     * once, so PHP does not have to drive URL detection, WHATWG-style candidate
+     * checks, base replacement, and lexical update assembly one URL at a time.
+     * Returning null means "native path unavailable; use the PHP implementation."
+     */
+    private function rewrite_text_urls_native(string $content): ?string
+    {
+        $rewrite_text_url_bases = 'wp_native_apis_' . 'rewrite_text_url_bases';
+        if (
+            $this->native_compact_mapping === ''
+            || !extension_loaded('wp_native_apis')
+            || !function_exists($rewrite_text_url_bases)
+        ) {
+            return null;
+        }
+
+        $rewritten = $rewrite_text_url_bases($content, $this->base_url, $this->native_compact_mapping);
+
+        return is_string($rewritten) ? $rewritten : null;
+    }
+
+    /**
      * Migrate URLs in post content. See WPRewriteUrlsTests for
      * specific examples. TODO: A better description.
      *
@@ -217,6 +250,13 @@ class StructuredDataUrlRewriter
 
         switch ( $content_type ) {
             case self::BLOCK_MARKUP:
+                if (strpos($content, '<') === false) {
+                    $native_rewritten = $this->rewrite_text_urls_native($content);
+                    if ($native_rewritten !== null) {
+                        return $native_rewritten;
+                    }
+                }
+
                 $p = new BlockMarkupUrlProcessor( $content, $base_url );
                 while ( $p->next_url() ) {
                     $parsed_url = $p->get_parsed_url();
@@ -231,6 +271,11 @@ class StructuredDataUrlRewriter
                 return $p->get_updated_html();
 
             case self::PLAIN_TEXT:
+                $native_rewritten = $this->rewrite_text_urls_native($content);
+                if ($native_rewritten !== null) {
+                    return $native_rewritten;
+                }
+
                 $p = new URLInTextProcessor( $content, $base_url );
                 while ( $p->next_url() ) {
                     $parsed_url = $p->get_parsed_url();

--- a/phpstan-bootstrap.php
+++ b/phpstan-bootstrap.php
@@ -17,3 +17,9 @@ if (!function_exists('trailingslashit')) {
         return rtrim($value, '/\\') . '/';
     }
 }
+
+if (!function_exists('wp_native_apis_rewrite_text_url_bases')) {
+    function wp_native_apis_rewrite_text_url_bases(string $text, ?string $base_url, string $compact_mapping): string {
+        return $text;
+    }
+}

--- a/tests/e2e/benchmark/bench-pull.mjs
+++ b/tests/e2e/benchmark/bench-pull.mjs
@@ -49,6 +49,10 @@ const PLAYGROUND_PHP_BINARY = process.env.BENCH_PLAYGROUND_PHP_BINARY || join(PR
 const PLAYGROUND_PHP_VERSION = process.env.PLAYGROUND_PHP_VERSION || '8.3';
 const REGISTRY = JSON.parse(readFileSync(join(import.meta.dirname, '..', 'site-registry.json'), 'utf-8'));
 const MYSQL_PARSER_MANIFEST = process.env.WP_MYSQL_PARSER_EXTENSION_MANIFEST || '';
+const NATIVE_APIS_EXTENSION_MANIFEST = process.env.WP_NATIVE_APIS_EXTENSION_MANIFEST || '';
+const NATIVE_APIS_EXTENSION_SO = process.env.WP_NATIVE_APIS_EXTENSION_SO || '';
+const STRUCTURED_TEXT_REWRITE_BENCHMARK = join(PROJECT_ROOT, 'tests', 'e2e', 'benchmark', 'structured-text-url-rewrite-bench.php');
+const STRUCTURED_TEXT_REWRITE_PHP_BINARY = process.env.BENCH_STRUCTURED_REWRITE_PHP_BINARY || PHP_BINARY;
 
 async function seedSourceDb() {
     const dbName = `e2e_${SITE.replace(/-/g, '_')}`;
@@ -239,6 +243,40 @@ function runNativeMysqlParserProof({ requireParser }) {
     }
 }
 
+function runNativeApisProof({ phpBinary = PHP_BINARY, env = {} } = {}) {
+    if (!NATIVE_APIS_EXTENSION_SO && !NATIVE_APIS_EXTENSION_MANIFEST) {
+        return {
+            ok: true,
+            details: {
+                wp_native_apis: 'disabled',
+            },
+        };
+    }
+
+    const verifierPath = join(PROJECT_ROOT, 'tests', 'e2e', 'ci', 'verify-wp-native-apis.php');
+    try {
+        const stdout = execFileSync(phpBinary, [verifierPath], {
+            cwd: PROJECT_ROOT,
+            timeout: 120_000,
+            encoding: 'utf-8',
+            maxBuffer: 16 * 1024 * 1024,
+            stdio: ['ignore', 'pipe', 'pipe'],
+            env: { ...process.env, ...env },
+        }).trim();
+        return {
+            ok: true,
+            details: stdout ? JSON.parse(stdout) : {},
+        };
+    } catch (e) {
+        return {
+            ok: false,
+            exitCode: e.status === null ? -1 : (e.status || 1),
+            stderr: (e.stderr || '').toString().slice(-4000),
+            stdout: (e.stdout || '').toString().slice(-4000),
+        };
+    }
+}
+
 function proofFailureResult(stage, start, proof, details) {
     return {
         stage,
@@ -254,6 +292,51 @@ function proofFailureResult(stage, start, proof, details) {
             native_parser_proof: 'failed',
         },
     };
+}
+
+function runStructuredTextRewriteBenchmark() {
+    const start = performance.now();
+    const proof = runNativeApisProof({ phpBinary: STRUCTURED_TEXT_REWRITE_PHP_BINARY });
+    const baseDetails = {
+        condition: 'StructuredDataUrlRewriter plain text batch URL base rewrite',
+        runtime: STRUCTURED_TEXT_REWRITE_PHP_BINARY.includes('playground-php.sh') ? `php.wasm ${PLAYGROUND_PHP_VERSION}` : 'host PHP',
+    };
+    if (!proof.ok) {
+        return proofFailureResult('structured-text-url-rewrite', start, proof, baseDetails);
+    }
+
+    try {
+        const stdout = execFileSync(STRUCTURED_TEXT_REWRITE_PHP_BINARY, [STRUCTURED_TEXT_REWRITE_BENCHMARK], {
+            cwd: PROJECT_ROOT,
+            timeout: 300_000,
+            encoding: 'utf-8',
+            maxBuffer: 16 * 1024 * 1024,
+            stdio: ['ignore', 'pipe', 'pipe'],
+        });
+        const details = JSON.parse(stdout.trim());
+        return {
+            stage: 'structured-text-url-rewrite',
+            elapsedMs: Number(details.elapsed_ms),
+            attempts: 1,
+            ok: true,
+            details: {
+                ...baseDetails,
+                ...details,
+                ...proof.details,
+            },
+        };
+    } catch (e) {
+        return {
+            stage: 'structured-text-url-rewrite',
+            elapsedMs: performance.now() - start,
+            attempts: 1,
+            ok: false,
+            exitCode: e.status === null ? -1 : (e.status || 1),
+            stderr: (e.stderr || '').toString().slice(-4000),
+            stdout: (e.stdout || '').toString().slice(-4000),
+            details: baseDetails,
+        };
+    }
 }
 
 function runPlaygroundSqliteDbPullBenchmark() {
@@ -583,6 +666,43 @@ function renderMarkdown(results, meta) {
 }
 
 async function main() {
+    const stageFilter = (process.env.BENCH_STAGES || '')
+        .split(',')
+        .map((s) => s.trim())
+        .filter(Boolean);
+    const shouldRun = (name) => stageFilter.length === 0 || stageFilter.includes(name);
+
+    if (stageFilter.length === 1 && shouldRun('structured-text-url-rewrite')) {
+        const structuredTextRewrite = runStructuredTextRewriteBenchmark();
+        const phpVersion = execFileSync(PHP_BINARY, ['-r', 'echo PHP_VERSION;'], { encoding: 'utf-8' }).trim();
+        const meta = {
+            site: SITE,
+            fileCount: 'not provisioned for focused structured text benchmark',
+            seedPosts: 0,
+            seedPostmeta: 0,
+            phpVersion,
+            importer: IMPORTER_PATH,
+            preflightImporter: PREFLIGHT_IMPORTER_PATH,
+        };
+        const md = renderMarkdown([structuredTextRewrite], meta);
+        console.log('\n' + md);
+
+        const label = process.env.BENCH_LABEL || 'pr';
+        const jsonOut = process.env.BENCH_JSON_OUT || 'bench-results.json';
+        const mdOut = process.env.BENCH_MD_OUT || 'bench-results.md';
+        writeFileSync(jsonOut, JSON.stringify({ meta: { ...meta, label }, results: [structuredTextRewrite] }, null, 2));
+        writeFileSync(mdOut, md);
+
+        if (process.env.GITHUB_STEP_SUMMARY) {
+            appendFileSync(process.env.GITHUB_STEP_SUMMARY, md + '\n');
+        }
+
+        if (!structuredTextRewrite.ok) {
+            process.exit(1);
+        }
+        return;
+    }
+
     console.log(`Provisioning site: ${SITE}`);
     await ensureSite(SITE, {
         files: 'none',
@@ -620,12 +740,6 @@ async function main() {
     // list of stage names), only those stages run on both sides of the
     // PR-vs-trunk comparison. This is how each PR limits its perf comment
     // to the single scenario it actually changes.
-    const stageFilter = (process.env.BENCH_STAGES || '')
-        .split(',')
-        .map((s) => s.trim())
-        .filter(Boolean);
-    const shouldRun = (name) => stageFilter.length === 0 || stageFilter.includes(name);
-
     const stages = [
         { name: 'preflight', extra: [] },
         { name: 'files-pull', extra: [] },
@@ -667,6 +781,17 @@ async function main() {
         if (!playgroundSqliteApply.ok) {
             console.error(`   stderr (tail):\n${playgroundSqliteApply.stderr}`);
             console.error(`   stdout (tail):\n${playgroundSqliteApply.stdout}`);
+        }
+    }
+
+    if (shouldRun('structured-text-url-rewrite')) {
+        console.log('-> structured-text-url-rewrite');
+        const structuredTextRewrite = runStructuredTextRewriteBenchmark();
+        results.push(structuredTextRewrite);
+        console.log(`   ${structuredTextRewrite.ok ? 'ok' : 'FAIL'} in ${fmtMs(structuredTextRewrite.elapsedMs)} (${fmtDetails(structuredTextRewrite.details)})`);
+        if (!structuredTextRewrite.ok) {
+            console.error(`   stderr (tail):\n${structuredTextRewrite.stderr}`);
+            console.error(`   stdout (tail):\n${structuredTextRewrite.stdout}`);
         }
     }
 

--- a/tests/e2e/benchmark/render-diff.mjs
+++ b/tests/e2e/benchmark/render-diff.mjs
@@ -1,9 +1,9 @@
 /**
  * Combine PR and baseline bench results into a single markdown table with
  * per-stage deltas. Reads bench-pr.json and bench-base.json (legacy:
- * bench-trunk.json), writes bench-results.md. The baseline label defaults
- * to "trunk" but can be overridden with BASELINE_LABEL — that's how stacked
- * PRs report their incremental impact against the parent branch.
+ * bench-trunk.json), writes bench-results.md. The result and baseline labels
+ * default to "PR" and "trunk" but can be overridden with RESULT_LABEL and
+ * BASELINE_LABEL.
  */
 import { readFileSync, writeFileSync, existsSync } from 'node:fs';
 
@@ -37,6 +37,7 @@ const prPath = process.env.PR_JSON || 'bench-pr.json';
 const basePath = process.env.TRUNK_JSON || 'bench-trunk.json';
 const outPath = process.env.OUT_MD || 'bench-results.md';
 const baselineLabel = process.env.BASELINE_LABEL || 'trunk';
+const resultLabel = process.env.RESULT_LABEL || 'PR';
 
 if (!existsSync(prPath)) {
     console.error(`Missing PR results: ${prPath}`);
@@ -59,7 +60,7 @@ lines.push('');
 
 if (base) {
     lines.push('');
-    lines.push(`| Stage | PR | ${baselineLabel} | Δ | Status | Details |`);
+    lines.push(`| Stage | ${resultLabel} | ${baselineLabel} | Δ | Status | Details |`);
     lines.push('|---|---:|---:|---:|---|---|');
     const baseByStage = Object.fromEntries(base.results.map((r) => [r.stage, r]));
     let prTotal = 0;

--- a/tests/e2e/benchmark/structured-text-url-rewrite-bench.php
+++ b/tests/e2e/benchmark/structured-text-url-rewrite-bench.php
@@ -1,0 +1,59 @@
+<?php
+
+$project_root = dirname( __DIR__, 3 );
+
+require_once $project_root . '/vendor/autoload.php';
+require_once $project_root . '/packages/reprint-importer/src/lib/url-rewrite/load.php';
+
+$iterations = (int) ( getenv( 'BENCH_STRUCTURED_REWRITE_ITERATIONS' ) ?: 10 );
+$rows       = (int) ( getenv( 'BENCH_STRUCTURED_REWRITE_ROWS' ) ?: 500 );
+
+$from_url = 'http://old.example';
+$to_url   = 'https://new.example/base';
+$parts    = array();
+
+for ( $i = 0; $i < $rows; $i++ ) {
+	$parts[] = sprintf(
+		'Entry %d links to %s/posts/%d?source=bench and %s/wp-content/uploads/%d.jpg.',
+		$i,
+		$from_url,
+		$i,
+		$from_url,
+		$i
+	);
+}
+
+$content  = implode( "\n", $parts );
+$rewriter = new StructuredDataUrlRewriter(
+	array(
+		$from_url => $to_url,
+	)
+);
+
+$start        = hrtime( true );
+$changed_urls = 0;
+for ( $i = 0; $i < $iterations; $i++ ) {
+	$rewritten = $rewriter->rewrite( $content, StructuredDataUrlRewriter::PLAIN_TEXT );
+	$changed_urls += substr_count( $rewritten, 'https://new.example/base/' );
+}
+$elapsed_ms = ( hrtime( true ) - $start ) / 1000000;
+
+$expected_urls = $iterations * $rows * 2;
+if ( $changed_urls !== $expected_urls ) {
+	fwrite( STDERR, "Structured text rewrite changed $changed_urls URLs; expected $expected_urls.\n" );
+	exit( 1 );
+}
+
+echo json_encode(
+	array(
+		'iterations'                 => $iterations,
+		'rows_per_iteration'         => $rows,
+		'urls_per_iteration'         => $rows * 2,
+		'total_urls_rewritten'       => $expected_urls,
+		'bytes_per_iteration'        => strlen( $content ),
+		'total_bytes_scanned'        => strlen( $content ) * $iterations,
+		'elapsed_ms'                 => $elapsed_ms,
+		'native_batch_text_rewrite'  => function_exists( 'wp_native_apis_rewrite_text_url_bases' ) ? 'yes' : 'no',
+		'condition'                  => 'StructuredDataUrlRewriter plain text batch URL base rewrite',
+	)
+);

--- a/tests/e2e/ci/native-php.sh
+++ b/tests/e2e/ci/native-php.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Wrapper used by benchmarks when the host PHP process should load the
+# wp_native_apis extension before running Reprint.
+set -euo pipefail
+
+if [ -n "${WP_NATIVE_APIS_EXTENSION_SO:-}" ]; then
+	exec php -d "extension=${WP_NATIVE_APIS_EXTENSION_SO}" "$@"
+fi
+
+exec php "$@"

--- a/tests/e2e/ci/php-wasm-runner.mjs
+++ b/tests/e2e/ci/php-wasm-runner.mjs
@@ -6,7 +6,10 @@ import { existsSync, statSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 
 const DEFAULT_PHP_VERSION = '8.3';
-const MYSQL_PARSER_MANIFEST_ENV = 'WP_MYSQL_PARSER_EXTENSION_MANIFEST';
+const EXTENSION_MANIFEST_ENVS = [
+    'WP_MYSQL_PARSER_EXTENSION_MANIFEST',
+    'WP_NATIVE_APIS_EXTENSION_MANIFEST',
+];
 
 function envRecord() {
     return Object.fromEntries(
@@ -109,8 +112,7 @@ async function main() {
     const argv = process.argv.slice(2);
     const phpVersion = process.env.PLAYGROUND_PHP_VERSION || DEFAULT_PHP_VERSION;
     const extensions = ['intl'];
-    const manifestUrl = process.env[MYSQL_PARSER_MANIFEST_ENV];
-    if (manifestUrl) {
+    for (const manifestUrl of EXTENSION_MANIFEST_ENVS.map((name) => process.env[name]).filter(Boolean)) {
         extensions.push({
             source: {
                 format: 'manifest',

--- a/tests/e2e/ci/playground-php.sh
+++ b/tests/e2e/ci/playground-php.sh
@@ -3,13 +3,13 @@
 # Used by e2e tests when PHP_BINARY points here instead of the system `php`.
 #
 # By default this delegates to @wp-playground/cli php so the CI still covers
-# the public CLI path. When WP_MYSQL_PARSER_EXTENSION_MANIFEST is set, or when
+# the public CLI path. When a custom extension manifest is set, or when
 # PLAYGROUND_PHP_USE_WASM_RUNNER=1 is set, it uses the npm-installed
 # @php-wasm/node runner because the CLI does not expose arbitrary external PHP
 # extensions.
 set -euo pipefail
 
-if [ -n "${WP_MYSQL_PARSER_EXTENSION_MANIFEST:-}" ] || [ "${PLAYGROUND_PHP_USE_WASM_RUNNER:-}" = "1" ]; then
+if [ -n "${WP_MYSQL_PARSER_EXTENSION_MANIFEST:-}" ] || [ -n "${WP_NATIVE_APIS_EXTENSION_MANIFEST:-}" ] || [ "${PLAYGROUND_PHP_USE_WASM_RUNNER:-}" = "1" ]; then
     SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
     NODE_CMD=(node)
     if ! node --experimental-wasm-jspi --input-type=module -e "import { jspi } from 'wasm-feature-detect'; process.exit(await jspi() ? 0 : 1);" >/dev/null 2>&1; then

--- a/tests/e2e/ci/verify-wp-native-apis.php
+++ b/tests/e2e/ci/verify-wp-native-apis.php
@@ -1,0 +1,56 @@
+<?php
+
+$project_root = $argv[1] ?? dirname( __DIR__, 3 );
+$autoloaders  = array(
+	$project_root . '/vendor/autoload.php',
+	dirname( __DIR__, 3 ) . '/vendor/autoload.php',
+);
+
+foreach ( $autoloaders as $autoloader ) {
+	if ( file_exists( $autoloader ) ) {
+		require_once $autoloader;
+		break;
+	}
+}
+
+$extension_classes = array(
+	'WP_HTML_Native_Tag_Processor',
+	'WP_HTML_Native_Processor',
+	'WordPress\\XML\\NativeXMLProcessor',
+	'WordPress\\DataLiberation\\URL\\NativeURLInTextProcessor',
+);
+
+$missing = array();
+foreach ( $extension_classes as $class_name ) {
+	if ( ! class_exists( $class_name, false ) ) {
+		$missing[] = $class_name;
+	}
+}
+
+if ( $missing ) {
+	fwrite( STDERR, 'Missing native API extension classes: ' . implode( ', ', $missing ) . "\n" );
+	exit( 1 );
+}
+
+if ( ! function_exists( 'wp_native_apis_rewrite_text_url_bases' ) ) {
+	fwrite( STDERR, "Missing native batch text URL rewrite function.\n" );
+	exit( 1 );
+}
+
+$rewritten = wp_native_apis_rewrite_text_url_bases(
+	'Visit http://old.example/posts/7.',
+	'http://old.example',
+	"http://old.example\x1fhttps://new.example"
+);
+if ( 'Visit https://new.example/posts/7.' !== $rewritten ) {
+	fwrite( STDERR, "Native batch text URL rewrite returned unexpected output: {$rewritten}\n" );
+	exit( 1 );
+}
+
+echo json_encode(
+	array(
+		'wp_native_apis'             => 'enabled',
+		'extension_classes'          => 'loaded',
+		'batch_text_url_rewrite'     => 'verified',
+	)
+);


### PR DESCRIPTION
## What it does

Uses the optional `wp_native_apis_rewrite_text_url_bases()` extension function from WordPress/php-toolkit#282 when Reprint rewrites plain-text URL values.

Also changes the PR performance workflow to compare the same Reprint artifact with and without the native extension loaded on both host PHP and PHP.wasm.

## Rationale

The previous native URL path still made PHP drive URL detection and rewriting one URL at a time. This PR measures a coarser boundary: pass the whole decoded value and whole URL mapping into the native extension, then get the rewritten value back in one call.

## Implementation

`StructuredDataUrlRewriter` builds a compact mapping string once in the constructor. For `plain_text`, and for `block_markup` values that are actually text-only, it calls the native batch function when the `wp_native_apis` extension is loaded. If the extension is unavailable, the existing PHP path is used unchanged.

The performance workflow now:

- builds `wp_native_apis` from `WordPress/php-toolkit` branch `codex-native-structured-rewrite`
- benchmarks host PHP userland vs host PHP native extension
- builds and serves a local PHP.wasm extension manifest
- benchmarks PHP.wasm userland vs PHP.wasm native extension
- posts one sticky PR comment with the deltas

## Benchmarks

Latest CI run: https://github.com/adamziel/reprint/actions/runs/26067523070/attempts/3

Focused case: `StructuredDataUrlRewriter` rewrites 10,000 URLs across 556,690 scanned bytes.

| Runtime | Userland | Native extension | Delta |
|---|---:|---:|---:|
| Host PHP | 2968.918 ms | 6.743 ms | -99.8%, about 440x faster |
| PHP.wasm 8.4 | 7616.311 ms | 7.632 ms | -99.9%, about 998x faster |

These are single-run CI measurements, so treat them as directional. They do show the intended effect: PHP no longer iterates URL-by-URL for plain text URL base rewrites.

## Testing instructions

Local checks run:

```bash
vendor/bin/phpunit tests/UrlRewriting/StructuredDataUrlRewriterTest.php
php tests/e2e/benchmark/structured-text-url-rewrite-bench.php
vendor/bin/phpstan analyze --memory-limit=1G
node --check tests/e2e/benchmark/bench-pull.mjs
node --check tests/e2e/benchmark/render-diff.mjs
node --check tests/e2e/ci/php-wasm-runner.mjs
git diff --check
composer build:phar
```

Local fallback benchmark result without the extension:

```json
{"total_urls_rewritten":10000,"elapsed_ms":3233.079262,"native_batch_text_rewrite":"no"}
```

CI checks are green on the Reprint PR, including PHPUnit, E2E, PHPStan, and the host/PHP.wasm performance workflow. I could not measure the native extension locally because this environment has no `php-config` and no package manager.

Depends on WordPress/php-toolkit#282.

