### PR TITLE
Speed up source-domain FROM_BASE64 rewrites

### DIFF
--- a/packages/reprint-importer/src/lib/url-rewrite/class-base64-value-scanner.php
+++ b/packages/reprint-importer/src/lib/url-rewrite/class-base64-value-scanner.php
@@ -156,20 +156,19 @@ class Base64ValueScanner
             return $this->sql;
         }
 
-        $result = $this->sql;
-
-        // Process in reverse order to preserve byte offsets
-        for ($i = count($this->entries) - 1; $i >= 0; $i--) {
-            $entry = $this->entries[$i];
+        $parts = [];
+        $cursor = 0;
+        foreach ($this->entries as $entry) {
             if ($entry['new_value'] !== null) {
                 $replacement = "'" . base64_encode($entry['new_value']) . "'";
-                $result = substr($result, 0, $entry['quote_start'])
-                    . $replacement
-                    . substr($result, $entry['quote_start'] + $entry['quote_length']);
+                $parts[] = substr($this->sql, $cursor, $entry['quote_start'] - $cursor);
+                $parts[] = $replacement;
+                $cursor = $entry['quote_start'] + $entry['quote_length'];
             }
         }
+        $parts[] = substr($this->sql, $cursor);
 
-        return $result;
+        return implode('', $parts);
     }
 
     /**

--- a/packages/reprint-importer/src/lib/url-rewrite/class-sql-statement-rewriter.php
+++ b/packages/reprint-importer/src/lib/url-rewrite/class-sql-statement-rewriter.php
@@ -191,9 +191,12 @@ class SqlStatementRewriter
                 }
             }
 
-            // Rewrite URLs in the value — StructuredDataUrlRewriter classifies the
-            // content type and applies the right strategy for each.
-            $rewritten = $this->url_rewriter->rewrite($value, $content_type);
+            // Rewrite URLs in the value. Known block-markup columns can first
+            // try a boundary-checked literal base URL swap before falling back
+            // to the full structured parser.
+            $rewritten = $content_type === StructuredDataUrlRewriter::BLOCK_MARKUP
+                ? $this->url_rewriter->rewrite_known_block_markup_value($value)
+                : $this->url_rewriter->rewrite($value, $content_type);
 
             // Only replace if the value actually changed
             if ($rewritten !== $value) {

--- a/packages/reprint-importer/src/lib/url-rewrite/class-structured-data-url-rewriter.php
+++ b/packages/reprint-importer/src/lib/url-rewrite/class-structured-data-url-rewriter.php
@@ -36,6 +36,12 @@ class StructuredDataUrlRewriter
     /** @var string[] Source domains extracted from url_mapping keys, for quick-reject checks. */
     private array $source_domains;
 
