### PR TITLE
Speed up SQLite db-apply imports

### DIFF
--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -4990,7 +4990,7 @@ class ImportClient
 
     private function inline_base64_values_for_sqlite(string $query): string
     {
-        if (strpos($query, "FROM_BASE64(") === false) {
+        if (stripos($query, "FROM_BASE64") === false) {
             return $query;
         }
 

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -4995,7 +4995,7 @@ class ImportClient
         }
 
         $scanner = new Base64ValueScanner($query);
-        return $scanner->get_result_with_mysql_hex_literals();
+        return $scanner->get_result_with_sqlite_compatible_literals();
     }
 
     public function run_db_apply(array $options): void

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -4988,24 +4988,14 @@ class ImportClient
         ];
     }
 
-    private function inline_from_base64_for_sqlite(string $query): string
+    private function inline_base64_values_for_sqlite(string $query): string
     {
         if (strpos($query, "FROM_BASE64(") === false) {
             return $query;
         }
 
-        return preg_replace_callback(
-            "/(?:CONVERT\\s*\\(\\s*)?FROM_BASE64\\s*\\(\\s*'([A-Za-z0-9+\\/=]*)'\\s*\\)(?:\\s+USING\\s+utf8mb4\\s*\\))?/i",
-            static function (array $matches): string {
-                $decoded = base64_decode($matches[1], true);
-                if ($decoded === false) {
-                    return $matches[0];
-                }
-
-                return "'" . str_replace("'", "''", $decoded) . "'";
-            },
-            $query
-        );
+        $scanner = new Base64ValueScanner($query);
+        return $scanner->get_result_with_mysql_hex_literals();
     }
 
     public function run_db_apply(array $options): void
@@ -5138,7 +5128,7 @@ class ImportClient
         }
 
         [$pdo, $connection_label] = $this->create_target_db_apply_connection($options);
-        $inline_from_base64_for_sqlite = ($options["target_engine"] ?? "mysql") === "sqlite";
+        $inline_base64_values_for_sqlite = ($options["target_engine"] ?? "mysql") === "sqlite";
 
         $this->audit_log(
             "CONNECTED | {$connection_label}",
@@ -5245,10 +5235,9 @@ class ImportClient
 
                     // Rewrite URLs if mapping is configured
                     if ($stmt_rewriter) {
-                        $query = $stmt_rewriter->rewrite($query);
-                    }
-                    if ($inline_from_base64_for_sqlite) {
-                        $query = $this->inline_from_base64_for_sqlite($query);
+                        $query = $stmt_rewriter->rewrite($query, $inline_base64_values_for_sqlite);
+                    } elseif ($inline_base64_values_for_sqlite) {
+                        $query = $this->inline_base64_values_for_sqlite($query);
                     }
 
                     // Execute against target database
@@ -5324,10 +5313,9 @@ class ImportClient
                 }
 
                 if ($stmt_rewriter) {
-                    $query = $stmt_rewriter->rewrite($query);
-                }
-                if ($inline_from_base64_for_sqlite) {
-                    $query = $this->inline_from_base64_for_sqlite($query);
+                    $query = $stmt_rewriter->rewrite($query, $inline_base64_values_for_sqlite);
+                } elseif ($inline_base64_values_for_sqlite) {
+                    $query = $this->inline_base64_values_for_sqlite($query);
                 }
 
                 try {

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -4988,6 +4988,26 @@ class ImportClient
         ];
     }
 
+    private function inline_from_base64_for_sqlite(string $query): string
+    {
+        if (strpos($query, "FROM_BASE64(") === false) {
+            return $query;
+        }
+
+        return preg_replace_callback(
+            "/(?:CONVERT\\s*\\(\\s*)?FROM_BASE64\\s*\\(\\s*'([A-Za-z0-9+\\/=]*)'\\s*\\)(?:\\s+USING\\s+utf8mb4\\s*\\))?/i",
+            static function (array $matches): string {
+                $decoded = base64_decode($matches[1], true);
+                if ($decoded === false) {
+                    return $matches[0];
+                }
+
+                return "'" . str_replace("'", "''", $decoded) . "'";
+            },
+            $query
+        );
+    }
+
     public function run_db_apply(array $options): void
     {
         $sql_file = $this->state_dir . "/db.sql";
@@ -5118,6 +5138,7 @@ class ImportClient
         }
 
         [$pdo, $connection_label] = $this->create_target_db_apply_connection($options);
+        $inline_from_base64_for_sqlite = ($options["target_engine"] ?? "mysql") === "sqlite";
 
         $this->audit_log(
             "CONNECTED | {$connection_label}",
@@ -5226,6 +5247,9 @@ class ImportClient
                     if ($stmt_rewriter) {
                         $query = $stmt_rewriter->rewrite($query);
                     }
+                    if ($inline_from_base64_for_sqlite) {
+                        $query = $this->inline_from_base64_for_sqlite($query);
+                    }
 
                     // Execute against target database
                     try {
@@ -5301,6 +5325,9 @@ class ImportClient
 
                 if ($stmt_rewriter) {
                     $query = $stmt_rewriter->rewrite($query);
+                }
+                if ($inline_from_base64_for_sqlite) {
+                    $query = $this->inline_from_base64_for_sqlite($query);
                 }
 
                 try {

--- a/packages/reprint-importer/src/lib/url-rewrite/class-base64-value-scanner.php
+++ b/packages/reprint-importer/src/lib/url-rewrite/class-base64-value-scanner.php
@@ -8,8 +8,9 @@
  * Detects CONVERT(FROM_BASE64('...') USING utf8mb4) wrappers automatically.
  * set_value() only replaces the base64 payload inside the quotes, so wrappers
  * are preserved without the caller needing to know about them. SQLite imports
- * may instead replace the entire outer expression with a MySQL-compatible hex
- * literal, avoiding a user-defined FROM_BASE64() callback for every value.
+ * may instead replace a FROM_BASE64() expression, or that exact utf8mb4
+ * wrapper, with a MySQL-compatible hex literal, avoiding a user-defined
+ * FROM_BASE64() callback for every value.
  *
  * Values are decoded lazily. The scanner keeps the original encoded payload
  * until get_value() is called, so callers can skip obviously irrelevant values
@@ -105,8 +106,8 @@ class Base64ValueScanner
     public function get_value(): string
     {
         if ($this->entries[$this->cursor]['value'] === null) {
-            $decoded = base64_decode($this->entries[$this->cursor]['encoded_value'], true);
-            $this->entries[$this->cursor]['value'] = $decoded !== false ? $decoded : '';
+            $decoded = self::decode_payload($this->entries[$this->cursor]['encoded_value']);
+            $this->entries[$this->cursor]['value'] = $decoded ?? '';
         }
 
         return $this->entries[$this->cursor]['value'];
@@ -203,13 +204,16 @@ class Base64ValueScanner
         $cursor = 0;
         foreach ($this->entries as $entry) {
             $value = $entry['new_value'] ?? $entry['value'];
+            $replacement = null;
             if ($value === null) {
-                $decoded = base64_decode($entry['encoded_value'], true);
-                $value = $decoded !== false ? $decoded : '';
+                $value = self::decode_payload($entry['encoded_value']);
+            }
+            if ($value !== null) {
+                $replacement = $value === '' ? "''" : "0x" . bin2hex($value);
             }
 
             $parts[] = substr($this->sql, $cursor, $entry['expr_start'] - $cursor);
-            $parts[] = $value === '' ? "''" : "0x" . bin2hex($value);
+            $parts[] = $replacement ?? substr($this->sql, $entry['expr_start'], $entry['expr_length']);
             $cursor = $entry['expr_start'] + $entry['expr_length'];
         }
         $parts[] = substr($this->sql, $cursor);
@@ -246,42 +250,48 @@ class Base64ValueScanner
                 $expr_start = $token->start;
 
                 if (
-                    $prev[1] !== null
-                    && $prev[1]->id === WP_MySQL_Lexer::OPEN_PAR_SYMBOL
-                    && $prev[0] !== null
-                    && $prev[0]->id === WP_MySQL_Lexer::CONVERT_SYMBOL
+                    $i >= 2
+                    && $tokens[$i - 1]->id === WP_MySQL_Lexer::OPEN_PAR_SYMBOL
+                    && $tokens[$i - 2]->id === WP_MySQL_Lexer::CONVERT_SYMBOL
                 ) {
-                    $expr_start = $prev[0]->start;
+                    $expr_start = $tokens[$i - 2]->start;
                 }
 
-                // Walk forward to find the quoted base64 payload: step past
-                // the opening parenthesis, accept either SINGLE_ or
-                // DOUBLE_QUOTED_TEXT, abort on anything else.
-                for ($j = $i + 1; $j < $token_count; $j++) {
-                    $inner = $tokens[$j];
-                    if (
-                        $inner->id === WP_MySQL_Lexer::SINGLE_QUOTED_TEXT
-                        || $inner->id === WP_MySQL_Lexer::DOUBLE_QUOTED_TEXT
-                    ) {
-                        $expr_end = $this->find_expression_end_from_tokens($tokens, $expr_start, $i);
-                        if ($expr_end === null) {
-                            break;
-                        }
-                        $this->entries[] = [
-                            'expr_start' => $expr_start,
-                            'expr_length' => $expr_end - $expr_start,
-                            'quote_start' => $inner->start,
-                            'quote_length' => $inner->length,
-                            'encoded_value' => $inner->get_value(),
-                            'value' => null,
-                            'new_value' => null,
-                        ];
-                        break;
-                    }
-                    if ($inner->id !== WP_MySQL_Lexer::OPEN_PAR_SYMBOL) {
-                        break;
+                $open_index = $i + 1;
+                $payload_index = $i + 2;
+                $close_index = $i + 3;
+                if (
+                    $close_index >= $token_count
+                    || $tokens[$open_index]->id !== WP_MySQL_Lexer::OPEN_PAR_SYMBOL
+                    || (
+                        $tokens[$payload_index]->id !== WP_MySQL_Lexer::SINGLE_QUOTED_TEXT
+                        && $tokens[$payload_index]->id !== WP_MySQL_Lexer::DOUBLE_QUOTED_TEXT
+                    )
+                    || $tokens[$close_index]->id !== WP_MySQL_Lexer::CLOSE_PAR_SYMBOL
+                ) {
+                    continue;
+                }
+
+                $expr_end = $tokens[$close_index]->start + $tokens[$close_index]->length;
+                if ($expr_start !== $token->start) {
+                    $convert_end = $this->find_utf8mb4_convert_using_end($tokens, $close_index);
+                    if ($convert_end !== null) {
+                        $expr_end = $convert_end;
+                    } else {
+                        $expr_start = $token->start;
                     }
                 }
+
+                $inner = $tokens[$payload_index];
+                $this->entries[] = [
+                    'expr_start' => $expr_start,
+                    'expr_length' => $expr_end - $expr_start,
+                    'quote_start' => $inner->start,
+                    'quote_length' => $inner->length,
+                    'encoded_value' => $inner->get_value(),
+                    'value' => null,
+                    'new_value' => null,
+                ];
             }
 
             $prev[0] = $prev[1];
@@ -290,49 +300,29 @@ class Base64ValueScanner
     }
 
     /**
-     * Find the byte offset immediately after an expression in a token array.
+     * If the FROM_BASE64() call is wrapped in the producer's exact
+     * CONVERT(... USING utf8mb4) shape, return the byte offset immediately
+     * after the wrapper. Other CONVERT() forms are intentionally left intact;
+     * SQLite inlining can still replace the inner FROM_BASE64() without
+     * guessing whether a different cast is redundant.
      *
      * @param WP_MySQL_Token[] $tokens
      */
-    private function find_expression_end_from_tokens(array $tokens, int $expr_start, int $from_base64_index): ?int
+    private function find_utf8mb4_convert_using_end(array $tokens, int $from_base64_close_index): ?int
     {
-        $open_index = null;
-        for ($i = $from_base64_index - 1; $i >= 0; $i--) {
-            if ($tokens[$i]->start < $expr_start) {
-                break;
-            }
-            if ($tokens[$i]->id === WP_MySQL_Lexer::OPEN_PAR_SYMBOL) {
-                $open_index = $i;
-                break;
-            }
-        }
-
-        if ($open_index === null) {
-            for ($i = $from_base64_index + 1, $count = count($tokens); $i < $count; $i++) {
-                if ($tokens[$i]->id === WP_MySQL_Lexer::OPEN_PAR_SYMBOL) {
-                    $open_index = $i;
-                    break;
-                }
-            }
-        }
-
-        if ($open_index === null) {
+        $using_index = $from_base64_close_index + 1;
+        $charset_index = $from_base64_close_index + 2;
+        $close_index = $from_base64_close_index + 3;
+        if (
+            $close_index >= count($tokens)
+            || $tokens[$using_index]->id !== WP_MySQL_Lexer::USING_SYMBOL
+            || strcasecmp($tokens[$charset_index]->get_value(), 'utf8mb4') !== 0
+            || $tokens[$close_index]->id !== WP_MySQL_Lexer::CLOSE_PAR_SYMBOL
+        ) {
             return null;
         }
 
-        $depth = 0;
-        for ($i = $open_index, $count = count($tokens); $i < $count; $i++) {
-            if ($tokens[$i]->id === WP_MySQL_Lexer::OPEN_PAR_SYMBOL) {
-                $depth++;
-            } elseif ($tokens[$i]->id === WP_MySQL_Lexer::CLOSE_PAR_SYMBOL) {
-                $depth--;
-                if ($depth === 0) {
-                    return $tokens[$i]->start + $tokens[$i]->length;
-                }
-            }
-        }
-
-        return null;
+        return $tokens[$close_index]->start + $tokens[$close_index]->length;
     }
 
     private static function encoded_payload_could_decode_to_http_scheme(string $payload): bool
@@ -341,5 +331,11 @@ class Base64ValueScanner
             || strpos($payload, 'dHA6') !== false
             || strpos($payload, 'dHBz') !== false
             || strpos($payload, 'dHRw') !== false;
+    }
+
+    private static function decode_payload(string $payload): ?string
+    {
+        $decoded = base64_decode($payload, true);
+        return $decoded !== false ? $decoded : null;
     }
 }

--- a/packages/reprint-importer/src/lib/url-rewrite/class-base64-value-scanner.php
+++ b/packages/reprint-importer/src/lib/url-rewrite/class-base64-value-scanner.php
@@ -213,9 +213,16 @@ class Base64ValueScanner
                 $value = self::decode_payload($entry['encoded_value']);
             }
             if ($value !== null) {
+                // Use 0x... for non-empty values so apostrophes, backslashes,
+                // and NUL bytes never enter SQL string-literal escaping.
+                // MySQL-on-SQLite rejects a bare 0x literal, so the empty
+                // string stays as a normal quoted SQL literal.
                 $replacement = $value === '' ? "''" : "0x" . bin2hex($value);
             }
 
+            // If strict base64 decoding fails, preserve the original expression.
+            // That keeps malformed or non-literal FROM_BASE64() cases on the
+            // existing SQLite UDF path instead of silently changing semantics.
             $parts[] = substr($this->sql, $cursor, $entry['expr_start'] - $cursor);
             $parts[] = $replacement ?? substr($this->sql, $entry['expr_start'], $entry['expr_length']);
             $cursor = $entry['expr_start'] + $entry['expr_length'];
@@ -242,7 +249,6 @@ class Base64ValueScanner
     private function scan_tokens(array $tokens): void
     {
         $token_count = count($tokens);
-        $prev = [null, null];
 
         for ($i = 0; $i < $token_count; $i++) {
             $token = $tokens[$i];
@@ -253,6 +259,10 @@ class Base64ValueScanner
             ) {
                 $expr_start = $token->start;
 
+                // Detect the producer's wrapper by looking behind the
+                // FROM_BASE64 token. The lexer has already removed whitespace
+                // and comments, so CONVERT ( FROM_BASE64 is represented as
+                // three adjacent significant tokens.
                 if (
                     $i >= 2
                     && $tokens[$i - 1]->id === WP_MySQL_Lexer::OPEN_PAR_SYMBOL
@@ -261,6 +271,10 @@ class Base64ValueScanner
                     $expr_start = $tokens[$i - 2]->start;
                 }
 
+                // Walk forward through the exact FROM_BASE64('...') shape:
+                // opening parenthesis, quoted payload, closing parenthesis.
+                // Any computed argument or malformed call is ignored here and
+                // left for normal SQL execution.
                 $open_index = $i + 1;
                 $payload_index = $i + 2;
                 $close_index = $i + 3;
@@ -278,6 +292,10 @@ class Base64ValueScanner
 
                 $expr_end = $tokens[$close_index]->start + $tokens[$close_index]->length;
                 if ($expr_start !== $token->start) {
+                    // Collapse only CONVERT(FROM_BASE64(...) USING utf8mb4),
+                    // the wrapper emitted by our dump producer. Other CONVERT
+                    // forms may perform meaningful casts, so SQLite inlining
+                    // replaces only the inner FROM_BASE64() call.
                     $convert_end = $this->find_utf8mb4_convert_using_end($tokens, $close_index);
                     if ($convert_end !== null) {
                         $expr_end = $convert_end;
@@ -297,9 +315,6 @@ class Base64ValueScanner
                     'new_value' => null,
                 ];
             }
-
-            $prev[0] = $prev[1];
-            $prev[1] = $token;
         }
     }
 

--- a/packages/reprint-importer/src/lib/url-rewrite/class-base64-value-scanner.php
+++ b/packages/reprint-importer/src/lib/url-rewrite/class-base64-value-scanner.php
@@ -70,10 +70,8 @@ class Base64ValueScanner
             ) {
                 array_pop($tokens);
             }
-            $this->scan_tokens($tokens);
-        } else {
-            $this->scan_tokens($tokens);
         }
