### PR TITLE
Use prepared inserts for SQLite base64 values

### DIFF
--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -5118,6 +5118,13 @@ class ImportClient
         }
 
         [$pdo, $connection_label] = $this->create_target_db_apply_connection($options);
+        $sqlite_prepared_pdo = null;
+        if (
+            strtolower((string) ($options["target_engine"] ?? "mysql")) === "sqlite"
+            && method_exists($pdo, 'get_connection')
+        ) {
+            $sqlite_prepared_pdo = $pdo->get_connection()->get_pdo();
+        }
 
         $this->audit_log(
             "CONNECTED | {$connection_label}",
@@ -5222,21 +5229,23 @@ class ImportClient
                         continue;
                     }
 
-                    // Rewrite URLs if mapping is configured
-                    if ($stmt_rewriter) {
-                        $query = $stmt_rewriter->rewrite($query);
-                    }
-
                     // Execute against target database
+                    $executed_query = $query;
                     try {
-                        $pdo->exec($query);
+                        $this->execute_db_apply_query(
+                            $pdo,
+                            $query,
+                            $stmt_rewriter,
+                            $sqlite_prepared_pdo,
+                            $executed_query,
+                        );
                     } catch (PDOException $e) {
                         $this->audit_log(
                             sprintf(
                                 "SQL ERROR | stmt=%d | %s | query=%.200s",
                                 $stmt_count,
                                 $e->getMessage(),
-                                $query,
+                                $executed_query,
                             ),
                             true,
                         );
@@ -5299,19 +5308,22 @@ class ImportClient
                     continue;
                 }
 
-                if ($stmt_rewriter) {
-                    $query = $stmt_rewriter->rewrite($query);
-                }
-
+                $executed_query = $query;
                 try {
-                    $pdo->exec($query);
+                    $this->execute_db_apply_query(
+                        $pdo,
+                        $query,
+                        $stmt_rewriter,
+                        $sqlite_prepared_pdo,
+                        $executed_query,
+                    );
                 } catch (PDOException $e) {
                     $this->audit_log(
                         sprintf(
                             "SQL ERROR | stmt=%d | %s | query=%.200s",
                             $stmt_count,
                             $e->getMessage(),
-                            $query,
+                            $executed_query,
                         ),
                         true,
                     );
@@ -5401,6 +5413,45 @@ class ImportClient
         } finally {
             fclose($sql_handle);
         }
+    }
+
+    private function execute_db_apply_query(
+        PDO $pdo,
+        string $query,
+        ?SqlStatementRewriter $stmt_rewriter,
+        ?PDO $sqlite_prepared_pdo,
+        string &$executed_query
+    ): void {
+        $executed_query = $query;
+
+        if ($sqlite_prepared_pdo !== null) {
+            $prepared_insert = $stmt_rewriter !== null
+                ? $stmt_rewriter->build_sqlite_prepared_insert($query)
+                : SQLitePreparedInsertBuilder::build($query);
+
+            if ($prepared_insert !== null) {
+                $executed_query = $prepared_insert['sql'];
+                $statement = $sqlite_prepared_pdo->prepare($prepared_insert['sql']);
+                if ($statement === false) {
+                    throw new PDOException('Failed to prepare SQLite INSERT statement.');
+                }
+
+                foreach ($prepared_insert['params'] as $index => $value) {
+                    $statement->bindValue($index + 1, $value, PDO::PARAM_STR);
+                }
+
+                if ($statement->execute() === false) {
+                    throw new PDOException('Failed to execute SQLite INSERT statement.');
+                }
+                return;
+            }
+        }
+
+        if ($stmt_rewriter !== null) {
+            $executed_query = $stmt_rewriter->rewrite($query);
+        }
+
+        $pdo->exec($executed_query);
     }
 
     /**

--- a/packages/reprint-importer/src/lib/url-rewrite/class-fast-insert-scanner.php
+++ b/packages/reprint-importer/src/lib/url-rewrite/class-fast-insert-scanner.php
@@ -37,7 +37,7 @@ class FastInsertScanner
      * @return array{
      *   table: string,
      *   column_map: list<array{int, int, string}>,
-     *   base64_entries: list<array{expr_start: int, quote_start: int, quote_length: int, encoded_value: string, value: ?string, new_value: ?string}>
+     *   base64_entries: list<array{expr_start: int, expr_length: int, quote_start: int, quote_length: int, encoded_value: string, value: ?string, new_value: ?string}>
      * }|null
      *   Null when the SQL doesn't match the recognised shape.
      */
