### PR TITLE
[codex] Scan sparse URL rewrite candidates

### DIFF
--- a/packages/reprint-importer/src/lib/url-rewrite/class-base64-value-scanner.php
+++ b/packages/reprint-importer/src/lib/url-rewrite/class-base64-value-scanner.php
@@ -37,8 +37,9 @@ class Base64ValueScanner
      *   'encoded_value'=> string The base64 payload
      *   'value'        => ?string The base64-decoded value, cached on demand
      *   'new_value'    => ?string Non-null when set_value() has been called
+     *   'column_name'  => ?string Optional column name from tokenization-free scanners
      *
-     * @var array<int, array{expr_start: int, quote_start: int, quote_length: int, encoded_value: string, value: ?string, new_value: ?string}>
+     * @var array<int, array{expr_start: int, quote_start: int, quote_length: int, encoded_value: string, value: ?string, new_value: ?string, column_name?: string}>
      */
     private array $entries = [];
 
@@ -70,7 +71,7 @@ class Base64ValueScanner
      * already located every FROM_BASE64() expression and captured its payload,
      * the scanner skips the lexer and still decodes values lazily.
      *
-     * @param list<array{expr_start: int, quote_start: int, quote_length: int, encoded_value: string, value: ?string, new_value: ?string}> $entries
+     * @param list<array{expr_start: int, quote_start: int, quote_length: int, encoded_value: string, value: ?string, new_value: ?string, column_name?: string}> $entries
      */
     public static function from_entries(string $sql, array $entries): self
     {
@@ -144,6 +145,11 @@ class Base64ValueScanner
     public function get_match_offset(): int
     {
         return $this->entries[$this->cursor]['expr_start'];
+    }
+
+    public function get_column_name(): ?string
+    {
+        return $this->entries[$this->cursor]['column_name'] ?? null;
     }
 
     /**

--- a/packages/reprint-importer/src/lib/url-rewrite/class-fast-insert-scanner.php
+++ b/packages/reprint-importer/src/lib/url-rewrite/class-fast-insert-scanner.php
@@ -41,7 +41,7 @@ class FastInsertScanner
      * }|null
      *   Null when the SQL doesn't match the recognised shape.
      */
-    public static function scan(string $sql): ?array
+    public static function scan(string $sql, bool $http_candidates_only = false): ?array
     {
         // Header: optional leading whitespace, INSERT (no priority/IGNORE
         // modifiers — producer never emits those), INTO, backticked table,
@@ -97,6 +97,10 @@ class FastInsertScanner
         $cursor = $values_end;
         $sql_len = strlen($sql);
 
+        if ($http_candidates_only) {
+            return self::scan_http_candidate_payloads($sql, $sql_len, $table, $columns, $values_end);
+        }
+
         // Walk one tuple at a time. Each tuple is `(v, v, v, …)` followed by
         // either a comma (next tuple) or the statement terminator family
         // ({whitespace} ; | $).
@@ -136,11 +140,11 @@ class FastInsertScanner
                     return null;
                 }
                 $value_end = $cursor;
-                $column_map[] = [$value_start, $value_end, $columns[$col_idx]];
 
                 if (is_array($value_kind)) {
-                    // FROM_BASE64 payload: kind = [expr_start, expr_length, quote_start, quote_length, encoded_value]
-                    $base64_entries[] = [
+                    // FROM_BASE64 payload: kind = [expr_start, expr_length, quote_start, quote_length, encoded_value].
+                    $column_map[] = [$value_start, $value_end, $columns[$col_idx]];
+                    $entry = [
                         'expr_start' => $value_kind[0],
                         'expr_length' => $value_kind[1],
                         'quote_start' => $value_kind[2],
@@ -149,6 +153,7 @@ class FastInsertScanner
                         'value' => null,
                         'new_value' => null,
                     ];
+                    $base64_entries[] = $entry;
                 }
 
                 while ($cursor < $sql_len && self::is_ws($sql[$cursor])) {
@@ -258,7 +263,7 @@ class FastInsertScanner
             }
             $cursor += 12;
             $entry = self::consume_base64_call($sql, $sql_len, $cursor, $expr_start);
-            if (!is_array($entry)) {
+            if ($entry === null) {
                 return null;
             }
             // Expect: USING utf8mb4 )
@@ -283,7 +288,9 @@ class FastInsertScanner
                 return null;
             }
             $cursor++;
-            $entry[1] = $cursor - $expr_start;
+            if (is_array($entry)) {
+                $entry[1] = $cursor - $expr_start;
+            }
             return $entry;
         }
 
@@ -365,5 +372,252 @@ class FastInsertScanner
     private static function is_ws(string $c): bool
     {
         return $c === ' ' || $c === "\t" || $c === "\n" || $c === "\r";
+    }
+
+    /**
+     * Sparse scanner used only by URL rewriting. The statement-level prefilter
+     * has already proved that at least one encoded http/https prefix appears
+     * somewhere in the SQL, so this path indexes those prefix hits and maps only
+     * matching FROM_BASE64 payloads back to their tuple column.
+     *
+     * @param list<string> $columns
+     * @return array{table: string, column_map: list<array{int, int, string}>, base64_entries: list<array{expr_start: int, expr_length: int, quote_start: int, quote_length: int, encoded_value: string, value: ?string, new_value: ?string, column_name?: string}>}|null
+     */
+    private static function scan_http_candidate_payloads(string $sql, int $sql_len, string $table, array $columns, int $values_end): ?array
+    {
+        // The sparse mapper only understands the producer tuple list. Let the
+        // lexer path handle trailers whose values do not correspond to the
+        // INSERT column list.
+        if (stripos($sql, ' ON DUPLICATE ') !== false || stripos($sql, ' RETURNING ') !== false) {
+            return null;
+        }
+
+        $offsets = self::http_prefix_offsets($sql, $values_end);
+        if ($offsets === []) {
+            return [
+                'table' => $table,
+                'column_map' => [],
+                'base64_entries' => [],
+            ];
+        }
+
+        $entries = [];
+        $seen_quotes = [];
+        $column_count = count($columns);
+        foreach ($offsets as $prefix_offset) {
+            $entry = self::entry_for_http_prefix_offset($sql, $sql_len, $prefix_offset, $values_end, $columns, $column_count);
+            if ($entry === false) {
+                return null;
+            }
+            if ($entry === null) {
+                continue;
+            }
+            if (isset($seen_quotes[$entry['quote_start']])) {
+                continue;
+            }
+            $seen_quotes[$entry['quote_start']] = true;
+            $entries[] = $entry;
+        }
+
+        usort(
+            $entries,
+            static fn(array $a, array $b): int => $a['expr_start'] <=> $b['expr_start']
+        );
+
+        return [
+            'table' => $table,
+            'column_map' => [],
+            'base64_entries' => $entries,
+        ];
+    }
+
+    /**
+     * @param list<string> $columns
+     * @return array{expr_start: int, expr_length: int, quote_start: int, quote_length: int, encoded_value: string, value: ?string, new_value: ?string, column_name: string}|false|null
+     */
+    private static function entry_for_http_prefix_offset(string $sql, int $sql_len, int $prefix_offset, int $values_end, array $columns, int $column_count)
+    {
+        $close = strpos($sql, "'", $prefix_offset);
+        if ($close === false) {
+            return null;
+        }
+
+        $quote_start = self::previous_quote($sql, $prefix_offset, $values_end);
+        if ($quote_start === null || $quote_start >= $prefix_offset || $prefix_offset >= $close) {
+            return null;
+        }
+
+        $open_paren = self::previous_non_ws($sql, $quote_start - 1, $values_end);
+        if ($open_paren === null || $sql[$open_paren] !== '(') {
+            return null;
+        }
+
+        $name_end = self::previous_non_ws($sql, $open_paren - 1, $values_end);
+        if ($name_end === null || $name_end - 10 < $values_end) {
+            return null;
+        }
+        $name_start = $name_end - 10;
+        if (substr_compare($sql, 'FROM_BASE64', $name_start, 11, true) !== 0) {
+            return null;
+        }
+
+        $cursor = $close + 1;
+        $quote_length = $cursor - $quote_start;
+        while ($cursor < $sql_len && self::is_ws($sql[$cursor])) {
+            $cursor++;
+        }
+        if ($cursor >= $sql_len || $sql[$cursor] !== ')') {
+            return false;
+        }
+        $cursor++;
+        $expr_start = $name_start;
+        $expr_end = $cursor;
+
+        $convert_open = self::previous_non_ws($sql, $name_start - 1, $values_end);
+        if ($convert_open !== null && $sql[$convert_open] === '(') {
+            $convert_name_end = self::previous_non_ws($sql, $convert_open - 1, $values_end);
+            if ($convert_name_end !== null && $convert_name_end - 6 >= $values_end) {
+                $convert_name_start = $convert_name_end - 6;
+                if (substr_compare($sql, 'CONVERT', $convert_name_start, 7, true) === 0) {
+                    $convert_end = self::consume_convert_tail($sql, $sql_len, $cursor);
+                    if ($convert_end === null) {
+                        return false;
+                    }
+                    $expr_start = $convert_name_start;
+                    $expr_end = $convert_end;
+                }
+            }
+        }
+
+        $column_index = self::column_index_for_expression($sql, $expr_start, $values_end);
+        if ($column_index === null || $column_index >= $column_count) {
+            return false;
+        }
+
+        $payload = substr($sql, $quote_start + 1, $close - $quote_start - 1);
+        if ($payload !== '' && !preg_match('/\A[A-Za-z0-9+\/=]*\z/', $payload)) {
+            return false;
+        }
+
+        return [
+            'expr_start' => $expr_start,
+            'expr_length' => $expr_end - $expr_start,
+            'quote_start' => $quote_start,
+            'quote_length' => $quote_length,
+            'encoded_value' => $payload,
+            'value' => null,
+            'new_value' => null,
+            'column_name' => $columns[$column_index],
+        ];
+    }
+
+    private static function consume_convert_tail(string $sql, int $sql_len, int $cursor): ?int
+    {
+        while ($cursor < $sql_len && self::is_ws($sql[$cursor])) {
+            $cursor++;
+        }
+        if ($cursor + 5 > $sql_len || substr_compare($sql, 'USING', $cursor, 5, true) !== 0) {
+            return null;
+        }
+        $cursor += 5;
+        while ($cursor < $sql_len && self::is_ws($sql[$cursor])) {
+            $cursor++;
+        }
+        if ($cursor + 7 > $sql_len || substr_compare($sql, 'utf8mb4', $cursor, 7, true) !== 0) {
+            return null;
+        }
+        $cursor += 7;
+        while ($cursor < $sql_len && self::is_ws($sql[$cursor])) {
+            $cursor++;
+        }
+        if ($cursor >= $sql_len || $sql[$cursor] !== ')') {
+            return null;
+        }
+        return $cursor + 1;
+    }
+
+    private static function column_index_for_expression(string $sql, int $expr_start, int $values_end): ?int
+    {
+        $depth = 0;
+        $tuple_start = null;
+        for ($i = $expr_start - 1; $i >= $values_end; $i--) {
+            $c = $sql[$i];
+            if ($c === ')') {
+                $depth++;
+            } elseif ($c === '(') {
+                if ($depth === 0) {
+                    $tuple_start = $i;
+                    break;
+                }
+                $depth--;
+            }
+        }
+        if ($tuple_start === null) {
+            return null;
+        }
+
+        $column_index = 0;
+        $depth = 0;
+        for ($i = $tuple_start + 1; $i < $expr_start; $i++) {
+            $c = $sql[$i];
+            if ($c === "'") {
+                $end = strpos($sql, "'", $i + 1);
+                if ($end === false || $end >= $expr_start) {
+                    return null;
+                }
+                $i = $end;
+                continue;
+            }
+            if ($c === '(') {
+                $depth++;
+            } elseif ($c === ')') {
+                if ($depth === 0) {
+                    return null;
+                }
+                $depth--;
+            } elseif ($c === ',' && $depth === 0) {
+                $column_index++;
+            }
+        }
+
+        return $column_index;
+    }
+
+    private static function previous_quote(string $sql, int $offset, int $floor): ?int
+    {
+        for ($i = $offset - 1; $i >= $floor; $i--) {
+            if ($sql[$i] === "'") {
+                return $i;
+            }
+        }
+        return null;
+    }
+
+    private static function previous_non_ws(string $sql, int $offset, int $floor): ?int
+    {
+        for ($i = $offset; $i >= $floor; $i--) {
+            if (!self::is_ws($sql[$i])) {
+                return $i;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * @return list<int>
+     */
+    private static function http_prefix_offsets(string $sql, int $offset = 0): array
+    {
+        $offsets = [];
+        foreach (['aHR0', 'dHA6', 'dHBz', 'dHRw'] as $prefix) {
+            $cursor = $offset;
+            while (($cursor = strpos($sql, $prefix, $cursor)) !== false) {
+                $offsets[] = $cursor;
+                $cursor++;
+            }
+        }
+
+        sort($offsets);
+        return $offsets;
     }
 }

--- a/packages/reprint-importer/src/lib/url-rewrite/class-fast-insert-scanner.php
+++ b/packages/reprint-importer/src/lib/url-rewrite/class-fast-insert-scanner.php
@@ -392,8 +392,7 @@ class FastInsertScanner
             return null;
         }
 
-        $offsets = self::http_prefix_offsets($sql, $values_end);
-        if ($offsets === []) {
+        if (!preg_match('/aHR0|dHA6|dHBz|dHRw/', $sql, $match, PREG_OFFSET_CAPTURE, $values_end)) {
             return [
                 'table' => $table,
                 'column_map' => [],
@@ -402,22 +401,22 @@ class FastInsertScanner
         }
 
         $entries = [];
-        $seen_quotes = [];
+        $search_offset = $match[0][1];
         $column_count = count($columns);
-        foreach ($offsets as $prefix_offset) {
+        do {
+            $prefix_offset = $match[0][1];
             $entry = self::entry_for_http_prefix_offset($sql, $sql_len, $prefix_offset, $values_end, $columns, $column_count);
             if ($entry === false) {
                 return null;
             }
             if ($entry === null) {
+                $search_offset = $prefix_offset + 1;
                 continue;
             }
-            if (isset($seen_quotes[$entry['quote_start']])) {
-                continue;
-            }
-            $seen_quotes[$entry['quote_start']] = true;
+
+            $search_offset = $entry['quote_start'] + $entry['quote_length'];
             $entries[] = $entry;
-        }
+        } while (preg_match('/aHR0|dHA6|dHBz|dHRw/', $sql, $match, PREG_OFFSET_CAPTURE, $search_offset));
 
         usort(
             $entries,
@@ -603,21 +602,4 @@ class FastInsertScanner
         return null;
     }
 
-    /**
-     * @return list<int>
-     */
-    private static function http_prefix_offsets(string $sql, int $offset = 0): array
-    {
-        $offsets = [];
-        foreach (['aHR0', 'dHA6', 'dHBz', 'dHRw'] as $prefix) {
-            $cursor = $offset;
-            while (($cursor = strpos($sql, $prefix, $cursor)) !== false) {
-                $offsets[] = $cursor;
-                $cursor++;
-            }
-        }
-
-        sort($offsets);
-        return $offsets;
-    }
 }

--- a/packages/reprint-importer/src/lib/url-rewrite/class-sql-statement-rewriter.php
+++ b/packages/reprint-importer/src/lib/url-rewrite/class-sql-statement-rewriter.php
@@ -138,14 +138,14 @@ class SqlStatementRewriter
         // recognise — UPDATE, INSERT … SELECT, qualified names, hex
         // literals, escaped quotes — falls through to the lexer path
         // below with identical behaviour.
-        $fast = FastInsertScanner::scan($sql);
+        $fast = FastInsertScanner::scan($sql, true);
         if ($fast !== null) {
             $value_to_column_map = [
                 'table' => $fast['table'],
                 'column_map' => $fast['column_map'],
             ];
             $scanner = Base64ValueScanner::from_entries($sql, $fast['base64_entries']);
-            return $this->rewrite_with_scanner($scanner, $value_to_column_map);
+            return $this->rewrite_with_scanner($scanner, $value_to_column_map, true);
         }
 
         // Slow path: lex once, share the token array between the column
@@ -205,10 +205,10 @@ class SqlStatementRewriter
      *
      * @param array{table: string, column_map: list<array{int, int, string}>}|null $value_to_column_map
      */
-    private function rewrite_with_scanner(Base64ValueScanner $scanner, ?array $value_to_column_map): string
+    private function rewrite_with_scanner(Base64ValueScanner $scanner, ?array $value_to_column_map, bool $payloads_prefiltered = false): string
     {
         while ($scanner->next_value()) {
-            if (!$scanner->encoded_payload_could_contain_http_scheme()) {
+            if (!$payloads_prefiltered && !$scanner->encoded_payload_could_contain_http_scheme()) {
                 continue;
             }
 
@@ -223,8 +223,8 @@ class SqlStatementRewriter
             }
 
             // Determine content type hint for this column.
-            $column_name = null;
-            if ($value_to_column_map !== null) {
+            $column_name = $scanner->get_column_name();
+            if ($column_name === null && $value_to_column_map !== null) {
                 $column_name = $this->find_column_at_offset(
                     $value_to_column_map['column_map'],
                     $scanner->get_match_offset()

--- a/tests/UrlRewriting/SqlStatementRewriterPrefilterTest.php
+++ b/tests/UrlRewriting/SqlStatementRewriterPrefilterTest.php
@@ -207,6 +207,14 @@ class SqlStatementRewriterPrefilterTest extends TestCase
         $this->assertNull(FastInsertScanner::scan($sql, true));
     }
 
+    public function testSparseFastInsertScannerRejectsMalformedCandidatePayload(): void
+    {
+        $sql = "INSERT INTO `wp_posts` (`ID`, `post_content`) VALUES"
+            . "(1, FROM_BASE64('aHR0!not-base64'));";
+
+        $this->assertNull(FastInsertScanner::scan($sql, true));
+    }
+
     /**
      * Exhaustive fuzz: 200 random padding lengths × random URL paths × both
      * schemes. Padding bytes are chosen from a wide alphabet so each

--- a/tests/UrlRewriting/SqlStatementRewriterPrefilterTest.php
+++ b/tests/UrlRewriting/SqlStatementRewriterPrefilterTest.php
@@ -149,6 +149,64 @@ class SqlStatementRewriterPrefilterTest extends TestCase
         $this->assertTrue($this->statementHasAnyPrefix($sql));
     }
 
+    public function testFastInsertScannerKeepsOnlyHttpCandidatePayloads(): void
+    {
+        $sql = sprintf(
+            "INSERT INTO `wp_posts` (`ID`, `post_title`, `post_content`, `post_type`) VALUES"
+            . "(1, FROM_BASE64('%s'), FROM_BASE64('%s'), FROM_BASE64('%s')), "
+            . "(2, FROM_BASE64('%s'), FROM_BASE64('%s'), FROM_BASE64('%s'));",
+            base64_encode('Plain title'),
+            base64_encode('No URL in this body'),
+            base64_encode('post'),
+            base64_encode('Another plain title'),
+            base64_encode('<a href="https://old-site.com/page">Link</a>'),
+            base64_encode('post')
+        );
+
+        $scan = FastInsertScanner::scan($sql, true);
+
+        $this->assertNotNull($scan);
+        $this->assertSame('wp_posts', $scan['table']);
+        $this->assertCount(1, $scan['base64_entries']);
+        $this->assertCount(0, $scan['column_map']);
+        $this->assertSame('post_content', $scan['base64_entries'][0]['column_name']);
+        $this->assertSame(
+            '<a href="https://old-site.com/page">Link</a>',
+            base64_decode($scan['base64_entries'][0]['encoded_value'], true)
+        );
+
+        $full_scan = FastInsertScanner::scan($sql);
+        $this->assertNotNull($full_scan);
+        $this->assertCount(6, $full_scan['base64_entries']);
+    }
+
+    public function testSparseFastInsertScannerDeduplicatesCandidatePrefixesInOnePayload(): void
+    {
+        $sql = sprintf(
+            "INSERT INTO `wp_posts` (`ID`, `post_content`) VALUES"
+            . "(1, CONVERT(FROM_BASE64('%s') USING utf8mb4));",
+            base64_encode('<a href="https://old-site.com/a">A</a><img src="https://old-site.com/b">')
+        );
+
+        $scan = FastInsertScanner::scan($sql, true);
+
+        $this->assertNotNull($scan);
+        $this->assertCount(1, $scan['base64_entries']);
+        $this->assertSame('post_content', $scan['base64_entries'][0]['column_name']);
+    }
+
+    public function testSparseFastInsertScannerFallsBackForDuplicateKeyTrailer(): void
+    {
+        $sql = sprintf(
+            "INSERT INTO `wp_posts` (`ID`, `post_content`) VALUES"
+            . "(1, FROM_BASE64('%s')) ON DUPLICATE KEY UPDATE `post_content` = FROM_BASE64('%s');",
+            base64_encode('Plain body'),
+            base64_encode('https://old-site.com/from-trailer')
+        );
+
+        $this->assertNull(FastInsertScanner::scan($sql, true));
+    }
+
     /**
      * Exhaustive fuzz: 200 random padding lengths × random URL paths × both
      * schemes. Padding bytes are chosen from a wide alphabet so each


### PR DESCRIPTION
## Summary

Keeps the sparse URL candidate scanner only because it has a measured full database-apply impact. The scanner narrows URL rewriting work to FROM_BASE64 payloads whose encoded bytes can contain an http/https prefix, while preserving fallback behavior for unsupported shapes.

This is evaluated only on the full database apply phase. Microbenchmarks are not used as evidence.

## Full db-apply benchmark

Both runs use `BENCH_STAGES=playground-sqlite-db-apply`, PHP.wasm 8.3, and the native `wp_mysql_parser` extension manifest.

| Branch | playground-sqlite-db-apply |
| --- | ---: |
| current trunk | 100.28 s |
| this branch, rebased on trunk | 89.78 s |

Native parser verification was enabled in the benchmark output.

## Verification

- `./vendor/bin/phpunit --configuration tests/phpunit.xml tests/UrlRewriting/SqlStatementRewriterPrefilterTest.php`
- Result: 28 tests, 1927 assertions.
