### PR TITLE
Inline base64 values for SQLite db apply

### DIFF
--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -5118,6 +5118,7 @@ class ImportClient
         }
 
         [$pdo, $connection_label] = $this->create_target_db_apply_connection($options);
+        $inline_base64_values_for_sqlite = strtolower((string) ($options["target_engine"] ?? "mysql")) === "sqlite";
 
         $this->audit_log(
             "CONNECTED | {$connection_label}",
@@ -5222,9 +5223,14 @@ class ImportClient
                         continue;
                     }
 
-                    // Rewrite URLs if mapping is configured
+                    // Rewrite URLs if mapping is configured. For SQLite,
+                    // also inline complete FROM_BASE64(...) expressions as
+                    // MySQL hex literals so the SQLite driver does not call a
+                    // PHP user-defined function for every encoded value.
                     if ($stmt_rewriter) {
-                        $query = $stmt_rewriter->rewrite($query);
+                        $query = $stmt_rewriter->rewrite($query, $inline_base64_values_for_sqlite);
+                    } elseif ($inline_base64_values_for_sqlite) {
+                        $query = SqlStatementRewriter::rewrite_base64_values_as_sqlite_literals($query);
                     }
 
                     // Execute against target database
@@ -5300,7 +5306,9 @@ class ImportClient
                 }
 
                 if ($stmt_rewriter) {
-                    $query = $stmt_rewriter->rewrite($query);
+                    $query = $stmt_rewriter->rewrite($query, $inline_base64_values_for_sqlite);
+                } elseif ($inline_base64_values_for_sqlite) {
+                    $query = SqlStatementRewriter::rewrite_base64_values_as_sqlite_literals($query);
                 }
 
                 try {

--- a/packages/reprint-importer/src/lib/url-rewrite/class-base64-value-scanner.php
+++ b/packages/reprint-importer/src/lib/url-rewrite/class-base64-value-scanner.php
@@ -5,9 +5,12 @@
  * statement, letting the caller read and replace each decoded value.
  *
  * Uses WP_MySQL_Lexer for proper tokenization instead of string scanning.
- * Detects CONVERT(FROM_BASE64('...') USING utf8mb4) wrappers automatically —
+ * Detects CONVERT(FROM_BASE64('...') USING utf8mb4) wrappers automatically.
  * set_value() only replaces the base64 payload inside the quotes, so wrappers
- * are preserved without the caller needing to know about them.
+ * are preserved without the caller needing to know about them. The scanner also
+ * records the full expression range when the wrapper shape is complete, which
+ * lets SQLite callers replace the function call with a literal instead of
+ * invoking a per-row user-defined function.
  *
  * Values are decoded lazily. The scanner keeps the original encoded payload
  * until get_value() is called, so callers can skip obviously irrelevant values
@@ -32,13 +35,14 @@ class Base64ValueScanner
     /**
      * Each entry tracks one FROM_BASE64() value found in the SQL:
      *   'expr_start'   => int    Offset of the outermost expression (CONVERT or FROM_BASE64)
+     *   'expr_length'  => ?int   Length of the complete outer expression, when recognised
      *   'quote_start'  => int    Offset of the quoted string token (including quotes)
      *   'quote_length' => int    Length of the quoted string token
      *   'encoded_value'=> string The base64 payload
      *   'value'        => ?string The base64-decoded value, cached on demand
      *   'new_value'    => ?string Non-null when set_value() has been called
      *
-     * @var array<int, array{expr_start: int, quote_start: int, quote_length: int, encoded_value: string, value: ?string, new_value: ?string}>
+     * @var array<int, array{expr_start: int, expr_length: ?int, quote_start: int, quote_length: int, encoded_value: string, value: ?string, new_value: ?string}>
      */
     private array $entries = [];
 
@@ -70,7 +74,7 @@ class Base64ValueScanner
      * already located every FROM_BASE64() expression and captured its payload,
      * the scanner skips the lexer and still decodes values lazily.
      *
-     * @param list<array{expr_start: int, quote_start: int, quote_length: int, encoded_value: string, value: ?string, new_value: ?string}> $entries
+     * @param list<array{expr_start: int, expr_length: ?int, quote_start: int, quote_length: int, encoded_value: string, value: ?string, new_value: ?string}> $entries
      */
     public static function from_entries(string $sql, array $entries): self
     {
@@ -172,66 +176,64 @@ class Base64ValueScanner
     }
 
     /**
+     * Return SQL with every complete FROM_BASE64(...) expression rewritten as a
+     * MySQL hex literal that the SQLite driver can translate.
+     *
+     * The replacement is 0x..., not a quoted SQL string. Hex literals keep
+     * arbitrary decoded bytes out of the SQL text, and WP_PDO_MySQL_On_SQLite
+     * already translates MySQL hex literals into the SQLite representation it
+     * expects. Empty strings use '' because bare 0x is not a valid MySQL token.
+     */
+    public function get_result_with_sqlite_compatible_literals(): string
+    {
+        if (empty($this->entries)) {
+            return $this->sql;
+        }
+
+        $parts = [];
+        $cursor = 0;
+        $used_sqlite_literals = false;
+        foreach ($this->entries as $entry) {
+            if ($entry['expr_length'] !== null) {
+                $value = $entry['new_value'] ?? $entry['value'];
+                if ($value === null) {
+                    $decoded = base64_decode($entry['encoded_value'], true);
+                    $value = $decoded !== false ? $decoded : '';
+                }
+
+                $hex = bin2hex($value);
+                $replacement = $hex === '' ? "''" : '0x' . $hex;
+                $parts[] = substr($this->sql, $cursor, $entry['expr_start'] - $cursor);
+                $parts[] = $replacement;
+                $cursor = $entry['expr_start'] + $entry['expr_length'];
+                $used_sqlite_literals = true;
+            } elseif ($entry['new_value'] !== null) {
+                $replacement = "'" . base64_encode($entry['new_value']) . "'";
+                $parts[] = substr($this->sql, $cursor, $entry['quote_start'] - $cursor);
+                $parts[] = $replacement;
+                $cursor = $entry['quote_start'] + $entry['quote_length'];
+            }
+        }
+        $parts[] = substr($this->sql, $cursor);
+
+        return $used_sqlite_literals || $this->dirty ? implode('', $parts) : $this->sql;
+    }
+
+    /**
      * Tokenize the SQL and find all FROM_BASE64('...') expressions.
-     * Tracks whether each is wrapped in CONVERT(...) for correct expr_start offset.
      */
     private function scan(): void
     {
         $lexer = new WP_MySQL_Lexer($this->sql);
-
-        // Track the last two tokens so we can detect CONVERT( before FROM_BASE64.
-        // next_token() skips whitespace/comments, so CONVERT ( FROM_BASE64 appears
-        // as three consecutive tokens.
-        $prev = [null, null];
-
-        while ($lexer->next_token()) {
-            $token = $lexer->get_token();
-
-            if (
-                $token->id === WP_MySQL_Lexer::IDENTIFIER
-                && strtoupper($token->get_value()) === 'FROM_BASE64'
-            ) {
-                $expr_start = $token->start;
-
-                // If the previous tokens are CONVERT + (, the outer expression
-                // starts at CONVERT, not at FROM_BASE64.
-                if (
-                    $prev[1] !== null
-                    && $prev[1]->id === WP_MySQL_Lexer::OPEN_PAR_SYMBOL
-                    && $prev[0] !== null
-                    && $prev[0]->id === WP_MySQL_Lexer::CONVERT_SYMBOL
-                ) {
-                    $expr_start = $prev[0]->start;
-                }
-
-                // Advance past ( to find the quoted base64 string
-                while ($lexer->next_token()) {
-                    $inner = $lexer->get_token();
-                    if (
-                        $inner->id === WP_MySQL_Lexer::SINGLE_QUOTED_TEXT
-                        || $inner->id === WP_MySQL_Lexer::DOUBLE_QUOTED_TEXT
-                    ) {
-                        $this->entries[] = [
-                            'expr_start' => $expr_start,
-                            'quote_start' => $inner->start,
-                            'quote_length' => $inner->length,
-                            'encoded_value' => $inner->get_value(),
-                            'value' => null,
-                            'new_value' => null,
-                        ];
-                        break;
-                    }
-                    // Skip the opening parenthesis of FROM_BASE64(
-                    if ($inner->id !== WP_MySQL_Lexer::OPEN_PAR_SYMBOL) {
-                        break;
-                    }
-                }
-            }
-
-            // Shift the two-token window
-            $prev[0] = $prev[1];
-            $prev[1] = $token;
+        $tokens = $lexer->remaining_tokens();
+        if (
+            !empty($tokens)
+            && end($tokens)->id === WP_MySQL_Lexer::EOF
+        ) {
+            array_pop($tokens);
         }
+
+        $this->scan_tokens($tokens);
     }
 
     /**
@@ -261,6 +263,7 @@ class Base64ValueScanner
                 && strtoupper($token->get_value()) === 'FROM_BASE64'
             ) {
                 $expr_start = $token->start;
+                $has_convert_wrapper = false;
 
                 if (
                     $prev[1] !== null
@@ -269,6 +272,7 @@ class Base64ValueScanner
                     && $prev[0]->id === WP_MySQL_Lexer::CONVERT_SYMBOL
                 ) {
                     $expr_start = $prev[0]->start;
+                    $has_convert_wrapper = true;
                 }
 
                 // Walk forward to find the quoted base64 payload, mirroring
@@ -280,8 +284,16 @@ class Base64ValueScanner
                         $inner->id === WP_MySQL_Lexer::SINGLE_QUOTED_TEXT
                         || $inner->id === WP_MySQL_Lexer::DOUBLE_QUOTED_TEXT
                     ) {
+                        $expr_length = self::get_expression_length(
+                            $tokens,
+                            $i,
+                            $j,
+                            $expr_start,
+                            $has_convert_wrapper
+                        );
                         $this->entries[] = [
                             'expr_start' => $expr_start,
+                            'expr_length' => $expr_length,
                             'quote_start' => $inner->start,
                             'quote_length' => $inner->length,
                             'encoded_value' => $inner->get_value(),
@@ -299,6 +311,40 @@ class Base64ValueScanner
             $prev[0] = $prev[1];
             $prev[1] = $token;
         }
+    }
+
+    /**
+     * Return the byte length of the complete expression when the token stream
+     * contains a balanced FROM_BASE64(...) or CONVERT(FROM_BASE64(...) USING ...)
+     * expression. Null means the scanner can still rewrite the quoted payload,
+     * but SQLite literal inlining should leave the expression intact.
+     *
+     * @param WP_MySQL_Token[] $tokens
+     */
+    private static function get_expression_length(array $tokens, int $from_base64_index, int $quote_index, int $expr_start, bool $has_convert_wrapper): ?int
+    {
+        $open_index = $from_base64_index + 1;
+        if (
+            !isset($tokens[$open_index])
+            || $tokens[$open_index]->id !== WP_MySQL_Lexer::OPEN_PAR_SYMBOL
+        ) {
+            return null;
+        }
+
+        $depth = $has_convert_wrapper ? 2 : 1;
+        $token_count = count($tokens);
+        for ($i = $quote_index + 1; $i < $token_count; $i++) {
+            if ($tokens[$i]->id === WP_MySQL_Lexer::OPEN_PAR_SYMBOL) {
+                $depth++;
+            } elseif ($tokens[$i]->id === WP_MySQL_Lexer::CLOSE_PAR_SYMBOL) {
+                $depth--;
+                if ($depth === 0) {
+                    return ($tokens[$i]->start + $tokens[$i]->length) - $expr_start;
+                }
+            }
+        }
+
+        return null;
     }
 
     private static function encoded_payload_could_decode_to_http_scheme(string $payload): bool

--- a/packages/reprint-importer/src/lib/url-rewrite/class-fast-insert-scanner.php
+++ b/packages/reprint-importer/src/lib/url-rewrite/class-fast-insert-scanner.php
@@ -37,7 +37,7 @@ class FastInsertScanner
      * @return array{
      *   table: string,
      *   column_map: list<array{int, int, string}>,
-     *   base64_entries: list<array{expr_start: int, quote_start: int, quote_length: int, encoded_value: string, value: ?string, new_value: ?string}>
+     *   base64_entries: list<array{expr_start: int, expr_length: ?int, quote_start: int, quote_length: int, encoded_value: string, value: ?string, new_value: ?string}>
      * }|null
      *   Null when the SQL doesn't match the recognised shape.
      */
@@ -139,12 +139,13 @@ class FastInsertScanner
                 $column_map[] = [$value_start, $value_end, $columns[$col_idx]];
 
                 if (is_array($value_kind)) {
-                    // FROM_BASE64 payload: kind = [expr_start, quote_start, quote_length, encoded_value]
+                    // FROM_BASE64 payload: kind = [expr_start, expr_length, quote_start, quote_length, encoded_value]
                     $base64_entries[] = [
                         'expr_start' => $value_kind[0],
-                        'quote_start' => $value_kind[1],
-                        'quote_length' => $value_kind[2],
-                        'encoded_value' => $value_kind[3],
+                        'expr_length' => $value_kind[1],
+                        'quote_start' => $value_kind[2],
+                        'quote_length' => $value_kind[3],
+                        'encoded_value' => $value_kind[4],
                         'value' => null,
                         'new_value' => null,
                     ];
@@ -199,10 +200,10 @@ class FastInsertScanner
     /**
      * Scan one value in producer's tuple shape, advancing $cursor past it.
      *
-     * @return null|true|array{int,int,int,string}
+     * @return null|true|array{int,int,int,int,string}
      *   null = unrecognized shape (caller bails)
      *   true = recognised, no FROM_BASE64 entry to record
-     *   array = FROM_BASE64 payload, [expr_start, quote_start, quote_length, encoded]
+     *   array = FROM_BASE64 payload, [expr_start, expr_length, quote_start, quote_length, encoded]
      */
     private static function scan_value(string $sql, int $sql_len, int &$cursor)
     {
@@ -235,7 +236,7 @@ class FastInsertScanner
         ) {
             $expr_start = $cursor;
             $cursor += 12; // step past "FROM_BASE64("
-            return self::consume_base64_call($sql, $sql_len, $cursor, $expr_start, /*has_convert=*/false);
+            return self::consume_base64_call($sql, $sql_len, $cursor, $expr_start);
         }
 
         // CONVERT(FROM_BASE64('…') USING utf8mb4)
@@ -256,7 +257,7 @@ class FastInsertScanner
                 return null;
             }
             $cursor += 12;
-            $entry = self::consume_base64_call($sql, $sql_len, $cursor, $expr_start, /*has_convert=*/true);
+            $entry = self::consume_base64_call($sql, $sql_len, $cursor, $expr_start);
             if (!is_array($entry)) {
                 return null;
             }
@@ -282,6 +283,7 @@ class FastInsertScanner
                 return null;
             }
             $cursor++;
+            $entry[1] = $cursor - $expr_start;
             return $entry;
         }
 
