### PR TITLE
Add whole URL hints for schema-known URL columns

### DIFF
--- a/packages/reprint-importer/src/lib/url-rewrite/class-sql-statement-rewriter.php
+++ b/packages/reprint-importer/src/lib/url-rewrite/class-sql-statement-rewriter.php
@@ -19,15 +19,15 @@
  * statements emitted by MySQLDumpProducer follow a constrained set of shapes
  * the walker recognises; for any shape it doesn't, it returns null and every
  * FROM_BASE64() value falls back to plain-text URL rewriting (which is the
- * safe default anyway — block_markup is only ever assigned to a small set of
- * WordPress core columns).
+ * safe default anyway — content-type hints are only assigned to WordPress
+ * core columns with well-defined storage semantics).
  */
 class SqlStatementRewriter
 {
     private StructuredDataUrlRewriter $url_rewriter;
 
     /** @var array<string, array<string, string>> full_table_name => [column_name => content_type] */
-    private array $db_columns_with_block_markup;
+    private array $db_column_content_types;
 
     /**
      * WordPress core columns that contain block markup and benefit from
@@ -52,6 +52,25 @@ class SqlStatementRewriter
     ];
 
     /**
+     * WordPress core columns that store a single URL/URI value rather than a
+     * structured container. These can go straight to whole-URL parsing without
+     * probing for serialized PHP, JSON, or arbitrary text spans.
+     */
+    private const WP_WHOLE_URL_COLUMNS = [
+        'posts' => [
+            'guid' => 'whole_url',
+        ],
+        'comments' => [
+            'comment_author_url' => 'whole_url',
+        ],
+        'links' => [
+            'link_url' => 'whole_url',
+            'link_image' => 'whole_url',
+            'link_rss' => 'whole_url',
+        ],
+    ];
+
+    /**
      * @param StructuredDataUrlRewriter $url_rewriter
      * @param string $table_prefix WordPress table prefix (e.g. "wp_"), used to
      *        build full table names for exact matching.
@@ -68,14 +87,15 @@ class SqlStatementRewriter
         // for the same table+column (e.g. marking post_content as 'skip').
         $by_suffix = array_replace_recursive(
 			self::WP_BLOCK_MARKUP_COLUMNS,
+            self::WP_WHOLE_URL_COLUMNS,
 			$extra_db_columns_with_block_markup
         );
-        $this->db_columns_with_block_markup = [];
+        $this->db_column_content_types = [];
         foreach ($by_suffix as $suffix => $columns) {
             // Some plugins create unprefixed tables, so we match both with and without the table
             // prefix.
-            $this->db_columns_with_block_markup[$table_prefix . $suffix] = $columns;
-            $this->db_columns_with_block_markup[$suffix] = $columns;
+            $this->db_column_content_types[$table_prefix . $suffix] = $columns;
+            $this->db_column_content_types[$suffix] = $columns;
         }
     }
 
@@ -668,7 +688,7 @@ class SqlStatementRewriter
 
     /**
      * Look up the content type for a given table and column. The
-     * db_columns_with_block_markup map is keyed by full table name (prefix
+     * db_column_content_types map is keyed by full table name (prefix
      * already applied at construction time), so this is a direct lookup.
      *
      * Returns null if there's no entry for this table+column, meaning
@@ -676,6 +696,6 @@ class SqlStatementRewriter
      */
     private function get_content_type(string $table, string $column): ?string
     {
-        return $this->db_columns_with_block_markup[$table][$column] ?? null;
+        return $this->db_column_content_types[$table][$column] ?? null;
     }
 }

--- a/packages/reprint-importer/src/lib/url-rewrite/class-structured-data-url-rewriter.php
+++ b/packages/reprint-importer/src/lib/url-rewrite/class-structured-data-url-rewriter.php
@@ -33,6 +33,7 @@ class StructuredDataUrlRewriter
 {
     const BLOCK_MARKUP = 'block_markup';
     const PLAIN_TEXT = 'plain_text';
+    const WHOLE_URL = 'whole_url';
     private const REWRITE_RESULT_CACHE_MAX = 4096;
 
     /** @var string[] Source domains extracted from url_mapping keys, for quick-reject checks. */
@@ -133,6 +134,14 @@ class StructuredDataUrlRewriter
 
         if ($content_type === null) {
             $content_type = self::PLAIN_TEXT;
+        }
+
+        if ($content_type === self::WHOLE_URL) {
+            if (!$this->value_might_contain_source_domain($value)) {
+                return $value;
+            }
+
+            return $this->rewrite_whole_url($value);
         }
 
         // Unknown SQL columns can still contain WordPress block markup. If we
@@ -275,6 +284,60 @@ class StructuredDataUrlRewriter
         }
 
         $this->rewrite_result_cache[$cache_key] = $value;