@@ -139,12 +139,13 @@ class FastInsertScanner
                 $column_map[] = [$value_start, $value_end, $columns[$col_idx]];
 
                 if (is_array($value_kind)) {
-                    // FROM_BASE64 payload: kind = [expr_start, quote_start, quote_length, encoded_value]
+                    // FROM_BASE64 payload: kind = [expr_start, expr_length, quote_start, quote_length, encoded_value]
                     $base64_entries[] = [
                         'expr_start' => $value_kind[0],
-                        'quote_start' => $value_kind[1],
-                        'quote_length' => $value_kind[2],
-                        'encoded_value' => $value_kind[3],
+                        'expr_length' => $value_kind[1],
+                        'quote_start' => $value_kind[2],
+                        'quote_length' => $value_kind[3],
+                        'encoded_value' => $value_kind[4],
                         'value' => null,
                         'new_value' => null,
                     ];
@@ -199,10 +200,10 @@ class FastInsertScanner
     /**
      * Scan one value in producer's tuple shape, advancing $cursor past it.
      *
-     * @return null|true|array{int,int,int,string}
+     * @return null|true|array{int,int,int,int,string}
      *   null = unrecognized shape (caller bails)
      *   true = recognised, no FROM_BASE64 entry to record
-     *   array = FROM_BASE64 payload, [expr_start, quote_start, quote_length, encoded]
+     *   array = FROM_BASE64 payload, [expr_start, expr_length, quote_start, quote_length, encoded]
      */
     private static function scan_value(string $sql, int $sql_len, int &$cursor)
     {
@@ -235,7 +236,7 @@ class FastInsertScanner
         ) {
             $expr_start = $cursor;
             $cursor += 12; // step past "FROM_BASE64("
-            return self::consume_base64_call($sql, $sql_len, $cursor, $expr_start, /*has_convert=*/false);
+            return self::consume_base64_call($sql, $sql_len, $cursor, $expr_start);
         }
 
         // CONVERT(FROM_BASE64('…') USING utf8mb4)
@@ -256,7 +257,7 @@ class FastInsertScanner
                 return null;
             }
             $cursor += 12;
-            $entry = self::consume_base64_call($sql, $sql_len, $cursor, $expr_start, /*has_convert=*/true);
+            $entry = self::consume_base64_call($sql, $sql_len, $cursor, $expr_start);
             if (!is_array($entry)) {
                 return null;
             }
@@ -282,6 +283,7 @@ class FastInsertScanner
                 return null;
             }
             $cursor++;
+            $entry[1] = $cursor - $expr_start;
             return $entry;
         }
 
@@ -319,11 +321,11 @@ class FastInsertScanner
     /**
      * Inside a FROM_BASE64( … ) call, with $cursor already past the opening
      * paren. Reads the quoted base64 string and the closing paren. Returns
-     * the [expr_start, quote_start, quote_length, encoded] tuple.
+     * the [expr_start, expr_length, quote_start, quote_length, encoded] tuple.
      *
-     * @return array{int,int,int,string}|null
+     * @return array{int,int,int,int,string}|null
      */
-    private static function consume_base64_call(string $sql, int $sql_len, int &$cursor, int $expr_start, bool $has_convert)
+    private static function consume_base64_call(string $sql, int $sql_len, int &$cursor, int $expr_start)
     {
         while ($cursor < $sql_len && self::is_ws($sql[$cursor])) {
             $cursor++;
@@ -348,17 +350,16 @@ class FastInsertScanner
         }
         $cursor = $close + 1;
         $quote_length = $cursor - $quote_start;
-        // The closing paren of FROM_BASE64( … )
-        if (!$has_convert) {
-            while ($cursor < $sql_len && self::is_ws($sql[$cursor])) {
-                $cursor++;
-            }
-            if ($cursor >= $sql_len || $sql[$cursor] !== ')') {
-                return null;
-            }
+        // The closing paren of FROM_BASE64( … ). CONVERT(...) callers still
+        // need this consumed before they can verify the USING charset wrapper.
+        while ($cursor < $sql_len && self::is_ws($sql[$cursor])) {
             $cursor++;
         }
-        return [$expr_start, $quote_start, $quote_length, $payload];
+        if ($cursor >= $sql_len || $sql[$cursor] !== ')') {
+            return null;
+        }
+        $cursor++;
+        return [$expr_start, $cursor - $expr_start, $quote_start, $quote_length, $payload];
     }
 
     private static function is_ws(string $c): bool

--- a/packages/reprint-importer/src/lib/url-rewrite/class-sql-statement-rewriter.php
+++ b/packages/reprint-importer/src/lib/url-rewrite/class-sql-statement-rewriter.php
@@ -190,6 +190,9 @@ class SqlStatementRewriter
             ? $this->get_content_type($table, $column)
             : null;
 
+        // Rewrite URLs in the value. Known block-markup columns can first
+        // try a boundary-checked literal base URL swap before falling back
+        // to the full structured parser.
         return $content_type === StructuredDataUrlRewriter::BLOCK_MARKUP
             ? $this->url_rewriter->rewrite_known_block_markup_value($value)
             : $this->url_rewriter->rewrite($value, $content_type);
@@ -227,9 +230,6 @@ class SqlStatementRewriter
                 );
             }
 