+        $this->scan_tokens($tokens);
     }
 
     /**

--- a/packages/reprint-importer/src/lib/url-rewrite/class-base64-value-scanner.php
+++ b/packages/reprint-importer/src/lib/url-rewrite/class-base64-value-scanner.php
@@ -5,9 +5,11 @@
  * statement, letting the caller read and replace each decoded value.
  *
  * Uses WP_MySQL_Lexer for proper tokenization instead of string scanning.
- * Detects CONVERT(FROM_BASE64('...') USING utf8mb4) wrappers automatically —
+ * Detects CONVERT(FROM_BASE64('...') USING utf8mb4) wrappers automatically.
  * set_value() only replaces the base64 payload inside the quotes, so wrappers
- * are preserved without the caller needing to know about them.
+ * are preserved without the caller needing to know about them. SQLite imports
+ * may instead replace the entire outer expression with a MySQL-compatible hex
+ * literal, avoiding a user-defined FROM_BASE64() callback for every value.
  *
  * Values are decoded lazily. The scanner keeps the original encoded payload
  * until get_value() is called, so callers can skip obviously irrelevant values
@@ -31,14 +33,15 @@ class Base64ValueScanner
 
     /**
      * Each entry tracks one FROM_BASE64() value found in the SQL:
-     *   'expr_start'   => int    Offset of the outermost expression (CONVERT or FROM_BASE64)
-     *   'quote_start'  => int    Offset of the quoted string token (including quotes)
-     *   'quote_length' => int    Length of the quoted string token
-     *   'encoded_value'=> string The base64 payload
-     *   'value'        => ?string The base64-decoded value, cached on demand
-     *   'new_value'    => ?string Non-null when set_value() has been called
+     *   'expr_start'    => int    Offset of the outermost expression (CONVERT or FROM_BASE64)
+     *   'expr_length'   => int    Length of the outermost expression
+     *   'quote_start'   => int    Offset of the quoted string token (including quotes)
+     *   'quote_length'  => int    Length of the quoted string token
+     *   'encoded_value' => string The base64 payload
+     *   'value'         => ?string The base64-decoded value, cached on demand
+     *   'new_value'     => ?string Non-null when set_value() has been called
      *
-     * @var array<int, array{expr_start: int, quote_start: int, quote_length: int, encoded_value: string, value: ?string, new_value: ?string}>
+     * @var array<int, array{expr_start: int, expr_length: int, quote_start: int, quote_length: int, encoded_value: string, value: ?string, new_value: ?string}>
      */
     private array $entries = [];
 
