### PR TITLE
Restore structured URL rewrite ownership

### DIFF
--- a/packages/reprint-importer/src/lib/url-rewrite/class-sql-statement-rewriter.php
+++ b/packages/reprint-importer/src/lib/url-rewrite/class-sql-statement-rewriter.php
@@ -12,7 +12,7 @@
  * WordPress core columns known to contain block markup (post_content, comment_content,
  * etc.) get the 'block_markup' hint so wp_rewrite_urls() handles HTML attributes,
  * block comment JSON, and CSS url(). All other columns default to auto-detect with
- * plain text strtr() replacement, which is simpler and more predictable for columns
+ * plain-text URL processing, which is simpler and more predictable for columns
  * that contain serialized PHP, JSON, or plain strings.
  *
  * Column resolution walks the lexer output directly. Both INSERT and UPDATE
@@ -191,9 +191,10 @@ class SqlStatementRewriter
                 }
             }
 
-            // Rewrite URLs in the value. Known block-markup columns can first
-            // try a boundary-checked literal base URL swap before falling back
-            // to the full structured parser.
+            // Rewrite URLs in the value. Known block-markup columns go through
+            // the block-markup parser first; unknown columns are treated as
+            // plain text only after the structured-data layers have declined
+            // ownership.
             $rewritten = $content_type === StructuredDataUrlRewriter::BLOCK_MARKUP
                 ? $this->url_rewriter->rewrite_known_block_markup_value($value)
                 : $this->url_rewriter->rewrite($value, $content_type);

--- a/packages/reprint-importer/src/lib/url-rewrite/class-structured-data-url-rewriter.php
+++ b/packages/reprint-importer/src/lib/url-rewrite/class-structured-data-url-rewriter.php
@@ -5,7 +5,6 @@ use WordPress\DataLiberation\URL\URLInTextProcessor;
 use WordPress\DataLiberation\URL\WPURL;
 
 use function WordPress\DataLiberation\URL\is_child_url_of;
-use function WordPress\DataLiberation\URL\wp_rewrite_urls;
 
 /**
  * Rewrites URLs in a single decoded database value by detecting the data
@@ -20,7 +19,7 @@ use function WordPress\DataLiberation\URL\wp_rewrite_urls;
  * 2. JSON → construct JsonStringIterator, if not malformed, iterate string
  *    values and recurse on each
  * 3. Base64 → decode, recurse on decoded content, re-encode if changed
- * 4. Leaf text → wp_rewrite_urls() (block_markup hint) or strtr() (default)
+ * 4. Leaf text → the URL processor for the caller-owned content type.
  *
  * HTML is never auto-detected — the caller must explicitly pass
  * content_type='block_markup' for values known to contain HTML/block markup.
@@ -35,12 +34,6 @@ class StructuredDataUrlRewriter
 
     /** @var string[] Source domains extracted from url_mapping keys, for quick-reject checks. */
     private array $source_domains;
-
-    /** @var array<string, string> Literal base URL replacements for the block-markup fast path. */
-    private array $literal_base_url_replacements;
-
-    /** @var string[] Unescaped source base URLs, used to avoid changing block-comment JSON formatting. */
-    private array $literal_source_base_urls;
 
     /**
      * Pre-parsed url_mapping: each entry is
@@ -94,22 +87,12 @@ class StructuredDataUrlRewriter
         // (scheme/host/path tokenisation, punycode, etc.) and used to be
         // repeated on every leaf we rewrote.
         $this->parsed_mapping = [];
-        $this->literal_base_url_replacements = [];
-        $this->literal_source_base_urls = [];
         foreach ($url_mapping as $from_url_string => $to_url_string) {
             $this->parsed_mapping[] = [
                 'from_url' => WPURL::parse($from_url_string),
                 'to_url'   => WPURL::parse($to_url_string),
             ];
-
-            $this->literal_source_base_urls[] = $from_url_string;
-            $this->literal_base_url_replacements[$from_url_string] = $to_url_string;
-            $this->literal_base_url_replacements[str_replace('/', '\/', $from_url_string)] = str_replace('/', '\/', $to_url_string);
         }
-        uksort(
-            $this->literal_base_url_replacements,
-            static fn ($a, $b) => strlen($b) <=> strlen($a)
-        );
         $this->mapping_cache_key = sha1(json_encode($url_mapping, JSON_UNESCAPED_SLASHES));
 
         // Default base_url: first from-url in the mapping. Preserves the
@@ -208,12 +191,10 @@ class StructuredDataUrlRewriter
     /**
      * Rewrite a decoded value already known by the SQL layer to be block markup.
      *
-     * This takes a conservative fast path for the common dump shape where the
-     * value contains literal absolute source URLs in HTML attributes, text, CSS,
-     * or block-comment JSON. In that case a boundary-checked base URL swap gives
-     * the same result as BlockMarkupUrlProcessor without constructing the full
-     * parser stack for every row. If any source URL occurrence is not at a URL
-     * boundary, we fall back to the full structured rewriter.
+     * The SQL layer owns the column-level decision that this value is block
+     * markup. Once it makes that decision, the value must stay in the structured
+     * block-markup path so URLs in HTML attributes, text nodes, block-comment
+     * JSON, and nested values are found and rewritten by their owning parsers.
      */
     public function rewrite_known_block_markup_value(string $value): string
     {
@@ -225,84 +206,7 @@ class StructuredDataUrlRewriter
             return $value;
         }
 