-            // Rewrite URLs in the value. Known block-markup columns can first
-            // try a boundary-checked literal base URL swap before falling back
-            // to the full structured parser.
             $rewritten = $this->rewrite_value_for_column(
                 $value,
                 $value_to_column_map['table'] ?? '',

--- a/packages/reprint-importer/src/lib/url-rewrite/class-sql-statement-rewriter.php
+++ b/packages/reprint-importer/src/lib/url-rewrite/class-sql-statement-rewriter.php
@@ -157,6 +157,45 @@ class SqlStatementRewriter
     }
 
     /**
+     * Build a SQLite prepared INSERT for producer-shaped statements.
+     *
+     * This follows the same column-aware URL rewriting decisions as rewrite()
+     * but returns SQL with placeholders plus decoded parameter bytes. Unknown
+     * statement shapes return null so callers can fall back to the normal
+     * MySQL-on-SQLite execution path.
+     *
+     * @return array{sql: string, params: list<string>}|null
+     */
+    public function build_sqlite_prepared_insert(string $sql): ?array
+    {
+        return SQLitePreparedInsertBuilder::build(
+            $sql,
+            function (string $value, string $table, ?string $column): string {
+                return $this->rewrite_value_for_column($value, $table, $column);
+            }
+        );
+    }
+
+    private function rewrite_value_for_column(string $value, string $table, ?string $column): string
+    {
+        if (strpos($value, 'http') === false) {
+            return $value;
+        }
+
+        if (!$this->url_rewriter->value_might_contain_source_domain($value)) {
+            return $value;
+        }
+
+        $content_type = $column !== null
+            ? $this->get_content_type($table, $column)
+            : null;
+
+        return $content_type === StructuredDataUrlRewriter::BLOCK_MARKUP
+            ? $this->url_rewriter->rewrite_known_block_markup_value($value)
+            : $this->url_rewriter->rewrite($value, $content_type);
+    }
+
+    /**
      * Run the value-rewriting loop given an already-populated scanner and
      * the table/column-map context. Shared between the fast and lexer paths.
      *
@@ -179,24 +218,23 @@ class SqlStatementRewriter
                 continue;
             }
 
-            // Determine content type hint for this column
-            $content_type = null;
+            // Determine content type hint for this column.
+            $column_name = null;
             if ($value_to_column_map !== null) {
                 $column_name = $this->find_column_at_offset(
                     $value_to_column_map['column_map'],
                     $scanner->get_match_offset()
                 );
-                if ($column_name !== null) {
-                    $content_type = $this->get_content_type($value_to_column_map['table'], $column_name);
-                }
             }
 
             // Rewrite URLs in the value. Known block-markup columns can first
             // try a boundary-checked literal base URL swap before falling back
             // to the full structured parser.
-            $rewritten = $content_type === StructuredDataUrlRewriter::BLOCK_MARKUP
-                ? $this->url_rewriter->rewrite_known_block_markup_value($value)
-                : $this->url_rewriter->rewrite($value, $content_type);
+            $rewritten = $this->rewrite_value_for_column(
+                $value,
+                $value_to_column_map['table'] ?? '',
+                $column_name
+            );
 
             // Only replace if the value actually changed
             if ($rewritten !== $value) {

--- a/packages/reprint-importer/src/lib/url-rewrite/class-sqlite-prepared-insert-builder.php
+++ b/packages/reprint-importer/src/lib/url-rewrite/class-sqlite-prepared-insert-builder.php
@@ -1,0 +1,87 @@
+<?php
+
+/**
+ * Builds SQLite prepared INSERT statements for MySQLDumpProducer-shaped SQL.
+ *
+ * This is deliberately narrower than SqlStatementRewriter: it only accepts
+ * INSERT statements that FastInsertScanner fully recognises. Every complete
+ * FROM_BASE64(...) expression is replaced with a positional placeholder and
+ * its decoded bytes are returned as a bound PHP string. Values that do not
+ * match the producer shape return null so db-apply can fall back to the normal
+ * MySQL-on-SQLite execution path.
+ *
+ * The important property is that decoded payload bytes never become SQL text.
+ * That avoids quoting, escaping, UTF-8, and "garbage codepoint" questions: the
+ * SQL parser sees only `?`, and SQLite receives the exact PHP string through
+ * PDO binding.
+ */
+class SQLitePreparedInsertBuilder
+{
+    /**
+     * @param callable|null $rewrite_value Optional callback:
+     *        fn(string $value, string $table, ?string $column): string
+     * @return array{sql: string, params: list<string>}|null
+     */
+    public static function build(string $sql, ?callable $rewrite_value = null): ?array
+    {
+        if (strpos($sql, 'FROM_BASE64(') === false) {
+            return null;
+        }
+
+        $fast = FastInsertScanner::scan($sql);
+        if ($fast === null || empty($fast['base64_entries'])) {
+            return null;
+        }
+
+        $parts = [];
+        $params = [];
+        $cursor = 0;
+
+        foreach ($fast['base64_entries'] as $entry) {
+            if ($entry['expr_start'] < $cursor || $entry['expr_length'] <= 0) {
+                return null;
+            }
+
+            $decoded = base64_decode($entry['encoded_value'], true);
+            $value = $decoded !== false ? $decoded : '';
+            if ($rewrite_value !== null) {
+                $column = self::find_column_at_offset($fast['column_map'], $entry['expr_start']);
+                $value = $rewrite_value($value, $fast['table'], $column);
+            }
+
+            $parts[] = substr($sql, $cursor, $entry['expr_start'] - $cursor);
+            $parts[] = '?';
+            $params[] = $value;
+            $cursor = $entry['expr_start'] + $entry['expr_length'];
+        }
+
+        $parts[] = substr($sql, $cursor);
+
+        return [
+            'sql' => implode('', $parts),
+            'params' => $params,
+        ];
+    }
+
+    /**
+     * @param list<array{int, int, string}> $column_map
+     */
+    private static function find_column_at_offset(array $column_map, int $offset): ?string
+    {
+        $low = 0;
+        $high = count($column_map) - 1;
+        while ($low <= $high) {
+            $mid = ($low + $high) >> 1;
+            $entry = $column_map[$mid];
+            if ($offset < $entry[0]) {
+                $high = $mid - 1;
+            } elseif ($offset >= $entry[1]) {
+                $low = $mid + 1;
+            } else {
+                return $entry[2];
+            }
+        }
+
+        return null;
+    }
+}