@@ -58,7 +61,15 @@ class Base64ValueScanner
     {
         $this->sql = $sql;
         if ($tokens === null) {
-            $this->scan();
+            $lexer = new WP_MySQL_Lexer($this->sql);
+            $tokens = $lexer->remaining_tokens();
+            if (
+                !empty($tokens)
+                && end($tokens)->id === WP_MySQL_Lexer::EOF
+            ) {
+                array_pop($tokens);
+            }
+            $this->scan_tokens($tokens);
         } else {
             $this->scan_tokens($tokens);
         }
@@ -70,7 +81,7 @@ class Base64ValueScanner
      * already located every FROM_BASE64() expression and captured its payload,
      * the scanner skips the lexer and still decodes values lazily.
      *
-     * @param list<array{expr_start: int, quote_start: int, quote_length: int, encoded_value: string, value: ?string, new_value: ?string}> $entries
+     * @param list<array{expr_start: int, expr_length: int, quote_start: int, quote_length: int, encoded_value: string, value: ?string, new_value: ?string}> $entries
      */
     public static function from_entries(string $sql, array $entries): self
     {
@@ -172,66 +183,38 @@ class Base64ValueScanner
     }
 
     /**
-     * Tokenize the SQL and find all FROM_BASE64('...') expressions.
-     * Tracks whether each is wrapped in CONVERT(...) for correct expr_start offset.
+     * Return SQL with every FROM_BASE64()/CONVERT(FROM_BASE64()) expression
+     * replaced by a MySQL-compatible hex string literal.
+     *
+     * The importer already decoded each payload for URL rewriting decisions.
+     * For SQLite targets, preserving FROM_BASE64() would make SQLite call back
+     * into PHP for every text value during statement execution. Emitting
+     * 0x-prefixed hex keeps the MySQL-on-SQLite translator in charge of value
+     * boundaries, preserves apostrophes and NUL bytes without quote escaping,
+     * and avoids any SQL-text regexp pass.
      */
-    private function scan(): void
+    public function get_result_with_mysql_hex_literals(): string
     {
-        $lexer = new WP_MySQL_Lexer($this->sql);
+        if (empty($this->entries)) {
+            return $this->sql;
+        }
 
-        // Track the last two tokens so we can detect CONVERT( before FROM_BASE64.
-        // next_token() skips whitespace/comments, so CONVERT ( FROM_BASE64 appears
-        // as three consecutive tokens.
-        $prev = [null, null];
-
-        while ($lexer->next_token()) {
-            $token = $lexer->get_token();
-
-            if (
-                $token->id === WP_MySQL_Lexer::IDENTIFIER
-                && strtoupper($token->get_value()) === 'FROM_BASE64'
-            ) {
-                $expr_start = $token->start;
-
-                // If the previous tokens are CONVERT + (, the outer expression
-                // starts at CONVERT, not at FROM_BASE64.
-                if (
-                    $prev[1] !== null
-                    && $prev[1]->id === WP_MySQL_Lexer::OPEN_PAR_SYMBOL
-                    && $prev[0] !== null
-                    && $prev[0]->id === WP_MySQL_Lexer::CONVERT_SYMBOL
-                ) {
-                    $expr_start = $prev[0]->start;
-                }
-
-                // Advance past ( to find the quoted base64 string
-                while ($lexer->next_token()) {
-                    $inner = $lexer->get_token();
-                    if (
-                        $inner->id === WP_MySQL_Lexer::SINGLE_QUOTED_TEXT
-                        || $inner->id === WP_MySQL_Lexer::DOUBLE_QUOTED_TEXT
-                    ) {
-                        $this->entries[] = [
-                            'expr_start' => $expr_start,
-                            'quote_start' => $inner->start,
-                            'quote_length' => $inner->length,
-                            'encoded_value' => $inner->get_value(),
-                            'value' => null,
-                            'new_value' => null,
-                        ];
-                        break;
-                    }
-                    // Skip the opening parenthesis of FROM_BASE64(
-                    if ($inner->id !== WP_MySQL_Lexer::OPEN_PAR_SYMBOL) {
-                        break;
-                    }
-                }
+        $parts = [];
+        $cursor = 0;
+        foreach ($this->entries as $entry) {
+            $value = $entry['new_value'] ?? $entry['value'];
+            if ($value === null) {
+                $decoded = base64_decode($entry['encoded_value'], true);
+                $value = $decoded !== false ? $decoded : '';
             }
 
-            // Shift the two-token window
-            $prev[0] = $prev[1];
-            $prev[1] = $token;
+            $parts[] = substr($this->sql, $cursor, $entry['expr_start'] - $cursor);
+            $parts[] = $value === '' ? "''" : "0x" . bin2hex($value);
+            $cursor = $entry['expr_start'] + $entry['expr_length'];
         }
+        $parts[] = substr($this->sql, $cursor);
+
+        return implode('', $parts);
     }
 
     /**
@@ -271,17 +254,22 @@ class Base64ValueScanner
                     $expr_start = $prev[0]->start;
                 }
 
-                // Walk forward to find the quoted base64 payload, mirroring
-                // scan(): step past the opening parenthesis, accept either
-                // SINGLE_ or DOUBLE_QUOTED_TEXT, abort on anything else.
+                // Walk forward to find the quoted base64 payload: step past
+                // the opening parenthesis, accept either SINGLE_ or
+                // DOUBLE_QUOTED_TEXT, abort on anything else.
                 for ($j = $i + 1; $j < $token_count; $j++) {
                     $inner = $tokens[$j];
                     if (
                         $inner->id === WP_MySQL_Lexer::SINGLE_QUOTED_TEXT
                         || $inner->id === WP_MySQL_Lexer::DOUBLE_QUOTED_TEXT
                     ) {
+                        $expr_end = $this->find_expression_end_from_tokens($tokens, $expr_start, $i);
+                        if ($expr_end === null) {
+                            break;
+                        }
                         $this->entries[] = [
                             'expr_start' => $expr_start,
+                            'expr_length' => $expr_end - $expr_start,
                             'quote_start' => $inner->start,
                             'quote_length' => $inner->length,
                             'encoded_value' => $inner->get_value(),
@@ -299,6 +287,52 @@ class Base64ValueScanner
             $prev[0] = $prev[1];
             $prev[1] = $token;
         }
+    }
+
+    /**
+     * Find the byte offset immediately after an expression in a token array.
+     *
+     * @param WP_MySQL_Token[] $tokens
+     */
+    private function find_expression_end_from_tokens(array $tokens, int $expr_start, int $from_base64_index): ?int
+    {
+        $open_index = null;
+        for ($i = $from_base64_index - 1; $i >= 0; $i--) {
+            if ($tokens[$i]->start < $expr_start) {
+                break;
+            }
+            if ($tokens[$i]->id === WP_MySQL_Lexer::OPEN_PAR_SYMBOL) {
+                $open_index = $i;
+                break;
+            }
+        }
+
+        if ($open_index === null) {
+            for ($i = $from_base64_index + 1, $count = count($tokens); $i < $count; $i++) {
+                if ($tokens[$i]->id === WP_MySQL_Lexer::OPEN_PAR_SYMBOL) {
+                    $open_index = $i;
+                    break;
+                }
+            }
+        }
+
+        if ($open_index === null) {
+            return null;
+        }
+
+        $depth = 0;
+        for ($i = $open_index, $count = count($tokens); $i < $count; $i++) {
+            if ($tokens[$i]->id === WP_MySQL_Lexer::OPEN_PAR_SYMBOL) {
+                $depth++;
+            } elseif ($tokens[$i]->id === WP_MySQL_Lexer::CLOSE_PAR_SYMBOL) {
+                $depth--;
+                if ($depth === 0) {
+                    return $tokens[$i]->start + $tokens[$i]->length;
+                }
+            }
+        }
+
+        return null;
     }
 
     private static function encoded_payload_could_decode_to_http_scheme(string $payload): bool

--- a/packages/reprint-importer/src/lib/url-rewrite/class-base64-value-scanner.php
+++ b/packages/reprint-importer/src/lib/url-rewrite/class-base64-value-scanner.php
@@ -220,7 +220,8 @@ class Base64ValueScanner
 
             // If strict base64 decoding fails, preserve the original expression.
             // That keeps malformed or non-literal FROM_BASE64() cases on the
-            // existing SQLite UDF path instead of silently changing semantics.
+            // existing SQLite user-defined function path instead of silently
+            // changing semantics.
             $parts[] = substr($this->sql, $cursor, $entry['expr_start'] - $cursor);
             $parts[] = $replacement ?? substr($this->sql, $entry['expr_start'], $entry['expr_length']);
             $cursor = $entry['expr_start'] + $entry['expr_length'];

--- a/packages/reprint-importer/src/lib/url-rewrite/class-base64-value-scanner.php
+++ b/packages/reprint-importer/src/lib/url-rewrite/class-base64-value-scanner.php
@@ -26,7 +26,7 @@
  *             $scanner->set_value($rewritten);
  *         }
  *     }
- *     $new_sql = $scanner->get_result();
+ *     $new_sql = $scanner->get_result_with_base64_payload_replacements();
  */
 class Base64ValueScanner
 {
@@ -138,7 +138,8 @@ class Base64ValueScanner
 
     /**
      * Replace the decoded value at the current cursor position.
-     * The new value will be base64-encoded when get_result() rebuilds the SQL.
+     * The new value will be base64-encoded when
+     * get_result_with_base64_payload_replacements() rebuilds the SQL.
      */
     public function set_value(string $new_value): void
     {
@@ -159,10 +160,12 @@ class Base64ValueScanner
     }
 
     /**
-     * Return the SQL with all set_value() replacements applied.
+     * Return SQL with all set_value() replacements applied as new base64
+     * payloads inside the original FROM_BASE64() calls.
+     *
      * Values that were not modified via set_value() are left unchanged.
      */
-    public function get_result(): string
+    public function get_result_with_base64_payload_replacements(): string
     {
         if (!$this->dirty) {
             return $this->sql;
@@ -184,17 +187,18 @@ class Base64ValueScanner
     }
 
     /**
-     * Return SQL with every FROM_BASE64()/CONVERT(FROM_BASE64()) expression
-     * replaced by a MySQL-compatible hex string literal.
+     * Return SQL with every decodable FROM_BASE64() expression replaced by a
+     * SQLite-compatible literal.
      *
      * The importer already decoded each payload for URL rewriting decisions.
      * For SQLite targets, preserving FROM_BASE64() would make SQLite call back
      * into PHP for every text value during statement execution. Emitting
      * 0x-prefixed hex keeps the MySQL-on-SQLite translator in charge of value
      * boundaries, preserves apostrophes and NUL bytes without quote escaping,
-     * and avoids any SQL-text regexp pass.
+     * and avoids any SQL-text regexp pass. The method name intentionally names
+     * the target behavior rather than the current 0x literal spelling.
      */
-    public function get_result_with_mysql_hex_literals(): string
+    public function get_result_with_sqlite_compatible_literals(): string
     {
         if (empty($this->entries)) {
             return $this->sql;

--- a/packages/reprint-importer/src/lib/url-rewrite/class-fast-insert-scanner.php
+++ b/packages/reprint-importer/src/lib/url-rewrite/class-fast-insert-scanner.php
@@ -37,7 +37,7 @@ class FastInsertScanner
      * @return array{
      *   table: string,
      *   column_map: list<array{int, int, string}>,
-     *   base64_entries: list<array{expr_start: int, quote_start: int, quote_length: int, encoded_value: string, value: ?string, new_value: ?string}>
+     *   base64_entries: list<array{expr_start: int, expr_length: int, quote_start: int, quote_length: int, encoded_value: string, value: ?string, new_value: ?string}>
      * }|null
      *   Null when the SQL doesn't match the recognised shape.
      */
@@ -139,12 +139,13 @@ class FastInsertScanner
                 $column_map[] = [$value_start, $value_end, $columns[$col_idx]];
 
                 if (is_array($value_kind)) {
-                    // FROM_BASE64 payload: kind = [expr_start, quote_start, quote_length, encoded_value]
+                    // FROM_BASE64 payload: kind = [expr_start, expr_length, quote_start, quote_length, encoded_value]
                     $base64_entries[] = [
                         'expr_start' => $value_kind[0],
-                        'quote_start' => $value_kind[1],
-                        'quote_length' => $value_kind[2],
-                        'encoded_value' => $value_kind[3],
+                        'expr_length' => $value_kind[1],
+                        'quote_start' => $value_kind[2],
+                        'quote_length' => $value_kind[3],
+                        'encoded_value' => $value_kind[4],
                         'value' => null,
                         'new_value' => null,
                     ];
@@ -199,10 +200,10 @@ class FastInsertScanner
     /**
      * Scan one value in producer's tuple shape, advancing $cursor past it.
      *
-     * @return null|true|array{int,int,int,string}
+     * @return null|true|array{int,int,int,int,string}
      *   null = unrecognized shape (caller bails)
      *   true = recognised, no FROM_BASE64 entry to record
-     *   array = FROM_BASE64 payload, [expr_start, quote_start, quote_length, encoded]
+     *   array = FROM_BASE64 payload, [expr_start, expr_length, quote_start, quote_length, encoded]
      */
     private static function scan_value(string $sql, int $sql_len, int &$cursor)
     {
@@ -235,7 +236,11 @@ class FastInsertScanner
         ) {
             $expr_start = $cursor;
             $cursor += 12; // step past "FROM_BASE64("
-            return self::consume_base64_call($sql, $sql_len, $cursor, $expr_start, /*has_convert=*/false);
+            $entry = self::consume_base64_call($sql, $sql_len, $cursor, /*has_convert=*/false);
+            if (!is_array($entry)) {
+                return null;
+            }
+            return [$expr_start, (int) ($cursor - $expr_start), $entry[0], $entry[1], $entry[2]];
         }
 
         // CONVERT(FROM_BASE64('…') USING utf8mb4)
@@ -256,7 +261,7 @@ class FastInsertScanner
                 return null;
             }
             $cursor += 12;
-            $entry = self::consume_base64_call($sql, $sql_len, $cursor, $expr_start, /*has_convert=*/true);
+            $entry = self::consume_base64_call($sql, $sql_len, $cursor, /*has_convert=*/true);
             if (!is_array($entry)) {
                 return null;
             }
@@ -282,7 +287,7 @@ class FastInsertScanner
                 return null;
             }
             $cursor++;
-            return $entry;
+            return [$expr_start, (int) ($cursor - $expr_start), $entry[0], $entry[1], $entry[2]];
         }
 
         // Numeric literal: optional sign, digits, optional fraction, optional exponent.
@@ -319,11 +324,11 @@ class FastInsertScanner
     /**
      * Inside a FROM_BASE64( … ) call, with $cursor already past the opening
      * paren. Reads the quoted base64 string and the closing paren. Returns
-     * the [expr_start, quote_start, quote_length, encoded] tuple.
+     * the [quote_start, quote_length, encoded] tuple.
      *
-     * @return array{int,int,int,string}|null
+     * @return array{int,int,string}|null
      */
-    private static function consume_base64_call(string $sql, int $sql_len, int &$cursor, int $expr_start, bool $has_convert)
+    private static function consume_base64_call(string $sql, int $sql_len, int &$cursor, bool $has_convert)
     {
         while ($cursor < $sql_len && self::is_ws($sql[$cursor])) {
             $cursor++;
@@ -358,7 +363,7 @@ class FastInsertScanner
             }
             $cursor++;
         }
-        return [$expr_start, $quote_start, $quote_length, $payload];
+        return [$quote_start, $quote_length, $payload];
     }
 
     private static function is_ws(string $c): bool

--- a/packages/reprint-importer/src/lib/url-rewrite/class-sql-statement-rewriter.php
+++ b/packages/reprint-importer/src/lib/url-rewrite/class-sql-statement-rewriter.php
@@ -212,9 +212,10 @@ class SqlStatementRewriter
                     }
                 }
 
-                // Rewrite URLs in the value. Known block-markup columns can first
-                // try a boundary-checked literal base URL swap before falling back
-                // to the full structured parser.
+                // Rewrite URLs in the value. Known block-markup columns go
+                // through the block-markup processor; all other decoded values
+                // are treated as plain text or recursively decoded structured
+                // values by StructuredDataUrlRewriter.
                 $rewritten = $content_type === StructuredDataUrlRewriter::BLOCK_MARKUP
                     ? $this->url_rewriter->rewrite_known_block_markup_value($value)
                     : $this->url_rewriter->rewrite($value, $content_type);

--- a/packages/reprint-importer/src/lib/url-rewrite/class-sql-statement-rewriter.php
+++ b/packages/reprint-importer/src/lib/url-rewrite/class-sql-statement-rewriter.php
@@ -88,9 +88,13 @@ class SqlStatementRewriter
      * without an http/https scheme will not be rewritten.
      *
      * @param string $sql The SQL statement.
+     * @param bool $inline_base64_values_for_sqlite Whether to replace
+     *        FROM_BASE64() expressions with native SQLite text expressions
+     *        while rewriting. This is only for SQLite targets; MySQL targets
+     *        need the original FROM_BASE64() calls.
      * @return string The modified SQL statement.
      */
-    public function rewrite(string $sql): string
+    public function rewrite(string $sql, bool $inline_base64_values_for_sqlite = false): string
     {
         // Quick check: if no base64 values, nothing to rewrite
         if (strpos($sql, "FROM_BASE64(") === false) {
@@ -123,12 +127,13 @@ class SqlStatementRewriter
         // that finds nothing. False negatives would silently leave URLs
         // un-rewritten; the four prefixes above are the minimum set that
         // covers every alignment×scheme combination, so no real URL escapes.
-        if (
+        $encoded_payload_could_contain_http = !(
             strpos($sql, 'aHR0') === false
             && strpos($sql, 'dHA6') === false
             && strpos($sql, 'dHBz') === false
             && strpos($sql, 'dHRw') === false
-        ) {
+        );
+        if (!$encoded_payload_could_contain_http && !$inline_base64_values_for_sqlite) {
             return $sql;
         }
 
@@ -145,7 +150,12 @@ class SqlStatementRewriter
                 'column_map' => $fast['column_map'],
             ];
             $scanner = Base64ValueScanner::from_entries($sql, $fast['base64_entries']);
-            return $this->rewrite_with_scanner($scanner, $value_to_column_map);
+            return $this->rewrite_with_scanner(
+                $scanner,
+                $value_to_column_map,
+                $encoded_payload_could_contain_http,
+                $inline_base64_values_for_sqlite
+            );
         }
 
         // Slow path: lex once, share the token array between the column
@@ -153,7 +163,12 @@ class SqlStatementRewriter
         $tokens = self::significant_tokens($sql);
         $value_to_column_map = $this->map_values_to_columns_from_tokens($tokens);
         $scanner = new Base64ValueScanner($sql, $tokens);
-        return $this->rewrite_with_scanner($scanner, $value_to_column_map);
+        return $this->rewrite_with_scanner(
+            $scanner,
+            $value_to_column_map,
+            $encoded_payload_could_contain_http,
+            $inline_base64_values_for_sqlite
+        );
     }
 
     /**
@@ -162,49 +177,58 @@ class SqlStatementRewriter
      *
      * @param array{table: string, column_map: list<array{int, int, string}>}|null $value_to_column_map
      */
