### PR TITLE
Use structured parsing for block URL rewrites

### DIFF
--- a/packages/reprint-importer/src/lib/url-rewrite/class-sql-statement-rewriter.php
+++ b/packages/reprint-importer/src/lib/url-rewrite/class-sql-statement-rewriter.php
@@ -10,10 +10,10 @@
  * Column-aware: for each FROM_BASE64() match, determines which column it belongs
  * to and passes the appropriate content type hint to StructuredDataUrlRewriter.
  * WordPress core columns known to contain block markup (post_content, comment_content,
- * etc.) get the 'block_markup' hint so wp_rewrite_urls() handles HTML attributes,
- * block comment JSON, and CSS url(). All other columns default to auto-detect with
- * plain text strtr() replacement, which is simpler and more predictable for columns
- * that contain serialized PHP, JSON, or plain strings.
+ * etc.) get the 'block_markup' hint so BlockMarkupUrlProcessor handles HTML
+ * attributes, block comment JSON, and CSS url(). All other columns default to
+ * auto-detect with URLInTextProcessor for leaf text, which is simpler and more
+ * predictable for columns that contain serialized PHP, JSON, or plain strings.
  *
  * Column resolution walks the lexer output directly. Both INSERT and UPDATE
  * statements emitted by MySQLDumpProducer follow a constrained set of shapes