--- a/packages/reprint-importer/src/lib/url-rewrite/load.php
+++ b/packages/reprint-importer/src/lib/url-rewrite/load.php
@@ -14,6 +14,7 @@ require_once __DIR__ . '/class-php-serialization-processor.php';
 require_once __DIR__ . '/class-json-string-iterator.php';
 require_once __DIR__ . '/class-base64-value-scanner.php';
 require_once __DIR__ . '/class-fast-insert-scanner.php';
+require_once __DIR__ . '/class-sqlite-prepared-insert-builder.php';
 
 // Depend on the iterators above
 require_once __DIR__ . '/class-structured-data-url-rewriter.php';

--- a/tests/Import/NewSiteUrlSqliteTest.php
+++ b/tests/Import/NewSiteUrlSqliteTest.php
@@ -314,4 +314,59 @@ class NewSiteUrlSqliteTest extends TestCase
         $this->assertStringContainsString('https://new-site.example.com/wp-content/uploads/photo.jpg', $postContent);
         $this->assertStringNotContainsString('old-site.example.com', $postContent);
     }
+
+    public function testSqliteDbApplyPreservesArbitraryBase64Bytes(): void
+    {
+        $bytes = '';
+        for ($i = 0; $i <= 255; $i++) {
+            $bytes .= chr($i);
+        }
+
+        $sqlitePath = $this->tempDir . '/database/wordpress.sqlite';
+        $stmts = [];
+        $stmts[] = "DROP TABLE IF EXISTS `wp_options`;";
+        $stmts[] = "CREATE TABLE `wp_options` ("
+            . "`option_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT, "
+            . "`option_name` varchar(191) NOT NULL DEFAULT '', "
+            . "`option_value` longtext NOT NULL, "
+            . "`autoload` varchar(20) NOT NULL DEFAULT 'yes', "
+            . "PRIMARY KEY (`option_id`), "
+            . "UNIQUE KEY `option_name` (`option_name`)"
+            . ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;";
+        $stmts[] = sprintf(
+            "INSERT INTO `wp_options` (`option_id`, `option_name`, `option_value`, `autoload`) VALUES "
+            . "(1, FROM_BASE64('%s'), FROM_BASE64('%s'), FROM_BASE64('%s'));",
+            base64_encode('binary_payload'),
+            base64_encode($bytes),
+            base64_encode('yes')
+        );
+
+        file_put_contents($this->tempDir . '/db.sql', implode("\n", $stmts) . "\n");
+        $this->writeState();
+
+        $client = new \ImportClient(
+            'https://old-site.example.com/?reprint-api',
+            $this->tempDir,
+            $this->tempDir . '/fs-root',
+        );
+        $client->run([
+            'command' => 'db-apply',
+            'abort' => false,
+            'verbose' => false,
+            'secret' => null,
+            'tuning_config' => [],
+            'target_engine' => 'sqlite',
+            'target_sqlite_path' => $sqlitePath,
+            'target_db' => 'wp_test',
+        ]);
+
+        $rows = $this->querySqlite(
+            $sqlitePath,
+            "SELECT hex(option_value) AS hex_value FROM wp_options WHERE option_name = 'binary_payload'",
+            'wp_test',
+        );
+
+        $this->assertCount(1, $rows);
+        $this->assertSame(strtoupper(bin2hex($bytes)), $rows[0]['hex_value']);
+    }
 }

