### PR TITLE
Cache structured URL rewrite results

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -8,7 +8,7 @@
     "packages": [
         {
             "name": "wp-php-toolkit/bytestream",
-            "version": "v0.7.9",
+            "version": "v0.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-php-toolkit/bytestream.git",
@@ -64,25 +64,25 @@
         },
         {
             "name": "wp-php-toolkit/data-liberation",
-            "version": "v0.7.9",
+            "version": "v0.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-php-toolkit/data-liberation.git",
-                "reference": "ee553c24a84f0669fd7d71b3a9d5122cc374fff1"
+                "reference": "6eaab346858777b197a5e530157b7388cf3e9cc7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-php-toolkit/data-liberation/zipball/ee553c24a84f0669fd7d71b3a9d5122cc374fff1",
-                "reference": "ee553c24a84f0669fd7d71b3a9d5122cc374fff1",
+                "url": "https://api.github.com/repos/wp-php-toolkit/data-liberation/zipball/6eaab346858777b197a5e530157b7388cf3e9cc7",
+                "reference": "6eaab346858777b197a5e530157b7388cf3e9cc7",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2",
-                "wp-php-toolkit/bytestream": "^0.7.9",
-                "wp-php-toolkit/filesystem": "^0.7.9",
-                "wp-php-toolkit/html": "^0.7.9",
-                "wp-php-toolkit/http-client": "^0.7.9",
-                "wp-php-toolkit/xml": "^0.7.9"
+                "wp-php-toolkit/bytestream": "^0.8",
+                "wp-php-toolkit/filesystem": "^0.8",
+                "wp-php-toolkit/html": "^0.8",
+                "wp-php-toolkit/http-client": "^0.8",
+                "wp-php-toolkit/xml": "^0.8"
             },
             "type": "library",
             "autoload": {
@@ -123,11 +123,11 @@
                 "issues": "https://github.com/WordPress/php-toolkit/issues",
                 "source": "https://github.com/WordPress/php-toolkit"
             },
-            "time": "2026-05-18T15:07:34+00:00"
+            "time": "2026-05-19T19:53:55+00:00"
         },
         {
             "name": "wp-php-toolkit/encoding",
-            "version": "v0.7.9",
+            "version": "v0.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-php-toolkit/encoding.git",
@@ -182,21 +182,21 @@
         },
         {
             "name": "wp-php-toolkit/filesystem",
-            "version": "v0.7.9",
+            "version": "v0.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-php-toolkit/filesystem.git",
-                "reference": "2a38ca4e45903120502fd7166f4ea2d40c9ccd46"
+                "reference": "5887e3a81cbed593180f9761cb1c855a5c0be80c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-php-toolkit/filesystem/zipball/2a38ca4e45903120502fd7166f4ea2d40c9ccd46",
-                "reference": "2a38ca4e45903120502fd7166f4ea2d40c9ccd46",
+                "url": "https://api.github.com/repos/wp-php-toolkit/filesystem/zipball/5887e3a81cbed593180f9761cb1c855a5c0be80c",
+                "reference": "5887e3a81cbed593180f9761cb1c855a5c0be80c",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2",
-                "wp-php-toolkit/bytestream": "^0.7.9"
+                "wp-php-toolkit/bytestream": "^0.8"
             },
             "require-dev": {
                 "phpunit/phpunit": "^9.5"
@@ -238,11 +238,11 @@
                 "issues": "https://github.com/WordPress/php-toolkit/issues",
                 "source": "https://github.com/WordPress/php-toolkit"
             },
-            "time": "2026-05-18T15:07:34+00:00"
+            "time": "2026-05-18T15:07:36+00:00"
         },
         {
             "name": "wp-php-toolkit/html",
-            "version": "v0.7.9",
+            "version": "v0.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-php-toolkit/html.git",
@@ -299,23 +299,23 @@
         },
         {
             "name": "wp-php-toolkit/http-client",
-            "version": "v0.7.9",
+            "version": "v0.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-php-toolkit/http-client.git",
-                "reference": "0806fce8858937467e5132e93bf5f1828bb1b5fa"
+                "reference": "7d3b83e4af8a5740f3f290bf1c641767e716b1cc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-php-toolkit/http-client/zipball/0806fce8858937467e5132e93bf5f1828bb1b5fa",
-                "reference": "0806fce8858937467e5132e93bf5f1828bb1b5fa",
+                "url": "https://api.github.com/repos/wp-php-toolkit/http-client/zipball/7d3b83e4af8a5740f3f290bf1c641767e716b1cc",
+                "reference": "7d3b83e4af8a5740f3f290bf1c641767e716b1cc",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2",
-                "wp-php-toolkit/bytestream": "^0.7.9",
-                "wp-php-toolkit/data-liberation": "^0.7.9",
-                "wp-php-toolkit/filesystem": "^0.7.9"
+                "wp-php-toolkit/bytestream": "^0.8",
+                "wp-php-toolkit/data-liberation": "^0.8",
+                "wp-php-toolkit/filesystem": "^0.8"
             },
             "require-dev": {
                 "phpunit/phpunit": "^9.5"
@@ -354,22 +354,22 @@
                 "issues": "https://github.com/WordPress/php-toolkit/issues",
                 "source": "https://github.com/WordPress/php-toolkit"
             },