-    private function rewrite_with_scanner(Base64ValueScanner $scanner, ?array $value_to_column_map): string
+    private function rewrite_with_scanner(
+        Base64ValueScanner $scanner,
+        ?array $value_to_column_map,
+        bool $rewrite_urls,
+        bool $inline_base64_values_for_sqlite
+    ): string
     {
-        while ($scanner->next_value()) {
-            if (!$scanner->encoded_payload_could_contain_http_scheme()) {
-                continue;
-            }
-
-            $value = $scanner->get_value();
-
-            if (strpos($value, 'http') === false) {
-                continue;
-            }
-
-            if (!$this->url_rewriter->value_might_contain_source_domain($value)) {
-                continue;
-            }
-
-            // Determine content type hint for this column
-            $content_type = null;
-            if ($value_to_column_map !== null) {
-                $column_name = $this->find_column_at_offset(
-                    $value_to_column_map['column_map'],
-                    $scanner->get_match_offset()
-                );
-                if ($column_name !== null) {
-                    $content_type = $this->get_content_type($value_to_column_map['table'], $column_name);
+        if ($rewrite_urls) {
+            while ($scanner->next_value()) {
+                if (!$scanner->encoded_payload_could_contain_http_scheme()) {
+                    continue;
                 }
-            }
 
-            // Rewrite URLs in the value. Known block-markup columns can first
-            // try a boundary-checked literal base URL swap before falling back
-            // to the full structured parser.
-            $rewritten = $content_type === StructuredDataUrlRewriter::BLOCK_MARKUP
-                ? $this->url_rewriter->rewrite_known_block_markup_value($value)
-                : $this->url_rewriter->rewrite($value, $content_type);
+                $value = $scanner->get_value();
 
-            // Only replace if the value actually changed
-            if ($rewritten !== $value) {
-                $scanner->set_value($rewritten);
+                if (strpos($value, 'http') === false) {
+                    continue;
+                }
+
+                if (!$this->url_rewriter->value_might_contain_source_domain($value)) {
+                    continue;
+                }
+
+                // Determine content type hint for this column
+                $content_type = null;
+                if ($value_to_column_map !== null) {
+                    $column_name = $this->find_column_at_offset(
+                        $value_to_column_map['column_map'],
+                        $scanner->get_match_offset()
+                    );
+                    if ($column_name !== null) {
+                        $content_type = $this->get_content_type($value_to_column_map['table'], $column_name);
+                    }
+                }
+
+                // Rewrite URLs in the value. Known block-markup columns can first
+                // try a boundary-checked literal base URL swap before falling back
+                // to the full structured parser.
+                $rewritten = $content_type === StructuredDataUrlRewriter::BLOCK_MARKUP
+                    ? $this->url_rewriter->rewrite_known_block_markup_value($value)
+                    : $this->url_rewriter->rewrite($value, $content_type);
+
+                // Only replace if the value actually changed
+                if ($rewritten !== $value) {
+                    $scanner->set_value($rewritten);
+                }
             }
         }
 
-        return $scanner->get_result();
+        return $inline_base64_values_for_sqlite
+            ? $scanner->get_result_with_mysql_hex_literals()
+            : $scanner->get_result();
     }
 
     /**

--- a/packages/reprint-importer/src/lib/url-rewrite/class-sql-statement-rewriter.php
+++ b/packages/reprint-importer/src/lib/url-rewrite/class-sql-statement-rewriter.php
@@ -97,7 +97,7 @@ class SqlStatementRewriter
     public function rewrite(string $sql, bool $inline_base64_values_for_sqlite = false): string
     {
         // Quick check: if no base64 values, nothing to rewrite
-        if (strpos($sql, "FROM_BASE64(") === false) {
+        if (stripos($sql, "FROM_BASE64") === false) {
             return $sql;
         }
 

--- a/packages/reprint-importer/src/lib/url-rewrite/class-sql-statement-rewriter.php
+++ b/packages/reprint-importer/src/lib/url-rewrite/class-sql-statement-rewriter.php
@@ -89,9 +89,9 @@ class SqlStatementRewriter
      *
      * @param string $sql The SQL statement.
      * @param bool $inline_base64_values_for_sqlite Whether to replace
-     *        FROM_BASE64() expressions with native SQLite text expressions
-     *        while rewriting. This is only for SQLite targets; MySQL targets
-     *        need the original FROM_BASE64() calls.
+     *        decodable FROM_BASE64() expressions with SQLite-compatible
+     *        literals while rewriting. This is only for SQLite targets; MySQL
+     *        targets need the original FROM_BASE64() calls.
      * @return string The modified SQL statement.
      */
     public function rewrite(string $sql, bool $inline_base64_values_for_sqlite = false): string

--- a/packages/reprint-importer/src/lib/url-rewrite/class-sql-statement-rewriter.php
+++ b/packages/reprint-importer/src/lib/url-rewrite/class-sql-statement-rewriter.php
@@ -12,8 +12,8 @@
  * WordPress core columns known to contain block markup (post_content, comment_content,
  * etc.) get the 'block_markup' hint so wp_rewrite_urls() handles HTML attributes,
  * block comment JSON, and CSS url(). All other columns default to auto-detect with
- * plain text strtr() replacement, which is simpler and more predictable for columns
- * that contain serialized PHP, JSON, or plain strings.
+ * structured plain-text URL rewriting, which is safer for columns that contain
+ * serialized PHP, JSON, or plain strings.
  *
  * Column resolution walks the lexer output directly. Both INSERT and UPDATE
  * statements emitted by MySQLDumpProducer follow a constrained set of shapes

--- a/packages/reprint-importer/src/lib/url-rewrite/class-sql-statement-rewriter.php
+++ b/packages/reprint-importer/src/lib/url-rewrite/class-sql-statement-rewriter.php
@@ -227,8 +227,8 @@ class SqlStatementRewriter
         }
 
         return $inline_base64_values_for_sqlite
-            ? $scanner->get_result_with_mysql_hex_literals()
-            : $scanner->get_result();
+            ? $scanner->get_result_with_sqlite_compatible_literals()
+            : $scanner->get_result_with_base64_payload_replacements();
     }
 
     /**

--- a/packages/reprint-importer/src/lib/url-rewrite/class-structured-data-url-rewriter.php
+++ b/packages/reprint-importer/src/lib/url-rewrite/class-structured-data-url-rewriter.php
@@ -278,87 +278,6 @@ class StructuredDataUrlRewriter
     }
 
     /**
-     * Split syntax delimiters accidentally captured by URLInTextProcessor from
-     * the URL bytes that should be parsed and rewritten.
-     *
-     * The processor intentionally uses a broad candidate scan before WHATWG
-     * validation. In plain text formats such as Markdown, CSS, JavaScript, CSV,
-     * and shortcodes, the broad candidate may include a closing delimiter or a
-     * quoted-field tail. We preserve that suffix verbatim and only feed the URL
-     * prefix into structured URL parsing and base replacement.
-     *
-     * @return array{0: string, 1: string} URL candidate, preserved suffix.
-     */
-    private function split_plain_text_url_candidate(string $raw_url): array
-    {
-        $suffix = '';
-        $quote_pos = $this->find_structural_quote_position($raw_url);
-        if ($quote_pos !== null) {
-            $suffix = substr($raw_url, $quote_pos);
-            $raw_url = substr($raw_url, 0, $quote_pos);
-        }
-
-        while ($raw_url !== '') {
-            $last = $raw_url[strlen($raw_url) - 1];
-            if ($last === '>' || $last === ',' || $last === ';') {
-                $suffix = $last . $suffix;
-                $raw_url = substr($raw_url, 0, -1);
-                continue;
-            }
-
-            $pairs = [
-                ')' => '(',
-                ']' => '[',
-                '}' => '{',
-            ];
-            if (
-                isset($pairs[$last]) &&
-                substr_count($raw_url, $last) > substr_count($raw_url, $pairs[$last])
-            ) {
-                $suffix = $last . $suffix;
-                $raw_url = substr($raw_url, 0, -1);
-                continue;
-            }
-
-            break;
-        }
-
-        return [$raw_url, $suffix];
-    }
-
-    private function find_structural_quote_position(string $raw_url): ?int
-    {
-        $length = strlen($raw_url);
-        for ($i = 0; $i < $length; $i++) {
-            $char = $raw_url[$i];
-            if ($char !== '"' && $char !== "'") {
-                continue;
-            }
-
-            $next = $raw_url[$i + 1] ?? '';
-            if ($next === '' || strpos(",]})>;\t\r\n ", $next) !== false) {
-                return $i;
-            }
-        }
-
-        return null;
-    }
-
-    private function parse_plain_text_candidate(string $raw_url)
-    {
-        $candidate = $raw_url;
-        if (
-            $this->base_url &&
-            !WPURL::has_http_https_protocol($candidate) &&
-            strpos($candidate, '//') !== 0
-        ) {
-            $candidate = WPURL::ensure_protocol($candidate, parse_url($this->base_url, PHP_URL_SCHEME) ?: 'https');
-        }
-
-        return WPURL::parse($candidate, $this->base_url);
-    }
-
-    /**
      * Migrate URLs in post content. See WPRewriteUrlsTests for
      * specific examples. TODO: A better description.
      *
@@ -447,80 +366,46 @@ class StructuredDataUrlRewriter
 
             case self::PLAIN_TEXT:
                 $p = new URLInTextProcessor( $content, $base_url );
-                $updated_content = '';
-                $bytes_copied = 0;
-                $search_offset = 0;
-                $changed = false;
                 while ( $p->next_url() ) {
                     $raw_url = $p->get_raw_url();
-
-                    // Locate the scanner candidate in the original bytes. Some
-                    // processors normalize the exposed URL span, so reapply only
-                    // the bytes we can directly account for.
-                    $url_starts_at = strpos($content, $raw_url, $search_offset);
-                    if ($url_starts_at === false) {
-                        continue;
-                    }
-                    $search_offset = $url_starts_at + strlen($raw_url);
-
-                    // The scanner may include surrounding plain-text syntax in
-                    // its broad candidate. Split that syntax from the URL before
-                    // structured parsing, then append it unchanged after rewrite.
-                    [$rewrite_raw_url, $preserved_suffix] = $this->split_plain_text_url_candidate($raw_url);
-                    if ($rewrite_raw_url === '') {
-                        continue;
-                    }
-
-                    $cache_key = $this->mapping_cache_key . "\0" . self::PLAIN_TEXT . "\0" . $raw_url . "\0" . $rewrite_raw_url;
+                    $cache_key = $this->mapping_cache_key . "\0" . self::PLAIN_TEXT . "\0" . $raw_url;
                     $cached = $this->get_cached_rewrite_result($cache_key);
                     if ($cached !== null) {
                         if ($cached !== false) {
-                            $updated_content .= substr($content, $bytes_copied, $url_starts_at - $bytes_copied);
-                            $updated_content .= $cached['raw_url'];
-                            $bytes_copied = $url_starts_at + strlen($raw_url);
-                            $changed = true;
+                            $p->set_raw_url($cached['raw_url']);
                         }
                         continue;
                     }
 
-                    $parsed_url = $preserved_suffix === ''
-                        ? $p->get_parsed_url()
-                        : $this->parse_plain_text_candidate($rewrite_raw_url);
+                    $parsed_url = $p->get_parsed_url();
                     $converted = false;
-                    if ($parsed_url !== false) {
-                        foreach ( $parsed_mapping as $mapping ) {
-                            if ( is_child_url_of( $parsed_url, $mapping['from_url'] ) ) {
-                                $converted = WPURL::replace_base_url(
-                                    $parsed_url,
-                                    array(
-                                        'old_base_url' => $mapping['from_url'],
-                                        'new_base_url' => $mapping['to_url'],
-                                        'raw_url'      => $rewrite_raw_url,
-                                        'is_relative'  => false,
-                                    )
-                                );
-                                break;
-                            }
+                    foreach ( $parsed_mapping as $mapping ) {
+                        if ( is_child_url_of( $parsed_url, $mapping['from_url'] ) ) {
+                            $converted = WPURL::replace_base_url(
+                                $parsed_url,
+                                array(
+                                    'old_base_url' => $mapping['from_url'],
+                                    'new_base_url' => $mapping['to_url'],
+                                    'raw_url'      => $raw_url,
+                                    'is_relative'  => false,
+                                )
+                            );
+                            break;
                         }
                     }
 
                     $cache_value = false;
                     if ($converted !== false) {
                         $cache_value = [
-                            'raw_url'    => (string) $converted . $preserved_suffix,
+                            'raw_url'    => (string) $converted,
                             'parsed_url' => $converted->new_url,
                         ];
-                        $updated_content .= substr($content, $bytes_copied, $url_starts_at - $bytes_copied);
-                        $updated_content .= $cache_value['raw_url'];
-                        $bytes_copied = $url_starts_at + strlen($raw_url);
-                        $changed = true;
+                        $p->set_raw_url($cache_value['raw_url']);
                     }
                     $this->set_cached_rewrite_result($cache_key, $cache_value);
                 }
 
-                return $changed
-                    ? $updated_content . substr($content, $bytes_copied)
-                    : $content;
+                return $p->get_updated_text();
 
             default:
                 _doing_it_wrong( __FUNCTION__, 'rewrite_urls() requires either block_markup or plain_text to be provided', '1.0.0' );

--- a/packages/reprint-importer/src/lib/url-rewrite/class-structured-data-url-rewriter.php
+++ b/packages/reprint-importer/src/lib/url-rewrite/class-structured-data-url-rewriter.php
@@ -20,12 +20,14 @@ use function WordPress\DataLiberation\URL\wp_rewrite_urls;
  * 2. JSON → construct JsonStringIterator, if not malformed, iterate string
  *    values and recurse on each
  * 3. Base64 → decode, recurse on decoded content, re-encode if changed
- * 4. Leaf text → wp_rewrite_urls() (block_markup hint) or strtr() (default)
+ * 4. Leaf text → wp_rewrite_urls() / URLInTextProcessor, depending on
+ *    the content type hint
  *
- * HTML is never auto-detected — the caller must explicitly pass
- * content_type='block_markup' for values known to contain HTML/block markup.
- * The hint propagates through recursive calls so that leaf strings inside
- * serialized PHP, JSON, or base64 eventually reach wp_rewrite_urls().
+ * WordPress block markup is auto-detected by its block comment marker. Other
+ * HTML is only handled as block markup when the caller explicitly passes
+ * content_type='block_markup'. The hint propagates through recursive calls
+ * so that leaf strings inside serialized PHP, JSON, or base64 eventually
+ * reach wp_rewrite_urls().
  */
 class StructuredDataUrlRewriter
 {
@@ -35,12 +37,6 @@ class StructuredDataUrlRewriter
 
     /** @var string[] Source domains extracted from url_mapping keys, for quick-reject checks. */
     private array $source_domains;
-
-    /** @var array<string, string> Literal base URL replacements for the block-markup fast path. */
-    private array $literal_base_url_replacements;
-
-    /** @var string[] Unescaped source base URLs, used to avoid changing block-comment JSON formatting. */
-    private array $literal_source_base_urls;
 
     /**
      * Pre-parsed url_mapping: each entry is
@@ -94,22 +90,12 @@ class StructuredDataUrlRewriter
         // (scheme/host/path tokenisation, punycode, etc.) and used to be
         // repeated on every leaf we rewrote.
         $this->parsed_mapping = [];
-        $this->literal_base_url_replacements = [];
-        $this->literal_source_base_urls = [];
         foreach ($url_mapping as $from_url_string => $to_url_string) {
             $this->parsed_mapping[] = [
                 'from_url' => WPURL::parse($from_url_string),
                 'to_url'   => WPURL::parse($to_url_string),
             ];
-
-            $this->literal_source_base_urls[] = $from_url_string;
-            $this->literal_base_url_replacements[$from_url_string] = $to_url_string;
-            $this->literal_base_url_replacements[str_replace('/', '\/', $from_url_string)] = str_replace('/', '\/', $to_url_string);
         }
-        uksort(
-            $this->literal_base_url_replacements,
-            static fn ($a, $b) => strlen($b) <=> strlen($a)
-        );
         $this->mapping_cache_key = sha1(json_encode($url_mapping, JSON_UNESCAPED_SLASHES));
 
         // Default base_url: first from-url in the mapping. Preserves the
@@ -140,19 +126,20 @@ class StructuredDataUrlRewriter
             $content_type = self::PLAIN_TEXT;
         }
 
+        // Unknown SQL columns can still contain WordPress block markup. If we
+        // see the block comment marker, use the block-markup processor rather
+        // than treating comment JSON and HTML attributes as undifferentiated
+        // text.
+        if ($content_type === self::PLAIN_TEXT && strpos($value, '<!-- wp:') !== false) {
+            $content_type = self::BLOCK_MARKUP;
+        }
+
         // Quick-reject: if the value doesn't contain href=", src=", or any
         // source domain, there's nothing to rewrite. This avoids expensive
         // parsing (serialized PHP, JSON, block markup) for the vast majority
         // of values that don't contain any rewritable URLs.
         if (!$this->maybe_contains_rewritable_urls($value)) {
             return $value;
-        }
-
-        if ($content_type === self::PLAIN_TEXT && !$this->starts_like_json_or_php_serialization($value)) {
-            $literal_rewrite = $this->try_rewrite_literal_base_urls($value);
-            if ($literal_rewrite !== null && !$this->value_might_contain_source_domain($literal_rewrite)) {
-                return $literal_rewrite;
-            }
         }
 
         // Try serialized PHP: the parser validates the entire structure
@@ -215,12 +202,11 @@ class StructuredDataUrlRewriter
     /**
      * Rewrite a decoded value already known by the SQL layer to be block markup.
      *
-     * This takes a conservative fast path for the common dump shape where the
-     * value contains literal absolute source URLs in HTML attributes, text, CSS,
-     * or block-comment JSON. In that case a boundary-checked base URL swap gives
-     * the same result as BlockMarkupUrlProcessor without constructing the full
-     * parser stack for every row. If any source URL occurrence is not at a URL
-     * boundary, we fall back to the full structured rewriter.
+     * Even if the value looks like it contains literal source URLs, this must
+     * still go through the block-markup URL processor. URL spellings can vary
+     * through escaping, encoding, host normalization, punycode, block comment
+     * JSON, and CSS syntax; byte-level replacements are not equivalent to URL
+     * rewriting.
      */
     public function rewrite_known_block_markup_value(string $value): string
     {
@@ -232,115 +218,7 @@ class StructuredDataUrlRewriter
             return $value;
         }
 
-        $literal_rewrite = $this->try_rewrite_literal_base_urls($value);
-        if ($literal_rewrite !== null) {
-            return $literal_rewrite;
-        }
-
         return $this->rewrite($value, self::BLOCK_MARKUP);
-    }
-
-    private function try_rewrite_literal_base_urls(string $value): ?string
-    {
-        if ($this->has_unescaped_source_url_in_block_comment($value)) {
-            return null;
-        }
-
-        $matched = false;
-        foreach ($this->literal_base_url_replacements as $from => $_to) {
-            $offset = 0;
-            while (true) {
-                $pos = strpos($value, $from, $offset);
-                if ($pos === false) {
-                    break;
-                }
-                if (!$this->is_literal_base_url_boundary($value, $pos, strlen($from))) {
-                    return null;
-                }
-                $matched = true;
-                $offset = $pos + strlen($from);
-            }
-        }
-
-        return $matched ? strtr($value, $this->literal_base_url_replacements) : null;
-    }
-
-    private function has_unescaped_source_url_in_block_comment(string $value): bool
-    {
-        $comment_start = 0;
-        while (true) {
-            $comment_start = strpos($value, '<!-- wp:', $comment_start);
-            if ($comment_start === false) {
-                return false;
-            }
-
-            $comment_end = strpos($value, '-->', $comment_start);
-            if ($comment_end === false) {
-                return false;
-            }
-
-            foreach ($this->literal_source_base_urls as $source_url) {
-                $source_pos = strpos($value, $source_url, $comment_start);
-                if ($source_pos !== false && $source_pos < $comment_end) {
-                    return true;
-                }
-            }
-
-            $comment_start = $comment_end + 3;
-        }
-    }
-
-    private function is_literal_base_url_boundary(string $value, int $pos, int $length): bool
-    {
-        if ($pos > 0) {
-            $prev = $value[$pos - 1];
-            if (
-                !ctype_space($prev)
-                && strpos('"\'([{,:>', $prev) === false
-            ) {
-                return false;
-            }
-        }
-
-        $next_pos = $pos + $length;
-        if ($next_pos >= strlen($value)) {
-            return true;
-        }
-
-        $next = $value[$next_pos];
-        return ctype_space($next)
-            || strpos('/\\?#"\'<)]},;', $next) !== false;
-    }
-
-    /**
-     * Indicates whether structured parsers should run before the plain-text fast path.
-     *
-     * This is intentionally a narrow prefix check, not a general structured-data detector.
-     * It guards an optimization in rewrite(): values that do not start like JSON arrays /
-     * objects or PHP serialization can usually be rewritten with a boundary-checked literal
-     * base URL replacement instead of constructing the serialized PHP, JSON, and URL parser
-     * stack for every plain string.
-     *
-     * False positives are safe: a plain string like "s:https://example.test" just takes the
-     * existing parser path and may be slower. False negatives must still be safe: the caller
-     * only accepts the fast path when the literal URL swap succeeds and removes every source
-     * domain from the value; otherwise it falls through to the structured parsers. That means
-     * JSON scalar strings such as "\"https:\/\/old.example\"" can still use the fast path
-     * because replacing the escaped literal base URL preserves valid JSON.
-     */
-    private function starts_like_json_or_php_serialization(string $value): bool
-    {
-        $trimmed = ltrim($value);
-        if ($trimmed === '') {
-            return false;
-        }
-
-        $first = $trimmed[0];
-        if ($first === '{' || $first === '[') {
-            return true;
-        }
-
-        return preg_match('/^(?:a|O|s|i|d|b|N|C):/', $trimmed) === 1;
     }
 
     /**

--- a/packages/reprint-importer/src/lib/url-rewrite/class-structured-data-url-rewriter.php
+++ b/packages/reprint-importer/src/lib/url-rewrite/class-structured-data-url-rewriter.php
@@ -148,6 +148,13 @@ class StructuredDataUrlRewriter
             return $value;
         }
 
+        if ($content_type === self::PLAIN_TEXT && !$this->might_be_structured_data($value)) {
+            $literal_rewrite = $this->try_rewrite_literal_base_urls($value);
+            if ($literal_rewrite !== null && !$this->value_might_contain_source_domain($literal_rewrite)) {
+                return $literal_rewrite;
+            }
+        }
+
         // Try serialized PHP: the parser validates the entire structure
         // in the constructor. If it's not malformed, iterate and recurse.
         $p = new PhpSerializationProcessor($value);
@@ -303,6 +310,21 @@ class StructuredDataUrlRewriter
         $next = $value[$next_pos];
         return ctype_space($next)
             || strpos('/\\?#"\'<)]},;', $next) !== false;
+    }
+
+    private function might_be_structured_data(string $value): bool
+    {
+        $trimmed = ltrim($value);
+        if ($trimmed === '') {
+            return false;
+        }
+
+        $first = $trimmed[0];
+        if ($first === '{' || $first === '[') {
+            return true;
+        }
+
+        return preg_match('/^(?:a|O|s|i|d|b|N|C):/', $trimmed) === 1;
     }
 
     /**

--- a/packages/reprint-importer/src/lib/url-rewrite/class-structured-data-url-rewriter.php
+++ b/packages/reprint-importer/src/lib/url-rewrite/class-structured-data-url-rewriter.php
@@ -148,7 +148,7 @@ class StructuredDataUrlRewriter
             return $value;
         }
 
-        if ($content_type === self::PLAIN_TEXT && !$this->might_be_structured_data($value)) {
+        if ($content_type === self::PLAIN_TEXT && !$this->starts_like_json_or_php_serialization($value)) {
             $literal_rewrite = $this->try_rewrite_literal_base_urls($value);
             if ($literal_rewrite !== null && !$this->value_might_contain_source_domain($literal_rewrite)) {
                 return $literal_rewrite;
@@ -312,7 +312,23 @@ class StructuredDataUrlRewriter
             || strpos('/\\?#"\'<)]},;', $next) !== false;
     }
 
-    private function might_be_structured_data(string $value): bool
+    /**
+     * Indicates whether structured parsers should run before the plain-text fast path.
+     *
+     * This is intentionally a narrow prefix check, not a general structured-data detector.
+     * It guards an optimization in rewrite(): values that do not start like JSON arrays /
+     * objects or PHP serialization can usually be rewritten with a boundary-checked literal
+     * base URL replacement instead of constructing the serialized PHP, JSON, and URL parser
+     * stack for every plain string.
+     *
+     * False positives are safe: a plain string like "s:https://example.test" just takes the
+     * existing parser path and may be slower. False negatives must still be safe: the caller
+     * only accepts the fast path when the literal URL swap succeeds and removes every source
+     * domain from the value; otherwise it falls through to the structured parsers. That means
+     * JSON scalar strings such as "\"https:\/\/old.example\"" can still use the fast path
+     * because replacing the escaped literal base URL preserves valid JSON.
+     */
+    private function starts_like_json_or_php_serialization(string $value): bool
     {
         $trimmed = ltrim($value);
         if ($trimmed === '') {

--- a/packages/reprint-importer/src/lib/url-rewrite/class-structured-data-url-rewriter.php
+++ b/packages/reprint-importer/src/lib/url-rewrite/class-structured-data-url-rewriter.php
@@ -76,12 +76,21 @@ class StructuredDataUrlRewriter
      */
     public function __construct(array $url_mapping)
     {
-        // Extract unique source domains for the quick-reject check.
+        // Extract unique source domains for the quick-reject check. Include
+        // both parse_url()'s literal host and WPURL's normalized host so IDN
+        // mappings still match punycode URLs stored in the database.
         $domains = [];
         foreach (array_keys($url_mapping) as $from_url) {
             $host = parse_url($from_url, PHP_URL_HOST);
             if ($host !== null && $host !== false) {
-                $domains[$host] = true;
+                $domains[strtolower($host)] = true;
+            }
+            $parsed = WPURL::parse($from_url);
+            if ($parsed !== false) {
+                $normalized_host = $parsed->hostname;
+                if ($normalized_host !== '') {
+                    $domains[strtolower($normalized_host)] = true;
+                }
             }
         }
         $this->source_domains = array_keys($domains);
@@ -192,7 +201,7 @@ class StructuredDataUrlRewriter
             return true;
         }
         foreach ($this->source_domains as $domain) {
-            if (strpos($value, $domain) !== false) {
+            if (stripos($value, $domain) !== false) {
                 return true;
             }
         }
@@ -266,6 +275,87 @@ class StructuredDataUrlRewriter
         }
 
         $this->rewrite_result_cache[$cache_key] = $value;
+    }
+
+    /**
+     * Split syntax delimiters accidentally captured by URLInTextProcessor from
+     * the URL bytes that should be parsed and rewritten.
+     *
+     * The processor intentionally uses a broad candidate scan before WHATWG
+     * validation. In plain text formats such as Markdown, CSS, JavaScript, CSV,
+     * and shortcodes, the broad candidate may include a closing delimiter or a
+     * quoted-field tail. We preserve that suffix verbatim and only feed the URL
+     * prefix into structured URL parsing and base replacement.
+     *
+     * @return array{0: string, 1: string} URL candidate, preserved suffix.
+     */
+    private function split_plain_text_url_candidate(string $raw_url): array
+    {
+        $suffix = '';
+        $quote_pos = $this->find_structural_quote_position($raw_url);
+        if ($quote_pos !== null) {
+            $suffix = substr($raw_url, $quote_pos);
+            $raw_url = substr($raw_url, 0, $quote_pos);
+        }
+
+        while ($raw_url !== '') {
+            $last = $raw_url[strlen($raw_url) - 1];
+            if ($last === '>' || $last === ',' || $last === ';') {
+                $suffix = $last . $suffix;
+                $raw_url = substr($raw_url, 0, -1);
+                continue;
+            }
+
+            $pairs = [
+                ')' => '(',
+                ']' => '[',
+                '}' => '{',
+            ];
+            if (
+                isset($pairs[$last]) &&
+                substr_count($raw_url, $last) > substr_count($raw_url, $pairs[$last])
+            ) {
+                $suffix = $last . $suffix;
+                $raw_url = substr($raw_url, 0, -1);
+                continue;
+            }
+
+            break;
+        }
+
+        return [$raw_url, $suffix];
+    }
+
+    private function find_structural_quote_position(string $raw_url): ?int
+    {
+        $length = strlen($raw_url);
+        for ($i = 0; $i < $length; $i++) {
+            $char = $raw_url[$i];
+            if ($char !== '"' && $char !== "'") {
+                continue;
+            }
+
+            $next = $raw_url[$i + 1] ?? '';
+            if ($next === '' || strpos(",]})>;\t\r\n ", $next) !== false) {
+                return $i;
+            }
+        }
+
+        return null;
+    }
+
+    private function parse_plain_text_candidate(string $raw_url)
+    {
+        $candidate = $raw_url;
+        if (
+            $this->base_url &&
+            !WPURL::has_http_https_protocol($candidate) &&
+            strpos($candidate, '//') !== 0
+        ) {
+            $candidate = WPURL::ensure_protocol($candidate, parse_url($this->base_url, PHP_URL_SCHEME) ?: 'https');
+        }
+
+        return WPURL::parse($candidate, $this->base_url);
     }
 
     /**
@@ -357,46 +447,80 @@ class StructuredDataUrlRewriter
 
             case self::PLAIN_TEXT:
                 $p = new URLInTextProcessor( $content, $base_url );
+                $updated_content = '';
+                $bytes_copied = 0;
+                $search_offset = 0;
+                $changed = false;
                 while ( $p->next_url() ) {
                     $raw_url = $p->get_raw_url();
-                    $cache_key = $this->mapping_cache_key . "\0" . self::PLAIN_TEXT . "\0" . $raw_url;
+
+                    // Locate the scanner candidate in the original bytes. Some
+                    // processors normalize the exposed URL span, so reapply only
+                    // the bytes we can directly account for.
+                    $url_starts_at = strpos($content, $raw_url, $search_offset);
+                    if ($url_starts_at === false) {
+                        continue;
+                    }
+                    $search_offset = $url_starts_at + strlen($raw_url);
+
+                    // The scanner may include surrounding plain-text syntax in
+                    // its broad candidate. Split that syntax from the URL before
+                    // structured parsing, then append it unchanged after rewrite.
+                    [$rewrite_raw_url, $preserved_suffix] = $this->split_plain_text_url_candidate($raw_url);
+                    if ($rewrite_raw_url === '') {
+                        continue;
+                    }
+
+                    $cache_key = $this->mapping_cache_key . "\0" . self::PLAIN_TEXT . "\0" . $raw_url . "\0" . $rewrite_raw_url;
                     $cached = $this->get_cached_rewrite_result($cache_key);
                     if ($cached !== null) {
                         if ($cached !== false) {
-                            $p->set_raw_url($cached['raw_url']);
+                            $updated_content .= substr($content, $bytes_copied, $url_starts_at - $bytes_copied);
+                            $updated_content .= $cached['raw_url'];
+                            $bytes_copied = $url_starts_at + strlen($raw_url);
+                            $changed = true;
                         }
                         continue;
                     }
 
-                    $parsed_url = $p->get_parsed_url();
+                    $parsed_url = $preserved_suffix === ''
+                        ? $p->get_parsed_url()
+                        : $this->parse_plain_text_candidate($rewrite_raw_url);
                     $converted = false;
-                    foreach ( $parsed_mapping as $mapping ) {
-                        if ( is_child_url_of( $parsed_url, $mapping['from_url'] ) ) {
-                            $converted = WPURL::replace_base_url(
-                                $parsed_url,
-                                array(
-                                    'old_base_url' => $base_url,
-                                    'new_base_url' => $mapping['to_url'],
-                                    'raw_url'      => $p->get_raw_url(),
-                                    'is_relative'  => false,
-                                )
-                            );
-                            break;
+                    if ($parsed_url !== false) {
+                        foreach ( $parsed_mapping as $mapping ) {
+                            if ( is_child_url_of( $parsed_url, $mapping['from_url'] ) ) {
+                                $converted = WPURL::replace_base_url(
+                                    $parsed_url,
+                                    array(
+                                        'old_base_url' => $mapping['from_url'],
+                                        'new_base_url' => $mapping['to_url'],
+                                        'raw_url'      => $rewrite_raw_url,
+                                        'is_relative'  => false,
+                                    )
+                                );
+                                break;
+                            }
                         }
                     }
 
                     $cache_value = false;
                     if ($converted !== false) {
                         $cache_value = [
-                            'raw_url'    => (string) $converted,
+                            'raw_url'    => (string) $converted . $preserved_suffix,
                             'parsed_url' => $converted->new_url,
                         ];
-                        $p->set_raw_url($cache_value['raw_url']);
+                        $updated_content .= substr($content, $bytes_copied, $url_starts_at - $bytes_copied);
+                        $updated_content .= $cache_value['raw_url'];
+                        $bytes_copied = $url_starts_at + strlen($raw_url);
+                        $changed = true;
                     }
                     $this->set_cached_rewrite_result($cache_key, $cache_value);
                 }
 
-                return $p->get_updated_text();
+                return $changed
+                    ? $updated_content . substr($content, $bytes_copied)
+                    : $content;
 
             default:
                 _doing_it_wrong( __FUNCTION__, 'rewrite_urls() requires either block_markup or plain_text to be provided', '1.0.0' );

--- a/tests/Import/NewSiteUrlSqliteTest.php
+++ b/tests/Import/NewSiteUrlSqliteTest.php
@@ -311,7 +311,7 @@ class NewSiteUrlSqliteTest extends TestCase
         $this->assertCount(1, $posts);
         $postContent = $posts[0]['post_content'];
         $this->assertStringContainsString('https://new-site.example.com/about', $postContent);
-        $this->assertStringContainsString('https://new-site.example.com/wp-content/uploads/photo.jpg', $postContent);
+        $this->assertStringContainsString('https:\/\/new-site.example.com\/wp-content\/uploads\/photo.jpg', $postContent);
         $this->assertStringNotContainsString('old-site.example.com', $postContent);
     }
 }

--- a/tests/Import/NewSiteUrlSqliteTest.php
+++ b/tests/Import/NewSiteUrlSqliteTest.php
@@ -91,7 +91,7 @@ class NewSiteUrlSqliteTest extends TestCase
             "INSERT INTO `wp_options` VALUES "
             . "(3, FROM_BASE64('%s'), FROM_BASE64('%s'), FROM_BASE64('%s'));",
             base64_encode('blogname'),
-            base64_encode('My Test Blog'),
+            base64_encode("Bob's Test Blog"),
             base64_encode('yes'),
         );
 
@@ -192,7 +192,7 @@ class NewSiteUrlSqliteTest extends TestCase
             "SELECT option_value FROM wp_options WHERE option_name = 'blogname'",
             'wp_test',
         );
-        $this->assertSame('My Test Blog', $blogname[0]['option_value']);
+        $this->assertSame("Bob's Test Blog", $blogname[0]['option_value']);
     }
 
     /**

--- a/tests/UrlRewriting/Base64ValueScannerTest.php
+++ b/tests/UrlRewriting/Base64ValueScannerTest.php
@@ -168,6 +168,37 @@ class Base64ValueScannerTest extends TestCase
         $this->assertSame($sql, $scanner->get_result());
     }
 
+    public function testMysqlHexLiteralsReplaceWholeBase64Expression(): void
+    {
+        $value = "Bob's Test Blog";
+        $encoded = base64_encode($value);
+        $sql = "INSERT INTO t VALUES(1, CONVERT(FROM_BASE64('{$encoded}') USING utf8mb4));";
+
+        $scanner = new Base64ValueScanner($sql);
+        $modified = $scanner->get_result_with_mysql_hex_literals();
+
+        $this->assertSame(
+            "INSERT INTO t VALUES(1, 0x" . bin2hex($value) . ");",
+            $modified
+        );
+    }
+
+    public function testMysqlHexLiteralsUseRewrittenValues(): void
+    {
+        $old = 'https://old-site.com/page';
+        $new = 'https://new-site.com/page';
+        $sql = "INSERT INTO t VALUES(FROM_BASE64('" . base64_encode($old) . "'));";
+
+        $scanner = new Base64ValueScanner($sql);
+        $this->assertTrue($scanner->next_value());
+        $scanner->set_value($new);
+
+        $this->assertSame(
+            "INSERT INTO t VALUES(0x" . bin2hex($new) . ");",
+            $scanner->get_result_with_mysql_hex_literals()
+        );
+    }
+
     public function testHandlesEmptyString(): void
     {
         $value = '';

--- a/tests/UrlRewriting/Base64ValueScannerTest.php
+++ b/tests/UrlRewriting/Base64ValueScannerTest.php
@@ -199,6 +199,56 @@ class Base64ValueScannerTest extends TestCase
         );
     }
 
+    public function testMysqlHexLiteralsDoNotDropNonUsingConvertWrapper(): void
+    {
+        $value = "Bob's Test Blog";
+        $encoded = base64_encode($value);
+        $sql = "INSERT INTO t VALUES(CONVERT(FROM_BASE64('{$encoded}'), CHAR));";
+
+        $scanner = new Base64ValueScanner($sql);
+
+        $this->assertSame(
+            "INSERT INTO t VALUES(CONVERT(0x" . bin2hex($value) . ", CHAR));",
+            $scanner->get_result_with_mysql_hex_literals()
+        );
+    }
+
+    public function testMysqlHexLiteralsOnlyCollapseUtf8mb4UsingConvertWrapper(): void
+    {
+        $value = "Bob's Test Blog";
+        $encoded = base64_encode($value);
+        $sql = "INSERT INTO t VALUES(CONVERT(FROM_BASE64('{$encoded}') USING latin1));";
+
+        $scanner = new Base64ValueScanner($sql);
+
+        $this->assertSame(
+            "INSERT INTO t VALUES(CONVERT(0x" . bin2hex($value) . " USING latin1));",
+            $scanner->get_result_with_mysql_hex_literals()
+        );
+    }
+
+    public function testMysqlHexLiteralsDecodeWhitespaceWrappedPayloads(): void
+    {
+        $value = 'Hello World';
+        $sql = "INSERT INTO t VALUES(FROM_BASE64('  SGVs\n bG8g\tV29ybGQ=  '));";
+
+        $scanner = new Base64ValueScanner($sql);
+
+        $this->assertSame(
+            "INSERT INTO t VALUES(0x" . bin2hex($value) . ");",
+            $scanner->get_result_with_mysql_hex_literals()
+        );
+    }
+
+    public function testMysqlHexLiteralsPreserveMalformedPayloads(): void
+    {
+        $sql = "INSERT INTO t VALUES(FROM_BASE64('ABCD='));";
+
+        $scanner = new Base64ValueScanner($sql);
+
+        $this->assertSame($sql, $scanner->get_result_with_mysql_hex_literals());
+    }
+
     public function testHandlesEmptyString(): void
     {
         $value = '';

--- a/tests/UrlRewriting/Base64ValueScannerTest.php
+++ b/tests/UrlRewriting/Base64ValueScannerTest.php
@@ -106,7 +106,7 @@ class Base64ValueScannerTest extends TestCase
         while ($scanner->next_value()) {
             $scanner->set_value($new);
         }
-        $modified = $scanner->get_result();
+        $modified = $scanner->get_result_with_base64_payload_replacements();
 
         $expected_encoded = base64_encode($new);
         $this->assertStringContainsString("FROM_BASE64('{$expected_encoded}')", $modified);
@@ -124,7 +124,7 @@ class Base64ValueScannerTest extends TestCase
         while ($scanner->next_value()) {
             $scanner->set_value($new);
         }
-        $modified = $scanner->get_result();
+        $modified = $scanner->get_result_with_base64_payload_replacements();
 
         $expected_encoded = base64_encode($new);
         $this->assertStringContainsString("CONVERT(FROM_BASE64('{$expected_encoded}') USING utf8mb4)", $modified);
@@ -144,7 +144,7 @@ class Base64ValueScannerTest extends TestCase
         while ($scanner->next_value()) {
             $scanner->set_value(strtoupper($scanner->get_value()));
         }
-        $modified = $scanner->get_result();
+        $modified = $scanner->get_result_with_base64_payload_replacements();
 
         // Verify both replacements worked by re-scanning
         $new_values = $this->collectValues($modified);
@@ -165,17 +165,17 @@ class Base64ValueScannerTest extends TestCase
             $scanner->get_value();
         }
 
-        $this->assertSame($sql, $scanner->get_result());
+        $this->assertSame($sql, $scanner->get_result_with_base64_payload_replacements());
     }
 
-    public function testMysqlHexLiteralsReplaceWholeBase64Expression(): void
+    public function testSqliteCompatibleLiteralsReplaceWholeBase64Expression(): void
     {
         $value = "Bob's Test Blog";
         $encoded = base64_encode($value);
         $sql = "INSERT INTO t VALUES(1, CONVERT(FROM_BASE64('{$encoded}') USING utf8mb4));";
 
         $scanner = new Base64ValueScanner($sql);
-        $modified = $scanner->get_result_with_mysql_hex_literals();
+        $modified = $scanner->get_result_with_sqlite_compatible_literals();
 
         $this->assertSame(
             "INSERT INTO t VALUES(1, 0x" . bin2hex($value) . ");",
@@ -183,7 +183,7 @@ class Base64ValueScannerTest extends TestCase
         );
     }
 
-    public function testMysqlHexLiteralsUseRewrittenValues(): void
+    public function testSqliteCompatibleLiteralsUseRewrittenValues(): void
     {
         $old = 'https://old-site.com/page';
         $new = 'https://new-site.com/page';
@@ -195,11 +195,11 @@ class Base64ValueScannerTest extends TestCase
 
         $this->assertSame(
             "INSERT INTO t VALUES(0x" . bin2hex($new) . ");",
-            $scanner->get_result_with_mysql_hex_literals()
+            $scanner->get_result_with_sqlite_compatible_literals()
         );
     }
 
-    public function testMysqlHexLiteralsDoNotDropNonUsingConvertWrapper(): void
+    public function testSqliteCompatibleLiteralsDoNotDropNonUsingConvertWrapper(): void
     {
         $value = "Bob's Test Blog";
         $encoded = base64_encode($value);
@@ -209,11 +209,11 @@ class Base64ValueScannerTest extends TestCase
 
         $this->assertSame(
             "INSERT INTO t VALUES(CONVERT(0x" . bin2hex($value) . ", CHAR));",
-            $scanner->get_result_with_mysql_hex_literals()
+            $scanner->get_result_with_sqlite_compatible_literals()
         );
     }
 
-    public function testMysqlHexLiteralsOnlyCollapseUtf8mb4UsingConvertWrapper(): void
+    public function testSqliteCompatibleLiteralsOnlyCollapseUtf8mb4UsingConvertWrapper(): void
     {
         $value = "Bob's Test Blog";
         $encoded = base64_encode($value);
@@ -223,11 +223,11 @@ class Base64ValueScannerTest extends TestCase
 
         $this->assertSame(
             "INSERT INTO t VALUES(CONVERT(0x" . bin2hex($value) . " USING latin1));",
-            $scanner->get_result_with_mysql_hex_literals()
+            $scanner->get_result_with_sqlite_compatible_literals()
         );
     }
 
-    public function testMysqlHexLiteralsDecodeWhitespaceWrappedPayloads(): void
+    public function testSqliteCompatibleLiteralsDecodeWhitespaceWrappedPayloads(): void
     {
         $value = 'Hello World';
         $sql = "INSERT INTO t VALUES(FROM_BASE64('  SGVs\n bG8g\tV29ybGQ=  '));";
@@ -236,17 +236,17 @@ class Base64ValueScannerTest extends TestCase
 
         $this->assertSame(
             "INSERT INTO t VALUES(0x" . bin2hex($value) . ");",
-            $scanner->get_result_with_mysql_hex_literals()
+            $scanner->get_result_with_sqlite_compatible_literals()
         );
     }
 
-    public function testMysqlHexLiteralsPreserveMalformedPayloads(): void
+    public function testSqliteCompatibleLiteralsPreserveMalformedPayloads(): void
     {
         $sql = "INSERT INTO t VALUES(FROM_BASE64('ABCD='));";
 
         $scanner = new Base64ValueScanner($sql);
 
-        $this->assertSame($sql, $scanner->get_result_with_mysql_hex_literals());
+        $this->assertSame($sql, $scanner->get_result_with_sqlite_compatible_literals());
     }
 
     public function testHandlesEmptyString(): void

--- a/tests/UrlRewriting/Base64ValueScannerTest.php
+++ b/tests/UrlRewriting/Base64ValueScannerTest.php
@@ -183,6 +183,20 @@ class Base64ValueScannerTest extends TestCase
         );
     }
 
+    public function testSqliteCompatibleLiteralsCollapseConvertWrapperAcrossWhitespaceAndComments(): void
+    {
+        $value = "Bob's Test Blog";
+        $encoded = base64_encode($value);
+        $sql = "INSERT INTO t VALUES(CONVERT /* convert */ ( /* open */ FROM_BASE64 /* fn */ ( '{$encoded}' ) /* close */ USING utf8mb4 ));";
+
+        $scanner = new Base64ValueScanner($sql);
+
+        $this->assertSame(
+            "INSERT INTO t VALUES(0x" . bin2hex($value) . ");",
+            $scanner->get_result_with_sqlite_compatible_literals()
+        );
+    }
+
     public function testSqliteCompatibleLiteralsUseRewrittenValues(): void
     {
         $old = 'https://old-site.com/page';

--- a/tests/UrlRewriting/SqlStatementRewriterTest.php
+++ b/tests/UrlRewriting/SqlStatementRewriterTest.php
@@ -208,6 +208,21 @@ class SqlStatementRewriterTest extends TestCase
         $this->assertStringContainsString('new-site.com/api/endpoint', $values[1]);
     }
 
