### PR TITLE
Document structured rewrite parser gates

### DIFF
--- a/packages/reprint-importer/src/lib/url-rewrite/class-json-string-iterator.php
+++ b/packages/reprint-importer/src/lib/url-rewrite/class-json-string-iterator.php
@@ -1,15 +1,16 @@
 <?php
 
 /**
- * Cursor-based iterator over string leaf values in a JSON object or array.
+ * Cursor-based iterator over string leaf values in a JSON value.
  *
  * Mirrors the PhpSerializationProcessor API: construct with the raw JSON,
  * then loop with next_value()/get_value()/set_value(). Call get_result()
  * to retrieve the (possibly modified) JSON string.
  *
  * Only string values are exposed — numbers, booleans, and nulls are skipped.
- * Both object values and array elements are visited. Object keys are NOT
- * visited (they're structural, not content), matching the PHP serialization
+ * JSON string scalars are exposed as a single value. For objects and arrays,
+ * object values and array elements are visited. Object keys are NOT visited
+ * (they're structural, not content), matching the PHP serialization
  * processor's behavior of skipping array keys and property names.
  *
  * Usage:
@@ -25,7 +26,7 @@ class JsonStringIterator
     /** @var string The original JSON string. */
     private string $original;
 
-    /** @var mixed The decoded JSON structure (array or object decoded as array). */
+    /** @var mixed The decoded JSON value (object decoded as array). */
     private $decoded;
 
     /** @var bool Whether decoding succeeded. */
@@ -49,7 +50,7 @@ class JsonStringIterator
         $this->original = $json;
         $this->decoded = json_decode($json, true);
 
-        if (json_last_error() !== JSON_ERROR_NONE || !is_array($this->decoded)) {
+        if (json_last_error() !== JSON_ERROR_NONE || (!is_array($this->decoded) && !is_string($this->decoded))) {
             $this->valid = false;
             return;
         }
@@ -59,7 +60,7 @@ class JsonStringIterator
     }
 
     /**
-     * Whether the input was not valid JSON (or was a scalar, not an object/array).
+     * Whether the input was not valid JSON or had no string leaves.
      *
      * Mirrors PhpSerializationProcessor::is_malformed() so both iterators
      * can be used with the same try-and-fail pattern.

--- a/packages/reprint-importer/src/lib/url-rewrite/class-structured-data-url-rewriter.php
+++ b/packages/reprint-importer/src/lib/url-rewrite/class-structured-data-url-rewriter.php
@@ -148,10 +148,10 @@ class StructuredDataUrlRewriter
             return $value;
         }
 
-        // Avoid constructing the serialized-PHP parser for ordinary URL
-        // strings and block markup. The parser still owns validation once
-        // entered; this gate only skips impossible first-byte shapes that
-        // cannot expose string values for rewriting.
+        // Performance guard: avoid constructing the serialized-PHP parser for
+        // ordinary URL strings and block markup. The parser still owns
+        // validation once entered; this gate only skips first-byte shapes that
+        // cannot expose serialized string values for rewriting.
         if ($this->could_be_php_serialization_with_strings($value)) {
             $p = new PhpSerializationProcessor($value);
             if (!$p->is_malformed()) {
@@ -168,9 +168,11 @@ class StructuredDataUrlRewriter
             }
         }
 
-        if ($this->could_be_json_container($value)) {
-            // Try JSON: the iterator calls json_decode in the constructor.
-            // If it's not malformed, iterate and recurse.
+        // Performance guard: avoid calling json_decode() for ordinary URL
+        // strings and block markup. JsonStringIterator still owns validation
+        // once entered; this gate only skips first non-whitespace bytes that
+        // cannot start a JSON value containing string leaves.
+        if ($this->could_be_json_with_strings($value)) {
             $iter = new JsonStringIterator($value);
             if (!$iter->is_malformed()) {
                 while ($iter->next_value()) {
@@ -217,6 +219,15 @@ class StructuredDataUrlRewriter
         return false;
     }
 
+    /**
+     * Return whether the value starts with a PHP serialization token that may
+     * expose string values to rewrite.
+     *
+     * This is a speed guard before constructing PhpSerializationProcessor. It
+     * deliberately omits scalar serialized types such as i:, d:, b:, N;, r:,
+     * and R: because they cannot contain string leaves. The processor remains
+     * responsible for full validation once this coarse first-byte check passes.
+     */
     private function could_be_php_serialization_with_strings(string $value): bool
     {
         $first_byte = $value[0] ?? '';
@@ -227,7 +238,17 @@ class StructuredDataUrlRewriter
             || $first_byte === 'C';
     }
 
