### PR TITLE
Gate structured parser probes by required starters

### DIFF
--- a/packages/reprint-importer/src/lib/url-rewrite/class-structured-data-url-rewriter.php
+++ b/packages/reprint-importer/src/lib/url-rewrite/class-structured-data-url-rewriter.php
@@ -151,32 +151,37 @@ class StructuredDataUrlRewriter
             return $value;
         }
 
-        // Try serialized PHP: the parser validates the entire structure
-        // in the constructor. If it's not malformed, iterate and recurse.
-        $p = new PhpSerializationProcessor($value);
-        if (!$p->is_malformed()) {
-            while ($p->next_value()) {
-                $original = $p->get_value();
-                $rewritten = $this->rewrite($original, $content_type);
-                if ($rewritten !== $original) {
-                    $p->set_value($rewritten);
+        // Try serialized PHP only when the first bytes can begin a valid PHP
+        // serialization document. The parser still owns validation; this only
+        // avoids constructing it for values that are impossible matches.
+        if ($this->can_start_serialized_php($value)) {
+            $p = new PhpSerializationProcessor($value);
+            if (!$p->is_malformed()) {
+                while ($p->next_value()) {
+                    $original = $p->get_value();
+                    $rewritten = $this->rewrite($original, $content_type);
+                    if ($rewritten !== $original) {
+                        $p->set_value($rewritten);
+                    }
                 }
+                return $p->get_updated_serialization();
             }
-            return $p->get_updated_serialization();
         }
 
-        // Try JSON: the iterator calls json_decode in the constructor.
-        // If it's not malformed, iterate and recurse.
-        $iter = new JsonStringIterator($value);
-        if (!$iter->is_malformed()) {
-            while ($iter->next_value()) {
-                $original = $iter->get_value();
-                $rewritten = $this->rewrite($original, $content_type);
-                if ($rewritten !== $original) {
-                    $iter->set_value($rewritten);
+        // JsonStringIterator accepts only object/array documents. After JSON
+        // whitespace, no other leading byte can be accepted by that iterator.
+        if ($this->can_start_json_container($value)) {
+            $iter = new JsonStringIterator($value);
+            if (!$iter->is_malformed()) {
+                while ($iter->next_value()) {
+                    $original = $iter->get_value();
+                    $rewritten = $this->rewrite($original, $content_type);
+                    if ($rewritten !== $original) {
+                        $iter->set_value($rewritten);
+                    }
                 }
+                return $iter->get_result();
             }
-            return $iter->get_result();
         }
 
         // Base64 decoding is temporarily disabled for performance.
@@ -206,6 +211,29 @@ class StructuredDataUrlRewriter
             }
         }
         return false;
+    }
+
+    private function can_start_serialized_php(string $value): bool
+    {
+        if (!isset($value[1])) {
+            return false;
+        }
+
+        if ($value[0] === 'N') {
+            return $value[1] === ';';
+        }
+
+        return strpos('sidbaOCrR', $value[0]) !== false && $value[1] === ':';
+    }
+
+    private function can_start_json_container(string $value): bool
+    {
+        $offset = strspn($value, " \t\r\n");
+        if (!isset($value[$offset])) {
+            return false;
+        }
+
+        return $value[$offset] === '{' || $value[$offset] === '[';
     }
 
     /**

--- a/tests/UrlRewriting/StructuredDataUrlRewriterTest.php
+++ b/tests/UrlRewriting/StructuredDataUrlRewriterTest.php
@@ -130,6 +130,18 @@ class StructuredDataUrlRewriterTest extends TestCase
         $this->assertStringNotContainsString('\\/', $result);
     }
 
+    public function testRewritesJsonAfterLeadingWhitespace(): void
+    {
+        $rewriter = $this->createRewriter();
+        $input = " \n\t{\"url\":\"https://old-site.com/path\"}";
+
+        $result = $rewriter->rewrite($input);
+        $decoded = json_decode($result, true);
+
+        $this->assertNotNull($decoded);
+        $this->assertSame('https://new-site.com/path', $decoded['url']);
+    }
+
     // --- Serialized PHP ---
 
     public function testRewritesUrlInSerializedArray(): void


### PR DESCRIPTION
## What it does

Adds necessary first-byte gates before trying the serialized-PHP and JSON container parsers in the structured URL rewriter.

## Rationale

This is an experiment to see whether avoiding parser construction for impossible values improves the large `db-apply` path. The checks are necessary conditions only: real parsing and validation still belongs to `PhpSerializationProcessor` and `JsonStringIterator`.

The measurement says this is not a useful speedup on the current fixture, but keeping it as a draft PR makes the rejected idea reviewable and keeps the benchmark record attached to the code.

## Implementation

`can_start_serialized_php()` recognizes only legal PHP serialization starters before the serialized parser is attempted. `can_start_json_container()` skips leading JSON whitespace and requires `{` or `[` because the current JSON iterator accepts container documents.

## Benchmark

Fixture: 262 MB SQL dump, PHP.wasm 8.4, php-toolkit native extension loaded, sqlite-database-integration native extension loaded.

| Run | Full `db-apply` | Rewrite-only profile | Notes |
| --- | ---: | ---: | --- |
| Parent PR #220 | 106.93 s | 99.79 s | rigorous parser-owned baseline |
| This branch | not run | 101.03 s | slower in rewrite-only profiling |
| Delta | n/a | +1.24 s (+1.2%) | measured rejection |

## Testing instructions

```bash
php -l packages/reprint-importer/src/lib/url-rewrite/class-structured-data-url-rewriter.php
php -l tests/UrlRewriting/StructuredDataUrlRewriterTest.php
composer test -- --filter StructuredDataUrlRewriterTest
composer analyze
```