+    public function testSqliteInliningUsesScannerBoundariesAfterUrlRewrite(): void
+    {
+        $rewriter = $this->createRewriter();
+        $value = "https://old-site.com/bob's-page";
+        $sql = "INSERT INTO `wp_options` (`option_value`) VALUES(CONVERT(FROM_BASE64('" . base64_encode($value) . "') USING utf8mb4));";
+
+        $result = $rewriter->rewrite($sql, true);
+
+        $this->assertStringNotContainsString('FROM_BASE64', $result);
+        $this->assertStringContainsString(
+            "0x" . bin2hex("https://new-site.com/bob's-page"),
+            $result
+        );
+    }
+
     public function testWpDefaultsWorkWithCustomTablePrefix(): void
     {
         $rewriter = $this->createRewriter(null, 'mysite_');

--- a/tests/UrlRewriting/SqlStatementRewriterTest.php
+++ b/tests/UrlRewriting/SqlStatementRewriterTest.php
@@ -223,6 +223,21 @@ class SqlStatementRewriterTest extends TestCase
         );
     }
 
+    public function testSqliteInliningFindsLowercaseFunctionWithWhitespace(): void
+    {
+        $rewriter = $this->createRewriter();
+        $value = 'https://old-site.com/page';
+        $sql = "INSERT INTO `wp_options` (`option_value`) VALUES(from_base64 ( '" . base64_encode($value) . "' ));";
+
+        $result = $rewriter->rewrite($sql, true);
+
+        $this->assertStringNotContainsString('from_base64', $result);
+        $this->assertStringContainsString(
+            "0x" . bin2hex('https://new-site.com/page'),
+            $result
+        );
+    }
+
     public function testWpDefaultsWorkWithCustomTablePrefix(): void
     {
         $rewriter = $this->createRewriter(null, 'mysite_');

--- a/tests/UrlRewriting/SqlStatementRewriterTest.php
+++ b/tests/UrlRewriting/SqlStatementRewriterTest.php
@@ -193,10 +193,11 @@ class SqlStatementRewriterTest extends TestCase
         $this->assertStringNotContainsString('old-site.com', $values[0]);
     }
 
