### PR TITLE
[codex] Cache SQLite prepared insert shapes

### DIFF
--- a/packages/reprint-importer/src/lib/url-rewrite/class-fast-insert-scanner.php
+++ b/packages/reprint-importer/src/lib/url-rewrite/class-fast-insert-scanner.php
@@ -37,7 +37,8 @@ class FastInsertScanner
      * @return array{
      *   table: string,
      *   column_map: list<array{int, int, string}>,
-     *   base64_entries: list<array{expr_start: int, expr_length: int, quote_start: int, quote_length: int, encoded_value: string, value: ?string, new_value: ?string}>
+     *   base64_entries: list<array{expr_start: int, expr_length: int, quote_start: int, quote_length: int, encoded_value: string, value: ?string, new_value: ?string}>,
+     *   value_entries: list<array{start: int, length: int, kind: string, column: string, quote_start?: int, quote_length?: int, encoded_value?: string}>
      * }|null
      *   Null when the SQL doesn't match the recognised shape.
      */
@@ -93,6 +94,7 @@ class FastInsertScanner
 
         $column_map = [];
         $base64_entries = [];
+        $value_entries = [];
 
         $cursor = $values_end;
         $sql_len = strlen($sql);
@@ -149,6 +151,22 @@ class FastInsertScanner
                         'value' => null,
                         'new_value' => null,
                     ];
+                    $value_entries[] = [
+                        'start' => $value_start,
+                        'length' => $value_end - $value_start,
+                        'kind' => 'base64',
+                        'column' => $columns[$col_idx],
+                        'quote_start' => $value_kind[2],
+                        'quote_length' => $value_kind[3],
+                        'encoded_value' => $value_kind[4],
+                    ];
+                } else {
+                    $value_entries[] = [
+                        'start' => $value_start,
+                        'length' => $value_end - $value_start,
+                        'kind' => self::classify_static_value($sql, $value_start, $value_end),
+                        'column' => $columns[$col_idx],
+                    ];
                 }
 
                 while ($cursor < $sql_len && self::is_ws($sql[$cursor])) {
@@ -194,7 +212,25 @@ class FastInsertScanner
             'table' => $table,
             'column_map' => $column_map,
             'base64_entries' => $base64_entries,
+            'value_entries' => $value_entries,
         ];