+    }
+
+    private function rewrite_whole_url(string $value): string
+    {
+        if (
+            strpbrk($value, " \t\r\n") !== false ||
+            (
+                !WPURL::has_http_https_protocol($value) &&
+                strpos($value, '//') !== 0
+            )
+        ) {
+            return $value;
+        }
+
+        $cache_key = $this->mapping_cache_key . "\0" . self::WHOLE_URL . "\0" . $value;
+        $cached = $this->get_cached_rewrite_result($cache_key);
+        if ($cached !== null) {
+            return $cached === false ? $value : $cached['raw_url'];
+        }
+
+        $parsed_url = WPURL::parse($value, $this->base_url);
+        if ($parsed_url === false) {
+            $this->set_cached_rewrite_result($cache_key, false);
+            return $value;
+        }
+
+        foreach ($this->parsed_mapping as $mapping) {
+            if (!is_child_url_of($parsed_url, $mapping['from_url'])) {
+                continue;
+            }
+
+            $converted = WPURL::replace_base_url(
+                $parsed_url,
+                array(
+                    'old_base_url' => $mapping['from_url'],
+                    'new_base_url' => $mapping['to_url'],
+                    'raw_url'      => $value,
+                    'is_relative'  => false,
+                )
+            );
+            if ($converted === false) {
+                break;
+            }
+
+            $cache_value = [
+                'raw_url'    => (string) $converted,
+                'parsed_url' => $converted->new_url,
+            ];
+            $this->set_cached_rewrite_result($cache_key, $cache_value);
+            return $cache_value['raw_url'];
+        }
+
+        $this->set_cached_rewrite_result($cache_key, false);
+        return $value;
     }
 
     /**

--- a/tests/UrlRewriting/SqlStatementRewriterTest.php
+++ b/tests/UrlRewriting/SqlStatementRewriterTest.php
@@ -208,6 +208,32 @@ class SqlStatementRewriterTest extends TestCase
         $this->assertStringContainsString('new-site.com/api/endpoint', $values[1]);
     }
 
+    public function testGuidColumnUsesWholeUrlRewriting(): void
+    {
+        $rewriter = $this->createRewriter();
+        $value = 'https://old-site.com/?p=123';
+        $encoded = base64_encode($value);
+        $sql = "INSERT INTO `wp_posts` (`ID`, `guid`) VALUES(1, FROM_BASE64('{$encoded}'));";
+
+        $result = $rewriter->rewrite($sql);
+
+        $values = $this->collectValues($result);
+        $this->assertSame('https://new-site.com/?p=123', $values[0]);
+    }
+
+    public function testGuidColumnDoesNotRewriteEmbeddedSourceUrl(): void
+    {
+        $rewriter = $this->createRewriter();
+        $value = 'https://webarchive.org/?url=https://old-site.com/?p=123';
+        $encoded = base64_encode($value);
+        $sql = "INSERT INTO `wp_posts` (`ID`, `guid`) VALUES(1, FROM_BASE64('{$encoded}'));";
+
+        $result = $rewriter->rewrite($sql);
+
+        $values = $this->collectValues($result);
+        $this->assertSame($value, $values[0]);
+    }
+
     public function testSqliteInliningUsesScannerBoundariesAfterUrlRewrite(): void
     {
         $rewriter = $this->createRewriter();


### PR DESCRIPTION
## What it does

Adds a `WHOLE_URL` content type and uses it for schema-known URL columns such as `wp_posts.guid`, comment author URLs, and links-table URL fields.

## Rationale

These columns store a URL-like value as the full column value, not structured markup. Parsing the entire value as a URL preserves the "URLs are structured data" rule while avoiding the generic text processor for values where the schema already gives us stronger information.

## Implementation

The SQL statement rewriter's column-content map can now mark columns as `WHOLE_URL`. `StructuredDataUrlRewriter` then parses the full value through the structured URL path and rewrites it only when the full value matches the source mapping. Tests cover `wp_posts.guid` rewriting and an embedded source URL that must not be rewritten.

## Benchmark

Fixture: 262 MB SQL dump, PHP.wasm 8.4, php-toolkit native extension loaded, sqlite-database-integration native extension loaded.

| Run | Full `db-apply` | Rewrite-only profile | Notes |
| --- | ---: | ---: | --- |
| Parent PR #220 | 106.93 s | 99.79 s | rigorous parser-owned baseline |
| This branch | 103.73 s | 99.37 s | 51,753 values use `WHOLE_URL` |
| Delta | -3.20 s (-3.0%) | -0.42 s (-0.4%) | small full-run win, rewrite-only mostly flat |

## Testing instructions

```bash
php -l packages/reprint-importer/src/lib/url-rewrite/class-sql-statement-rewriter.php
php -l packages/reprint-importer/src/lib/url-rewrite/class-structured-data-url-rewriter.php
php -l tests/UrlRewriting/SqlStatementRewriterTest.php
php -l tests/UrlRewriting/StructuredDataUrlRewriterTest.php
composer test -- --filter 'SqlStatementRewriterTest|StructuredDataUrlRewriterTest'
composer analyze
```
