### PR TITLE
[codex] Skip block text scans for markup-only URL hits

### DIFF
--- a/packages/reprint-importer/src/lib/url-rewrite/class-structured-data-url-rewriter.php
+++ b/packages/reprint-importer/src/lib/url-rewrite/class-structured-data-url-rewriter.php
@@ -364,9 +364,10 @@ class StructuredDataUrlRewriter
     }
 
     /**
-     * Return true when every configured source-domain occurrence is inside
-     * HTML tag/comment markup, so block-markup rewriting can skip text-node
-     * URL scanning while still using structured setters for tags and blocks.
+     * Return true when the raw source-domain occurrences are confined to
+     * closed HTML tag/comment markup, so block-markup rewriting can skip
+     * text-node URL scanning while still using structured setters for tags
+     * and blocks.
      */
     private function source_domain_occurrences_are_inside_markup(string $value): bool
     {
@@ -374,63 +375,133 @@ class StructuredDataUrlRewriter
             return false;
         }
 
-        $source_domain_offsets = [];
+        $has_source_domain = false;
         foreach ($this->source_domains as $domain) {
-            $offset = 0;
-            while (false !== ($found = stripos($value, $domain, $offset))) {
-                $source_domain_offsets[] = $found;
-                $offset = $found + strlen($domain);
+            if (stripos($value, $domain) !== false) {
+                $has_source_domain = true;
+                break;
             }
         }
 
-        if ($source_domain_offsets === []) {
+        if (!$has_source_domain) {
             return false;
         }
 
-        sort($source_domain_offsets);
-        $next_source_domain = 0;
-        $source_domain_count = count($source_domain_offsets);
         $length = strlen($value);
-        $in_markup = false;
-        $quote = null;
+        $text_start = 0;
 
-        for ($i = 0; $i < $length && $next_source_domain < $source_domain_count; $i++) {
-            while (
-                $next_source_domain < $source_domain_count &&
-                $source_domain_offsets[$next_source_domain] === $i
-            ) {
-                if (!$in_markup) {
-                    return false;
-                }
-                $next_source_domain++;
+        for ($i = 0; $i < $length; $i++) {
+            if ($value[$i] !== '<' || !$this->is_likely_markup_opener_at($value, $i)) {
+                continue;
             }
 
+            $markup_end = $this->find_likely_markup_end($value, $i);
+            if ($markup_end === null) {
+                continue;
+            }
+
+            if ($this->text_span_might_contain_source_domain($value, $text_start, $i - $text_start)) {
+                return false;
+            }
+
+            $i = $markup_end;
+            $text_start = $markup_end + 1;
+        }
+
+        return !$this->text_span_might_contain_source_domain($value, $text_start, $length - $text_start);
+    }
+
+    private function is_likely_markup_opener_at(string $value, int $offset): bool
+    {
+        $next = $value[$offset + 1] ?? '';
+        if ($next === '') {
+            return false;
+        }
+
+        if ($this->is_ascii_alpha($next) || $next === '!' || $next === '?') {
+            return true;
+        }
+
+        if ($next === '/') {
+            return $this->is_ascii_alpha($value[$offset + 2] ?? '');
+        }
+
+        return false;
+    }
+
+    private function is_ascii_alpha(string $char): bool
+    {
+        if ($char === '') {
+            return false;
+        }
+
+        $ord = ord($char);
+        return ($ord >= 65 && $ord <= 90) || ($ord >= 97 && $ord <= 122);
+    }
+
+    private function find_likely_markup_end(string $value, int $offset): ?int
+    {
+        if (substr($value, $offset, 4) === '<!--') {
+            $comment_end = strpos($value, '-->', $offset + 4);
+            return $comment_end === false ? null : $comment_end + 2;
+        }
+
+        $length = strlen($value);
+        $quote = null;
+        for ($i = $offset + 1; $i < $length; $i++) {
             $char = $value[$i];
-            if ($in_markup) {
-                if ($quote !== null) {
-                    if ($char === $quote) {
-                        $quote = null;
-                    }
-                    continue;
-                }
-
-                if ($char === '"' || $char === "'") {
-                    $quote = $char;
-                    continue;
-                }
-
-                if ($char === '>') {
-                    $in_markup = false;
+            if ($quote !== null) {
+                if ($char === $quote) {
+                    $quote = null;
                 }
                 continue;
             }
 
-            if ($char === '<') {
-                $in_markup = true;
+            if ($char === '"' || $char === "'") {
+                $quote = $char;
+                continue;
+            }
+
+            if ($char === '>') {
+                return $i;
             }
         }
 
-        return true;
+        return null;
+    }
+
+    private function text_span_might_contain_source_domain(string $value, int $offset, int $length): bool
+    {
+        if ($length <= 0) {
+            return false;
+        }
+
+        $end = $offset + $length;
+        foreach ($this->source_domains as $domain) {
+            $found = stripos($value, $domain, $offset);
+            if ($found !== false && $found < $end) {
+                return true;
+            }
+        }
+
+        $first_entity = strpos($value, '&', $offset);
+        if ($first_entity === false || $first_entity >= $end) {
+            return false;
+        }
+
+        $text = substr($value, $offset, $length);
+        $decoded = html_entity_decode($text, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+        if ($decoded === $text) {
+            return false;
+        }
+
+        foreach ($this->source_domains as $domain) {
+            if (stripos($decoded, $domain) !== false) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/packages/reprint-importer/src/lib/url-rewrite/class-structured-data-url-rewriter.php
+++ b/packages/reprint-importer/src/lib/url-rewrite/class-structured-data-url-rewriter.php
@@ -364,6 +364,76 @@ class StructuredDataUrlRewriter
     }
 
     /**
+     * Return true when every configured source-domain occurrence is inside
+     * HTML tag/comment markup, so block-markup rewriting can skip text-node
+     * URL scanning while still using structured setters for tags and blocks.
+     */
+    private function source_domain_occurrences_are_inside_markup(string $value): bool
+    {
+        if (strpos($value, '<') === false) {
+            return false;
+        }
+
+        $source_domain_offsets = [];
+        foreach ($this->source_domains as $domain) {
+            $offset = 0;
+            while (false !== ($found = stripos($value, $domain, $offset))) {
+                $source_domain_offsets[] = $found;
+                $offset = $found + strlen($domain);
+            }
+        }
+
+        if ($source_domain_offsets === []) {
+            return false;
+        }
+
+        sort($source_domain_offsets);
+        $next_source_domain = 0;
+        $source_domain_count = count($source_domain_offsets);
+        $length = strlen($value);
+        $in_markup = false;
+        $quote = null;
+
+        for ($i = 0; $i < $length && $next_source_domain < $source_domain_count; $i++) {
+            while (
+                $next_source_domain < $source_domain_count &&
+                $source_domain_offsets[$next_source_domain] === $i
+            ) {
+                if (!$in_markup) {
+                    return false;
+                }
+                $next_source_domain++;
+            }
+
+            $char = $value[$i];
+            if ($in_markup) {
+                if ($quote !== null) {
+                    if ($char === $quote) {
+                        $quote = null;
+                    }
+                    continue;
+                }
+
+                if ($char === '"' || $char === "'") {
+                    $quote = $char;
+                    continue;
+                }
+
+                if ($char === '>') {
+                    $in_markup = false;
+                }
+                continue;
+            }
+
+            if ($char === '<') {
+                $in_markup = true;
+            }
+        }
+
+        return true;
+    }
+
+    /**
      * Return whether a decoded value may contain one of the configured source
      * domains. This intentionally checks hosts instead of full source URLs so
      * escaped spellings of `://` in block markup or JSON do not matter.
@@ -452,47 +522,21 @@ class StructuredDataUrlRewriter
         switch ( $content_type ) {
             case self::BLOCK_MARKUP:
                 $p = new BlockMarkupUrlProcessor( $content, $base_url );
-                while ( $p->next_url() ) {
-                    $raw_url = $p->get_raw_url();
-                    $token_type = $p->get_token_type() ?? '';
-                    $cache_key = $this->mapping_cache_key . "\0" . self::BLOCK_MARKUP . "\0" . $token_type . "\0" . $raw_url;
-                    $cached = $this->get_cached_rewrite_result($cache_key);
-                    if ($cached !== null) {
-                        if ($cached !== false) {
-                            $p->set_url($cached['raw_url'], $cached['parsed_url']);
-                        }
-                        continue;
+                $scan_text_nodes = !$this->source_domain_occurrences_are_inside_markup($content);
+                if ($scan_text_nodes) {
+                    while ( $p->next_url() ) {
+                        $this->rewrite_current_block_markup_url($p, $parsed_mapping, $base_url);
                     }
+                } else {
+                    while ($p->next_token()) {
+                        if ($p->get_token_type() === '#text') {
+                            continue;
+                        }
 
-                    $parsed_url = $p->get_parsed_url();
-                    $converted = false;
-                    foreach ( $parsed_mapping as $mapping ) {
-                        if ( is_child_url_of( $parsed_url, $mapping['from_url'] ) ) {
-                            $converted = WPURL::replace_base_url(
-                                $parsed_url,
-                                array(
-                                    'old_base_url' => $base_url,
-                                    'new_base_url' => $mapping['to_url'],
-                                    'raw_url'      => $raw_url,
-                                    'is_relative'  => (
-                                        '#text' !== $token_type &&
-                                        ! WPURL::can_parse($raw_url)
-                                    ),
-                                )
-                            );
-                            break;
+                        while ($p->next_url_in_current_token()) {
+                            $this->rewrite_current_block_markup_url($p, $parsed_mapping, $base_url);
                         }
                     }
-
-                    $cache_value = false;
-                    if ($converted !== false) {
-                        $cache_value = [
-                            'raw_url'    => (string) $converted,
-                            'parsed_url' => $converted->new_url,
-                        ];
-                        $p->set_url($cache_value['raw_url'], $cache_value['parsed_url']);
-                    }
-                    $this->set_cached_rewrite_result($cache_key, $cache_value);
                 }
 
                 return $p->get_updated_html();
@@ -544,5 +588,52 @@ class StructuredDataUrlRewriter
                 _doing_it_wrong( __FUNCTION__, 'rewrite_urls() requires either block_markup or plain_text to be provided', '1.0.0' );
                 return '';
         }
+    }
+
+    /**
+     * @param array<int, array{from_url: mixed, to_url: mixed}> $parsed_mapping
+     */
+    private function rewrite_current_block_markup_url(BlockMarkupUrlProcessor $p, array $parsed_mapping, string $base_url): void
+    {
+        $raw_url = $p->get_raw_url();
+        $token_type = $p->get_token_type() ?? '';
+        $cache_key = $this->mapping_cache_key . "\0" . self::BLOCK_MARKUP . "\0" . $token_type . "\0" . $raw_url;
+        $cached = $this->get_cached_rewrite_result($cache_key);
+        if ($cached !== null) {
+            if ($cached !== false) {
+                $p->set_url($cached['raw_url'], $cached['parsed_url']);
+            }
+            return;
+        }
+
+        $parsed_url = $p->get_parsed_url();
+        $converted = false;
+        foreach ( $parsed_mapping as $mapping ) {
+            if ( is_child_url_of( $parsed_url, $mapping['from_url'] ) ) {
+                $converted = WPURL::replace_base_url(
+                    $parsed_url,
+                    array(
+                        'old_base_url' => $base_url,
+                        'new_base_url' => $mapping['to_url'],
+                        'raw_url'      => $raw_url,
+                        'is_relative'  => (
+                            '#text' !== $token_type &&
+                            ! WPURL::can_parse($raw_url)
+                        ),
+                    )
+                );
+                break;
+            }
+        }
+
+        $cache_value = false;
+        if ($converted !== false) {
+            $cache_value = [
+                'raw_url'    => (string) $converted,
+                'parsed_url' => $converted->new_url,
+            ];
+            $p->set_url($cache_value['raw_url'], $cache_value['parsed_url']);
+        }
+        $this->set_cached_rewrite_result($cache_key, $cache_value);
     }
 }

--- a/tests/UrlRewriting/StructuredDataUrlRewriterTest.php
+++ b/tests/UrlRewriting/StructuredDataUrlRewriterTest.php
@@ -485,6 +485,28 @@ class StructuredDataUrlRewriterTest extends TestCase
         $this->assertStringContainsString('https://old-site.com/comment', $result);
     }
 
+    public function testKnownBlockMarkupRewritesTextUrlAfterLiteralLessThan(): void
+    {
+        $rewriter = $this->createRewriter();
+        $input = 'Plain text < https://old-site.com/page > after comparison.';
+
+        $result = $rewriter->rewrite_known_block_markup_value($input);
+
+        $this->assertStringContainsString('https://new-site.com/page', $result);
+        $this->assertStringNotContainsString('old-site.com/page', $result);
+    }
+
+    public function testKnownBlockMarkupRewritesEntityDecodedTextUrlWhenRawSourceDomainIsOnlyInMarkup(): void
+    {
+        $rewriter = $this->createRewriter();
+        $input = '<a data-note="https://old-site.com/not-a-url-attribute">https://old&#45;site.com/text</a>';
+
+        $result = $rewriter->rewrite_known_block_markup_value($input);
+
+        $this->assertStringContainsString('data-note="https://old-site.com/not-a-url-attribute"', $result);
+        $this->assertStringContainsString('https://new-site.com/text', $result);
+    }
+
     // --- Content type hint: null (default) uses plain text URL scanning ---
 
     public function testDefaultHintUsesPlainTextUrlScanning(): void

--- a/tests/UrlRewriting/StructuredDataUrlRewriterTest.php
+++ b/tests/UrlRewriting/StructuredDataUrlRewriterTest.php
@@ -470,6 +470,21 @@ class StructuredDataUrlRewriterTest extends TestCase
         $this->assertStringNotContainsString('old-site.com', $result);
     }
 
+    public function testKnownBlockMarkupMarkupOnlyFastPathIgnoresUnknownAttributesAndComments(): void
+    {
+        $rewriter = $this->createRewriter();
+        $input = '<!-- wp:html -->'
+            . '<!-- https://old-site.com/comment -->'
+            . '<a href="https://old-site.com/link" data-note="https://old-site.com/not-a-url-attribute">Link</a>'
+            . '<!-- /wp:html -->';
+
+        $result = $rewriter->rewrite_known_block_markup_value($input);
+
+        $this->assertStringContainsString('href="https://new-site.com/link"', $result);
+        $this->assertStringContainsString('data-note="https://old-site.com/not-a-url-attribute"', $result);
+        $this->assertStringContainsString('https://old-site.com/comment', $result);
+    }
+
     // --- Content type hint: null (default) uses plain text URL scanning ---
 
     public function testDefaultHintUsesPlainTextUrlScanning(): void

--- a/tests/UrlRewriting/StructuredDataUrlRewriterTest.php
+++ b/tests/UrlRewriting/StructuredDataUrlRewriterTest.php
@@ -454,6 +454,22 @@ class StructuredDataUrlRewriterTest extends TestCase
         $this->assertSame($input, $block_result);
     }
 
+    public function testKnownBlockMarkupRewritesMultipleUrlsInOneTagWhenTextHasNoSourceDomain(): void
+    {
+        $rewriter = $this->createRewriter();
+        $input = '<!-- wp:image {"src":"https:\/\/old-site.com\/img.jpg"} -->'
+            . '<figure><img src="https://old-site.com/img.jpg" style="background:url(https://old-site.com/bg.jpg);mask-image:url(https://old-site.com/mask.svg)" /></figure>'
+            . '<!-- /wp:image -->';
+
+        $result = $rewriter->rewrite_known_block_markup_value($input);
+
+        $this->assertStringContainsString('https:\/\/new-site.com\/img.jpg', $result);
+        $this->assertStringContainsString('src="https://new-site.com/img.jpg"', $result);
+        $this->assertStringContainsString('https://new-site.com/bg.jpg', $result);
+        $this->assertStringContainsString('https://new-site.com/mask.svg', $result);
+        $this->assertStringNotContainsString('old-site.com', $result);
+    }
+
     // --- Content type hint: null (default) uses plain text URL scanning ---
 
     public function testDefaultHintUsesPlainTextUrlScanning(): void


### PR DESCRIPTION
## What it does

Skips block text-node URL scanning when raw source-domain hits are confined to closed HTML tag/comment markup, while preserving structured block/HTML rewriting.

## Rationale

The original goal is full `playground-sqlite-db-apply` speed, not method-level timing. Avoiding unnecessary text scans helps the actual SQLite apply phase, but the fast path must not skip text URLs that only become visible after entity decoding or after literal angle-bracket text.

Full-stage evidence for the current branch:

- `trunk`: `100.28s`
- this branch after the correctness hardening: `85.41s`

Both timings are full `BENCH_STAGES=playground-sqlite-db-apply` runs with PHP 8.3, `PLAYGROUND_PHP_USE_WASM_RUNNER=1`, and native `wp_mysql_parser` verified.

## Implementation

- Treats only closed, likely tag/comment spans as markup for the skip decision.
- Checks raw and HTML entity-decoded text spans before skipping text-node scanning.
- Adds adversarial coverage for literal `< ... >` text and entity-decoded text URLs.

## Testing instructions

```bash
vendor/bin/phpunit --configuration tests/phpunit.xml tests/UrlRewriting/StructuredDataUrlRewriterTest.php
BENCH_STAGES=playground-sqlite-db-apply \
BENCH_LABEL=pr235-supervised-correctness-fix \
WP_MYSQL_PARSER_EXTENSION_MANIFEST=https://wordpress.github.io/sqlite-database-integration/wp_mysql_parser-wasm-extension/latest/manifest.json \
PLAYGROUND_PHP_USE_WASM_RUNNER=1 \
PLAYGROUND_PHP_VERSION=8.3 \
node tests/e2e/benchmark/bench-pull.mjs
```

Observed test result: `53 tests`, `84 assertions`, `7 skipped`.
Observed full db-apply result: `85.41s`, native parser verified.