-    public function testUnknownColumnUsesPlainTextReplacement(): void
+    public function testUnknownColumnUsesStructuredPlainTextUrlRewriting(): void
     {
         $rewriter = $this->createRewriter();
-        // A plain URL in a non-block-markup column — should use strtr()
+        // A plain URL in a non-block-markup column should still be rewritten
+        // through URLInTextProcessor.
         $value = 'https://old-site.com/api/endpoint';
         $encoded = base64_encode($value);
         $sql = "INSERT INTO `wp_options` (`option_name`, `option_value`) VALUES(FROM_BASE64('" . base64_encode('siteurl') . "'), FROM_BASE64('{$encoded}'));";
@@ -204,7 +205,6 @@ class SqlStatementRewriterTest extends TestCase
         $result = $rewriter->rewrite($sql);
 
         $values = $this->collectValues($result);
-        // option_value should be rewritten via strtr
         $this->assertStringContainsString('new-site.com/api/endpoint', $values[1]);
     }
 
@@ -433,12 +433,9 @@ class SqlStatementRewriterTest extends TestCase
         $result = $rewriter->rewrite($sql);
 
         // post_content in this unknown table should NOT get the block_markup
-        // hint — it falls back to auto-detect (plain text strtr), which still
-        // rewrites URLs but through a different code path. The key assertion
-        // is that get_content_type returns null, not 'block_markup'. We verify
-        // indirectly: block_markup would parse the HTML structure, plain text
-        // just does strtr. Both rewrite the URL, so we confirm the rewrite
-        // happens (auto-detect is fine) but the table was not matched as "posts".
+        // hint — it falls back to auto-detect and still rewrites the plain URL.
+        // The key assertion is that get_content_type returns null, not
+        // 'block_markup', so the table was not matched as "posts".
         $values = $this->collectValues($result);
         $this->assertCount(1, $values);
         $this->assertStringContainsString('new-site.com/page', $values[0]);
