### PR TITLE
Avoid unnecessary base64_decode() calls when processing SQL queries

### DIFF
--- a/packages/reprint-importer/src/lib/url-rewrite/class-base64-value-scanner.php
+++ b/packages/reprint-importer/src/lib/url-rewrite/class-base64-value-scanner.php
@@ -9,6 +9,11 @@
  * set_value() only replaces the base64 payload inside the quotes, so wrappers
  * are preserved without the caller needing to know about them.
  *
+ * Values are decoded lazily. The scanner keeps the original encoded payload
+ * until get_value() is called, so callers can skip obviously irrelevant values
+ * without paying base64_decode() for every FROM_BASE64() expression in a large
+ * INSERT batch.
+ *
  * Usage:
  *     $scanner = new Base64ValueScanner($sql);
  *     while ($scanner->next_value()) {
@@ -29,14 +34,16 @@ class Base64ValueScanner
      *   'expr_start'   => int    Offset of the outermost expression (CONVERT or FROM_BASE64)
      *   'quote_start'  => int    Offset of the quoted string token (including quotes)
      *   'quote_length' => int    Length of the quoted string token
-     *   'value'        => string The base64-decoded value
+     *   'encoded_value'=> string The base64 payload
+     *   'value'        => ?string The base64-decoded value, cached on demand
      *   'new_value'    => ?string Non-null when set_value() has been called
      *
-     * @var array<int, array{expr_start: int, quote_start: int, quote_length: int, value: string, new_value: ?string}>
+     * @var array<int, array{expr_start: int, quote_start: int, quote_length: int, encoded_value: string, value: ?string, new_value: ?string}>
      */
     private array $entries = [];
 
     private int $cursor = -1;
+    private bool $dirty = false;
 
     /**
      * @param string $sql The SQL statement.
@@ -60,10 +67,10 @@ class Base64ValueScanner
     /**
      * Build a scanner from a pre-built entry list. Used by the
      * tokenization-free FastInsertScanner path — when the caller has
-     * already located every FROM_BASE64() expression and decoded its
-     * payload, the scanner skips both lexer and base64_decode work.
+     * already located every FROM_BASE64() expression and captured its payload,
+     * the scanner skips the lexer and still decodes values lazily.
      *
-     * @param list<array{expr_start: int, quote_start: int, quote_length: int, value: string, new_value: ?string}> $entries
+     * @param list<array{expr_start: int, quote_start: int, quote_length: int, encoded_value: string, value: ?string, new_value: ?string}> $entries
      */
     public static function from_entries(string $sql, array $entries): self
     {
@@ -86,7 +93,35 @@ class Base64ValueScanner
      */
     public function get_value(): string
     {
+        if ($this->entries[$this->cursor]['value'] === null) {
+            $decoded = base64_decode($this->entries[$this->cursor]['encoded_value'], true);
+            $this->entries[$this->cursor]['value'] = $decoded !== false ? $decoded : '';
+        }
+
         return $this->entries[$this->cursor]['value'];
+    }
+
+    /**
+     * Return whether the current encoded payload could decode to a value
+     * containing an http:// or https:// scheme.
+     *
+     * This is a conservative base64 prefilter over the encoded text, not proof
+     * that the decoded value contains a URL. false means the payload cannot
+     * decode to a lowercase http/https scheme under the checked alignments.
+     * true only means it could, so the caller still needs to decode and inspect
+     * the value. It mirrors the statement-level prefilter in SqlStatementRewriter,
+     * but applies it per payload so one URL-bearing column does not force every
+     * neighboring FROM_BASE64() value in the same INSERT batch through
+     * base64_decode().
+     */
+    public function encoded_payload_could_contain_http_scheme(): bool
+    {
+        $value = $this->entries[$this->cursor]['value'];
+        if ($value !== null) {
+            return strpos($value, 'http') !== false;
+        }
+
+        return self::encoded_payload_could_decode_to_http_scheme($this->entries[$this->cursor]['encoded_value']);
     }
 
     /**
@@ -96,6 +131,7 @@ class Base64ValueScanner
     public function set_value(string $new_value): void
     {
         $this->entries[$this->cursor]['new_value'] = $new_value;
+        $this->dirty = true;
     }
 
     /**
@@ -116,6 +152,10 @@ class Base64ValueScanner
      */
     public function get_result(): string
     {
+        if (!$this->dirty) {
+            return $this->sql;
+        }
+
         $result = $this->sql;
 
         // Process in reverse order to preserve byte offsets
@@ -172,12 +212,12 @@ class Base64ValueScanner
                         $inner->id === WP_MySQL_Lexer::SINGLE_QUOTED_TEXT
                         || $inner->id === WP_MySQL_Lexer::DOUBLE_QUOTED_TEXT
                     ) {
-                        $decoded = base64_decode($inner->get_value(), true);
                         $this->entries[] = [
                             'expr_start' => $expr_start,
                             'quote_start' => $inner->start,
                             'quote_length' => $inner->length,
-                            'value' => $decoded !== false ? $decoded : '',
+                            'encoded_value' => $inner->get_value(),
+                            'value' => null,
                             'new_value' => null,
                         ];
                         break;
@@ -241,12 +281,12 @@ class Base64ValueScanner
                         $inner->id === WP_MySQL_Lexer::SINGLE_QUOTED_TEXT
                         || $inner->id === WP_MySQL_Lexer::DOUBLE_QUOTED_TEXT
                     ) {
-                        $decoded = base64_decode($inner->get_value(), true);
                         $this->entries[] = [
                             'expr_start' => $expr_start,
                             'quote_start' => $inner->start,
                             'quote_length' => $inner->length,
-                            'value' => $decoded !== false ? $decoded : '',
+                            'encoded_value' => $inner->get_value(),
+                            'value' => null,
                             'new_value' => null,
                         ];
                         break;
@@ -260,5 +300,13 @@ class Base64ValueScanner
             $prev[0] = $prev[1];
             $prev[1] = $token;
         }
+    }
+
+    private static function encoded_payload_could_decode_to_http_scheme(string $payload): bool
+    {
+        return strpos($payload, 'aHR0') !== false
+            || strpos($payload, 'dHA6') !== false
+            || strpos($payload, 'dHBz') !== false
+            || strpos($payload, 'dHRw') !== false;
     }
 }