--- a/tests/UrlRewriting/SQLitePreparedInsertBuilderTest.php
+++ b/tests/UrlRewriting/SQLitePreparedInsertBuilderTest.php
@@ -1,0 +1,102 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../vendor/autoload.php';
+require_once __DIR__ . '/../../packages/reprint-importer/src/lib/url-rewrite/load.php';
+
+class SQLitePreparedInsertBuilderTest extends TestCase
+{
+    public function testBuildsPreparedInsertForArbitraryBytes(): void
+    {
+        $bytes = '';
+        for ($i = 0; $i <= 255; $i++) {
+            $bytes .= chr($i);
+        }
+
+        $sql = sprintf(
+            "INSERT INTO `wp_options` (`option_id`, `option_value`) VALUES(1, FROM_BASE64('%s'));",
+            base64_encode($bytes)
+        );
+
+        $prepared = SQLitePreparedInsertBuilder::build($sql);
+
+        $this->assertNotNull($prepared);
+        $this->assertSame(
+            "INSERT INTO `wp_options` (`option_id`, `option_value`) VALUES(1, ?);",
+            $prepared['sql']
+        );
+        $this->assertSame([$bytes], $prepared['params']);
+    }
+
+    public function testBuildsPreparedInsertForConvertWrappedPayload(): void
+    {
+        $value = '{"url":"https://example.com"}';
+        $sql = sprintf(
+            "INSERT INTO `wp_postmeta` (`meta_value`) VALUES(CONVERT(FROM_BASE64('%s') USING utf8mb4));",
+            base64_encode($value)
+        );
+
+        $prepared = SQLitePreparedInsertBuilder::build($sql);
+
+        $this->assertNotNull($prepared);
+        $this->assertSame(
+            "INSERT INTO `wp_postmeta` (`meta_value`) VALUES(?);",
+            $prepared['sql']
+        );
+        $this->assertSame([$value], $prepared['params']);
+    }
+
+    public function testRewriteCallbackReceivesTableAndColumn(): void
+    {
+        $sql = sprintf(
+            "INSERT INTO `wp_posts` (`ID`, `post_content`) VALUES(1, FROM_BASE64('%s'));",
+            base64_encode('before')
+        );
+
+        $prepared = SQLitePreparedInsertBuilder::build(
+            $sql,
+            function (string $value, string $table, ?string $column): string {
+                $this->assertSame('before', $value);
+                $this->assertSame('wp_posts', $table);
+                $this->assertSame('post_content', $column);
+                return 'after';
+            }
+        );
+
+        $this->assertNotNull($prepared);
+        $this->assertSame(['after'], $prepared['params']);
+    }
+
+    public function testUnknownInsertShapeReturnsNull(): void
+    {
+        $sql = sprintf(
+            "INSERT INTO `wp_options` VALUES(1, FROM_BASE64('%s'));",
+            base64_encode('value')
+        );
+
+        $this->assertNull(SQLitePreparedInsertBuilder::build($sql));
+    }
+
+    public function testSqlStatementRewriterBuildsPreparedInsertWithRewrittenParam(): void
+    {
+        $rewriter = new SqlStatementRewriter(
+            new StructuredDataUrlRewriter([
+                'https://old-site.com' => 'https://new-site.com',
+            ])
+        );
+        $sql = sprintf(
+            "INSERT INTO `wp_posts` (`ID`, `post_content`) VALUES(1, FROM_BASE64('%s'));",
+            base64_encode('<a href="https://old-site.com/page">Link</a>')
+        );
+
+        $prepared = $rewriter->build_sqlite_prepared_insert($sql);
+
+        $this->assertNotNull($prepared);
+        $this->assertSame(
+            "INSERT INTO `wp_posts` (`ID`, `post_content`) VALUES(1, ?);",
+            $prepared['sql']
+        );
+        $this->assertSame('<a href="https://new-site.com/page">Link</a>', $prepared['params'][0]);
+    }
+}