@@ -319,11 +321,11 @@ class FastInsertScanner
     /**
      * Inside a FROM_BASE64( … ) call, with $cursor already past the opening
      * paren. Reads the quoted base64 string and the closing paren. Returns
-     * the [expr_start, quote_start, quote_length, encoded] tuple.
+     * the [expr_start, expr_length, quote_start, quote_length, encoded] tuple.
      *
-     * @return array{int,int,int,string}|null
+     * @return array{int,int,int,int,string}|null
      */
-    private static function consume_base64_call(string $sql, int $sql_len, int &$cursor, int $expr_start, bool $has_convert)
+    private static function consume_base64_call(string $sql, int $sql_len, int &$cursor, int $expr_start)
     {
         while ($cursor < $sql_len && self::is_ws($sql[$cursor])) {
             $cursor++;
@@ -348,17 +350,16 @@ class FastInsertScanner
         }
         $cursor = $close + 1;
         $quote_length = $cursor - $quote_start;
-        // The closing paren of FROM_BASE64( … )
-        if (!$has_convert) {
-            while ($cursor < $sql_len && self::is_ws($sql[$cursor])) {
-                $cursor++;
-            }
-            if ($cursor >= $sql_len || $sql[$cursor] !== ')') {
-                return null;
-            }
+        // The closing paren of FROM_BASE64( … ). CONVERT(...) callers still
+        // need this consumed before they can verify the USING charset wrapper.
+        while ($cursor < $sql_len && self::is_ws($sql[$cursor])) {
             $cursor++;
         }
-        return [$expr_start, $quote_start, $quote_length, $payload];
+        if ($cursor >= $sql_len || $sql[$cursor] !== ')') {
+            return null;
+        }
+        $cursor++;
+        return [$expr_start, $cursor - $expr_start, $quote_start, $quote_length, $payload];
     }
 
     private static function is_ws(string $c): bool

--- a/packages/reprint-importer/src/lib/url-rewrite/class-sql-statement-rewriter.php
+++ b/packages/reprint-importer/src/lib/url-rewrite/class-sql-statement-rewriter.php
@@ -88,9 +88,11 @@ class SqlStatementRewriter
      * without an http/https scheme will not be rewritten.
      *
      * @param string $sql The SQL statement.
+     * @param bool $inline_base64_values_for_sqlite Whether to replace complete
+     *        FROM_BASE64(...) expressions with SQLite-compatible text literals.
      * @return string The modified SQL statement.
      */
-    public function rewrite(string $sql): string
+    public function rewrite(string $sql, bool $inline_base64_values_for_sqlite = false): string
     {
         // Quick check: if no base64 values, nothing to rewrite
         if (strpos($sql, "FROM_BASE64(") === false) {
@@ -129,7 +131,9 @@ class SqlStatementRewriter
             && strpos($sql, 'dHBz') === false
             && strpos($sql, 'dHRw') === false
         ) {
-            return $sql;
+            return $inline_base64_values_for_sqlite
+                ? self::rewrite_base64_values_as_sqlite_literals($sql)
+                : $sql;
         }
 
         // Fast path: producer-shape INSERTs (the overwhelming majority of
@@ -145,7 +149,7 @@ class SqlStatementRewriter
                 'column_map' => $fast['column_map'],
             ];
             $scanner = Base64ValueScanner::from_entries($sql, $fast['base64_entries']);
-            return $this->rewrite_with_scanner($scanner, $value_to_column_map);
+            return $this->rewrite_with_scanner($scanner, $value_to_column_map, $inline_base64_values_for_sqlite);
         }
 
         // Slow path: lex once, share the token array between the column