-            "time": "2026-05-18T15:07:34+00:00"
+            "time": "2026-05-18T15:07:36+00:00"
         },
         {
             "name": "wp-php-toolkit/reprint-exporter",
-            "version": "dev-d4f76bfa91e6beafc129880cb322ab8ec6b92430",
+            "version": "dev-codex/cache-structured-url-rewrites",
             "dist": {
                 "type": "path",
                 "url": "packages/reprint-exporter",
-                "reference": "53111b45f1d3fefa4b50aaa63cc49aeeb974770d"
+                "reference": "9e8e2886a687a785a91676f20c505a413926b7b3"
             },
             "require": {
                 "ext-pdo": "*",
                 "ext-pdo_mysql": "*",
                 "php": ">=7.4",
-                "wp-php-toolkit/data-liberation": "^0.7.9",
-                "wp-php-toolkit/html": "^0.7.9"
+                "wp-php-toolkit/data-liberation": "^0.8.0",
+                "wp-php-toolkit/html": "^0.8.0"
             },
             "type": "library",
             "autoload": {
@@ -399,18 +399,18 @@
         },
         {
             "name": "wp-php-toolkit/reprint-importer",
-            "version": "dev-d4f76bfa91e6beafc129880cb322ab8ec6b92430",
+            "version": "dev-codex/cache-structured-url-rewrites",
             "dist": {
                 "type": "path",
                 "url": "packages/reprint-importer",
-                "reference": "b64ec25454efd6b3ac6e2772849bab26f51335a8"
+                "reference": "d76b96ae7385f7e97eff350bbe1f06c55e48e58b"
             },
             "require": {
                 "ext-pdo": "*",
                 "ext-pdo_mysql": "*",
                 "php": ">=7.4",
-                "wp-php-toolkit/data-liberation": "^0.7.9",
-                "wp-php-toolkit/html": "^0.7.9",
+                "wp-php-toolkit/data-liberation": "^0.8.0",
+                "wp-php-toolkit/html": "^0.8.0",
                 "wp-php-toolkit/reprint-exporter": "*@dev"
             },
             "bin": [
@@ -428,21 +428,21 @@
         },
         {
             "name": "wp-php-toolkit/xml",
-            "version": "v0.7.9",
+            "version": "v0.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-php-toolkit/xml.git",
-                "reference": "639d3ff1d29751a2458538dee2edc0c59ddbdd99"
+                "reference": "02ebcc706b1639751380a6501a7ec05431329865"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-php-toolkit/xml/zipball/639d3ff1d29751a2458538dee2edc0c59ddbdd99",
-                "reference": "639d3ff1d29751a2458538dee2edc0c59ddbdd99",
+                "url": "https://api.github.com/repos/wp-php-toolkit/xml/zipball/02ebcc706b1639751380a6501a7ec05431329865",
+                "reference": "02ebcc706b1639751380a6501a7ec05431329865",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2",
-                "wp-php-toolkit/encoding": "^0.7.9"
+                "wp-php-toolkit/encoding": "^0.8"
             },
             "require-dev": {
                 "phpunit/phpunit": "^9.5"
@@ -481,7 +481,7 @@
                 "issues": "https://github.com/WordPress/php-toolkit/issues",
                 "source": "https://github.com/WordPress/php-toolkit"
             },
-            "time": "2026-05-18T15:07:34+00:00"
+            "time": "2026-05-18T15:07:36+00:00"
         }
     ],
     "packages-dev": [
@@ -2459,5 +2459,5 @@
         "ext-pdo_mysql": "*"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/packages/reprint-exporter/composer.json
+++ b/packages/reprint-exporter/composer.json
@@ -7,8 +7,8 @@
         "php": ">=7.4",
         "ext-pdo": "*",
         "ext-pdo_mysql": "*",
-        "wp-php-toolkit/data-liberation": "^0.7.9",
-        "wp-php-toolkit/html": "^0.7.9"
+        "wp-php-toolkit/data-liberation": "^0.8.0",
+        "wp-php-toolkit/html": "^0.8.0"
     },
     "autoload": {
         "psr-4": {

--- a/packages/reprint-importer/composer.json
+++ b/packages/reprint-importer/composer.json
@@ -7,8 +7,8 @@
         "php": ">=7.4",
         "ext-pdo": "*",
         "ext-pdo_mysql": "*",
-        "wp-php-toolkit/data-liberation": "^0.7.9",
-        "wp-php-toolkit/html": "^0.7.9",
+        "wp-php-toolkit/data-liberation": "^0.8.0",
+        "wp-php-toolkit/html": "^0.8.0",
         "wp-php-toolkit/reprint-exporter": "*@dev"
     },
     "bin": [

--- a/packages/reprint-importer/src/lib/url-rewrite/class-structured-data-url-rewriter.php
+++ b/packages/reprint-importer/src/lib/url-rewrite/class-structured-data-url-rewriter.php
@@ -31,6 +31,7 @@ class StructuredDataUrlRewriter
 {
     const BLOCK_MARKUP = 'block_markup';
     const PLAIN_TEXT = 'plain_text';
+    private const REWRITE_RESULT_CACHE_MAX = 4096;
 
     /** @var string[] Source domains extracted from url_mapping keys, for quick-reject checks. */
     private array $source_domains;
@@ -57,6 +58,17 @@ class StructuredDataUrlRewriter
     /** @var string Default base_url used by the URL processors (first from-url). */
     private string $base_url;
 
+    /** @var string Cache namespace for this rewriter's URL mapping. */
+    private string $mapping_cache_key;
+
+    /** @var array<string, false|array{raw_url: string, parsed_url: mixed}> */
+    private array $rewrite_result_cache = [];
+
+    /** @var string[] */
+    private array $rewrite_result_cache_ring = [];
+
+    private int $rewrite_result_cache_next = 0;
+
     /**
      * @param array<string, string> $url_mapping Source URL => target URL mapping.
      */
@@ -82,6 +94,7 @@ class StructuredDataUrlRewriter
                 'to_url'   => WPURL::parse($to_url_string),
             ];
         }
+        $this->mapping_cache_key = sha1(json_encode($url_mapping, JSON_UNESCAPED_SLASHES));
 
         // Default base_url: first from-url in the mapping. Preserves the
         // behaviour of the previous per-call default so outputs are unchanged.
@@ -176,6 +189,33 @@ class StructuredDataUrlRewriter
         return false;
     }
 
