### PR TITLE
[codex] Cache repeated structured URL rewrites

### DIFF
--- a/packages/reprint-importer/src/lib/url-rewrite/class-structured-data-url-rewriter.php
+++ b/packages/reprint-importer/src/lib/url-rewrite/class-structured-data-url-rewriter.php
@@ -333,19 +333,11 @@ class StructuredDataUrlRewriter
             return $value;
         }
 
-        $structured_cache_key = self::PLAIN_TEXT . "\0scalar\0" . $value;
-        $cached = $this->get_cached_structured_rewrite($structured_cache_key);
-        if ($cached !== null) {
-            return $cached;
-        }
-
         if (!$this->maybe_contains_rewritable_urls($value)) {
             return $value;
         }
 
-        $rewritten_value = $this->rewrite_urls($value, self::PLAIN_TEXT);
-        $this->set_cached_structured_rewrite($structured_cache_key, $rewritten_value);
-        return $rewritten_value;
+        return $this->rewrite_urls($value, self::PLAIN_TEXT);
     }
 
     /**

--- a/packages/reprint-importer/src/lib/url-rewrite/class-structured-data-url-rewriter.php
+++ b/packages/reprint-importer/src/lib/url-rewrite/class-structured-data-url-rewriter.php
@@ -148,9 +148,11 @@ class StructuredDataUrlRewriter
             return $value;
         }
 
+        // Avoid constructing the serialized-PHP parser for ordinary URL
+        // strings and block markup. The parser still owns validation once
+        // entered; this gate only skips impossible first-byte shapes that
+        // cannot expose string values for rewriting.
         if ($this->could_be_php_serialization_with_strings($value)) {
-            // Try serialized PHP: the parser validates the entire structure
-            // in the constructor. If it's not malformed, iterate and recurse.
             $p = new PhpSerializationProcessor($value);
             if (!$p->is_malformed()) {
                 while ($p->next_value()) {

--- a/packages/reprint-importer/src/lib/url-rewrite/class-structured-data-url-rewriter.php
+++ b/packages/reprint-importer/src/lib/url-rewrite/class-structured-data-url-rewriter.php
@@ -9,9 +9,10 @@ use function WordPress\DataLiberation\URL\is_child_url_of;
  * Rewrites URLs in a single decoded database value by detecting the data
  * format and applying the appropriate rewriting strategy.
  *
- * Format detection is try-and-fail: construct the real parser, check if
- * it accepted the input. No heuristic pre-checks, no format detection
- * class — the parsers themselves are the authority on what's valid.
+ * Format detection is try-and-fail after conservative syntax gates: construct
+ * the real parser, check if it accepted the input. The gates only skip parser
+ * attempts for byte prefixes that cannot contain string leaves for that format;
+ * the parsers themselves remain the authority on what's valid.
  *
  * 1. Serialized PHP → construct PhpSerializationProcessor, if not malformed,
  *    iterate string values and recurse on each
@@ -31,6 +32,7 @@ class StructuredDataUrlRewriter
 {
     const BLOCK_MARKUP = 'block_markup';
     const PLAIN_TEXT = 'plain_text';
+    private const STRUCTURED_REWRITE_CACHE_MAX = 4096;
     private const REWRITE_RESULT_CACHE_MAX = 4096;
 
     /** @var string[] Source domains extracted from url_mapping keys, for quick-reject checks. */
@@ -60,6 +62,14 @@ class StructuredDataUrlRewriter
 
     /** @var string Cache namespace for this rewriter's URL mapping. */
     private string $mapping_cache_key;
+
+    /** @var array<string, array{content_type: string, input: string, output: string}> */
+    private array $structured_rewrite_cache = [];
+
+    /** @var string[] */
+    private array $structured_rewrite_cache_ring = [];
+
+    private int $structured_rewrite_cache_next = 0;
 
     /** @var array<string, false|array{raw_url: string, parsed_url: mixed}> */
     private array $rewrite_result_cache = [];
@@ -124,6 +134,12 @@ class StructuredDataUrlRewriter
             $content_type = self::PLAIN_TEXT;
         }
 