-    private function could_be_json_container(string $value): bool
+    /**
+     * Return whether the value starts with a JSON token that may expose string
+     * leaves to rewrite.
+     *
+     * This is a speed guard before constructing JsonStringIterator, whose
+     * constructor calls json_decode(). Objects and arrays can contain nested
+     * string leaves, and JSON string scalars can themselves be rewritten. The
+     * iterator remains responsible for full JSON validation after this coarse
+     * first-byte check passes.
+     */
+    private function could_be_json_with_strings(string $value): bool
     {
         $length = strlen($value);
         for ($i = 0; $i < $length; $i++) {
@@ -236,7 +257,7 @@ class StructuredDataUrlRewriter
                 continue;
             }
 
-            return $byte === '{' || $byte === '[';
+            return $byte === '{' || $byte === '[' || $byte === '"';
         }
 
         return false;

--- a/tests/UrlRewriting/JsonStringIteratorTest.php
+++ b/tests/UrlRewriting/JsonStringIteratorTest.php
@@ -37,6 +37,16 @@ class JsonStringIteratorTest extends TestCase
         );
     }
 
+    public function testCollectsJsonStringScalar(): void
+    {
+        $json = json_encode('https://old-site.com/page', JSON_UNESCAPED_SLASHES);
+
+        $this->assertSame(
+            ['https://old-site.com/page'],
+            $this->collectValues($json)
+        );
+    }
+
     public function testNoChangeReturnsOriginalJson(): void
     {
         $json = '{"title":"Hello","items":["first","second"]}';
@@ -65,6 +75,18 @@ class JsonStringIteratorTest extends TestCase
         $decoded = json_decode($iter->get_result(), true);
         $this->assertSame('https://new-site.com/page', $decoded['nested']['url']);
         $this->assertSame(['keep'], $decoded['items']);
+    }
+
+    public function testSetValueUpdatesJsonStringScalar(): void
+    {
+        $iter = new JsonStringIterator('"https:\/\/old-site.com\/page"');
+
+        $this->assertTrue($iter->next_value());
+        $this->assertSame('https://old-site.com/page', $iter->get_value());
+
+        $iter->set_value('https://new-site.com/page');
+
+        $this->assertSame('https://new-site.com/page', json_decode($iter->get_result(), true));
     }
 
     public function testMalformedJsonIsMalformed(): void

--- a/tests/UrlRewriting/StructuredDataUrlRewriterTest.php
+++ b/tests/UrlRewriting/StructuredDataUrlRewriterTest.php
@@ -121,6 +121,16 @@ class StructuredDataUrlRewriterTest extends TestCase
         $this->assertTrue($decoded['active']);
     }
 
+    public function testRewritesUrlInJsonStringScalar(): void
+    {
+        $rewriter = $this->createRewriter();
+        $input = '"https:\/\/old-site.com\/api"';
+
+        $result = $rewriter->rewrite($input);
+
+        $this->assertSame('https://new-site.com/api', json_decode($result, true));
+    }
+
     public function testJsonOutputUsesUnescapedSlashes(): void
     {
         $rewriter = $this->createRewriter();


### PR DESCRIPTION
## Summary

- documents the serialized PHP and JSON parser gates as performance guards directly above the relevant `if` statements
- adds docblocks to the helper methods explaining what they skip and what still owns validation
- renames the JSON helper from container-specific wording and treats JSON string scalars (`"`) as possible string-bearing JSON values
- lets `JsonStringIterator` expose JSON string scalars and adds tests for escaped-slash scalar strings

## Verification

- `./vendor/bin/phpunit --configuration tests/phpunit.xml tests/UrlRewriting/JsonStringIteratorTest.php tests/UrlRewriting/StructuredDataUrlRewriterTest.php`
- `./vendor/bin/phpunit --configuration tests/phpunit.xml tests/UrlRewriting` (`220 tests`, `2293 assertions`, `7 skipped`)

PHPStan on the two touched files was attempted, but the repo config currently fails on existing unmatched ignore patterns for `URLInTextProcessor`; no new line-level type errors were reported.