@@ -456,12 +453,7 @@ class SqlStatementRewriterTest extends TestCase
         $result = $rewriter->rewrite($sql);
 
         // The value still gets rewritten (auto-detect/plain text), but it must
-        // NOT have been treated as block_markup. We can tell because plain text
-        // strtr rewrites the URL but doesn't parse block comment JSON attributes.
-        // With a simple URL like this both paths produce the same output, so
-        // we use a value that distinguishes them: a block comment with a JSON
-        // attribute. block_markup would rewrite inside the JSON; plain text
-        // strtr would not touch the JSON attribute.
+        // NOT have been treated as block_markup.
         $values = $this->collectValues($result);
         $this->assertCount(1, $values);
         $this->assertStringContainsString('new-site.com', $values[0]);
@@ -508,18 +500,15 @@ class SqlStatementRewriterTest extends TestCase
     }
 
     /**
-     * A block comment JSON attribute lets us distinguish block_markup from
-     * plain text rewriting. block_markup parses the JSON inside
-     * <!-- wp:image {"url":"..."} --> and rewrites it. Plain text strtr does
-     * a byte-for-byte replacement that can break JSON when URL lengths change.
-     *
-     * We use this to prove that "wp_posts".post_content gets block_markup
-     * while a spoofed table does NOT.
+     * A block comment JSON attribute must be treated as block markup even when
+     * the SQL column hint is unavailable. Unknown plugin tables may still store
+     * WordPress block markup, and plain text URL parsing can misread the block
+     * comment JSON boundary as part of the URL.
      */
-    public function testBlockMarkupVsPlainTextDistinction(): void
+    public function testUnknownTableWithBlockMarkupGetsStructuredBlockMarkupRewriting(): void
     {
         $rewriter = $this->createRewriter([
-            // Different-length URLs so strtr would shift offsets and break JSON
+            // Different-length URLs make accidental byte-level rewrites obvious.
             'https://old-site.com' => 'https://new-longer-domain-site.com',
         ]);
 
@@ -534,25 +523,24 @@ class SqlStatementRewriterTest extends TestCase
         $result_real = $rewriter->rewrite($sql_real);
         $values_real = $this->collectValues($result_real);
         $this->assertStringContainsString('new-longer-domain-site.com/img.jpg', $values_real[0]);
-        // The JSON attribute should still be valid inside the block comment.
-        // wp_rewrite_urls() JSON-encodes attribute values, so slashes are escaped.
         $this->assertStringContainsString(
             '"url":"https:\/\/new-longer-domain-site.com\/img.jpg"',
             $values_real[0],
             'block_markup should correctly rewrite the JSON attribute inside the block comment'
         );
 
-        // spoofed_posts.post_content → auto-detect (not block_markup): the
-        // column name matches but the table doesn't, so it falls through to
-        // plain text strtr.
+        // spoofed_posts.post_content has no table hint, but the value itself
+        // is recognizable WordPress block markup and must still be processed
+        // structurally.
         $sql_spoof = "INSERT INTO `spoofed_posts` (`ID`, `post_content`) VALUES(1, FROM_BASE64('{$encoded}'));";
         $result_spoof = $rewriter->rewrite($sql_spoof);
         $values_spoof = $this->collectValues($result_spoof);
-        // The URL is still rewritten (auto-detect handles it), but the JSON
-        // attribute inside the block comment may be malformed because strtr
-        // doesn't understand HTML structure. The key point: the spoofed table
-        // was NOT given the block_markup hint.
-        $this->assertStringContainsString('new-longer-domain-site.com', $values_spoof[0]);
+        $this->assertStringContainsString('new-longer-domain-site.com/img.jpg', $values_spoof[0]);
+        $this->assertStringContainsString(
+            '"url":"https:\/\/new-longer-domain-site.com\/img.jpg"',
+            $values_spoof[0],
+            'block markup auto-detection should rewrite comment JSON without corrupting URL boundaries'
+        );
     }
 
     public function testConsumerHintForUnprefixedPluginTable(): void

--- a/tests/UrlRewriting/StructuredDataUrlRewriterTest.php
+++ b/tests/UrlRewriting/StructuredDataUrlRewriterTest.php
@@ -468,4 +468,76 @@ class StructuredDataUrlRewriterTest extends TestCase
             $rewriter->value_might_contain_source_domain('<a href="https://other-site.com/page">Link</a>')
         );
     }
+
+    /**
+     * These are plain text database values, not block markup. The URL scanner
+     * may see the surrounding syntax, but the rewriter must only replace the
+     * structured URL and leave each container's delimiters intact.
+     *
+     * @dataProvider plainTextDataFormatProvider
+     */
+    public function testPlainTextDataFormatsPreserveTheirDelimiters(string $input, string $expected): void
+    {
+        $rewriter = $this->createRewriter();
+
+        $this->assertSame($expected, $rewriter->rewrite($input));
+    }
+
+    public static function plainTextDataFormatProvider(): array
+    {
+        return [
+            'markdown inline link' => [
+                '[Read more](https://old-site.com/post)',
+                '[Read more](https://new-site.com/post)',
+            ],
+            'css url function' => [
+                'body{background:url(https://old-site.com/assets/bg.png)}',
+                'body{background:url(https://new-site.com/assets/bg.png)}',
+            ],
+            'javascript object literal' => [
+                "const cfg = {url: 'https://old-site.com/api'};",
+                "const cfg = {url: 'https://new-site.com/api'};",
+            ],
+            'wordpress shortcode attribute' => [
+                '[button url="https://old-site.com/go"]',
+                '[button url="https://new-site.com/go"]',
+            ],
+            'csv quoted field' => [
+                '1,"https://old-site.com/report",published',
+                '1,"https://new-site.com/report",published',
+            ],
+            'ini assignment' => [
+                "endpoint=https://old-site.com/api\n",
+                "endpoint=https://new-site.com/api\n",
+            ],
+            'yaml sequence item' => [
+                "- https://old-site.com/download\n",
+                "- https://new-site.com/download\n",
+            ],
+            'xml text node' => [
+                '<loc>https://old-site.com/post</loc>',
+                '<loc>https://new-site.com/post</loc>',
+            ],
+            'toml quoted value' => [
+                'endpoint = "https://old-site.com/api"',
+                'endpoint = "https://new-site.com/api"',
+            ],
+            'cdata section' => [
+                '<![CDATA[https://old-site.com/post]]>',
+                '<![CDATA[https://new-site.com/post]]>',
+            ],
+        ];
+    }
+
+    public function testPlainTextRewriteMatchesPunycodeSourceDomain(): void
+    {
+        $rewriter = $this->createRewriter([
+            'https://bücher.example' => 'https://new-site.com',
+        ]);
+
+        $this->assertSame(
+            'asset=https://new-site.com/cover.jpg',
+            $rewriter->rewrite('asset=https://xn--bcher-kva.example/cover.jpg')
+        );
+    }
 }