@@ -153,7 +157,30 @@ class SqlStatementRewriter
         $tokens = self::significant_tokens($sql);
         $value_to_column_map = $this->map_values_to_columns_from_tokens($tokens);
         $scanner = new Base64ValueScanner($sql, $tokens);
-        return $this->rewrite_with_scanner($scanner, $value_to_column_map);
+        return $this->rewrite_with_scanner($scanner, $value_to_column_map, $inline_base64_values_for_sqlite);
+    }
+
+    /**
+     * Rewrite complete FROM_BASE64(...) expressions as SQLite-compatible MySQL
+     * hex literals without doing URL rewriting.
+     *
+     * This is used for SQLite db-apply even when there is no URL mapping. It
+     * preserves the same decoded bytes the registered FROM_BASE64
+     * user-defined function would return, but avoids invoking that PHP callback
+     * for every encoded value in a large INSERT batch.
+     */
+    public static function rewrite_base64_values_as_sqlite_literals(string $sql): string
+    {
+        if (strpos($sql, "FROM_BASE64(") === false) {
+            return $sql;
+        }
+
+        $fast = FastInsertScanner::scan($sql);
+        $scanner = $fast !== null
+            ? Base64ValueScanner::from_entries($sql, $fast['base64_entries'])
+            : new Base64ValueScanner($sql);
+
+        return $scanner->get_result_with_sqlite_compatible_literals();
     }
 
     /**
@@ -162,7 +189,7 @@ class SqlStatementRewriter
      *
      * @param array{table: string, column_map: list<array{int, int, string}>}|null $value_to_column_map
      */