+        $structured_cache_key = sha1($content_type . "\0" . $value);
+        $cached = $this->get_cached_structured_rewrite($structured_cache_key, $content_type, $value);
+        if ($cached !== null) {
+            return $cached;
+        }
+
         // Quick-reject: if the value doesn't contain href=", src=", or any
         // source domain, there's nothing to rewrite. This avoids expensive
         // parsing (serialized PHP, JSON, block markup) for the vast majority
@@ -132,32 +148,40 @@ class StructuredDataUrlRewriter
             return $value;
         }
 
-        // Try serialized PHP: the parser validates the entire structure
-        // in the constructor. If it's not malformed, iterate and recurse.
-        $p = new PhpSerializationProcessor($value);
-        if (!$p->is_malformed()) {
-            while ($p->next_value()) {
-                $original = $p->get_value();
-                $rewritten = $this->rewrite($original, $content_type);
-                if ($rewritten !== $original) {
-                    $p->set_value($rewritten);
+        if ($this->could_be_php_serialization_with_strings($value)) {
+            // Try serialized PHP: the parser validates the entire structure
+            // in the constructor. If it's not malformed, iterate and recurse.
+            $p = new PhpSerializationProcessor($value);
+            if (!$p->is_malformed()) {
+                while ($p->next_value()) {
+                    $original = $p->get_value();
+                    $rewritten = $this->rewrite($original, $content_type);
+                    if ($rewritten !== $original) {
+                        $p->set_value($rewritten);
+                    }
                 }
+                $rewritten_value = $p->get_updated_serialization();
+                $this->set_cached_structured_rewrite($structured_cache_key, $content_type, $value, $rewritten_value);
+                return $rewritten_value;
             }
-            return $p->get_updated_serialization();
         }
 
-        // Try JSON: the iterator calls json_decode in the constructor.
-        // If it's not malformed, iterate and recurse.
-        $iter = new JsonStringIterator($value);
-        if (!$iter->is_malformed()) {
-            while ($iter->next_value()) {
-                $original = $iter->get_value();
-                $rewritten = $this->rewrite($original, $content_type);
-                if ($rewritten !== $original) {
-                    $iter->set_value($rewritten);
+        if ($this->could_be_json_container($value)) {
+            // Try JSON: the iterator calls json_decode in the constructor.
+            // If it's not malformed, iterate and recurse.
+            $iter = new JsonStringIterator($value);
+            if (!$iter->is_malformed()) {
+                while ($iter->next_value()) {
+                    $original = $iter->get_value();
+                    $rewritten = $this->rewrite($original, $content_type);
+                    if ($rewritten !== $original) {
+                        $iter->set_value($rewritten);
+                    }
                 }
+                $rewritten_value = $iter->get_result();
+                $this->set_cached_structured_rewrite($structured_cache_key, $content_type, $value, $rewritten_value);
+                return $rewritten_value;
             }
-            return $iter->get_result();
         }
 
         // Base64 decoding is temporarily disabled for performance.
@@ -165,7 +189,9 @@ class StructuredDataUrlRewriter
         // Base64ValueScanner in SqlStatementRewriter — this block
         // was for base64-within-base64 nesting which is rare in practice.
 
-        return $this->rewrite_urls($value, $content_type);
+        $rewritten_value = $this->rewrite_urls($value, $content_type);
+        $this->set_cached_structured_rewrite($structured_cache_key, $content_type, $value, $rewritten_value);
+        return $rewritten_value;
     }
 
     /**
@@ -186,6 +212,31 @@ class StructuredDataUrlRewriter
                 return true;
             }
         }
+        return false;
+    }
+
+    private function could_be_php_serialization_with_strings(string $value): bool
+    {
+        $first_byte = $value[0] ?? '';
+
+        return $first_byte === 'a'
+            || $first_byte === 's'
+            || $first_byte === 'O'
+            || $first_byte === 'C';
+    }
+
+    private function could_be_json_container(string $value): bool
+    {
+        $length = strlen($value);
+        for ($i = 0; $i < $length; $i++) {
+            $byte = $value[$i];
+            if ($byte === ' ' || $byte === "\n" || $byte === "\r" || $byte === "\t") {
+                continue;
+            }
+
+            return $byte === '{' || $byte === '[';
+        }
+
         return false;
     }
 
@@ -219,6 +270,41 @@ class StructuredDataUrlRewriter
         }
     }
 
+    private function get_cached_structured_rewrite(string $cache_key, string $content_type, string $value): ?string
+    {
+        if (!array_key_exists($cache_key, $this->structured_rewrite_cache)) {
+            return null;
+        }
+
+        $entry = $this->structured_rewrite_cache[$cache_key];
+        if ($entry['content_type'] !== $content_type || $entry['input'] !== $value) {
+            return null;
+        }
+
+        return $entry['output'];
+    }
+
+    private function set_cached_structured_rewrite(string $cache_key, string $content_type, string $input, string $output): void
+    {
+        if (!array_key_exists($cache_key, $this->structured_rewrite_cache)) {
+            if (count($this->structured_rewrite_cache_ring) < self::STRUCTURED_REWRITE_CACHE_MAX) {
+                $this->structured_rewrite_cache_ring[] = $cache_key;
+            } else {
+                $evicted_key = $this->structured_rewrite_cache_ring[$this->structured_rewrite_cache_next];
+                unset($this->structured_rewrite_cache[$evicted_key]);
+                $this->structured_rewrite_cache_ring[$this->structured_rewrite_cache_next] = $cache_key;
+            }
+
+            $this->structured_rewrite_cache_next = ($this->structured_rewrite_cache_next + 1) % self::STRUCTURED_REWRITE_CACHE_MAX;
+        }
+
+        $this->structured_rewrite_cache[$cache_key] = [
+            'content_type' => $content_type,
+            'input'       => $input,
+            'output'      => $output,
+        ];
+    }
+
     /**
      * Rewrite a decoded value already known by the SQL layer to be block markup.
      *
@@ -232,6 +318,34 @@ class StructuredDataUrlRewriter
     public function rewrite_known_block_markup_value(string $value): string
     {
         return $this->rewrite($value, self::BLOCK_MARKUP);
+    }
+
+    /**
+     * Rewrite a decoded value known from schema context to be scalar text.
+     *
+     * This still routes through URLInTextProcessor; it only skips the
+     * serialized-PHP and JSON container probes that are impossible for narrow
+     * core URL columns such as wp_posts.guid or wp_users.user_url.
+     */
+    public function rewrite_known_plain_text_value(string $value): string
+    {
+        if ($value === '') {
+            return $value;
+        }
+
+        $structured_cache_key = self::PLAIN_TEXT . "\0scalar\0" . $value;
+        $cached = $this->get_cached_structured_rewrite($structured_cache_key);
+        if ($cached !== null) {
+            return $cached;
+        }
+
+        if (!$this->maybe_contains_rewritable_urls($value)) {
+            return $value;
+        }
+
+        $rewritten_value = $this->rewrite_urls($value, self::PLAIN_TEXT);
+        $this->set_cached_structured_rewrite($structured_cache_key, $rewritten_value);
+        return $rewritten_value;
     }
 
     /**

--- a/tests/UrlRewriting/JsonStringIteratorTest.php
+++ b/tests/UrlRewriting/JsonStringIteratorTest.php
@@ -1,0 +1,77 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../packages/reprint-importer/src/lib/url-rewrite/load.php';
+
+class JsonStringIteratorTest extends TestCase
+{
+    /**
+     * @return string[]
+     */
+    private function collectValues(string $json): array
+    {
+        $values = [];
+        $iter = new JsonStringIterator($json);
+        while ($iter->next_value()) {
+            $values[] = $iter->get_value();
+        }
+        return $values;
+    }
+
+    public function testCollectsOnlyStringLeafValues(): void
+    {
+        $json = json_encode([
+            'title' => 'Hello',
+            'nested' => [
+                'url' => 'https://example.com',
+                'count' => 3,
+                'enabled' => true,
+            ],
+            'items' => ['first', null, 'second'],
+        ], JSON_UNESCAPED_SLASHES);
+
+        $this->assertSame(
+            ['Hello', 'https://example.com', 'first', 'second'],
+            $this->collectValues($json)
+        );
+    }
+
+    public function testNoChangeReturnsOriginalJson(): void
+    {
+        $json = '{"title":"Hello","items":["first","second"]}';
+        $iter = new JsonStringIterator($json);
+
+        while ($iter->next_value()) {
+            $iter->get_value();
+        }
+
+        $this->assertSame($json, $iter->get_result());
+    }
+
+    public function testSetValueUpdatesNestedLeaf(): void
+    {
+        $json = '{"nested":{"url":"https://old-site.com/page"},"items":["keep"]}';
+        $iter = new JsonStringIterator($json);
+
+        while ($iter->next_value()) {
+            $value = $iter->get_value();
+            if ($value === 'https://old-site.com/page') {
+                $iter->set_value('https://new-site.com/page');
+                $this->assertSame('https://new-site.com/page', $iter->get_value());
+            }
+        }
+
+        $decoded = json_decode($iter->get_result(), true);
+        $this->assertSame('https://new-site.com/page', $decoded['nested']['url']);
+        $this->assertSame(['keep'], $decoded['items']);
+    }
+
+    public function testMalformedJsonIsMalformed(): void
+    {
+        $iter = new JsonStringIterator('{"broken":');
+
+        $this->assertTrue($iter->is_malformed());
+        $this->assertFalse($iter->next_value());
+    }
+}

--- a/tests/UrlRewriting/StructuredDataUrlRewriterTest.php
+++ b/tests/UrlRewriting/StructuredDataUrlRewriterTest.php
@@ -432,6 +432,18 @@ class StructuredDataUrlRewriterTest extends TestCase
         $this->assertStringNotContainsString('old-site.com', strtolower($result));
     }
 
+    public function testRewriteCacheSeparatesPlainTextAndBlockMarkupSemantics(): void
+    {
+        $rewriter = $this->createRewriter();
+        $input = '<div data-note="https://old-site.com/not-a-url-attribute">Content</div>';
+
+        $plain_result = $rewriter->rewrite($input);
+        $block_result = $rewriter->rewrite($input, 'block_markup');
+
+        $this->assertStringContainsString('https://new-site.com/not-a-url-attribute', $plain_result);
+        $this->assertSame($input, $block_result);
+    }
+
     // --- Content type hint: null (default) uses plain text URL scanning ---
 
     public function testDefaultHintUsesPlainTextUrlScanning(): void


### PR DESCRIPTION
## Summary

Caches repeated structured URL rewrite work inside each `StructuredDataUrlRewriter` instance. This is targeted at repeated decoded database values where the same structured payload appears many times during db-apply.

The cache is keyed by content type plus a hash of the original bytes and is guarded by an exact input-byte recheck before reuse. It is capped at 4096 entries. The branch also adds conservative parser-entry gates so values that cannot be PHP serialized string/container values or JSON containers skip those failed parser constructions and proceed to the existing URL processors.

URL handling stays structured-only: PHP serialization parser, JSON string iterator, `BlockMarkupUrlProcessor`, `URLInTextProcessor`, `WPURL::parse()`, `is_child_url_of()`, and `WPURL::replace_base_url()` remain the mechanisms that decide and apply rewrites. There is no literal URL `str_replace` path.

## Adversarial scrutiny

- Added coverage proving the cache does not mix plain-text and block-markup semantics for the same input bytes.
- The cache stores the original input and content type with each entry and rechecks both before returning a cached output.
- Rebased onto current `trunk`; GitHub now reports the PR as mergeable.

## Benchmark

Focused db-apply-shaped decoded-value benchmark against PR #231 base, using 10,000 repeated serialized values containing both a nested URL and block-markup URL:

| Case | Time | Delta |
| --- | ---: | ---: |
| PR #231 base | 7.709582 s | baseline |
| this branch | 0.021913 s | 351.8x faster |

A unique plain-text URL control was also run to watch overhead on non-repeated leaves:

| Case | Time |
| --- | ---: |
| PR #231 base | 3.778649 s |
| this branch | 5.115104 s |

That control shows this is a targeted win for repeated structured values, not a universal full-dump win.

## Verification

```bash
./vendor/bin/phpunit --configuration tests/phpunit.xml tests/UrlRewriting
```

Current rebased head result: 217 tests, 2288 assertions, 7 skipped.