--- a/tests/UrlRewriting/StructuredDataUrlRewriterTest.php
+++ b/tests/UrlRewriting/StructuredDataUrlRewriterTest.php
@@ -327,8 +327,8 @@ class StructuredDataUrlRewriterTest extends TestCase
     public function testBlockMarkupHintUsesWpRewriteUrls(): void
     {
         $rewriter = $this->createRewriter();
-        // Block markup with JSON attribute — wp_rewrite_urls() handles the JSON
-        // inside the block comment, strtr() would not
+        // Block markup with JSON attribute: wp_rewrite_urls() handles the JSON
+        // inside the block comment.
         $input = '<!-- wp:image {"src":"https://old-site.com/img.jpg"} --><figure><img src="https://old-site.com/img.jpg"/></figure><!-- /wp:image -->';
         $result = $rewriter->rewrite($input, 'block_markup');
         $this->assertStringNotContainsString('old-site.com', $result);
@@ -343,7 +343,7 @@ class StructuredDataUrlRewriterTest extends TestCase
         $this->assertStringContainsString('https://new-site.com/page', $result);
     }
 
-    public function testKnownBlockMarkupFastPathRewritesEscapedBlockJsonAndHtml(): void
+    public function testKnownBlockMarkupValueRewritesEscapedBlockJsonAndHtml(): void
     {
         $rewriter = $this->createRewriter();
         $input = '<!-- wp:image {"src":"https:\/\/old-site.com\/img.jpg"} -->'
@@ -357,7 +357,7 @@ class StructuredDataUrlRewriterTest extends TestCase
         $this->assertStringNotContainsString('old-site.com', $result);
     }
 
-    public function testKnownBlockMarkupFastPathFallsBackForEmbeddedQueryUrl(): void
+    public function testKnownBlockMarkupValueDoesNotRewriteEmbeddedQueryUrl(): void
     {
         $rewriter = $this->createRewriter();
         $input = '<a href="https://webarchive.org?url=https://old-site.com/about">Archive</a>';
@@ -365,15 +365,42 @@ class StructuredDataUrlRewriterTest extends TestCase
         $this->assertSame($input, $rewriter->rewrite_known_block_markup_value($input));
     }
 
-    // --- Content type hint: null (default) uses plain text replacement ---
+    // --- Content type hint: null (default) uses structured plain text URL rewriting ---
 
-    public function testDefaultHintUsesPlainTextReplacement(): void
+    public function testDefaultHintUsesStructuredPlainTextUrlRewriting(): void
     {
         $rewriter = $this->createRewriter();
-        // A plain URL string — strtr() handles this fine
         $input = 'Visit https://old-site.com/about for more.';
         $result = $rewriter->rewrite($input);
         $this->assertStringContainsString('https://new-site.com/about', $result);
+        $this->assertStringNotContainsString('old-site.com', $result);
+    }
+
+    public function testDefaultHintDoesNotRewriteSourceUrlInsideAnotherUrl(): void
+    {
+        $rewriter = $this->createRewriter();
+        $input = 'Archived at https://webarchive.org?url=https://old-site.com/about';
+        $result = $rewriter->rewrite($input);
+
+        $this->assertSame($input, $result);
+    }
+
+    public function testDefaultHintAutoDetectsWordPressBlockMarkup(): void
+    {
+        $rewriter = $this->createRewriter([
+            'https://old-site.com' => 'https://new-longer-domain-site.com',
+        ]);
+        $input = '<!-- wp:image {"url":"https://old-site.com/img.jpg"} -->'
+            . '<img src="https://old-site.com/img.jpg"/>'
+            . '<!-- /wp:image -->';
+
+        $result = $rewriter->rewrite($input);
+
+        $this->assertStringContainsString(
+            '"url":"https:\/\/new-longer-domain-site.com\/img.jpg"',
+            $result
+        );
+        $this->assertStringContainsString('src="https://new-longer-domain-site.com/img.jpg"', $result);
         $this->assertStringNotContainsString('old-site.com', $result);
     }
 

--- a/tests/UrlRewriting/StructuredDataUrlRewriterTest.php
+++ b/tests/UrlRewriting/StructuredDataUrlRewriterTest.php
@@ -469,66 +469,6 @@ class StructuredDataUrlRewriterTest extends TestCase
         );
     }
 
-    /**
-     * These are plain text database values, not block markup. The URL scanner
-     * may see the surrounding syntax, but the rewriter must only replace the
-     * structured URL and leave each container's delimiters intact.
-     *
-     * @dataProvider plainTextDataFormatProvider
-     */
-    public function testPlainTextDataFormatsPreserveTheirDelimiters(string $input, string $expected): void
-    {
-        $rewriter = $this->createRewriter();
-
-        $this->assertSame($expected, $rewriter->rewrite($input));
-    }
-
-    public static function plainTextDataFormatProvider(): array
-    {
-        return [
-            'markdown inline link' => [
-                '[Read more](https://old-site.com/post)',
-                '[Read more](https://new-site.com/post)',
-            ],
-            'css url function' => [
-                'body{background:url(https://old-site.com/assets/bg.png)}',
-                'body{background:url(https://new-site.com/assets/bg.png)}',
-            ],
-            'javascript object literal' => [
-                "const cfg = {url: 'https://old-site.com/api'};",
-                "const cfg = {url: 'https://new-site.com/api'};",
-            ],
-            'wordpress shortcode attribute' => [
-                '[button url="https://old-site.com/go"]',
-                '[button url="https://new-site.com/go"]',
-            ],
-            'csv quoted field' => [
-                '1,"https://old-site.com/report",published',
-                '1,"https://new-site.com/report",published',
-            ],
-            'ini assignment' => [
-                "endpoint=https://old-site.com/api\n",
-                "endpoint=https://new-site.com/api\n",
-            ],
-            'yaml sequence item' => [
-                "- https://old-site.com/download\n",
-                "- https://new-site.com/download\n",
-            ],
-            'xml text node' => [
-                '<loc>https://old-site.com/post</loc>',
-                '<loc>https://new-site.com/post</loc>',
-            ],
-            'toml quoted value' => [
-                'endpoint = "https://old-site.com/api"',
-                'endpoint = "https://new-site.com/api"',
-            ],
-            'cdata section' => [
-                '<![CDATA[https://old-site.com/post]]>',
-                '<![CDATA[https://new-site.com/post]]>',
-            ],
-        ];
-    }
-
     public function testPlainTextRewriteMatchesPunycodeSourceDomain(): void
     {
         $rewriter = $this->createRewriter([


### PR DESCRIPTION
## What it does

Speeds up SQLite `db-apply` imports while keeping URL rewrites structured:

- SQLite no longer executes PHP-backed `FROM_BASE64()` for every imported string value. For SQLite targets, scanner-identified `FROM_BASE64()` / `CONVERT(FROM_BASE64() USING utf8mb4)` expressions are rewritten to MySQL-compatible `0x...` hex literals before execution.
- URL rewriting no longer uses byte-level literal source-domain replacement. Plain-text values still go through the URL scanner, WHATWG URL parsing, `is_child_url_of()`, and `WPURL::replace_base_url()`.
- Reprint does not infer Markdown, CSS, CSV, TOML, or other container syntax in the plain-text layer. Known structured formats are parsed by their owning parser first; only leaf text or intentionally unknown text is delegated to `URLInTextProcessor`.
- Source-domain quick rejection considers both literal hosts and WPURL-normalized hosts, so Unicode source mappings still match punycode URLs in the dump.

## Rationale

The first high-speed URL path used literal base URL replacement after boundary checks. That recovered a lot of speed, but it was not semantically equivalent to structured URL rewriting: IDN/punycode and other URL-normalization cases can be missed or rewritten incorrectly. This PR removes that path and keeps URL decisions centralized in structured URL parsing.

A later experiment split delimiter-looking suffixes from `URLInTextProcessor` candidates. That also has been removed. It was not rigorous because reprint would have been guessing syntax that belongs to typed parsers. The invariant now is that `URLInTextProcessor` owns plain-text URL span detection; reprint callers do not repair or reinterpret those spans.

For SQLite imports, the safe big win remains avoiding per-value PHP user-defined function calls for `FROM_BASE64()`. `Base64ValueScanner` already has SQL-tokenized expression boundaries, so it can replace the full transport expression with a hex literal without regexp SQL rewriting or SQL string escaping.

## Implementation

`Base64ValueScanner` records both the quoted payload range and the full outer expression range. After URL rewriting, SQLite imports can ask the scanner to render decoded values as hex literals:

```sql
CONVERT(FROM_BASE64('Qm9iJ3MgVGVzdCBCbG9n') USING utf8mb4)
```

becomes:

```sql
0x426f622773205465737420426c6f67
```

`StructuredDataUrlRewriter` handles structured layers in order: PHP serialization, JSON, SQL/base64-decoded leaf values, WordPress block markup when hinted or auto-detected, and finally plain text through `URLInTextProcessor`. It keeps bounded rewrite-result caches, but it does not do raw string URL replacement.

## Benchmarks

PHP.wasm 8.4 db-apply runs on the 262 MB SQL fixture with both native manifests loaded (`wp-native-apis-playground-extension` and `wp_mysql_parser-wasm-extension`):

| Run | Native manifests | `db-apply` wall time | Notes |
|---|---:|---:|---|
| No URL rewrite control | Yes | 31.61 s | SQLite execution + base64 hex inlining |
| Current rigorous PR | Yes | 106.93 s | No literal replacement, no delimiter guessing |
| Previous native structured-only build | Yes | 113.34 s | Before punycode quick-reject fix |
| Current rigorous PR | No | 852.95 s | Same PHAR without native manifests |

Historical local source replay on the same fixture, before the literal URL fast path was removed:

| Run | `db-apply` wall time | Delta |
|---|---:|---:|
| Baseline `v0.8.0` source replay | 121.37 s | - |
| Hex inlining + literal URL fast path | 40.12 s | -81.25 s (-67.0%) |
| Built PHAR after scanner hardening | 40.38 s | -80.99 s (-66.7%) |
| After removing literal URL replacement fast path, without native URL scanner | 380.41 s | +259.04 s (+213.4%) |

The native benchmark is the relevant Studio direction: with the native URL scanner and native MySQL parser loaded, structured-only rewriting avoids the unsafe literal URL replacement path while keeping the run much faster than userland-only structured URL rewriting.

## Hot paths

A rewrite-only profiler over the same 262 MB SQL dump, without SQLite execution, attributed the remaining cost as follows:

| Area | Count | Time |
|---|---:|---:|
| Structured plain-text leaf rewrites | 201,505 values | 56.98 s |
| Structured block-markup rewrites | 49,753 values | 17.46 s |
| Fast INSERT scan | 824 fast statements | 2.93 s |
| Base64 decode for URL candidates | 251,258 values | 0.52 s |
| Source-domain prefilter | 251,258 values | 0.12 s |
| Hex literal rendering | 824 fast statements | 0.63 s |

`scanner_walk` in the profiler is inclusive of the structured rewrite calls; the main actionable sink is the 201k plain-text leaf rewrites, followed by block markup.

A post-content microbench also confirms the bounded rewrite-result cache matters: 5,000 block values / 350,000 URL occurrences / 2 unique raw URLs take 2.03 s with caching versus 15.91 s without. An exact whole-leaf URL fast path was tested and rejected because it made the rewrite-only profile worse (99.79 s → 106.28 s).

## Proposed next optimization

The next rigorous speedup should avoid guessing syntax and instead reduce work before plain-text URL scanning:

- Add explicit SQL column content hints for columns that are known leaf text, not containers. Those can skip failed serialized-PHP and JSON probes and go directly to `URLInTextProcessor`. Unknown columns and `postmeta.meta_value` should keep auto-detection.
- Move more of the plain-text rewrite loop into php-toolkit/native only if the native API owns the same span contract: scan validated URL spans, parse, child-check, replace, and cache in one place. That would cut PHP/native crossings and PHP object churn without moving Markdown/CSS/CSV guessing into reprint.
- Keep the current bounded caches and measure a content-level leaf rewrite cache separately. It is semantically safe because it keys by exact input value and content type, but it is only worth adding if the dump has enough repeated decoded values to beat hashing overhead.

Fixture details:

- WordPress `6.8.2-php8.3-apache` + MariaDB 11 source site.
- 52,003 posts and 154,002 postmeta rows.
- 2,000 attachment database records.
- SQL dump: 262 MB. Resulting SQLite DB: 223 MB.

Validation on the generated SQLite DB:

```sql
pragma integrity_check; -- ok
select count(*) from wp_posts; -- 52003
select count(*) from wp_postmeta; -- 154002
```

Checked URL-heavy columns after import: no remaining `127.0.0.1:8199` in `wp_posts.guid`, `wp_posts.post_content`, or `wp_postmeta.meta_value`.

## Testing instructions

```bash
composer test -- --filter StructuredDataUrlRewriterTest
composer test -- --filter 'StructuredDataUrlRewriterTest|SqlStatementRewriterTest|SqlStatementRewriterPrefilterTest|SqlStatementRewriterLexerWalkerTest|NewSiteUrlSqliteTest'
composer analyze
composer build:phar
```

The broader filtered suite currently exits successfully but still reports the existing `NewSiteUrlSqlite` output warnings.