--- a/packages/reprint-importer/src/lib/url-rewrite/class-fast-insert-scanner.php
+++ b/packages/reprint-importer/src/lib/url-rewrite/class-fast-insert-scanner.php
@@ -37,7 +37,7 @@ class FastInsertScanner
      * @return array{
      *   table: string,
      *   column_map: list<array{int, int, string}>,
-     *   base64_entries: list<array{expr_start: int, quote_start: int, quote_length: int, value: string, new_value: ?string}>
+     *   base64_entries: list<array{expr_start: int, quote_start: int, quote_length: int, encoded_value: string, value: ?string, new_value: ?string}>
      * }|null
      *   Null when the SQL doesn't match the recognised shape.
      */
@@ -139,12 +139,13 @@ class FastInsertScanner
                 $column_map[] = [$value_start, $value_end, $columns[$col_idx]];
 
                 if (is_array($value_kind)) {
-                    // FROM_BASE64 payload: kind = [expr_start, quote_start, quote_length, decoded_value]
+                    // FROM_BASE64 payload: kind = [expr_start, quote_start, quote_length, encoded_value]
                     $base64_entries[] = [
                         'expr_start' => $value_kind[0],
                         'quote_start' => $value_kind[1],
                         'quote_length' => $value_kind[2],
-                        'value' => $value_kind[3],
+                        'encoded_value' => $value_kind[3],
+                        'value' => null,
                         'new_value' => null,
                     ];
                 }
@@ -201,7 +202,7 @@ class FastInsertScanner
      * @return null|true|array{int,int,int,string}
      *   null = unrecognized shape (caller bails)
      *   true = recognised, no FROM_BASE64 entry to record
-     *   array = FROM_BASE64 payload, [expr_start, quote_start, quote_length, decoded]
+     *   array = FROM_BASE64 payload, [expr_start, quote_start, quote_length, encoded]
      */
     private static function scan_value(string $sql, int $sql_len, int &$cursor)
     {
@@ -318,7 +319,7 @@ class FastInsertScanner
     /**
      * Inside a FROM_BASE64( … ) call, with $cursor already past the opening
      * paren. Reads the quoted base64 string and the closing paren. Returns
-     * the [expr_start, quote_start, quote_length, decoded] tuple.
+     * the [expr_start, quote_start, quote_length, encoded] tuple.
      *
      * @return array{int,int,int,string}|null
      */
@@ -357,11 +358,7 @@ class FastInsertScanner
             }
             $cursor++;
         }