+    private function get_cached_rewrite_result(string $cache_key)
+    {
+        return array_key_exists($cache_key, $this->rewrite_result_cache)
+            ? $this->rewrite_result_cache[$cache_key]
+            : null;
+    }
+
+    /**
+     * @param false|array{raw_url: string, parsed_url: mixed} $value
+     */
+    private function set_cached_rewrite_result(string $cache_key, $value): void
+    {
+        if (!array_key_exists($cache_key, $this->rewrite_result_cache)) {
+            if (count($this->rewrite_result_cache_ring) < self::REWRITE_RESULT_CACHE_MAX) {
+                $this->rewrite_result_cache_ring[] = $cache_key;
+            } else {
+                $evicted_key = $this->rewrite_result_cache_ring[$this->rewrite_result_cache_next];
+                unset($this->rewrite_result_cache[$evicted_key]);
+                $this->rewrite_result_cache_ring[$this->rewrite_result_cache_next] = $cache_key;
+            }
+
+            $this->rewrite_result_cache_next = ($this->rewrite_result_cache_next + 1) % self::REWRITE_RESULT_CACHE_MAX;
+        }
+
+        $this->rewrite_result_cache[$cache_key] = $value;
+    }
+
     /**
      * Migrate URLs in post content. See WPRewriteUrlsTests for
      * specific examples. TODO: A better description.
@@ -219,13 +259,46 @@ class StructuredDataUrlRewriter
             case self::BLOCK_MARKUP:
                 $p = new BlockMarkupUrlProcessor( $content, $base_url );
                 while ( $p->next_url() ) {
+                    $raw_url = $p->get_raw_url();
+                    $token_type = $p->get_token_type() ?? '';
+                    $cache_key = $this->mapping_cache_key . "\0" . self::BLOCK_MARKUP . "\0" . $token_type . "\0" . $raw_url;
+                    $cached = $this->get_cached_rewrite_result($cache_key);
+                    if ($cached !== null) {
+                        if ($cached !== false) {
+                            $p->set_url($cached['raw_url'], $cached['parsed_url']);
+                        }
+                        continue;
+                    }
+
                     $parsed_url = $p->get_parsed_url();
+                    $converted = false;
                     foreach ( $parsed_mapping as $mapping ) {
                         if ( is_child_url_of( $parsed_url, $mapping['from_url'] ) ) {
-                            $p->replace_base_url( $mapping['to_url'] );
+                            $converted = WPURL::replace_base_url(
+                                $parsed_url,
+                                array(
+                                    'old_base_url' => $base_url,
+                                    'new_base_url' => $mapping['to_url'],
+                                    'raw_url'      => $raw_url,
+                                    'is_relative'  => (
+                                        '#text' !== $token_type &&
+                                        ! WPURL::can_parse($raw_url)
+                                    ),
+                                )
+                            );
                             break;
                         }
                     }
+
+                    $cache_value = false;
+                    if ($converted !== false) {
+                        $cache_value = [
+                            'raw_url'    => (string) $converted,
+                            'parsed_url' => $converted->new_url,
+                        ];
+                        $p->set_url($cache_value['raw_url'], $cache_value['parsed_url']);
+                    }
+                    $this->set_cached_rewrite_result($cache_key, $cache_value);
                 }
 
                 return $p->get_updated_html();
@@ -233,10 +306,21 @@ class StructuredDataUrlRewriter
             case self::PLAIN_TEXT:
                 $p = new URLInTextProcessor( $content, $base_url );
                 while ( $p->next_url() ) {
+                    $raw_url = $p->get_raw_url();
+                    $cache_key = $this->mapping_cache_key . "\0" . self::PLAIN_TEXT . "\0" . $raw_url;
+                    $cached = $this->get_cached_rewrite_result($cache_key);
+                    if ($cached !== null) {
+                        if ($cached !== false) {
+                            $p->set_raw_url($cached['raw_url']);
+                        }
+                        continue;
+                    }
+
                     $parsed_url = $p->get_parsed_url();
+                    $converted = false;
                     foreach ( $parsed_mapping as $mapping ) {
                         if ( is_child_url_of( $parsed_url, $mapping['from_url'] ) ) {
-                            $new_raw_url = WPURL::replace_base_url(
+                            $converted = WPURL::replace_base_url(
                                 $parsed_url,
                                 array(
                                     'old_base_url' => $base_url,
@@ -245,11 +329,19 @@ class StructuredDataUrlRewriter
                                     'is_relative'  => false,
                                 )
                             );
-
-                            $p->set_raw_url( $new_raw_url );
                             break;
                         }
                     }
+
+                    $cache_value = false;
+                    if ($converted !== false) {
+                        $cache_value = [
+                            'raw_url'    => (string) $converted,
+                            'parsed_url' => $converted->new_url,
+                        ];
+                        $p->set_raw_url($cache_value['raw_url']);
+                    }
+                    $this->set_cached_rewrite_result($cache_key, $cache_value);
                 }
 
                 return $p->get_updated_text();

--- a/reprint-exporter-wp/composer.lock
+++ b/reprint-exporter-wp/composer.lock
@@ -8,16 +8,16 @@
     "packages": [
         {
             "name": "wp-php-toolkit/bytestream",
-            "version": "v0.7.0",
+            "version": "v0.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-php-toolkit/bytestream.git",
-                "reference": "275c423f714e8a16278b939eede1c1c1a21f6561"
+                "reference": "38617382ea9cecd057202bed34739c53e804173b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-php-toolkit/bytestream/zipball/275c423f714e8a16278b939eede1c1c1a21f6561",
-                "reference": "275c423f714e8a16278b939eede1c1c1a21f6561",
+                "url": "https://api.github.com/repos/wp-php-toolkit/bytestream/zipball/38617382ea9cecd057202bed34739c53e804173b",
+                "reference": "38617382ea9cecd057202bed34739c53e804173b",
                 "shasum": ""
             },
             "require": {
@@ -50,32 +50,39 @@
                 }
             ],
             "description": "ByteStream component for WordPress.",
+            "homepage": "https://wordpress.github.io/php-toolkit/reference/bytestream.html",
+            "keywords": [
+                "php-toolkit",
+                "wordpress"
+            ],
             "support": {
-                "issues": "https://github.com/wp-php-toolkit/bytestream/issues",
-                "source": "https://github.com/wp-php-toolkit/bytestream/tree/v0.7.0"
+                "docs": "https://wordpress.github.io/php-toolkit/reference/bytestream.html",
+                "issues": "https://github.com/WordPress/php-toolkit/issues",
+                "source": "https://github.com/WordPress/php-toolkit"
             },
-            "time": "2026-04-29T23:59:06+00:00"
+            "time": "2026-05-14T14:42:57+00:00"
         },
         {
             "name": "wp-php-toolkit/data-liberation",
-            "version": "v0.7.0",
+            "version": "v0.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-php-toolkit/data-liberation.git",
-                "reference": "25f3385ae145b9befcc53cfbeeb71264d82f3df1"
+                "reference": "6eaab346858777b197a5e530157b7388cf3e9cc7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-php-toolkit/data-liberation/zipball/25f3385ae145b9befcc53cfbeeb71264d82f3df1",
-                "reference": "25f3385ae145b9befcc53cfbeeb71264d82f3df1",
+                "url": "https://api.github.com/repos/wp-php-toolkit/data-liberation/zipball/6eaab346858777b197a5e530157b7388cf3e9cc7",
+                "reference": "6eaab346858777b197a5e530157b7388cf3e9cc7",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2",
-                "wp-php-toolkit/bytestream": "^0.7",
-                "wp-php-toolkit/filesystem": "^0.7",
-                "wp-php-toolkit/http-client": "^0.7",
-                "wp-php-toolkit/xml": "^0.7"
+                "wp-php-toolkit/bytestream": "^0.8",
+                "wp-php-toolkit/filesystem": "^0.8",
+                "wp-php-toolkit/html": "^0.8",
+                "wp-php-toolkit/http-client": "^0.8",
+                "wp-php-toolkit/xml": "^0.8"
             },
             "type": "library",
             "autoload": {
@@ -87,7 +94,8 @@
                     "vendor-patched/"
                 ],
                 "exclude-from-classmap": [
-                    "/Tests/"
+                    "/Tests/",
+                    "/bin/"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -105,24 +113,30 @@
                 }
             ],
             "description": "Data Liberation component for WordPress.",
+            "homepage": "https://wordpress.github.io/php-toolkit/reference/dataliberation.html",
+            "keywords": [
+                "php-toolkit",
+                "wordpress"
+            ],
             "support": {
-                "issues": "https://github.com/wp-php-toolkit/data-liberation/issues",
-                "source": "https://github.com/wp-php-toolkit/data-liberation/tree/v0.7.0"
+                "docs": "https://wordpress.github.io/php-toolkit/reference/dataliberation.html",
+                "issues": "https://github.com/WordPress/php-toolkit/issues",
+                "source": "https://github.com/WordPress/php-toolkit"
             },
-            "time": "2026-04-29T23:59:06+00:00"
+            "time": "2026-05-19T19:53:55+00:00"
         },
         {
             "name": "wp-php-toolkit/encoding",
-            "version": "v0.7.0",
+            "version": "v0.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-php-toolkit/encoding.git",
-                "reference": "14ce8b2fed7c1f259f31bde60a11e431ec7fc8c9"
+                "reference": "0da853cd2ce08deee92dddaa0bd5c3fbf7507608"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-php-toolkit/encoding/zipball/14ce8b2fed7c1f259f31bde60a11e431ec7fc8c9",
-                "reference": "14ce8b2fed7c1f259f31bde60a11e431ec7fc8c9",
+                "url": "https://api.github.com/repos/wp-php-toolkit/encoding/zipball/0da853cd2ce08deee92dddaa0bd5c3fbf7507608",
+                "reference": "0da853cd2ce08deee92dddaa0bd5c3fbf7507608",
                 "shasum": ""
             },
             "require": {
@@ -154,29 +168,35 @@
                 }
             ],
             "description": "Encoding component for WordPress.",
+            "homepage": "https://wordpress.github.io/php-toolkit/reference/encoding.html",
+            "keywords": [
+                "php-toolkit",
+                "wordpress"
+            ],
             "support": {
-                "issues": "https://github.com/wp-php-toolkit/encoding/issues",
-                "source": "https://github.com/wp-php-toolkit/encoding/tree/v0.7.0"
+                "docs": "https://wordpress.github.io/php-toolkit/reference/encoding.html",
+                "issues": "https://github.com/WordPress/php-toolkit/issues",
+                "source": "https://github.com/WordPress/php-toolkit"
             },
-            "time": "2026-04-29T23:59:06+00:00"
+            "time": "2026-05-14T14:42:57+00:00"
         },
         {
             "name": "wp-php-toolkit/filesystem",
-            "version": "v0.7.0",
+            "version": "v0.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-php-toolkit/filesystem.git",
-                "reference": "0452bd4784287039b24cea5d760a6657b6c7998c"
+                "reference": "5887e3a81cbed593180f9761cb1c855a5c0be80c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-php-toolkit/filesystem/zipball/0452bd4784287039b24cea5d760a6657b6c7998c",
-                "reference": "0452bd4784287039b24cea5d760a6657b6c7998c",
+                "url": "https://api.github.com/repos/wp-php-toolkit/filesystem/zipball/5887e3a81cbed593180f9761cb1c855a5c0be80c",
+                "reference": "5887e3a81cbed593180f9761cb1c855a5c0be80c",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2",
-                "wp-php-toolkit/bytestream": "^0.7"
+                "wp-php-toolkit/bytestream": "^0.8"
             },
             "require-dev": {
                 "phpunit/phpunit": "^9.5"
@@ -186,9 +206,9 @@
                 "files": [
                     "functions.php"
                 ],
-                "psr-4": {
-                    "WordPress\\Filesystem\\": ""
-                },
+                "classmap": [
+                    "./"
+                ],
                 "exclude-from-classmap": [
                     "/Tests/"
                 ]
@@ -208,28 +228,94 @@
                 }
             ],
             "description": "Filesystem component for WordPress.",
+            "homepage": "https://wordpress.github.io/php-toolkit/reference/filesystem.html",
+            "keywords": [
+                "php-toolkit",
+                "wordpress"
+            ],
             "support": {
-                "issues": "https://github.com/wp-php-toolkit/filesystem/issues",
-                "source": "https://github.com/wp-php-toolkit/filesystem/tree/v0.7.0"
+                "docs": "https://wordpress.github.io/php-toolkit/reference/filesystem.html",
+                "issues": "https://github.com/WordPress/php-toolkit/issues",
+                "source": "https://github.com/WordPress/php-toolkit"
             },
-            "time": "2026-04-29T23:59:06+00:00"
+            "time": "2026-05-18T15:07:36+00:00"
         },
         {
             "name": "wp-php-toolkit/html",
-            "version": "v0.7.0",
+            "version": "v0.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-php-toolkit/html.git",
-                "reference": "bc02065e16da7b7a3072a0a63642b48d944e5c37"
+                "reference": "6c845f71340cec388fac1dfabe7694712b94190a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-php-toolkit/html/zipball/bc02065e16da7b7a3072a0a63642b48d944e5c37",
-                "reference": "bc02065e16da7b7a3072a0a63642b48d944e5c37",
+                "url": "https://api.github.com/repos/wp-php-toolkit/html/zipball/6c845f71340cec388fac1dfabe7694712b94190a",
+                "reference": "6c845f71340cec388fac1dfabe7694712b94190a",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.5"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "./"
+                ],
+                "exclude-from-classmap": [
+                    "/Tests/",
+                    "/html5-named-character-references.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Adam Zielinski",
+                    "email": "adam@adamziel.com"
+                },
+                {
+                    "name": "WordPress Team",
+                    "email": "wordpress@wordpress.org"
+                }
+            ],
+            "description": "HTML component for WordPress.",
+            "homepage": "https://wordpress.github.io/php-toolkit/reference/html.html",
+            "keywords": [
+                "php-toolkit",
+                "wordpress"
+            ],
+            "support": {
+                "docs": "https://wordpress.github.io/php-toolkit/reference/html.html",
+                "issues": "https://github.com/WordPress/php-toolkit/issues",
+                "source": "https://github.com/WordPress/php-toolkit"
+            },
+            "time": "2026-05-18T15:06:45+00:00"
+        },
+        {
+            "name": "wp-php-toolkit/http-client",
+            "version": "v0.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/wp-php-toolkit/http-client.git",
+                "reference": "7d3b83e4af8a5740f3f290bf1c641767e716b1cc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/wp-php-toolkit/http-client/zipball/7d3b83e4af8a5740f3f290bf1c641767e716b1cc",
+                "reference": "7d3b83e4af8a5740f3f290bf1c641767e716b1cc",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2",
+                "wp-php-toolkit/bytestream": "^0.8",
+                "wp-php-toolkit/data-liberation": "^0.8",
+                "wp-php-toolkit/filesystem": "^0.8"
             },
             "require-dev": {
                 "phpunit/phpunit": "^9.5"
@@ -257,80 +343,33 @@
                     "email": "wordpress@wordpress.org"
                 }
             ],
-            "description": "HTML component for WordPress.",
-            "support": {
-                "issues": "https://github.com/wp-php-toolkit/html/issues",
-                "source": "https://github.com/wp-php-toolkit/html/tree/v0.7.0"
-            },
-            "time": "2026-04-29T23:59:06+00:00"
-        },
-        {
-            "name": "wp-php-toolkit/http-client",
-            "version": "v0.7.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/wp-php-toolkit/http-client.git",
-                "reference": "35eeea11f95801e8d1d788a3301b6cb880373b32"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/wp-php-toolkit/http-client/zipball/35eeea11f95801e8d1d788a3301b6cb880373b32",
-                "reference": "35eeea11f95801e8d1d788a3301b6cb880373b32",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.2",
-                "wp-php-toolkit/bytestream": "^0.7",
-                "wp-php-toolkit/data-liberation": "^0.7",
-                "wp-php-toolkit/filesystem": "^0.7"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.5"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "WordPress\\HttpClient\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "GPL-2.0-or-later"
-            ],
-            "authors": [
-                {
-                    "name": "Adam Zielinski",
-                    "email": "adam@adamziel.com"
-                },
-                {
-                    "name": "WordPress Team",
-                    "email": "wordpress@wordpress.org"
-                }
-            ],
             "description": "HttpClient component for WordPress.",
+            "homepage": "https://wordpress.github.io/php-toolkit/reference/httpclient.html",
+            "keywords": [
+                "php-toolkit",
+                "wordpress"
+            ],
             "support": {
-                "issues": "https://github.com/wp-php-toolkit/http-client/issues",
-                "source": "https://github.com/wp-php-toolkit/http-client/tree/v0.7.0"
+                "docs": "https://wordpress.github.io/php-toolkit/reference/httpclient.html",
+                "issues": "https://github.com/WordPress/php-toolkit/issues",
+                "source": "https://github.com/WordPress/php-toolkit"
             },
-            "time": "2026-04-29T23:59:06+00:00"
+            "time": "2026-05-18T15:07:36+00:00"
         },
         {
             "name": "wp-php-toolkit/reprint-exporter",
-            "version": "dev-adamziel/bump-toolkit-0.7.0",
+            "version": "dev-codex/cache-structured-url-rewrites",
             "dist": {
                 "type": "path",
                 "url": "../packages/reprint-exporter",
-                "reference": "3688174c0966c8fd3ae8104f2449d4e34f736b93"
+                "reference": "9e8e2886a687a785a91676f20c505a413926b7b3"
             },
             "require": {
                 "ext-pdo": "*",
                 "ext-pdo_mysql": "*",
                 "php": ">=7.4",
-                "wp-php-toolkit/data-liberation": "^0.7.0",
-                "wp-php-toolkit/html": "^0.7.0"
+                "wp-php-toolkit/data-liberation": "^0.8.0",
+                "wp-php-toolkit/html": "^0.8.0"
             },
             "type": "library",
             "autoload": {
@@ -360,21 +399,21 @@
         },
         {
             "name": "wp-php-toolkit/xml",
-            "version": "v0.7.0",
+            "version": "v0.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-php-toolkit/xml.git",
-                "reference": "650fd70a788fa4189126aed79676c70ca69500d2"
+                "reference": "02ebcc706b1639751380a6501a7ec05431329865"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-php-toolkit/xml/zipball/650fd70a788fa4189126aed79676c70ca69500d2",
-                "reference": "650fd70a788fa4189126aed79676c70ca69500d2",
+                "url": "https://api.github.com/repos/wp-php-toolkit/xml/zipball/02ebcc706b1639751380a6501a7ec05431329865",
+                "reference": "02ebcc706b1639751380a6501a7ec05431329865",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2",
-                "wp-php-toolkit/encoding": "^0.7"
+                "wp-php-toolkit/encoding": "^0.8"
             },
             "require-dev": {
                 "phpunit/phpunit": "^9.5"
@@ -403,11 +442,17 @@
                 }
             ],
             "description": "XML component for WordPress.",
+            "homepage": "https://wordpress.github.io/php-toolkit/reference/xml.html",
+            "keywords": [
+                "php-toolkit",
+                "wordpress"
+            ],
             "support": {
-                "issues": "https://github.com/wp-php-toolkit/xml/issues",
-                "source": "https://github.com/wp-php-toolkit/xml/tree/v0.7.0"
+                "docs": "https://wordpress.github.io/php-toolkit/reference/xml.html",
+                "issues": "https://github.com/WordPress/php-toolkit/issues",
+                "source": "https://github.com/WordPress/php-toolkit"
             },
-            "time": "2026-04-29T23:59:06+00:00"
+            "time": "2026-05-18T15:07:36+00:00"
         }
     ],
     "packages-dev": [],

--- a/tests/e2e/ci/php-wasm-runner.mjs
+++ b/tests/e2e/ci/php-wasm-runner.mjs
@@ -7,6 +7,7 @@ import { dirname, resolve } from 'node:path';
 
 const DEFAULT_PHP_VERSION = '8.3';
 const MYSQL_PARSER_MANIFEST_ENV = 'WP_MYSQL_PARSER_EXTENSION_MANIFEST';
+const NATIVE_APIS_MANIFEST_ENV = 'WP_NATIVE_APIS_EXTENSION_MANIFEST';
 
 function envRecord() {
     return Object.fromEntries(
@@ -78,7 +79,8 @@ function mountRootFor(pathCandidate) {
 }
 
 function collectMounts(args) {
-    const candidates = new Set([process.cwd()]);
+    const projectRoot = resolve(import.meta.dirname, '..', '..', '..');
+    const candidates = new Set([process.cwd(), projectRoot]);
     for (const root of ['/tmp', '/srv']) {
         if (existsSync(root)) {
             candidates.add(root);
@@ -115,6 +117,15 @@ async function main() {
             source: {
                 format: 'manifest',
                 manifestUrl,
+            },
+        });
+    }
+    const nativeApisManifestUrl = process.env[NATIVE_APIS_MANIFEST_ENV];
+    if (nativeApisManifestUrl) {
+        extensions.push({
+            source: {
+                format: 'manifest',
+                manifestUrl: nativeApisManifestUrl,
             },
         });
     }

--- a/tests/e2e/ci/playground-php.sh
+++ b/tests/e2e/ci/playground-php.sh
@@ -9,7 +9,7 @@
 # extensions.
 set -euo pipefail
 
-if [ -n "${WP_MYSQL_PARSER_EXTENSION_MANIFEST:-}" ] || [ "${PLAYGROUND_PHP_USE_WASM_RUNNER:-}" = "1" ]; then
+if [ -n "${WP_MYSQL_PARSER_EXTENSION_MANIFEST:-}" ] || [ -n "${WP_NATIVE_APIS_EXTENSION_MANIFEST:-}" ] || [ "${PLAYGROUND_PHP_USE_WASM_RUNNER:-}" = "1" ]; then
     SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
     NODE_CMD=(node)
     if ! node --experimental-wasm-jspi --input-type=module -e "import { jspi } from 'wasm-feature-detect'; process.exit(await jspi() ? 0 : 1);" >/dev/null 2>&1; then


### PR DESCRIPTION
## What

Adds a bounded 4096-entry ring cache to `StructuredDataUrlRewriter` for URL rewrite decisions.

For each matched raw URL, the importer now caches whether it maps to a target URL and, when it does, the rewritten raw URL plus parsed target URL. The cache key includes the rewriter's URL mapping, content type, token type, and raw URL so block markup and plain text keep their existing semantics.

## Why

Large imports often repeat the same source URLs many times. Without a cache, every occurrence repeats `is_child_url_of()` and `WPURL::replace_base_url()` work even when the result is identical.

This complements WordPress/php-toolkit#283, which makes `URLInTextProcessor` use the native URL candidate scanner and adds a parsed-candidate cache in the shared DataLiberation layer.

## Validation

- `php -l packages/reprint-importer/src/lib/url-rewrite/class-structured-data-url-rewriter.php`
- `vendor/bin/phpcs --standard=PHPCompatibility --runtime-set testVersion 7.4- -ps packages/reprint-importer/src/lib/url-rewrite/class-structured-data-url-rewriter.php`
- `../vendor/bin/phpunit --testdox --colors=never UrlRewriting/StructuredDataUrlRewriterTest.php`

The focused URL rewriter suite passed: 39 tests, 48 assertions, 7 skipped.