### PR TITLE
Use plain text rewriting for markup-free block values

### DIFF
--- a/packages/reprint-importer/src/lib/url-rewrite/class-structured-data-url-rewriter.php
+++ b/packages/reprint-importer/src/lib/url-rewrite/class-structured-data-url-rewriter.php
@@ -318,6 +318,14 @@ class StructuredDataUrlRewriter
 
         switch ( $content_type ) {
             case self::BLOCK_MARKUP:
+                // Without a `<` byte there can be no HTML tag or WordPress
+                // block-comment opener for BlockMarkupUrlProcessor to own.
+                // Treat the value as the leaf text it is instead of running
+                // the block-markup parser stack.
+                if ( strpos( $content, '<' ) === false ) {
+                    return $this->rewrite_urls( $content, self::PLAIN_TEXT );
+                }
+
                 $p = new BlockMarkupUrlProcessor( $content, $base_url );
                 while ( $p->next_url() ) {
                     $raw_url = $p->get_raw_url();

--- a/tests/UrlRewriting/StructuredDataUrlRewriterTest.php
+++ b/tests/UrlRewriting/StructuredDataUrlRewriterTest.php
@@ -343,6 +343,15 @@ class StructuredDataUrlRewriterTest extends TestCase
         $this->assertStringContainsString('https://new-site.com/page', $result);
     }
 
+    public function testBlockMarkupHintWithoutMarkupUsesPlainTextUrlRewriting(): void
+    {
+        $rewriter = $this->createRewriter();
+        $input = 'Visit https://old-site.com/page';
+        $result = $rewriter->rewrite($input, 'block_markup');
+
+        $this->assertSame('Visit https://new-site.com/page', $result);
+    }
+
     public function testKnownBlockMarkupValueRewritesEscapedBlockJsonAndHtml(): void
     {
         $rewriter = $this->createRewriter();


### PR DESCRIPTION
## What it does

For values already classified as `block_markup`, this skips `BlockMarkupUrlProcessor` when the value has no `<` byte and delegates directly to the plain text URL processor.

## Rationale

Under the current rigor contract, `URLInTextProcessor` should only see leaf text or unknown text after structured formats have had first ownership. For a block-markup-hinted value, the owning block/HTML parser has nothing to parse unless the value contains a `<` byte: there can be no HTML tag and no WordPress block-comment opener. This keeps parser ownership intact while avoiding a costly parser stack on plain post content.

## Implementation

The `BLOCK_MARKUP` path now checks for `<` before constructing `BlockMarkupUrlProcessor`. When absent, it treats the value as leaf text and calls the existing `PLAIN_TEXT` path. A regression test covers the delegation.

## Benchmark

Fixture: 262 MB SQL dump, PHP.wasm 8.4, php-toolkit native extension loaded, sqlite-database-integration native extension loaded.

| Run | Full `db-apply` | Rewrite-only profile | Notes |
| --- | ---: | ---: | --- |
| Parent PR #220 | 106.93 s | 99.79 s | rigorous parser-owned baseline |
| This branch | 94.24 s | 90.15 s | `structured_rewrite_block` drops from 17.46 s to 6.86 s |
| Delta | -12.69 s (-11.9%) | -9.64 s (-9.7%) | fastest experiment so far |

## Testing instructions

```bash
php -l packages/reprint-importer/src/lib/url-rewrite/class-structured-data-url-rewriter.php
php -l tests/UrlRewriting/StructuredDataUrlRewriterTest.php
composer test -- --filter 'StructuredDataUrlRewriterTest|SqlStatementRewriterTest|SqlStatementRewriterPrefilterTest|SqlStatementRewriterLexerWalkerTest|NewSiteUrlSqliteTest'
composer analyze
```

The filtered suite passes with the existing `NewSiteUrlSqlite` warning output.