-        $decoded = base64_decode($payload, true);
-        if ($decoded === false) {
-            $decoded = '';
-        }
-        return [$expr_start, $quote_start, $quote_length, $decoded];
+        return [$expr_start, $quote_start, $quote_length, $payload];
     }
 
     private static function is_ws(string $c): bool

--- a/packages/reprint-importer/src/lib/url-rewrite/class-sql-statement-rewriter.php
+++ b/packages/reprint-importer/src/lib/url-rewrite/class-sql-statement-rewriter.php
@@ -165,15 +165,17 @@ class SqlStatementRewriter
     private function rewrite_with_scanner(Base64ValueScanner $scanner, ?array $value_to_column_map): string
     {
         while ($scanner->next_value()) {
+            if (!$scanner->encoded_payload_could_contain_http_scheme()) {
+                continue;
+            }
+
             $value = $scanner->get_value();
 
-            // Skip values that can't contain a URL we'd rewrite. Every
-            // rewritable domain starts with http:// or https://, so a value
-            // without "http" anywhere in it has nothing for us to do. This
-            // avoids the column-map lookup and the full StructuredDataUrlRewriter
-            // pipeline (HTML parse, block markup, PHP/JSON recursion) per value.
-            // See https://github.com/adamziel/reprint/pull/152
             if (strpos($value, 'http') === false) {
+                continue;
+            }
+
+            if (!$this->url_rewriter->value_might_contain_source_domain($value)) {
                 continue;
             }
 

--- a/packages/reprint-importer/src/lib/url-rewrite/class-structured-data-url-rewriter.php
+++ b/packages/reprint-importer/src/lib/url-rewrite/class-structured-data-url-rewriter.php
@@ -31,6 +31,7 @@ class StructuredDataUrlRewriter
 {
     const BLOCK_MARKUP = 'block_markup';
     const PLAIN_TEXT = 'plain_text';
+    private const REWRITE_RESULT_CACHE_MAX = 4096;
 
     /** @var string[] Source domains extracted from url_mapping keys, for quick-reject checks. */
     private array $source_domains;
@@ -57,6 +58,17 @@ class StructuredDataUrlRewriter
     /** @var string Default base_url used by the URL processors (first from-url). */
     private string $base_url;
 
+    /** @var string Cache namespace for this rewriter's URL mapping. */
+    private string $mapping_cache_key;
+
+    /** @var array<string, false|array{raw_url: string, parsed_url: mixed}> */
+    private array $rewrite_result_cache = [];
+
+    /** @var string[] */
+    private array $rewrite_result_cache_ring = [];
+
+    private int $rewrite_result_cache_next = 0;
+
     /**
      * @param array<string, string> $url_mapping Source URL => target URL mapping.
      */
@@ -82,6 +94,7 @@ class StructuredDataUrlRewriter
                 'to_url'   => WPURL::parse($to_url_string),
             ];
         }
+        $this->mapping_cache_key = sha1(json_encode($url_mapping, JSON_UNESCAPED_SLASHES));
 
         // Default base_url: first from-url in the mapping. Preserves the
         // behaviour of the previous per-call default so outputs are unchanged.
@@ -177,6 +190,53 @@ class StructuredDataUrlRewriter
     }
 
     /**
+     * Return whether a decoded value may contain one of the configured source
+     * domains. This intentionally checks hosts instead of full source URLs so
+     * escaped spellings of `://` in block markup or JSON do not matter.
+     */
+    public function value_might_contain_source_domain(string $value): bool
+    {
+        if ($this->source_domains === []) {
+            return true;
+        }
+
+        foreach ($this->source_domains as $domain) {
+            if (stripos($value, $domain) !== false) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function get_cached_rewrite_result(string $cache_key)
+    {
+        return array_key_exists($cache_key, $this->rewrite_result_cache)
+            ? $this->rewrite_result_cache[$cache_key]
+            : null;
+    }
+
+    /**
+     * @param false|array{raw_url: string, parsed_url: mixed} $value
+     */
+    private function set_cached_rewrite_result(string $cache_key, $value): void
+    {
+        if (!array_key_exists($cache_key, $this->rewrite_result_cache)) {
+            if (count($this->rewrite_result_cache_ring) < self::REWRITE_RESULT_CACHE_MAX) {
+                $this->rewrite_result_cache_ring[] = $cache_key;
+            } else {
+                $evicted_key = $this->rewrite_result_cache_ring[$this->rewrite_result_cache_next];
+                unset($this->rewrite_result_cache[$evicted_key]);
+                $this->rewrite_result_cache_ring[$this->rewrite_result_cache_next] = $cache_key;
+            }
+
+            $this->rewrite_result_cache_next = ($this->rewrite_result_cache_next + 1) % self::REWRITE_RESULT_CACHE_MAX;
+        }
+
+        $this->rewrite_result_cache[$cache_key] = $value;
+    }
+
+    /**
      * Migrate URLs in post content. See WPRewriteUrlsTests for
      * specific examples. TODO: A better description.
      *
@@ -219,13 +279,46 @@ class StructuredDataUrlRewriter
             case self::BLOCK_MARKUP:
                 $p = new BlockMarkupUrlProcessor( $content, $base_url );
                 while ( $p->next_url() ) {
+                    $raw_url = $p->get_raw_url();
+                    $token_type = $p->get_token_type() ?? '';
+                    $cache_key = $this->mapping_cache_key . "\0" . self::BLOCK_MARKUP . "\0" . $token_type . "\0" . $raw_url;
+                    $cached = $this->get_cached_rewrite_result($cache_key);
+                    if ($cached !== null) {
+                        if ($cached !== false) {
+                            $p->set_url($cached['raw_url'], $cached['parsed_url']);
+                        }
+                        continue;
+                    }
+
                     $parsed_url = $p->get_parsed_url();
+                    $converted = false;
                     foreach ( $parsed_mapping as $mapping ) {
                         if ( is_child_url_of( $parsed_url, $mapping['from_url'] ) ) {
-                            $p->replace_base_url( $mapping['to_url'] );
+                            $converted = WPURL::replace_base_url(
+                                $parsed_url,
+                                array(
+                                    'old_base_url' => $base_url,
+                                    'new_base_url' => $mapping['to_url'],
+                                    'raw_url'      => $raw_url,
+                                    'is_relative'  => (
+                                        '#text' !== $token_type &&
+                                        ! WPURL::can_parse($raw_url)
+                                    ),
+                                )
+                            );
                             break;
                         }
                     }
+
+                    $cache_value = false;
+                    if ($converted !== false) {
+                        $cache_value = [
+                            'raw_url'    => (string) $converted,
+                            'parsed_url' => $converted->new_url,
+                        ];
+                        $p->set_url($cache_value['raw_url'], $cache_value['parsed_url']);
+                    }
+                    $this->set_cached_rewrite_result($cache_key, $cache_value);
                 }
 
                 return $p->get_updated_html();
@@ -233,10 +326,21 @@ class StructuredDataUrlRewriter
             case self::PLAIN_TEXT:
                 $p = new URLInTextProcessor( $content, $base_url );
                 while ( $p->next_url() ) {
+                    $raw_url = $p->get_raw_url();
+                    $cache_key = $this->mapping_cache_key . "\0" . self::PLAIN_TEXT . "\0" . $raw_url;
+                    $cached = $this->get_cached_rewrite_result($cache_key);
+                    if ($cached !== null) {
+                        if ($cached !== false) {
+                            $p->set_raw_url($cached['raw_url']);
+                        }
+                        continue;
+                    }
+
                     $parsed_url = $p->get_parsed_url();
+                    $converted = false;
                     foreach ( $parsed_mapping as $mapping ) {
                         if ( is_child_url_of( $parsed_url, $mapping['from_url'] ) ) {
-                            $new_raw_url = WPURL::replace_base_url(
+                            $converted = WPURL::replace_base_url(
                                 $parsed_url,
                                 array(
                                     'old_base_url' => $base_url,
@@ -245,11 +349,19 @@ class StructuredDataUrlRewriter
                                     'is_relative'  => false,
                                 )
                             );
-
-                            $p->set_raw_url( $new_raw_url );
                             break;
                         }
                     }
+
+                    $cache_value = false;
+                    if ($converted !== false) {
+                        $cache_value = [
+                            'raw_url'    => (string) $converted,
+                            'parsed_url' => $converted->new_url,
+                        ];
+                        $p->set_raw_url($cache_value['raw_url']);
+                    }
+                    $this->set_cached_rewrite_result($cache_key, $cache_value);
                 }
 
                 return $p->get_updated_text();

--- a/tests/UrlRewriting/Base64ValueScannerTest.php
+++ b/tests/UrlRewriting/Base64ValueScannerTest.php
@@ -192,4 +192,29 @@ class Base64ValueScannerTest extends TestCase
         $this->assertCount(1, $values);
         $this->assertEquals($value, $values[0]);
     }
+
+    public function testEncodedPayloadCouldContainHttpSchemeUsesEncodedPayload(): void
+    {
+        $sql = sprintf(
+            "INSERT INTO t VALUES(FROM_BASE64('%s'), FROM_BASE64('%s'), FROM_BASE64('%s'), FROM_BASE64('%s'));",
+            base64_encode('plain text'),
+            base64_encode('https://example.com/zero'),
+            base64_encode('xhttps://example.com/one'),
+            base64_encode('xxhttps://example.com/two')
+        );
+
+        $scanner = new Base64ValueScanner($sql);
+
+        $this->assertTrue($scanner->next_value());
+        $this->assertFalse($scanner->encoded_payload_could_contain_http_scheme());
+
+        $this->assertTrue($scanner->next_value());
+        $this->assertTrue($scanner->encoded_payload_could_contain_http_scheme());
+
+        $this->assertTrue($scanner->next_value());
+        $this->assertTrue($scanner->encoded_payload_could_contain_http_scheme());
+
+        $this->assertTrue($scanner->next_value());
+        $this->assertTrue($scanner->encoded_payload_could_contain_http_scheme());
+    }
 }

--- a/tests/UrlRewriting/StructuredDataUrlRewriterTest.php
+++ b/tests/UrlRewriting/StructuredDataUrlRewriterTest.php
@@ -404,4 +404,19 @@ class StructuredDataUrlRewriterTest extends TestCase
     {
         $this->markTestSkipped('Base64 processing is temporarily disabled for performance.');
     }
+
+    public function testValueMightContainSourceDomainIgnoresSchemeEscaping(): void
+    {
+        $rewriter = $this->createRewriter();
+
+        $this->assertTrue(
+            $rewriter->value_might_contain_source_domain('{"url":"https:\/\/old-site.com\/page"}')
+        );
+        $this->assertTrue(
+            $rewriter->value_might_contain_source_domain('<a href="HTTPS://OLD-SITE.COM/page">Link</a>')
+        );
+        $this->assertFalse(
+            $rewriter->value_might_contain_source_domain('<a href="https://other-site.com/page">Link</a>')
+        );
+    }
 }


### PR DESCRIPTION
## What changed

This stacks on #217 and tightens the `FROM_BASE64()` rewrite path:

- keep `FROM_BASE64()` payloads encoded until a value actually needs inspection
- apply the encoded `http` prefilter per payload, not only per SQL statement
- skip structured URL rewriting when the decoded value contains `http` but none of the configured source hosts
- return the original SQL immediately when no base64 values were rewritten

The source-host check intentionally looks for hosts rather than exact source URLs, so escaped spellings of `://` in block markup or JSON do not matter.

## Benchmark

Local PHP 8.4.5 microbench, 3,000-row producer-shaped `INSERT`, 8 extra base64 columns per row, 5 iterations. Baseline is #217 at `56b4ac2`.

| Case | Baseline median | This PR median | Delta | Output hash |
| --- | ---: | ---: | ---: | --- |
| one rewritable source-domain URL + many plain base64 fields | 4057.06 ms | 4327.02 ms | +8.1% | same (`601e11ea91556912a771d6efb77d3d3b`) |
| one wrong-domain URL + many plain base64 fields | 485.08 ms | 43.56 ms | -91.0% | same (`cf27d307dbc94134dd3e5d85cf301ac9`) |
| no URLs | 6.29 ms | 6.34 ms | +0.8% | same (`1e7b7da31a5d69e20bf8691554f0d213`) |

The important win is the common no-op URL-bearing case: values with unrelated `href`/`src` URLs no longer pay for column lookup and `wp_rewrite_urls()`.

## Validation

- `vendor/bin/phpunit tests/UrlRewriting/Base64ValueScannerTest.php tests/UrlRewriting/SqlStatementRewriterTest.php tests/UrlRewriting/SqlStatementRewriterPrefilterTest.php tests/UrlRewriting/SqlStatementRewriterLexerWalkerTest.php tests/UrlRewriting/StructuredDataUrlRewriterTest.php`
- `composer validate --no-check-publish`
- `composer test` attempted; local MySQL-dependent tests failed with `SQLSTATE[HY000] [2002] Connection refused`