-    private function rewrite_with_scanner(Base64ValueScanner $scanner, ?array $value_to_column_map): string
+    private function rewrite_with_scanner(Base64ValueScanner $scanner, ?array $value_to_column_map, bool $inline_base64_values_for_sqlite = false): string
     {
         while ($scanner->next_value()) {
             if (!$scanner->encoded_payload_could_contain_http_scheme()) {
@@ -205,7 +232,9 @@ class SqlStatementRewriter
             }
         }
 
-        return $scanner->get_result();
+        return $inline_base64_values_for_sqlite
+            ? $scanner->get_result_with_sqlite_compatible_literals()
+            : $scanner->get_result();
     }
 
     /**

--- a/tests/UrlRewriting/Base64ValueScannerTest.php
+++ b/tests/UrlRewriting/Base64ValueScannerTest.php
@@ -130,6 +130,61 @@ class Base64ValueScannerTest extends TestCase
         $this->assertStringContainsString("CONVERT(FROM_BASE64('{$expected_encoded}') USING utf8mb4)", $modified);
     }
 
+    public function testSqliteCompatibleResultReplacesSimpleExpressionWithTextLiteral(): void
+    {
+        $value = 'hello world';
+        $encoded = base64_encode($value);
+        $sql = "INSERT INTO t VALUES(1, FROM_BASE64('{$encoded}'), NULL);";
+
+        $scanner = new Base64ValueScanner($sql);
+        $modified = $scanner->get_result_with_sqlite_compatible_literals();
+
+        $this->assertStringNotContainsString('FROM_BASE64', $modified);
+        $this->assertStringContainsString("0x" . bin2hex($value), $modified);
+    }
+
+    public function testSqliteCompatibleResultReplacesConvertWrapperWithTextLiteral(): void
+    {
+        $value = '{"key": "value"}';
+        $encoded = base64_encode($value);
+        $sql = "INSERT INTO t VALUES(1, CONVERT(FROM_BASE64('{$encoded}') USING utf8mb4));";
+
+        $scanner = new Base64ValueScanner($sql);
+        $modified = $scanner->get_result_with_sqlite_compatible_literals();
+
+        $this->assertStringNotContainsString('CONVERT', $modified);
+        $this->assertStringNotContainsString('FROM_BASE64', $modified);
+        $this->assertStringContainsString("0x" . bin2hex($value), $modified);
+    }
+
+    public function testSqliteCompatibleResultUsesUpdatedValueWhenSet(): void
+    {
+        $old = 'old value';
+        $new = 'new value';
+        $encoded_old = base64_encode($old);
+        $sql = "INSERT INTO t VALUES(FROM_BASE64('{$encoded_old}'));";
+
+        $scanner = new Base64ValueScanner($sql);
+        while ($scanner->next_value()) {
+            $scanner->set_value($new);
+        }
+        $modified = $scanner->get_result_with_sqlite_compatible_literals();
+
+        $this->assertStringNotContainsString('FROM_BASE64', $modified);
+        $this->assertStringContainsString("0x" . bin2hex($new), $modified);
+        $this->assertStringNotContainsString(bin2hex($old), $modified);
+    }
+
+    public function testSqliteCompatibleResultUsesQuotedLiteralForEmptyString(): void
+    {
+        $sql = "INSERT INTO t VALUES(FROM_BASE64(''));";
+
+        $scanner = new Base64ValueScanner($sql);
+        $modified = $scanner->get_result_with_sqlite_compatible_literals();
+
+        $this->assertSame("INSERT INTO t VALUES('');", $modified);
+    }
+
     public function testSetValueOnMultipleValues(): void
     {
         $v1 = 'first';

--- a/tests/UrlRewriting/SqlStatementRewriterTest.php
+++ b/tests/UrlRewriting/SqlStatementRewriterTest.php
@@ -49,6 +49,45 @@ class SqlStatementRewriterTest extends TestCase
         $this->assertStringNotContainsString('old-site.com', $values[0]);
     }
 
+    public function testRewriteCanInlineSqliteCompatibleLiterals(): void
+    {
+        $rewriter = $this->createRewriter();
+        $html = '<a href="https://old-site.com/page">Link</a>';
+        $encoded = base64_encode($html);
+        $sql = "INSERT INTO `wp_posts` VALUES(1, FROM_BASE64('{$encoded}'));";
+
+        $result = $rewriter->rewrite($sql, true);
+        $expected = '<a href="https://new-site.com/page">Link</a>';
+
+        $this->assertStringNotContainsString('FROM_BASE64', $result);
+        $this->assertStringContainsString("0x" . bin2hex($expected), $result);
+    }
+
+    public function testSqliteLiteralInliningDoesNotRequireUrlMappingHit(): void
+    {
+        $rewriter = $this->createRewriter();
+        $value = 'plain text without a URL';
+        $encoded = base64_encode($value);
+        $sql = "INSERT INTO `wp_options` VALUES(1, FROM_BASE64('{$encoded}'));";
+
+        $result = $rewriter->rewrite($sql, true);
+
+        $this->assertStringNotContainsString('FROM_BASE64', $result);
+        $this->assertStringContainsString("0x" . bin2hex($value), $result);
+    }
+
+    public function testStaticSqliteLiteralInliningWorksWithoutUrlRewriter(): void
+    {
+        $value = 'siteurl';
+        $encoded = base64_encode($value);
+        $sql = "INSERT INTO `wp_options` VALUES(1, FROM_BASE64('{$encoded}'));";
+
+        $result = SqlStatementRewriter::rewrite_base64_values_as_sqlite_literals($sql);
+
+        $this->assertStringNotContainsString('FROM_BASE64', $result);
+        $this->assertStringContainsString("0x" . bin2hex($value), $result);
+    }
+
     public function testPassesThroughDdlStatements(): void
     {
         $rewriter = $this->createRewriter();


### PR DESCRIPTION
## What it does

- Rewrites complete `FROM_BASE64(...)` expressions to SQLite-adapter-compatible MySQL hex literals during SQLite `db-apply`.
- Reuses the existing scanner when URL rewriting is already walking the statement.
- Adds a standalone no-mapping path so SQLite imports avoid `FROM_BASE64` callbacks even when no URL mapping is configured.
- Keeps the registered SQLite `FROM_BASE64` function as a fallback for statements that are not inlined and for post-apply maintenance queries.

## Rationale

The SQLite adapter was spending substantial time invoking a PHP user-defined function for every encoded value. The importer has already scanned the SQL statement, and the dump's encoded payloads are base64, so it can decode them once and hand the SQLite adapter a MySQL hex literal (`0x...`) instead of a function call.

Empty decoded strings use `''` because bare `0x` is not a valid MySQL token. Non-empty values use hex literals so arbitrary bytes do not enter the SQL text as quoted strings.

## Benchmark

Fixture: manual large db-apply run, 262 MB SQL, 865 statements, 932,459 `FROM_BASE64` values, PHP.wasm 8.4, both native manifests loaded (`wp_native_apis` and `wp_mysql_parser`).

Command shape: `db-apply --target-engine=sqlite --rewrite-url https://127.0.0.1:8199 http://localhost:8881 --rewrite-url http://127.0.0.1:8199 http://localhost:8881`

| Comparison | Base | Candidate | Delta |
|---|---:|---:|---:|
| previous PR -> this PR | 158.91 s | 125.12 s | -33.79 s / -21.3% |
| `trunk` -> full stack | 139.06 s | 125.12 s | -13.94 s / -10.0% |

This is the only branch in the stack that produced a meaningful speedup on the large fixture.

## Testing

- `vendor/bin/phpunit --configuration tests/phpunit.xml tests/UrlRewriting tests/Import/NewSiteUrlSqliteTest.php`
- Included in stack benchmark under `.context/reprint-profile/stack-bench-1779308725`
