### PR TITLE
Use native plain text literal URL rewrites

### DIFF
--- a/packages/reprint-importer/src/lib/url-rewrite/class-structured-data-url-rewriter.php
+++ b/packages/reprint-importer/src/lib/url-rewrite/class-structured-data-url-rewriter.php
@@ -46,6 +46,12 @@ class StructuredDataUrlRewriter
      */
     private array $plain_text_literal_origin_mappings;
 
+    /** @var string Compact source-origin to target-prefix mappings for the native fast path. */
+    private string $native_plain_text_literal_origin_mapping;
+
+    /** @var bool Whether the native plain text literal URL rewrite function is available. */
+    private bool $native_plain_text_literal_url_rewriter_available;
+
     /**
      * Pre-parsed url_mapping grouped by the URL origin fields used by
      * is_child_url_of(): protocol and normalized hostname. Each entry is
@@ -108,6 +114,7 @@ class StructuredDataUrlRewriter
         // repeated on every leaf we rewrote.
         $this->parsed_mapping_by_origin = [];
         $this->plain_text_literal_origin_mappings = [];
+        $native_plain_text_literal_origin_mappings = [];
         foreach ($url_mapping as $from_url_string => $to_url_string) {
             $from_url = WPURL::parse($from_url_string);
             $mapping = [
@@ -123,8 +130,13 @@ class StructuredDataUrlRewriter
             $literal_mapping = $this->build_plain_text_literal_origin_mapping($from_url_string, $to_url_string);
             if ($literal_mapping !== null) {
                 $this->plain_text_literal_origin_mappings[] = $literal_mapping;
+                $native_plain_text_literal_origin_mappings[] = $literal_mapping['from'] . "\x1f" . $literal_mapping['to'];
             }
         }
+        $this->native_plain_text_literal_origin_mapping = implode("\x1e", $native_plain_text_literal_origin_mappings);
+        $this->native_plain_text_literal_url_rewriter_available =
+            function_exists('wp_native_apis_rewrite_plain_text_literal_urls') &&
+            (!defined('WP_NATIVE_APIS_DISABLE_DEFAULTS') || !WP_NATIVE_APIS_DISABLE_DEFAULTS);
         $this->mapping_cache_key = sha1(json_encode($url_mapping, JSON_UNESCAPED_SLASHES));
 
         // Default base_url: first from-url in the mapping. Preserves the
@@ -499,7 +511,39 @@ class StructuredDataUrlRewriter
      */
     public function rewrite_plain_text_literal_leaf(string $content)
     {
+        $native_rewrite = $this->try_native_rewrite_plain_text_literal_urls($content);
+        if ($native_rewrite !== false) {
+            return $native_rewrite;
+        }
+
         return $this->try_rewrite_plain_text_literal_origins($content);
+    }
+
+    /**
+     * Try native plain text literal source-origin rewriting.
+     *
+     * The native primitive has the same rigor as the PHP path below: it only
+     * rewrites known plain text leaves using pre-normalized HTTP(S)
+     * source-origin mappings, and returns false when the generic parser-owned
+     * path must handle the value.
+     *
+     * @return false|string false when the generic URL processor must handle it.
+     */
+    private function try_native_rewrite_plain_text_literal_urls(string $content)
+    {
+        if (
+            !$this->native_plain_text_literal_url_rewriter_available ||
+            $this->native_plain_text_literal_origin_mapping === ''
+        ) {
+            return false;
+        }
+
+        $rewritten = \wp_native_apis_rewrite_plain_text_literal_urls(
+            $content,
+            $this->native_plain_text_literal_origin_mapping
+        );
+
+        return is_string($rewritten) ? $rewritten : false;
     }
 
     /**

--- a/phpstan-bootstrap.php
+++ b/phpstan-bootstrap.php
@@ -17,3 +17,14 @@ if (!function_exists('trailingslashit')) {
         return rtrim($value, '/\\') . '/';
     }
 }
+
+if (!function_exists('wp_native_apis_rewrite_plain_text_literal_urls')) {
+    /**
+     * PHPStan bootstrap stub for the optional php-toolkit PHP.wasm native extension.
+     *
+     * @return false|string
+     */
+    function wp_native_apis_rewrite_plain_text_literal_urls(string $content, string $compact_mapping) {
+        return false;
+    }
+}

--- a/tests/UrlRewriting/StructuredDataUrlRewriterTest.php
+++ b/tests/UrlRewriting/StructuredDataUrlRewriterTest.php
@@ -5,6 +5,21 @@ use PHPUnit\Framework\TestCase;
 require_once __DIR__ . '/../../vendor/autoload.php';
 require_once __DIR__ . '/../../packages/reprint-importer/src/lib/url-rewrite/load.php';
 