### PR DESCRIPTION
## What it does

Adds a SQLite `db-apply` fast path for producer-shaped INSERT statements. When `FastInsertScanner` fully recognises an INSERT, reprint now:

1. replaces each complete `FROM_BASE64(...)` / `CONVERT(FROM_BASE64(...) USING utf8mb4)` expression with `?`
2. decodes the payload in PHP
3. applies the existing column-aware URL rewrite logic to decoded values when URL mapping is configured
4. binds the resulting PHP strings on the raw SQLite PDO connection

Unknown SQL shapes still fall back to the existing MySQL-on-SQLite wrapper execution path.

## Rationale

The hex-literal experiment avoided `FROM_BASE64` user-defined function callbacks, but it put decoded bytes back into SQL text. Prepared statements are the rigorous version of the same idea: arbitrary bytes, NULs, invalid UTF-8, and garbage non-codepoints never become SQL syntax.

The SQL parser sees placeholders. SQLite receives exact bound PHP strings.

## Implementation

`SQLitePreparedInsertBuilder` builds `{ sql, params }` from `FastInsertScanner` output. `SqlStatementRewriter::build_sqlite_prepared_insert()` reuses that builder with the same table/column-aware rewrite decisions as `rewrite()`.

`ImportClient::execute_db_apply_query()` tries the prepared INSERT path only for SQLite targets. If the builder returns `null`, execution continues through the existing wrapper and `FROM_BASE64` user-defined function.

## Benchmark

Fixture: manual large db-apply run, 262 MB SQL, 865 statements, 932,459 `FROM_BASE64` values, PHP.wasm 8.4, both native manifests loaded (`wp_native_apis` and `wp_mysql_parser`).

Command shape: `db-apply --target-engine=sqlite --rewrite-url https://127.0.0.1:8199 http://localhost:8881 --rewrite-url http://127.0.0.1:8199 http://localhost:8881`

| Branch | Time | Delta vs trunk |
|---|---:|---:|
| `trunk` (`438de2d`) | 135.91 s | baseline |
| this PR (`0d83ce1`) | 84.41 s | -51.50 s / -37.9% |

Benchmark logs: `.context/reprint-profile/prepared-bench-1779315797`

## Testing instructions

```bash
vendor/bin/phpunit --configuration tests/phpunit.xml tests/UrlRewriting tests/Import/NewSiteUrlSqliteTest.php
vendor/bin/phpunit --configuration tests/phpunit.xml tests/UrlRewriting/SQLitePreparedInsertBuilderTest.php tests/Import/NewSiteUrlSqliteTest.php
```