@@ -31,7 +31,7 @@ class SqlStatementRewriter
 
     /**
      * WordPress core columns that contain block markup and benefit from
-     * wp_rewrite_urls() over simple string replacement. Keyed by table suffix
+     * BlockMarkupUrlProcessor over plain-text URL scanning. Keyed by table suffix
      * (without prefix) — the constructor prepends the actual table_prefix to
      * build full table names for exact matching.
      *
@@ -190,9 +190,10 @@ class SqlStatementRewriter
             ? $this->get_content_type($table, $column)
             : null;
 
-        // Rewrite URLs in the value. Known block-markup columns can first
-        // try a boundary-checked literal base URL swap before falling back
-        // to the full structured parser.
+        // Rewrite URLs in the value. Known block-markup columns go through
+        // the structured block parser so alternate URL spellings (for example
+        // escaped JSON, uppercase schemes/hosts, and IDNs) are handled by the
+        // URL model instead of byte-level replacement.
         return $content_type === StructuredDataUrlRewriter::BLOCK_MARKUP
             ? $this->url_rewriter->rewrite_known_block_markup_value($value)
             : $this->url_rewriter->rewrite($value, $content_type);

--- a/packages/reprint-importer/src/lib/url-rewrite/class-structured-data-url-rewriter.php
+++ b/packages/reprint-importer/src/lib/url-rewrite/class-structured-data-url-rewriter.php
@@ -5,8 +5,6 @@ use WordPress\DataLiberation\URL\URLInTextProcessor;
 use WordPress\DataLiberation\URL\WPURL;
 
 use function WordPress\DataLiberation\URL\is_child_url_of;
-use function WordPress\DataLiberation\URL\wp_rewrite_urls;
-
 /**
  * Rewrites URLs in a single decoded database value by detecting the data
  * format and applying the appropriate rewriting strategy.
@@ -20,12 +18,14 @@ use function WordPress\DataLiberation\URL\wp_rewrite_urls;
  * 2. JSON → construct JsonStringIterator, if not malformed, iterate string
  *    values and recurse on each
  * 3. Base64 → decode, recurse on decoded content, re-encode if changed
- * 4. Leaf text → wp_rewrite_urls() (block_markup hint) or strtr() (default)
+ * 4. Leaf text → BlockMarkupUrlProcessor (block_markup hint) or
+ *    URLInTextProcessor (default)
  *
  * HTML is never auto-detected — the caller must explicitly pass
  * content_type='block_markup' for values known to contain HTML/block markup.
  * The hint propagates through recursive calls so that leaf strings inside
- * serialized PHP, JSON, or base64 eventually reach wp_rewrite_urls().
+ * serialized PHP, JSON, or base64 eventually reach the same block-markup
+ * parser.
  */
 class StructuredDataUrlRewriter
 {
@@ -35,12 +35,6 @@ class StructuredDataUrlRewriter
 
     /** @var string[] Source domains extracted from url_mapping keys, for quick-reject checks. */
     private array $source_domains;
-
-    /** @var array<string, string> Literal base URL replacements for the block-markup fast path. */
-    private array $literal_base_url_replacements;
-
-    /** @var string[] Unescaped source base URLs, used to avoid changing block-comment JSON formatting. */
-    private array $literal_source_base_urls;
 
     /**
      * Pre-parsed url_mapping: each entry is
@@ -85,7 +79,7 @@ class StructuredDataUrlRewriter
         foreach (array_keys($url_mapping) as $from_url) {
             $host = parse_url($from_url, PHP_URL_HOST);
             if ($host !== null && $host !== false) {
-                $domains[$host] = true;
+                $this->add_source_domain_variants($domains, $host);
             }
         }
         $this->source_domains = array_keys($domains);
@@ -94,22 +88,12 @@ class StructuredDataUrlRewriter
         // (scheme/host/path tokenisation, punycode, etc.) and used to be
         // repeated on every leaf we rewrote.
         $this->parsed_mapping = [];
-        $this->literal_base_url_replacements = [];
-        $this->literal_source_base_urls = [];
         foreach ($url_mapping as $from_url_string => $to_url_string) {
             $this->parsed_mapping[] = [
                 'from_url' => WPURL::parse($from_url_string),
                 'to_url'   => WPURL::parse($to_url_string),
             ];
-
-            $this->literal_source_base_urls[] = $from_url_string;
-            $this->literal_base_url_replacements[$from_url_string] = $to_url_string;
-            $this->literal_base_url_replacements[str_replace('/', '\/', $from_url_string)] = str_replace('/', '\/', $to_url_string);
         }
-        uksort(
-            $this->literal_base_url_replacements,
-            static fn ($a, $b) => strlen($b) <=> strlen($a)
-        );
         $this->mapping_cache_key = sha1(json_encode($url_mapping, JSON_UNESCAPED_SLASHES));
 
         // Default base_url: first from-url in the mapping. Preserves the
@@ -123,7 +107,7 @@ class StructuredDataUrlRewriter
      *
      * @param string      $value        The decoded database value.
      * @param string|null $content_type Content type hint: null (auto-detect, plain text default),
-     *                                  'block_markup' (use wp_rewrite_urls), or 'skip' (no-op).
+     *                                  'block_markup' (use BlockMarkupUrlProcessor), or 'skip' (no-op).
      * @return string The rewritten value, or the original if no changes were made.
      */
     public function rewrite(string $value, ?string $content_type = null): string
@@ -194,11 +178,11 @@ class StructuredDataUrlRewriter
      */
     private function maybe_contains_rewritable_urls(string $value): bool
     {
-        if (strpos($value, 'href="') !== false || strpos($value, 'src="') !== false) {
+        if (stripos($value, 'href=') !== false || stripos($value, 'src=') !== false) {
             return true;
         }
         foreach ($this->source_domains as $domain) {
-            if (strpos($value, $domain) !== false) {
+            if (stripos($value, $domain) !== false) {
                 return true;
             }
         }
@@ -206,103 +190,48 @@ class StructuredDataUrlRewriter
     }
 
     /**
+     * @param array<string, true> $domains
+     */
+    private function add_source_domain_variants(array &$domains, string $host): void
+    {
+        if ($host === '') {
+            return;
+        }
+
+        $domains[$host] = true;
+
+        if (function_exists('idn_to_ascii')) {
+            $ascii = defined('INTL_IDNA_VARIANT_UTS46')
+                ? @idn_to_ascii($host, 0, INTL_IDNA_VARIANT_UTS46)
+                : @idn_to_ascii($host);
+            if (is_string($ascii) && $ascii !== '') {
+                $domains[$ascii] = true;
+            }
+        }
+
+        if (function_exists('idn_to_utf8')) {
+            $unicode = defined('INTL_IDNA_VARIANT_UTS46')
+                ? @idn_to_utf8($host, 0, INTL_IDNA_VARIANT_UTS46)
+                : @idn_to_utf8($host);
+            if (is_string($unicode) && $unicode !== '') {
+                $domains[$unicode] = true;
+            }
+        }
+    }
+
+    /**
      * Rewrite a decoded value already known by the SQL layer to be block markup.
      *
-     * This takes a conservative fast path for the common dump shape where the
-     * value contains literal absolute source URLs in HTML attributes, text, CSS,
-     * or block-comment JSON. In that case a boundary-checked base URL swap gives
-     * the same result as BlockMarkupUrlProcessor without constructing the full
-     * parser stack for every row. If any source URL occurrence is not at a URL
-     * boundary, we fall back to the full structured rewriter.
+     * Block markup owns HTML attributes, block-comment JSON, CSS url() values,
+     * text URLs, entity decoding, URL casing, and IDN canonicalization. This
+     * intentionally routes through the structured parser instead of doing a
+     * literal source-base replacement, because one database value may contain
+     * multiple spellings of the same URL that only the parser can recognize as
+     * equivalent.
      */
     public function rewrite_known_block_markup_value(string $value): string
     {
-        if ($value === '') {
-            return $value;
-        }
-
-        if (!$this->maybe_contains_rewritable_urls($value)) {
-            return $value;
-        }
-
-        $literal_rewrite = $this->try_rewrite_literal_base_urls($value);
-        if ($literal_rewrite !== null) {
-            return $literal_rewrite;
-        }
-
         return $this->rewrite($value, self::BLOCK_MARKUP);
-    }
-
-    private function try_rewrite_literal_base_urls(string $value): ?string
-    {
-        if ($this->has_unescaped_source_url_in_block_comment($value)) {
-            return null;
-        }
-
-        $matched = false;
-        foreach ($this->literal_base_url_replacements as $from => $_to) {
-            $offset = 0;
-            while (true) {
-                $pos = strpos($value, $from, $offset);
-                if ($pos === false) {
-                    break;
-                }
-                if (!$this->is_literal_base_url_boundary($value, $pos, strlen($from))) {
-                    return null;
-                }
-                $matched = true;
-                $offset = $pos + strlen($from);
-            }
-        }
-
-        return $matched ? strtr($value, $this->literal_base_url_replacements) : null;
-    }
-
-    private function has_unescaped_source_url_in_block_comment(string $value): bool
-    {
-        $comment_start = 0;
-        while (true) {
-            $comment_start = strpos($value, '<!-- wp:', $comment_start);
-            if ($comment_start === false) {
-                return false;
-            }
-
-            $comment_end = strpos($value, '-->', $comment_start);
-            if ($comment_end === false) {
-                return false;
-            }
-
-            foreach ($this->literal_source_base_urls as $source_url) {
-                $source_pos = strpos($value, $source_url, $comment_start);
-                if ($source_pos !== false && $source_pos < $comment_end) {
-                    return true;
-                }
-            }
-
-            $comment_start = $comment_end + 3;
-        }
-    }
-
-    private function is_literal_base_url_boundary(string $value, int $pos, int $length): bool
-    {
-        if ($pos > 0) {
-            $prev = $value[$pos - 1];
-            if (
-                !ctype_space($prev)
-                && strpos('"\'([{,:>', $prev) === false
-            ) {
-                return false;
-            }
-        }
-
-        $next_pos = $pos + $length;
-        if ($next_pos >= strlen($value)) {
-            return true;
-        }
-
-        $next = $value[$next_pos];
-        return ctype_space($next)
-            || strpos('/\\?#"\'<)]},;', $next) !== false;
     }
 
     /**

--- a/tests/UrlRewriting/SqlStatementRewriterTest.php
+++ b/tests/UrlRewriting/SqlStatementRewriterTest.php
@@ -193,10 +193,11 @@ class SqlStatementRewriterTest extends TestCase
         $this->assertStringNotContainsString('old-site.com', $values[0]);
     }
 
-    public function testUnknownColumnUsesPlainTextReplacement(): void
+    public function testUnknownColumnUsesPlainTextUrlScanning(): void
     {
         $rewriter = $this->createRewriter();
-        // A plain URL in a non-block-markup column — should use strtr()
+        // A plain URL in a non-block-markup column should use the plain-text
+        // URL scanner.
         $value = 'https://old-site.com/api/endpoint';
         $encoded = base64_encode($value);
         $sql = "INSERT INTO `wp_options` (`option_name`, `option_value`) VALUES(FROM_BASE64('" . base64_encode('siteurl') . "'), FROM_BASE64('{$encoded}'));";
@@ -204,7 +205,6 @@ class SqlStatementRewriterTest extends TestCase
         $result = $rewriter->rewrite($sql);
 
         $values = $this->collectValues($result);
-        // option_value should be rewritten via strtr
         $this->assertStringContainsString('new-site.com/api/endpoint', $values[1]);
     }
 
@@ -221,6 +221,75 @@ class SqlStatementRewriterTest extends TestCase
         $values = $this->collectValues($result);
         $this->assertCount(1, $values);
         $this->assertStringContainsString('new-site.com/page', $values[0]);
+    }
+
+    public function testPostContentUsesStructuredParserForMixedUrlSpellings(): void
+    {
+        $rewriter = $this->createRewriter();
+        $markup = '<a href="https://old-site.com/literal">Literal</a>'
+            . '<a href="HTTPS://OLD-SITE.COM/case-variant">Case variant</a>';
+        $encoded = base64_encode($markup);
+        $sql = "INSERT INTO `wp_posts` (`ID`, `post_content`) VALUES(1, FROM_BASE64('{$encoded}'));";
+
+        $result = $rewriter->rewrite($sql);
+
+        $values = $this->collectValues($result);
+        $this->assertCount(1, $values);
+        $this->assertStringContainsString('https://new-site.com/literal', $values[0]);
+        $this->assertStringContainsString('https://new-site.com/case-variant', $values[0]);
+        $this->assertStringNotContainsString('old-site.com', strtolower($values[0]));
+    }
+
+    public function testPostContentUsesStructuredParserForCaseVariantHostWithoutLiteralSourceDomain(): void
+    {
+        $rewriter = $this->createRewriter();
+        $markup = '<a href=\'https://OLD-SITE.COM/case-variant\'>Case variant</a>';
+        $encoded = base64_encode($markup);
+        $sql = "INSERT INTO `wp_posts` (`ID`, `post_content`) VALUES(1, FROM_BASE64('{$encoded}'));";
+
+        $result = $rewriter->rewrite($sql);
+
+        $values = $this->collectValues($result);
+        $this->assertCount(1, $values);
+        $this->assertStringContainsString('https://new-site.com/case-variant', $values[0]);
+        $this->assertStringNotContainsString('old-site.com', strtolower($values[0]));
+    }
+
+    public function testPostContentUsesStructuredParserForPunycodeAndUnicodeHostSpellings(): void
+    {
+        $rewriter = $this->createRewriter([
+            'https://xn--bcher-kva.example' => 'https://new.example',
+        ]);
+        $markup = '<a href="https://xn--bcher-kva.example/punycode">Punycode</a>'
+            . '<a href="https://bücher.example/unicode">Unicode</a>';
+        $encoded = base64_encode($markup);
+        $sql = "INSERT INTO `wp_posts` (`ID`, `post_content`) VALUES(1, FROM_BASE64('{$encoded}'));";
+
+        $result = $rewriter->rewrite($sql);
+
+        $values = $this->collectValues($result);
+        $this->assertCount(1, $values);
+        $this->assertStringContainsString('https://new.example/punycode', $values[0]);
+        $this->assertStringContainsString('https://new.example/unicode', $values[0]);
+        $this->assertStringNotContainsString('xn--bcher-kva.example', $values[0]);
+        $this->assertStringNotContainsString('bücher.example', $values[0]);
+    }
+
+    public function testPostContentUsesStructuredParserForUnicodeHostInBlockCommentJson(): void
+    {
+        $rewriter = $this->createRewriter([
+            'https://xn--bcher-kva.example' => 'https://new.example',
+        ]);
+        $markup = '<!-- wp:image {"src":"https://bücher.example/unicode"} -->';
+        $encoded = base64_encode($markup);
+        $sql = "INSERT INTO `wp_posts` (`ID`, `post_content`) VALUES(1, FROM_BASE64('{$encoded}'));";
+
+        $result = $rewriter->rewrite($sql);
+
+        $values = $this->collectValues($result);
+        $this->assertCount(1, $values);
+        $this->assertStringContainsString('https:\/\/new.example\/unicode', $values[0]);
+        $this->assertStringNotContainsString('bücher.example', $values[0]);
     }
 
     public function testCommentContentUsesBlockMarkup(): void
@@ -403,12 +472,9 @@ class SqlStatementRewriterTest extends TestCase
         $result = $rewriter->rewrite($sql);
 
         // post_content in this unknown table should NOT get the block_markup
-        // hint — it falls back to auto-detect (plain text strtr), which still
-        // rewrites URLs but through a different code path. The key assertion
-        // is that get_content_type returns null, not 'block_markup'. We verify
-        // indirectly: block_markup would parse the HTML structure, plain text
-        // just does strtr. Both rewrite the URL, so we confirm the rewrite
-        // happens (auto-detect is fine) but the table was not matched as "posts".
+        // hint — it falls back to auto-detect and uses the plain-text URL
+        // scanner for leaf text. This confirms the URL is still rewritten
+        // without matching the table as "posts".
         $values = $this->collectValues($result);
         $this->assertCount(1, $values);
         $this->assertStringContainsString('new-site.com/page', $values[0]);
@@ -425,13 +491,10 @@ class SqlStatementRewriterTest extends TestCase
 
         $result = $rewriter->rewrite($sql);
 
-        // The value still gets rewritten (auto-detect/plain text), but it must
-        // NOT have been treated as block_markup. We can tell because plain text
-        // strtr rewrites the URL but doesn't parse block comment JSON attributes.
-        // With a simple URL like this both paths produce the same output, so
-        // we use a value that distinguishes them: a block comment with a JSON
-        // attribute. block_markup would rewrite inside the JSON; plain text
-        // strtr would not touch the JSON attribute.
+        // The value still gets rewritten through the auto-detect path, but it
+        // must NOT have been treated as block_markup. With a simple URL both
+        // paths produce the same output, so this primarily guards table-name
+        // matching rather than parser behavior.
         $values = $this->collectValues($result);
         $this->assertCount(1, $values);
         $this->assertStringContainsString('new-site.com', $values[0]);
@@ -480,8 +543,7 @@ class SqlStatementRewriterTest extends TestCase
     /**
      * A block comment JSON attribute lets us distinguish block_markup from
      * plain text rewriting. block_markup parses the JSON inside
-     * <!-- wp:image {"url":"..."} --> and rewrites it. Plain text strtr does
-     * a byte-for-byte replacement that can break JSON when URL lengths change.
+     * <!-- wp:image {"url":"..."} --> and rewrites it with the block parser.
      *
      * We use this to prove that "wp_posts".post_content gets block_markup
      * while a spoofed table does NOT.
@@ -489,7 +551,6 @@ class SqlStatementRewriterTest extends TestCase
     public function testBlockMarkupVsPlainTextDistinction(): void
     {
         $rewriter = $this->createRewriter([
-            // Different-length URLs so strtr would shift offsets and break JSON
             'https://old-site.com' => 'https://new-longer-domain-site.com',
         ]);
 
@@ -505,7 +566,7 @@ class SqlStatementRewriterTest extends TestCase
         $values_real = $this->collectValues($result_real);
         $this->assertStringContainsString('new-longer-domain-site.com/img.jpg', $values_real[0]);
         // The JSON attribute should still be valid inside the block comment.
-        // wp_rewrite_urls() JSON-encodes attribute values, so slashes are escaped.
+        // The block parser JSON-encodes attribute values, so slashes are escaped.
         $this->assertStringContainsString(
             '"url":"https:\/\/new-longer-domain-site.com\/img.jpg"',
             $values_real[0],
@@ -514,14 +575,12 @@ class SqlStatementRewriterTest extends TestCase
 
         // spoofed_posts.post_content → auto-detect (not block_markup): the
         // column name matches but the table doesn't, so it falls through to
-        // plain text strtr.
+        // plain-text URL scanning.
         $sql_spoof = "INSERT INTO `spoofed_posts` (`ID`, `post_content`) VALUES(1, FROM_BASE64('{$encoded}'));";
         $result_spoof = $rewriter->rewrite($sql_spoof);
         $values_spoof = $this->collectValues($result_spoof);
-        // The URL is still rewritten (auto-detect handles it), but the JSON
-        // attribute inside the block comment may be malformed because strtr
-        // doesn't understand HTML structure. The key point: the spoofed table
-        // was NOT given the block_markup hint.
+        // The URL is still rewritten (auto-detect handles it). The key point:
+        // the spoofed table was NOT given the block_markup hint.
         $this->assertStringContainsString('new-longer-domain-site.com', $values_spoof[0]);
     }
 

--- a/tests/UrlRewriting/StructuredDataUrlRewriterTest.php
+++ b/tests/UrlRewriting/StructuredDataUrlRewriterTest.php
@@ -324,11 +324,11 @@ class StructuredDataUrlRewriterTest extends TestCase
 
     // --- Content type hint: 'block_markup' ---
 
-    public function testBlockMarkupHintUsesWpRewriteUrls(): void
+    public function testBlockMarkupHintUsesStructuredBlockParser(): void
     {
         $rewriter = $this->createRewriter();
-        // Block markup with JSON attribute — wp_rewrite_urls() handles the JSON
-        // inside the block comment, strtr() would not
+        // Block markup with JSON attribute — the block parser handles the JSON
+        // inside the block comment.
         $input = '<!-- wp:image {"src":"https://old-site.com/img.jpg"} --><figure><img src="https://old-site.com/img.jpg"/></figure><!-- /wp:image -->';
         $result = $rewriter->rewrite($input, 'block_markup');
         $this->assertStringNotContainsString('old-site.com', $result);
@@ -343,7 +343,7 @@ class StructuredDataUrlRewriterTest extends TestCase
         $this->assertStringContainsString('https://new-site.com/page', $result);
     }
 
-    public function testKnownBlockMarkupFastPathRewritesEscapedBlockJsonAndHtml(): void
+    public function testKnownBlockMarkupRewritesEscapedBlockJsonAndHtml(): void
     {
         $rewriter = $this->createRewriter();
         $input = '<!-- wp:image {"src":"https:\/\/old-site.com\/img.jpg"} -->'
@@ -357,7 +357,7 @@ class StructuredDataUrlRewriterTest extends TestCase
         $this->assertStringNotContainsString('old-site.com', $result);
     }
 
-    public function testKnownBlockMarkupFastPathFallsBackForEmbeddedQueryUrl(): void
+    public function testKnownBlockMarkupDoesNotRewriteEmbeddedQueryUrl(): void
     {
         $rewriter = $this->createRewriter();
         $input = '<a href="https://webarchive.org?url=https://old-site.com/about">Archive</a>';
@@ -365,12 +365,79 @@ class StructuredDataUrlRewriterTest extends TestCase
         $this->assertSame($input, $rewriter->rewrite_known_block_markup_value($input));
     }
 
-    // --- Content type hint: null (default) uses plain text replacement ---
-
-    public function testDefaultHintUsesPlainTextReplacement(): void
+    public function testKnownBlockMarkupRewritesMixedLiteralAndCaseVariantUrls(): void
     {
         $rewriter = $this->createRewriter();
-        // A plain URL string — strtr() handles this fine
+        $input = '<a href="https://old-site.com/literal">Literal</a>'
+            . '<a href="HTTPS://OLD-SITE.COM/case-variant">Case variant</a>';
+
+        $result = $rewriter->rewrite_known_block_markup_value($input);
+
+        $this->assertStringContainsString('https://new-site.com/literal', $result);
+        $this->assertStringContainsString('https://new-site.com/case-variant', $result);
+        $this->assertStringNotContainsString('old-site.com', strtolower($result));
+    }
+
+    public function testKnownBlockMarkupRewritesCaseVariantHostWithoutLiteralSourceDomain(): void
+    {
+        $rewriter = $this->createRewriter();
+        $input = '<a href=\'https://OLD-SITE.COM/case-variant\'>Case variant</a>';
+
+        $result = $rewriter->rewrite_known_block_markup_value($input);
+
+        $this->assertStringContainsString('https://new-site.com/case-variant', $result);
+        $this->assertStringNotContainsString('old-site.com', strtolower($result));
+    }
+
+    public function testKnownBlockMarkupRewritesPunycodeAndUnicodeHostSpellings(): void
+    {
+        $rewriter = $this->createRewriter([
+            'https://xn--bcher-kva.example' => 'https://new.example',
+        ]);
+        $input = '<a href="https://xn--bcher-kva.example/punycode">Punycode</a>'
+            . '<a href="https://bücher.example/unicode">Unicode</a>';
+
+        $result = $rewriter->rewrite_known_block_markup_value($input);
+
+        $this->assertStringContainsString('https://new.example/punycode', $result);
+        $this->assertStringContainsString('https://new.example/unicode', $result);
+        $this->assertStringNotContainsString('xn--bcher-kva.example', $result);
+        $this->assertStringNotContainsString('bücher.example', $result);
+    }
+
+    public function testKnownBlockMarkupRewritesUnicodeHostInBlockCommentJson(): void
+    {
+        $rewriter = $this->createRewriter([
+            'https://xn--bcher-kva.example' => 'https://new.example',
+        ]);
+        $input = '<!-- wp:image {"src":"https://bücher.example/unicode"} -->';
+
+        $result = $rewriter->rewrite_known_block_markup_value($input);
+
+        $this->assertStringContainsString('https:\/\/new.example\/unicode', $result);
+        $this->assertStringNotContainsString('bücher.example', $result);
+    }
+
+    public function testKnownBlockMarkupRewritesEscapedJsonAndCaseVariantHtmlTogether(): void
+    {
+        $rewriter = $this->createRewriter();
+        $input = '<!-- wp:image {"src":"https:\/\/old-site.com\/img.jpg"} -->'
+            . '<figure><img src="HTTPS://OLD-SITE.COM/img.jpg"/></figure>'
+            . '<!-- /wp:image -->';
+
+        $result = $rewriter->rewrite_known_block_markup_value($input);
+
+        $this->assertStringContainsString('https:\/\/new-site.com\/img.jpg', $result);
+        $this->assertStringContainsString('src="https://new-site.com/img.jpg"', $result);
+        $this->assertStringNotContainsString('old-site.com', strtolower($result));
+    }
+
+    // --- Content type hint: null (default) uses plain text URL scanning ---
+
+    public function testDefaultHintUsesPlainTextUrlScanning(): void
+    {
+        $rewriter = $this->createRewriter();
+        // A plain URL string is handled by URLInTextProcessor.
         $input = 'Visit https://old-site.com/about for more.';
         $result = $rewriter->rewrite($input);
         $this->assertStringContainsString('https://new-site.com/about', $result);
@@ -402,7 +469,7 @@ class StructuredDataUrlRewriterTest extends TestCase
     {
         $rewriter = $this->createRewriter();
         // Serialized PHP containing a block markup string — the block_markup
-        // hint should propagate so the inner text gets wp_rewrite_urls()
+        // hint should propagate so the inner text gets the block parser.
         $markup = '<!-- wp:image {"src":"https://old-site.com/img.jpg"} --><figure><img src="https://old-site.com/img.jpg"/></figure><!-- /wp:image -->';
         $input = serialize(['content' => $markup]);
         $result = $rewriter->rewrite($input, 'block_markup');


### PR DESCRIPTION
## What it does

Removes the known-block-markup literal base URL replacement path and routes those values through the structured block URL parser instead.

This fixes cases where a single `post_content` value contains multiple spellings of the same source URL. The old shortcut could rewrite the literal `https://old-site.com/...` occurrence and then return before the parser saw equivalent URLs like uppercase hosts or Unicode IDN hosts.

## Rationale

The literal replacement path was fast, but it was not rigorous. It treated the source URL as bytes instead of structured URL data, so it could miss URLs that `BlockMarkupUrlProcessor` and `WPURL` correctly recognize as equivalent.

Examples now covered by tests:

```html
<a href="https://old-site.com/literal">Literal</a>
<a href="HTTPS://OLD-SITE.COM/case-variant">Case variant</a>
```

```html
<a href="https://xn--bcher-kva.example/punycode">Punycode</a>
<a href="https://bücher.example/unicode">Unicode</a>
```

## Implementation

- Deletes `try_rewrite_literal_base_urls()` and the literal replacement maps from `StructuredDataUrlRewriter`.
- Keeps `rewrite_known_block_markup_value()` as the column-aware entrypoint, but makes it delegate to `rewrite(..., block_markup)`.
- Makes the quick reject use case-insensitive host checks and adds IDN host variants when `intl` is available.
- Updates stale comments that still described `strtr()` or literal block-markup rewriting.
- Adds regressions for mixed literal/case-variant URLs, case-variant hosts without a lowercase literal source domain, and punycode/Unicode host spellings through both `StructuredDataUrlRewriter` and `SqlStatementRewriter`.

## Benchmark

Fixture: prior prepared-insert db-apply fixture, 262 MB SQL dump, 865 statements, PHP.wasm 8.4.

### Native php-toolkit benchmark

Both native manifests were loaded and verified:

- `wp_mysql_parser=yes`
- `wp_native_apis=yes`

Command shape:

```bash
PLAYGROUND_PHP_VERSION=8.4 \
WP_MYSQL_PARSER_EXTENSION_MANIFEST=/Users/cloudnik/conductor/workspaces/studio/amsterdam/.context/wasm-extensions/sqlite/wp_mysql_parser-wasm-extension/manifest.json \
WP_NATIVE_APIS_EXTENSION_MANIFEST=/Users/cloudnik/conductor/workspaces/studio/amsterdam/.context/wasm-extensions/php-toolkit/wp-native-apis-playground-extension/manifest.json \
node --experimental-wasm-jspi .context/scripts/php-wasm-runner-two-extensions.mjs importer/import.php db-apply - \
  --target-engine=sqlite \
  --rewrite-url https://127.0.0.1:8199 http://localhost:8881 \
  --rewrite-url http://127.0.0.1:8199 http://localhost:8881
```

| Case | db-apply wall time | Exit | Delta vs trunk |
|---|---:|---:|---:|
| `trunk` | 91.809 s | 0 | baseline |
| this branch | 111.876 s | 0 | +20.067 s (+21.9%, 1.22x slower) |

Artifacts:

- `.context/reprint-profile/structured-block-rewrite-native-1779322850/trunk/result.tsv`
- `.context/reprint-profile/structured-block-rewrite-native-1779322850/branch/result.tsv`

### SQLite-parser-only control

The same fixture with only the sqlite-database-integration `wp_mysql_parser` extension loaded shows the PHP fallback cost when `wp_native_apis` is not available:

| Case | db-apply wall time | Exit | Delta vs trunk |
|---|---:|---:|---:|
| `trunk` | 96.299 s | 0 | baseline |
| this branch | 842.333 s | 0 | +746.034 s (+774.7%, 8.75x slower) |

Artifacts:

- `.context/reprint-profile/structured-block-rewrite-1779321121/trunk/result.tsv`
- `.context/reprint-profile/structured-block-rewrite-1779321121/branch/result.tsv`

## Testing instructions

```bash
php -l packages/reprint-importer/src/lib/url-rewrite/class-structured-data-url-rewriter.php
php -l packages/reprint-importer/src/lib/url-rewrite/class-sql-statement-rewriter.php
vendor/bin/phpunit --configuration tests/phpunit.xml tests/UrlRewriting tests/Import/NewSiteUrlSqliteTest.php
vendor/bin/phpstan analyze --memory-limit=1G packages/reprint-importer/src/lib/url-rewrite
```

Note: `vendor/bin/phpstan analyze --memory-limit=1G packages/reprint-importer/src/lib/url-rewrite tests/UrlRewriting` still fails because PHPStan does not resolve PHPUnit assertion methods in the existing test classes; the source-only PHPStan run passes.
