### PR TITLE
[codex] Cache SQLite prepared statements during db apply

### DIFF
--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -5166,6 +5166,7 @@ class ImportClient
         $skipped = 0;
         $save_every = 100;
         $stmts_since_save = 0;
+        $sqlite_prepared_statement_cache = [];
 
         // Load pre-computed statement count from db-pull for progress reporting
         $sql_stats_file = $this->state_dir . "/.import-sql-stats.json";
@@ -5237,6 +5238,7 @@ class ImportClient
                             $query,
                             $stmt_rewriter,
                             $sqlite_prepared_pdo,
+                            $sqlite_prepared_statement_cache,
                             $executed_query,
                         );
                     } catch (PDOException $e) {
@@ -5315,6 +5317,7 @@ class ImportClient
                         $query,
                         $stmt_rewriter,
                         $sqlite_prepared_pdo,
+                        $sqlite_prepared_statement_cache,
                         $executed_query,
                     );
                 } catch (PDOException $e) {
@@ -5420,6 +5423,7 @@ class ImportClient
         string $query,
         ?SqlStatementRewriter $stmt_rewriter,
         ?PDO $sqlite_prepared_pdo,
+        array &$sqlite_prepared_statement_cache,
         string &$executed_query
     ): void {
         $executed_query = $query;
@@ -5431,9 +5435,17 @@ class ImportClient
 
             if ($prepared_insert !== null) {
                 $executed_query = $prepared_insert['sql'];
-                $statement = $sqlite_prepared_pdo->prepare($prepared_insert['sql']);
-                if ($statement === false) {
-                    throw new PDOException('Failed to prepare SQLite INSERT statement.');
+                $statement = $sqlite_prepared_statement_cache[$prepared_insert['sql']] ?? null;
+                if (!$statement instanceof PDOStatement) {
+                    $statement = $sqlite_prepared_pdo->prepare($prepared_insert['sql']);
+                    if ($statement === false) {
+                        throw new PDOException('Failed to prepare SQLite INSERT statement.');
+                    }
+
+                    if (count($sqlite_prepared_statement_cache) >= 64) {
+                        array_shift($sqlite_prepared_statement_cache);
+                    }
+                    $sqlite_prepared_statement_cache[$prepared_insert['sql']] = $statement;
                 }
 
                 foreach ($prepared_insert['params'] as $index => $value) {


### PR DESCRIPTION
## What it does

Stacks on #235 and caches SQLite `PDOStatement` objects during `db-apply` for repeated prepared INSERT SQL templates.

The URL rewrite and SQL-shape logic is unchanged. `SqlStatementRewriter::build_sqlite_prepared_insert()` still owns structured URL rewriting and returns the exact prepared SQL plus params. This PR only avoids calling `PDO::prepare()` again when the prepared SQL template has already been seen in the current `db-apply` process.

The cache is bounded to 64 statement templates and falls back to preparing normally on misses.

## Rationale

The native-extension PR #231 profile shows SQLite apply time is dominated by prepared INSERT construction and execution:

```text
wall_seconds: 91.44
db_apply.execute_query_total: 83.55 s, 91.4%
execute.prepared_insert_build: 52.45 s, 57.4%
execute.sqlite_execute: 20.62 s, 22.6%
execute.sqlite_prepare: 7.35 s, 8.0%
structured rewrite value work: ~0.06 s total
```

This PR targets the `execute.sqlite_prepare` bucket without changing URL behavior.

## Benchmark

Focused SQLite prepared statement microbenchmark with one repeated INSERT shape and varying params:

| Rows | Uncached prepare median | Cached statement median | Delta |
|---:|---:|---:|---:|
| 20,000 | 69.7 ms | 22.8 ms | 3.06x faster |

Agent run on the same shape measured 2.89x before my rerun.

This is a targeted win for repeated prepared SQL templates. The full PR #231 native baseline remains:

```text
playground-sqlite-db-apply: 77.35 s
php.wasm 8.3
wp_mysql_parser=enabled
native parser and SQLite driver parser verified
```

## Testing

```bash
php -l packages/reprint-importer/src/import.php
./vendor/bin/phpunit --configuration tests/phpunit.xml tests/Import/DeactivateHostPluginsTest.php tests/UrlRewriting
./vendor/bin/phpstan analyze --memory-limit=1G packages/reprint-importer/src/import.php
```

Results: focused PHPUnit passed (`223 tests`, `2300 assertions`, `11 skipped`); PHPStan passed for `import.php`.