+    /** @var array<string, string> Literal base URL replacements for the block-markup fast path. */
+    private array $literal_base_url_replacements;
+
+    /** @var string[] Unescaped source base URLs, used to avoid changing block-comment JSON formatting. */
+    private array $literal_source_base_urls;
+
     /**
      * Pre-parsed url_mapping: each entry is
      *   [ 'from_url' => <parsed URL>, 'to_url' => <parsed URL> ]
@@ -88,12 +94,22 @@ class StructuredDataUrlRewriter
         // (scheme/host/path tokenisation, punycode, etc.) and used to be
         // repeated on every leaf we rewrote.
         $this->parsed_mapping = [];
+        $this->literal_base_url_replacements = [];
+        $this->literal_source_base_urls = [];
         foreach ($url_mapping as $from_url_string => $to_url_string) {
             $this->parsed_mapping[] = [
                 'from_url' => WPURL::parse($from_url_string),
                 'to_url'   => WPURL::parse($to_url_string),
             ];
+
+            $this->literal_source_base_urls[] = $from_url_string;
+            $this->literal_base_url_replacements[$from_url_string] = $to_url_string;
+            $this->literal_base_url_replacements[str_replace('/', '\/', $from_url_string)] = str_replace('/', '\/', $to_url_string);
         }
+        uksort(
+            $this->literal_base_url_replacements,
+            static fn ($a, $b) => strlen($b) <=> strlen($a)
+        );
         $this->mapping_cache_key = sha1(json_encode($url_mapping, JSON_UNESCAPED_SLASHES));
 
         // Default base_url: first from-url in the mapping. Preserves the
@@ -187,6 +203,106 @@ class StructuredDataUrlRewriter
             }
         }
         return false;
+    }
+
+    /**
+     * Rewrite a decoded value already known by the SQL layer to be block markup.
+     *
+     * This takes a conservative fast path for the common dump shape where the
+     * value contains literal absolute source URLs in HTML attributes, text, CSS,
+     * or block-comment JSON. In that case a boundary-checked base URL swap gives
+     * the same result as BlockMarkupUrlProcessor without constructing the full
+     * parser stack for every row. If any source URL occurrence is not at a URL
+     * boundary, we fall back to the full structured rewriter.
+     */
+    public function rewrite_known_block_markup_value(string $value): string
+    {
+        if ($value === '') {
+            return $value;
+        }
+
+        if (!$this->maybe_contains_rewritable_urls($value)) {
+            return $value;
+        }
+
+        $literal_rewrite = $this->try_rewrite_literal_base_urls($value);
+        if ($literal_rewrite !== null) {
+            return $literal_rewrite;
+        }
+
+        return $this->rewrite($value, self::BLOCK_MARKUP);
+    }
+
+    private function try_rewrite_literal_base_urls(string $value): ?string
+    {
+        if ($this->has_unescaped_source_url_in_block_comment($value)) {
+            return null;
+        }
+
+        $matched = false;
+        foreach ($this->literal_base_url_replacements as $from => $_to) {
+            $offset = 0;
+            while (true) {
+                $pos = strpos($value, $from, $offset);
+                if ($pos === false) {
+                    break;
+                }
+                if (!$this->is_literal_base_url_boundary($value, $pos, strlen($from))) {
+                    return null;
+                }
+                $matched = true;
+                $offset = $pos + strlen($from);
+            }
+        }
+
+        return $matched ? strtr($value, $this->literal_base_url_replacements) : null;
+    }
+
+    private function has_unescaped_source_url_in_block_comment(string $value): bool
+    {
+        $comment_start = 0;
+        while (true) {
+            $comment_start = strpos($value, '<!-- wp:', $comment_start);
+            if ($comment_start === false) {
+                return false;
+            }
+
+            $comment_end = strpos($value, '-->', $comment_start);
+            if ($comment_end === false) {
+                return false;
+            }
+
+            foreach ($this->literal_source_base_urls as $source_url) {
+                $source_pos = strpos($value, $source_url, $comment_start);
+                if ($source_pos !== false && $source_pos < $comment_end) {
+                    return true;
+                }
+            }
+
+            $comment_start = $comment_end + 3;
+        }
+    }
+
+    private function is_literal_base_url_boundary(string $value, int $pos, int $length): bool
+    {
+        if ($pos > 0) {
+            $prev = $value[$pos - 1];
+            if (
+                !ctype_space($prev)
+                && strpos('"\'([{,:>', $prev) === false
+            ) {
+                return false;
+            }
+        }
+
+        $next_pos = $pos + $length;
+        if ($next_pos >= strlen($value)) {
+            return true;
+        }
+
+        $next = $value[$next_pos];
+        return ctype_space($next)
+            || strpos('/\\?#"\'<)]},;', $next) !== false;
     }
 
     /**

--- a/tests/UrlRewriting/StructuredDataUrlRewriterTest.php
+++ b/tests/UrlRewriting/StructuredDataUrlRewriterTest.php
@@ -343,6 +343,28 @@ class StructuredDataUrlRewriterTest extends TestCase
         $this->assertStringContainsString('https://new-site.com/page', $result);
     }
 
+    public function testKnownBlockMarkupFastPathRewritesEscapedBlockJsonAndHtml(): void
+    {
+        $rewriter = $this->createRewriter();
+        $input = '<!-- wp:image {"src":"https:\/\/old-site.com\/img.jpg"} -->'
+            . '<figure><img src="https://old-site.com/img.jpg"/></figure>'
+            . '<!-- /wp:image -->';
+
+        $result = $rewriter->rewrite_known_block_markup_value($input);
+
+        $this->assertStringContainsString('https:\/\/new-site.com\/img.jpg', $result);
+        $this->assertStringContainsString('src="https://new-site.com/img.jpg"', $result);
+        $this->assertStringNotContainsString('old-site.com', $result);
+    }
+
+    public function testKnownBlockMarkupFastPathFallsBackForEmbeddedQueryUrl(): void
+    {
+        $rewriter = $this->createRewriter();
+        $input = '<a href="https://webarchive.org?url=https://old-site.com/about">Archive</a>';
+
+        $this->assertSame($input, $rewriter->rewrite_known_block_markup_value($input));
+    }
+
     // --- Content type hint: null (default) uses plain text replacement ---
 
     public function testDefaultHintUsesPlainTextReplacement(): void


### PR DESCRIPTION
## What changed

This stacks on #218 and removes the main cost in the real-rewrite path:

- rebuild modified SQL in one forward pass instead of repeatedly slicing the full statement per changed `FROM_BASE64()` value
- add a narrow block-markup fast path for known `post_content`-style values that only need literal base URL swaps
- fall back to the existing `BlockMarkupUrlProcessor` when a literal source URL appears in unescaped block-comment JSON or at a suspicious boundary

The SQL rebuild change is the big win. The previous implementation was effectively `statement size × changed values`, so rewriting thousands of rows in one large `INSERT` spent most of its time copying the same SQL string again and again.

## Benchmark

Local PHP 8.4.5 microbench, 3,000-row producer-shaped `INSERT`, 8 extra base64 columns per row, 5 iterations.

Baseline is #218.

| Case | #218 median | This PR median | Delta | Output hash |
| --- | ---: | ---: | ---: | --- |
| one rewritable source-domain URL + many plain base64 fields | 4327.02 ms | 51.85 ms | -98.8% | same (`601e11ea91556912a771d6efb77d3d3b`) |
| one wrong-domain URL + many plain base64 fields | 43.56 ms | 44.89 ms | +3.1% | same (`cf27d307dbc94134dd3e5d85cf301ac9`) |
| no URLs | 6.34 ms | 6.37 ms | +0.5% | same (`1e7b7da31a5d69e20bf8691554f0d213`) |

## Validation

- `vendor/bin/phpunit tests/UrlRewriting/Base64ValueScannerTest.php tests/UrlRewriting/SqlStatementRewriterTest.php tests/UrlRewriting/SqlStatementRewriterPrefilterTest.php tests/UrlRewriting/SqlStatementRewriterLexerWalkerTest.php tests/UrlRewriting/StructuredDataUrlRewriterTest.php`
- `composer validate --no-check-publish`