+    }
+
+    private static function classify_static_value(string $sql, int $start, int $end): string
+    {
+        if ($start >= $end) {
+            return 'unknown';
+        }
+
+        $c = $sql[$start];
+        if ($c === "'") {
+            return 'empty';
+        }
+        if ($c === 'N' || $c === 'n') {
+            return 'null';
+        }
+
+        return 'number';
     }
 
     /**
@@ -296,24 +332,35 @@ class FastInsertScanner
         while ($cursor < $sql_len && $sql[$cursor] >= '0' && $sql[$cursor] <= '9') {
             $cursor++;
         }
+        $digits_before_decimal = $cursor > $digit_start;
         if ($cursor < $sql_len && $sql[$cursor] === '.') {
             $cursor++;
+            $fraction_start = $cursor;
             while ($cursor < $sql_len && $sql[$cursor] >= '0' && $sql[$cursor] <= '9') {
                 $cursor++;
             }
+            if (!$digits_before_decimal && $cursor === $fraction_start) {
+                $cursor = $start;
+                return null;
+            }
+        }
+        if (!$digits_before_decimal && $cursor === $digit_start) {
+            $cursor = $start;
+            return null;
         }
         if ($cursor < $sql_len && ($sql[$cursor] === 'e' || $sql[$cursor] === 'E')) {
+            $exponent_start = $cursor;
             $cursor++;
             if ($cursor < $sql_len && ($sql[$cursor] === '+' || $sql[$cursor] === '-')) {
                 $cursor++;
             }
+            $exponent_digits_start = $cursor;
             while ($cursor < $sql_len && $sql[$cursor] >= '0' && $sql[$cursor] <= '9') {
                 $cursor++;
             }
-        }
-        if ($cursor === $digit_start) {
-            $cursor = $start;
-            return null;
+            if ($cursor === $exponent_digits_start) {
+                $cursor = $exponent_start;
+            }
         }
         return true;
     }

--- a/packages/reprint-importer/src/lib/url-rewrite/class-sqlite-prepared-insert-builder.php
+++ b/packages/reprint-importer/src/lib/url-rewrite/class-sqlite-prepared-insert-builder.php
@@ -17,6 +17,11 @@
  */
 class SQLitePreparedInsertBuilder
 {
+    private const SHAPE_CACHE_LIMIT = 32;
+
+    /** @var list<array{table: string, chunks: list<string>, values: list<array<string, mixed>>, base64_indexes: list<int>}> */
+    private static array $shape_cache = [];
+
     /**
      * @param callable|null $rewrite_value Optional callback:
      *        fn(string $value, string $table, ?string $column): string
@@ -28,11 +33,32 @@ class SQLitePreparedInsertBuilder
             return null;
         }
 
+        $cached = self::build_from_cached_shape($sql, $rewrite_value);
+        if ($cached !== null) {
+            return $cached;
+        }
+
         $fast = FastInsertScanner::scan($sql);
         if ($fast === null || empty($fast['base64_entries'])) {
             return null;
         }
 
+        self::remember_shape($sql, $fast);
+
+        return self::build_from_scan($sql, $fast, $rewrite_value);
+    }
+
+    /**
+     * @param array{
+     *   table: string,
+     *   column_map: list<array{int, int, string}>,
+     *   base64_entries: list<array{expr_start: int, expr_length: int, quote_start: int, quote_length: int, encoded_value: string, value: ?string, new_value: ?string}>
+     * } $fast
+     * @param callable|null $rewrite_value
+     * @return array{sql: string, params: list<string>}|null
+     */
+    private static function build_from_scan(string $sql, array $fast, ?callable $rewrite_value): ?array
+    {
         $parts = [];
         $params = [];
         $cursor = 0;
@@ -61,6 +87,232 @@ class SQLitePreparedInsertBuilder
             'sql' => implode('', $parts),
             'params' => $params,
         ];
+    }
+
+    /**
+     * @param array{
+     *   table: string,
+     *   value_entries: list<array{start: int, length: int, kind: string, column: string, quote_start?: int, quote_length?: int, encoded_value?: string}>
+     * } $fast
+     */
+    private static function remember_shape(string $sql, array $fast): void
+    {
+        if (empty($fast['value_entries'])) {
+            return;
+        }
+
+        $chunks = [];
+        $values = [];
+        $base64_indexes = [];
+        $cursor = 0;
+
+        foreach ($fast['value_entries'] as $index => $entry) {
+            $start = $entry['start'];
+            $end = $start + $entry['length'];
+            $chunks[] = substr($sql, $cursor, $start - $cursor);
+
+            $shape_entry = [
+                'kind' => $entry['kind'],
+                'column' => $entry['column'],
+            ];
+
+            if ($entry['kind'] === 'base64') {
+                $quote_start = $entry['quote_start'];
+                $quote_end = $quote_start + $entry['quote_length'];
+                $payload_start = $quote_start + 1;
+                $payload_end = $quote_end - 1;
+
+                $shape_entry['prefix'] = substr($sql, $start, $payload_start - $start);
+                $shape_entry['suffix'] = substr($sql, $payload_end, $end - $payload_end);
+                $base64_indexes[] = $index;
+            } elseif ($entry['kind'] !== 'number') {
+                $shape_entry['literal'] = substr($sql, $start, $entry['length']);
+            }
+
+            $values[] = $shape_entry;
+            $cursor = $end;
+        }
+
+        $chunks[] = substr($sql, $cursor);
+
+        self::$shape_cache[] = [
+            'table' => $fast['table'],
+            'chunks' => $chunks,
+            'values' => $values,
+            'base64_indexes' => $base64_indexes,
+        ];
+
+        if (count(self::$shape_cache) > self::SHAPE_CACHE_LIMIT) {
+            array_shift(self::$shape_cache);
+        }
+    }
+
+    /**
+     * @param callable|null $rewrite_value
+     * @return array{sql: string, params: list<string>}|null
+     */
+    private static function build_from_cached_shape(string $sql, ?callable $rewrite_value): ?array
+    {
+        $count = count(self::$shape_cache);
+        for ($i = $count - 1; $i >= 0; $i--) {
+            $matched = self::match_shape(self::$shape_cache[$i], $sql, $rewrite_value);
+            if ($matched === null) {
+                continue;
+            }
+
+            if ($i !== $count - 1) {
+                $shape = self::$shape_cache[$i];
+                array_splice(self::$shape_cache, $i, 1);
+                self::$shape_cache[] = $shape;
+            }
+
+            return $matched;
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array{table: string, chunks: list<string>, values: list<array<string, mixed>>, base64_indexes: list<int>} $shape
+     * @param callable|null $rewrite_value
+     * @return array{sql: string, params: list<string>}|null
+     */
+    private static function match_shape(array $shape, string $sql, ?callable $rewrite_value): ?array
+    {
+        $pos = 0;
+        $sql_len = strlen($sql);
+        $value_ranges = [];
+        $encoded_by_index = [];
+
+        $first_chunk = $shape['chunks'][0];
+        if (!self::consume_literal($sql, $sql_len, $pos, $first_chunk)) {
+            return null;
+        }
+
+        foreach ($shape['values'] as $index => $entry) {
+            $value_start = $pos;
+            if ($entry['kind'] === 'base64') {
+                $prefix = $entry['prefix'];
+                if (!self::consume_literal($sql, $sql_len, $pos, $prefix)) {
+                    return null;
+                }
+                $payload_start = $pos;
+                $quote = strpos($sql, "'", $payload_start);
+                if ($quote === false) {
+                    return null;
+                }
+                $encoded = substr($sql, $payload_start, $quote - $payload_start);
+                $pos = $quote;
+                if (!self::consume_literal($sql, $sql_len, $pos, $entry['suffix'])) {
+                    return null;
+                }
+                $encoded_by_index[$index] = $encoded;
+            } elseif ($entry['kind'] === 'number') {
+                if (!self::consume_number($sql, $sql_len, $pos)) {
+                    return null;
+                }
+            } else {
+                if (!self::consume_literal($sql, $sql_len, $pos, $entry['literal'])) {
+                    return null;
+                }
+            }
+
+            $value_ranges[$index] = [$value_start, $pos];
+            if (!self::consume_literal($sql, $sql_len, $pos, $shape['chunks'][$index + 1])) {
+                return null;
+            }
+        }
+
+        if ($pos !== $sql_len) {
+            return null;
+        }
+
+        $parts = [];
+        $params = [];
+        $cursor = 0;
+
+        foreach ($shape['base64_indexes'] as $index) {
+            [$value_start, $value_end] = $value_ranges[$index];
+            if ($value_start < $cursor || $value_end <= $value_start) {
+                return null;
+            }
+
+            $decoded = base64_decode($encoded_by_index[$index], true);
+            if ($decoded === false) {
+                return null;
+            }
+            $value = $decoded;
+            if ($rewrite_value !== null) {
+                $value = $rewrite_value($value, $shape['table'], $shape['values'][$index]['column']);
+            }
+
+            $parts[] = substr($sql, $cursor, $value_start - $cursor);
+            $parts[] = '?';
+            $params[] = $value;
+            $cursor = $value_end;
+        }
+
+        $parts[] = substr($sql, $cursor);
+
+        return [
+            'sql' => implode('', $parts),
+            'params' => $params,
+        ];
+    }
+
+    private static function consume_literal(string $sql, int $sql_len, int &$pos, string $literal): bool
+    {
+        $length = strlen($literal);
+        if ($pos + $length > $sql_len || substr_compare($sql, $literal, $pos, $length) !== 0) {
+            return false;
+        }
+
+        $pos += $length;
+        return true;
+    }
+
+    private static function consume_number(string $sql, int $sql_len, int &$pos): bool
+    {
+        $start = $pos;
+        if ($pos < $sql_len && ($sql[$pos] === '+' || $sql[$pos] === '-')) {
+            $pos++;
+        }
+        $digit_start = $pos;
+        while ($pos < $sql_len && $sql[$pos] >= '0' && $sql[$pos] <= '9') {
+            $pos++;
+        }
+        $digits_before_decimal = $pos > $digit_start;
+        if ($pos < $sql_len && $sql[$pos] === '.') {
+            $pos++;
+            $fraction_start = $pos;
+            while ($pos < $sql_len && $sql[$pos] >= '0' && $sql[$pos] <= '9') {
+                $pos++;
+            }
+            if (!$digits_before_decimal && $pos === $fraction_start) {
+                $pos = $start;
+                return false;
+            }
+        }
+        if (!$digits_before_decimal && $pos === $digit_start) {
+            $pos = $start;
+            return false;
+        }
+        if ($pos < $sql_len && ($sql[$pos] === 'e' || $sql[$pos] === 'E')) {
+            $exponent_start = $pos;
+            $pos++;
+            if ($pos < $sql_len && ($sql[$pos] === '+' || $sql[$pos] === '-')) {
+                $pos++;
+            }
+            $exponent_digits_start = $pos;
+            while ($pos < $sql_len && $sql[$pos] >= '0' && $sql[$pos] <= '9') {
+                $pos++;
+            }
+            if ($pos === $exponent_digits_start) {
+                $pos = $exponent_start;
+            }
+        }
+
+        return true;
     }
 
     /**

--- a/tests/UrlRewriting/SQLitePreparedInsertBuilderTest.php
+++ b/tests/UrlRewriting/SQLitePreparedInsertBuilderTest.php
@@ -68,6 +68,68 @@ class SQLitePreparedInsertBuilderTest extends TestCase
         $this->assertSame(['after'], $prepared['params']);
     }
 
+    public function testCachedShapeKeepsDynamicLiteralsAndPerValueColumns(): void
+    {
+        $seen = [];
+        $callback = function (string $value, string $table, ?string $column) use (&$seen): string {
+            $seen[] = [$value, $table, $column];
+            return strtoupper($value);
+        };
+
+        $first = SQLitePreparedInsertBuilder::build(
+            sprintf(
+                "INSERT INTO `wp_posts` (`ID`, `post_title`, `post_content`) VALUES(1, FROM_BASE64('%s'), CONVERT(FROM_BASE64('%s') USING utf8mb4));",
+                base64_encode('first title'),
+                base64_encode('first body')
+            ),
+            $callback
+        );
+        $second = SQLitePreparedInsertBuilder::build(
+            sprintf(
+                "INSERT INTO `wp_posts` (`ID`, `post_title`, `post_content`) VALUES(245, FROM_BASE64('%s'), CONVERT(FROM_BASE64('%s') USING utf8mb4));",
+                base64_encode('second title'),
+                base64_encode('second body')
+            ),
+            $callback
+        );
+
+        $this->assertNotNull($first);
+        $this->assertNotNull($second);
+        $this->assertSame(
+            "INSERT INTO `wp_posts` (`ID`, `post_title`, `post_content`) VALUES(245, ?, ?);",
+            $second['sql']
+        );
+        $this->assertSame(['SECOND TITLE', 'SECOND BODY'], $second['params']);
+        $this->assertSame(
+            [
+                ['first title', 'wp_posts', 'post_title'],
+                ['first body', 'wp_posts', 'post_content'],
+                ['second title', 'wp_posts', 'post_title'],
+                ['second body', 'wp_posts', 'post_content'],
+            ],
+            $seen
+        );
+    }
+
+    public function testCachedShapeRejectsMalformedNumericSlots(): void
+    {
+        $first = SQLitePreparedInsertBuilder::build(
+            sprintf(
+                "INSERT INTO `wp_posts` (`ID`, `post_content`) VALUES(1, FROM_BASE64('%s'));",
+                base64_encode('first body')
+            )
+        );
+        $second = SQLitePreparedInsertBuilder::build(
+            sprintf(
+                "INSERT INTO `wp_posts` (`ID`, `post_content`) VALUES(1e, FROM_BASE64('%s'));",
+                base64_encode('second body')
+            )
+        );
+
+        $this->assertNotNull($first);
+        $this->assertNull($second);
+    }
+
     public function testUnknownInsertShapeReturnsNull(): void
     {
         $sql = sprintf(


### PR DESCRIPTION
## Summary

Stacked on #235. This caches the parsed producer INSERT shape in `SQLitePreparedInsertBuilder`, so repeated table/column/value layouts can skip the full `FastInsertScanner` pass while still decoding each current FROM_BASE64 payload and running the structured rewrite callback with the current table and column.

The cached path validates literal slots, numeric slots, wrapper syntax, statement length, and strict base64 decoding before using the shape. If the current SQL does not match, it falls back to the normal scanner path.

## Adversarial scrutiny

- Added coverage proving dynamic numeric slots and per-value columns remain current across cache hits.
- Added coverage for malformed numeric slots like `1e`, which must not be accepted by the cached fast path.
- Tightened the shared scanner numeric parser as well, so the fallback path and cached path fail consistently.
- Removed duplicate regex base64 validation from the cached path and now fail closed on strict `base64_decode(..., true)` instead.

## Benchmark

Builder-only benchmark using 30,000 precomputed producer-shaped INSERTs with dynamic numeric IDs and two FROM_BASE64 payload columns:

| branch | median | speed-up |
| --- | ---: | ---: |
| `origin/codex/pr231-skip-block-text-scan` | 287.941 ms | 1.00x |
| `codex/pr235-sqlite-shape-cache` | 138.708 ms | 2.08x |

This intentionally excludes SQL generation time and measures the hot builder path directly.

## Checks

- `./vendor/bin/phpunit --configuration tests/phpunit.xml tests/UrlRewriting/SQLitePreparedInsertBuilderTest.php`
- `./vendor/bin/phpunit --configuration tests/phpunit.xml tests/UrlRewriting`
- `./vendor/bin/phpstan analyze --memory-limit=1G packages/reprint-importer/src/lib/url-rewrite/class-sqlite-prepared-insert-builder.php packages/reprint-importer/src/lib/url-rewrite/class-fast-insert-scanner.php`