+if (!function_exists('wp_native_apis_rewrite_plain_text_literal_urls')) {
+    define('REPRINT_TEST_FAKE_NATIVE_PLAIN_TEXT_LITERAL_URL_REWRITE', true);
+    function wp_native_apis_rewrite_plain_text_literal_urls(string $content, string $compact_mapping)
+    {
+        $GLOBALS['reprint_test_native_plain_text_literal_url_rewrite_calls'] =
+            ($GLOBALS['reprint_test_native_plain_text_literal_url_rewrite_calls'] ?? 0) + 1;
+
+        if (array_key_exists('reprint_test_native_plain_text_literal_url_rewrite_result', $GLOBALS)) {
+            return $GLOBALS['reprint_test_native_plain_text_literal_url_rewrite_result'];
+        }
+
+        return false;
+    }
+}
+
 class StructuredDataUrlRewriterTest extends TestCase
 {
     private function createRewriter(?array $mapping = null): StructuredDataUrlRewriter
@@ -61,6 +76,27 @@ class StructuredDataUrlRewriterTest extends TestCase
         $input = 'Visit us at https://old-site.com/about for more info.';
         $result = $rewriter->rewrite($input);
         $this->assertStringContainsString('https://new-site.com/about', $result);
+    }
+
+    public function testUsesNativePlainTextLiteralUrlRewriteWhenAvailable(): void
+    {
+        if (!defined('REPRINT_TEST_FAKE_NATIVE_PLAIN_TEXT_LITERAL_URL_REWRITE')) {
+            $this->markTestSkipped('The real native extension is loaded; this test only exercises the fake native hook.');
+        }
+
+        $GLOBALS['reprint_test_native_plain_text_literal_url_rewrite_calls'] = 0;
+        $GLOBALS['reprint_test_native_plain_text_literal_url_rewrite_result'] = 'native rewrite result';
+
+        try {
+            $rewriter = $this->createRewriter();
+            $this->assertSame(
+                'native rewrite result',
+                $rewriter->rewrite_plain_text_literal_leaf('Visit https://old-site.com/about')
+            );
+            $this->assertSame(1, $GLOBALS['reprint_test_native_plain_text_literal_url_rewrite_calls']);
+        } finally {
+            unset($GLOBALS['reprint_test_native_plain_text_literal_url_rewrite_result']);
+        }
     }
 
     public function testDoesNotRewriteNonUrlsInText(): void


### PR DESCRIPTION
## What changed

Uses the optional `wp_native_apis_rewrite_plain_text_literal_urls()` function when the php-toolkit native extension exposes it.

The existing PHP literal fast path remains the fallback. If the native function is missing, disabled, or returns `false`, reprint continues through the same parser-owned PHP path as before.

Depends on WordPress/php-toolkit#285 for the native PHP.wasm function.

## Why

The PHP literal fast path removed the large URL parser cost, but still handled 251k plain leaf rewrites in userland on the large fixture. This moves that narrow leaf rewrite into native code without changing the rigor boundary: structured data still has to be parsed by its owning parser, and the native function refuses ambiguous text.

## Benchmarks

Fixture: 262 MB SQL dump, 865 statements, 928,540 base64 values, 251,258 rewritten source-domain values. PHP.wasm 8.4.21, sqlite parser native extension loaded. Native run uses the locally built manifest from WordPress/php-toolkit#285.

### Rewrite-only profile

| path | total profile | plain literal rewrite bucket | change |
|---|---:|---:|---:|
| PHP literal fallback | 7.53 s | 1.86 s | baseline |
| Native literal function | 6.45 s | 0.83 s | 1.17x total, 2.25x bucket |

### Full db-apply

| path | run 1 | run 2 | mean |
|---|---:|---:|---:|
| PHP literal fallback | 31.60 s | - | 31.60 s |
| Native literal function | 28.80 s | 30.12 s | 29.46 s |

That is roughly 6.8% faster end-to-end on this fixture. The smaller full-run delta is expected: after the previous fast path, URL rewriting is no longer the dominant cost and the remaining SQLite/import floor is large.

## Validation

- `composer test -- UrlRewriting/StructuredDataUrlRewriterTest.php UrlRewriting/SqlStatementRewriterTest.php`
- `composer analyze`
- `composer build:phar`
- Full PHP.wasm db-apply with old php-toolkit manifest
- Full PHP.wasm db-apply with the locally built php-toolkit native literal manifest
- Rewrite-only PHP.wasm profiles for both manifests