-        $literal_rewrite = $this->try_rewrite_literal_base_urls($value);
-        if ($literal_rewrite !== null) {
-            return $literal_rewrite;
-        }
-
         return $this->rewrite($value, self::BLOCK_MARKUP);
-    }
-
-    private function try_rewrite_literal_base_urls(string $value): ?string
-    {
-        if ($this->has_unescaped_source_url_in_block_comment($value)) {
-            return null;
-        }
-
-        $matched = false;
-        foreach ($this->literal_base_url_replacements as $from => $_to) {
-            $offset = 0;
-            while (true) {
-                $pos = strpos($value, $from, $offset);
-                if ($pos === false) {
-                    break;
-                }
-                if (!$this->is_literal_base_url_boundary($value, $pos, strlen($from))) {
-                    return null;
-                }
-                $matched = true;
-                $offset = $pos + strlen($from);
-            }
-        }
-
-        return $matched ? strtr($value, $this->literal_base_url_replacements) : null;
-    }
-
-    private function has_unescaped_source_url_in_block_comment(string $value): bool
-    {
-        $comment_start = 0;
-        while (true) {
-            $comment_start = strpos($value, '<!-- wp:', $comment_start);
-            if ($comment_start === false) {
-                return false;
-            }
-
-            $comment_end = strpos($value, '-->', $comment_start);
-            if ($comment_end === false) {
-                return false;
-            }
-
-            foreach ($this->literal_source_base_urls as $source_url) {
-                $source_pos = strpos($value, $source_url, $comment_start);
-                if ($source_pos !== false && $source_pos < $comment_end) {
-                    return true;
-                }
-            }
-
-            $comment_start = $comment_end + 3;
-        }
-    }
-
-    private function is_literal_base_url_boundary(string $value, int $pos, int $length): bool
-    {
-        if ($pos > 0) {
-            $prev = $value[$pos - 1];
-            if (
-                !ctype_space($prev)
-                && strpos('"\'([{,:>', $prev) === false
-            ) {
-                return false;
-            }
-        }
-
-        $next_pos = $pos + $length;
-        if ($next_pos >= strlen($value)) {
-            return true;
-        }
-
-        $next = $value[$next_pos];
-        return ctype_space($next)
-            || strpos('/\\?#"\'<)]},;', $next) !== false;
     }
 
     /**

--- a/tests/UrlRewriting/SqlStatementRewriterTest.php
+++ b/tests/UrlRewriting/SqlStatementRewriterTest.php
@@ -196,7 +196,8 @@ class SqlStatementRewriterTest extends TestCase
     public function testUnknownColumnUsesPlainTextReplacement(): void
     {
         $rewriter = $this->createRewriter();
-        // A plain URL in a non-block-markup column — should use strtr()
+        // A plain URL in a non-block-markup column uses the plain-text URL
+        // processor after the structured-data layers decline ownership.
         $value = 'https://old-site.com/api/endpoint';
         $encoded = base64_encode($value);
         $sql = "INSERT INTO `wp_options` (`option_name`, `option_value`) VALUES(FROM_BASE64('" . base64_encode('siteurl') . "'), FROM_BASE64('{$encoded}'));";
@@ -204,7 +205,7 @@ class SqlStatementRewriterTest extends TestCase
         $result = $rewriter->rewrite($sql);
 
         $values = $this->collectValues($result);
-        // option_value should be rewritten via strtr
+        // option_value should still be rewritten.
         $this->assertStringContainsString('new-site.com/api/endpoint', $values[1]);
     }
 
@@ -403,12 +404,8 @@ class SqlStatementRewriterTest extends TestCase
         $result = $rewriter->rewrite($sql);
 
         // post_content in this unknown table should NOT get the block_markup
-        // hint — it falls back to auto-detect (plain text strtr), which still
-        // rewrites URLs but through a different code path. The key assertion
-        // is that get_content_type returns null, not 'block_markup'. We verify
-        // indirectly: block_markup would parse the HTML structure, plain text
-        // just does strtr. Both rewrite the URL, so we confirm the rewrite
-        // happens (auto-detect is fine) but the table was not matched as "posts".
+        // hint. It still rewrites plain text URLs after the structured-data
+        // layers decline ownership, but the table was not matched as "posts".
         $values = $this->collectValues($result);
         $this->assertCount(1, $values);
         $this->assertStringContainsString('new-site.com/page', $values[0]);
@@ -425,13 +422,8 @@ class SqlStatementRewriterTest extends TestCase
 
         $result = $rewriter->rewrite($sql);
 
-        // The value still gets rewritten (auto-detect/plain text), but it must
-        // NOT have been treated as block_markup. We can tell because plain text
-        // strtr rewrites the URL but doesn't parse block comment JSON attributes.
-        // With a simple URL like this both paths produce the same output, so
-        // we use a value that distinguishes them: a block comment with a JSON
-        // attribute. block_markup would rewrite inside the JSON; plain text
-        // strtr would not touch the JSON attribute.
+        // The value still gets rewritten by the plain-text leaf processor, but
+        // it must NOT have been treated as block_markup.
         $values = $this->collectValues($result);
         $this->assertCount(1, $values);
         $this->assertStringContainsString('new-site.com', $values[0]);
@@ -480,8 +472,8 @@ class SqlStatementRewriterTest extends TestCase
     /**
      * A block comment JSON attribute lets us distinguish block_markup from
      * plain text rewriting. block_markup parses the JSON inside
-     * <!-- wp:image {"url":"..."} --> and rewrites it. Plain text strtr does
-     * a byte-for-byte replacement that can break JSON when URL lengths change.
+     * <!-- wp:image {"url":"..."} --> and rewrites it as block markup; plain
+     * text URL processing treats the whole value as unknown leaf text.
      *
      * We use this to prove that "wp_posts".post_content gets block_markup
      * while a spoofed table does NOT.
@@ -489,7 +481,7 @@ class SqlStatementRewriterTest extends TestCase
     public function testBlockMarkupVsPlainTextDistinction(): void
     {
         $rewriter = $this->createRewriter([
-            // Different-length URLs so strtr would shift offsets and break JSON
+            // Different-length URLs make the two processors easier to tell apart.
             'https://old-site.com' => 'https://new-longer-domain-site.com',
         ]);
 
@@ -514,14 +506,12 @@ class SqlStatementRewriterTest extends TestCase
 
         // spoofed_posts.post_content → auto-detect (not block_markup): the
         // column name matches but the table doesn't, so it falls through to
-        // plain text strtr.
+        // plain text leaf processing.
         $sql_spoof = "INSERT INTO `spoofed_posts` (`ID`, `post_content`) VALUES(1, FROM_BASE64('{$encoded}'));";
         $result_spoof = $rewriter->rewrite($sql_spoof);
         $values_spoof = $this->collectValues($result_spoof);
         // The URL is still rewritten (auto-detect handles it), but the JSON
-        // attribute inside the block comment may be malformed because strtr
-        // doesn't understand HTML structure. The key point: the spoofed table
-        // was NOT given the block_markup hint.
+        // The key point: the spoofed table was NOT given the block_markup hint.
         $this->assertStringContainsString('new-longer-domain-site.com', $values_spoof[0]);
     }
 

--- a/tests/UrlRewriting/StructuredDataUrlRewriterTest.php
+++ b/tests/UrlRewriting/StructuredDataUrlRewriterTest.php
@@ -328,7 +328,7 @@ class StructuredDataUrlRewriterTest extends TestCase
     {
         $rewriter = $this->createRewriter();
         // Block markup with JSON attribute — wp_rewrite_urls() handles the JSON
-        // inside the block comment, strtr() would not
+        // inside the block comment.
         $input = '<!-- wp:image {"src":"https://old-site.com/img.jpg"} --><figure><img src="https://old-site.com/img.jpg"/></figure><!-- /wp:image -->';
         $result = $rewriter->rewrite($input, 'block_markup');
         $this->assertStringNotContainsString('old-site.com', $result);
@@ -343,7 +343,7 @@ class StructuredDataUrlRewriterTest extends TestCase
         $this->assertStringContainsString('https://new-site.com/page', $result);
     }
 
-    public function testKnownBlockMarkupFastPathRewritesEscapedBlockJsonAndHtml(): void
+    public function testKnownBlockMarkupRewritesEscapedBlockJsonAndHtml(): void
     {
         $rewriter = $this->createRewriter();
         $input = '<!-- wp:image {"src":"https:\/\/old-site.com\/img.jpg"} -->'
@@ -357,7 +357,7 @@ class StructuredDataUrlRewriterTest extends TestCase
         $this->assertStringNotContainsString('old-site.com', $result);
     }
 
-    public function testKnownBlockMarkupFastPathFallsBackForEmbeddedQueryUrl(): void
+    public function testKnownBlockMarkupLeavesEmbeddedQueryUrlAlone(): void
     {
         $rewriter = $this->createRewriter();
         $input = '<a href="https://webarchive.org?url=https://old-site.com/about">Archive</a>';
@@ -365,12 +365,12 @@ class StructuredDataUrlRewriterTest extends TestCase
         $this->assertSame($input, $rewriter->rewrite_known_block_markup_value($input));
     }
 
-    // --- Content type hint: null (default) uses plain text replacement ---
+    // --- Content type hint: null (default) uses plain text URL processing ---
 
     public function testDefaultHintUsesPlainTextReplacement(): void
     {
         $rewriter = $this->createRewriter();
-        // A plain URL string — strtr() handles this fine
+        // A plain URL string is handled by URLInTextProcessor.
         $input = 'Visit https://old-site.com/about for more.';
         $result = $rewriter->rewrite($input);
         $this->assertStringContainsString('https://new-site.com/about', $result);


### PR DESCRIPTION
## What it does

- Removes the literal base-URL replacement shortcut from `StructuredDataUrlRewriter`.
- Keeps values known to be block markup on the block-markup parser path.
- Updates comments and tests that described plain-text URL rewriting as `strtr()`.

## Rationale

The removed shortcut rewrote URL bytes before the structured URL processors owned the value. That was fast, but it violated the parser-ownership rule: block markup, block-comment JSON, HTML attributes, and plain text should each be rewritten by the processor responsible for that format.

This PR intentionally establishes the rigorous baseline for the follow-up speed experiments.

## Benchmark

Fixture: manual large db-apply run, 262 MB SQL, 865 statements, 932,459 `FROM_BASE64` values, PHP.wasm 8.4, both native manifests loaded (`wp_native_apis` and `wp_mysql_parser`).

Command shape: `db-apply --target-engine=sqlite --rewrite-url https://127.0.0.1:8199 http://localhost:8881 --rewrite-url http://127.0.0.1:8199 http://localhost:8881`

| Comparison | Base | Candidate | Delta |
|---|---:|---:|---:|
| `trunk` -> this PR | 139.06 s | 155.27 s | +16.21 s / +11.7% |

The regression is expected: this removes an unsafe shortcut and restores parser-owned rewriting. Follow-up PRs in the stack try to recover the performance without reintroducing literal URL replacement.

## Testing

- `vendor/bin/phpunit --configuration tests/phpunit.xml tests/UrlRewriting`
- Included in stack benchmark under `.context/reprint-profile/stack-bench-1779308725`
