### PR TITLE
[codex] Cache SQLite prepared insert shapes

### DIFF
--- a/packages/reprint-importer/src/lib/url-rewrite/class-fast-insert-scanner.php
+++ b/packages/reprint-importer/src/lib/url-rewrite/class-fast-insert-scanner.php
@@ -37,7 +37,17 @@ class FastInsertScanner
      * @return array{
      *   table: string,
      *   column_map: list<array{int, int, string}>,
-     *   base64_entries: list<array{expr_start: int, expr_length: int, quote_start: int, quote_length: int, encoded_value: string, value: ?string, new_value: ?string}>
+     *   base64_entries: list<array{
+     *     expr_start: int,
+     *     expr_length: int,
+     *     quote_start: int,
+     *     quote_length: int,
+     *     encoded_value: string,
+     *     value: ?string,
+     *     new_value: ?string,
+     *     column: string
+     *   }>,
+     *   value_entries: list<array{start: int, length: int, kind: string, column: string, quote_start?: int, quote_length?: int, encoded_value?: string}>
      * }|null
      *   Null when the SQL doesn't match the recognised shape.
      */
@@ -93,6 +103,7 @@ class FastInsertScanner
 
         $column_map = [];
         $base64_entries = [];
+        $value_entries = [];
 
         $cursor = $values_end;
         $sql_len = strlen($sql);
@@ -148,6 +159,23 @@ class FastInsertScanner
                         'encoded_value' => $value_kind[4],
                         'value' => null,
                         'new_value' => null,
+                        'column' => $columns[$col_idx],
+                    ];
+                    $value_entries[] = [
+                        'start' => $value_start,
+                        'length' => $value_end - $value_start,
+                        'kind' => 'base64',
+                        'column' => $columns[$col_idx],
+                        'quote_start' => $value_kind[2],
+                        'quote_length' => $value_kind[3],
+                        'encoded_value' => $value_kind[4],
+                    ];
+                } else {
+                    $value_entries[] = [
+                        'start' => $value_start,
+                        'length' => $value_end - $value_start,
+                        'kind' => self::classify_static_value($sql, $value_start, $value_end),
+                        'column' => $columns[$col_idx],
                     ];
                 }
 
@@ -194,7 +222,25 @@ class FastInsertScanner
             'table' => $table,
             'column_map' => $column_map,
             'base64_entries' => $base64_entries,
+            'value_entries' => $value_entries,
         ];
+    }
+
+    private static function classify_static_value(string $sql, int $start, int $end): string
+    {
+        if ($start >= $end) {
+            return 'unknown';
+        }
+
+        $c = $sql[$start];
+        if ($c === "'") {
+            return 'empty';
+        }
+        if ($c === 'N' || $c === 'n') {
+            return 'null';
+        }
+
+        return 'number';
     }
 
     /**
@@ -296,24 +342,35 @@ class FastInsertScanner
         while ($cursor < $sql_len && $sql[$cursor] >= '0' && $sql[$cursor] <= '9') {
             $cursor++;
         }
+        $digits_before_decimal = $cursor > $digit_start;
         if ($cursor < $sql_len && $sql[$cursor] === '.') {
             $cursor++;
+            $fraction_start = $cursor;
             while ($cursor < $sql_len && $sql[$cursor] >= '0' && $sql[$cursor] <= '9') {
                 $cursor++;
             }
+            if (!$digits_before_decimal && $cursor === $fraction_start) {
+                $cursor = $start;
+                return null;
+            }
+        }
+        if (!$digits_before_decimal && $cursor === $digit_start) {
+            $cursor = $start;
+            return null;
         }
         if ($cursor < $sql_len && ($sql[$cursor] === 'e' || $sql[$cursor] === 'E')) {
+            $exponent_start = $cursor;
             $cursor++;
             if ($cursor < $sql_len && ($sql[$cursor] === '+' || $sql[$cursor] === '-')) {
                 $cursor++;
             }
+            $exponent_digits_start = $cursor;
             while ($cursor < $sql_len && $sql[$cursor] >= '0' && $sql[$cursor] <= '9') {
                 $cursor++;
             }
-        }
-        if ($cursor === $digit_start) {
-            $cursor = $start;
-            return null;
+            if ($cursor === $exponent_digits_start) {
+                $cursor = $exponent_start;
+            }
         }
         return true;
     }

--- a/packages/reprint-importer/src/lib/url-rewrite/class-sql-statement-rewriter.php
+++ b/packages/reprint-importer/src/lib/url-rewrite/class-sql-statement-rewriter.php
@@ -123,12 +123,7 @@ class SqlStatementRewriter
         // that finds nothing. False negatives would silently leave URLs
         // un-rewritten; the four prefixes above are the minimum set that
         // covers every alignment×scheme combination, so no real URL escapes.
-        if (
-            strpos($sql, 'aHR0') === false
-            && strpos($sql, 'dHA6') === false
-            && strpos($sql, 'dHBz') === false
-            && strpos($sql, 'dHRw') === false
-        ) {
+        if (!self::encoded_payload_could_contain_http_scheme($sql)) {
             return $sql;
         }
 
@@ -172,8 +167,21 @@ class SqlStatementRewriter
             $sql,
             function (string $value, string $table, ?string $column): string {
                 return $this->rewrite_value_for_column($value, $table, $column);
+            },
+            function (string $encoded_value, string $decoded_value): bool {
+                unset($encoded_value);
+                return strpos($decoded_value, 'http') !== false
+                    && $this->url_rewriter->value_might_contain_source_domain($decoded_value);
             }
         );
+    }
+
+    private static function encoded_payload_could_contain_http_scheme(string $encoded_value): bool
+    {
+        return strpos($encoded_value, 'aHR0') !== false
+            || strpos($encoded_value, 'dHA6') !== false
+            || strpos($encoded_value, 'dHBz') !== false
+            || strpos($encoded_value, 'dHRw') !== false;
     }
 
     private function rewrite_value_for_column(string $value, string $table, ?string $column): string

--- a/packages/reprint-importer/src/lib/url-rewrite/class-sqlite-prepared-insert-builder.php
+++ b/packages/reprint-importer/src/lib/url-rewrite/class-sqlite-prepared-insert-builder.php
@@ -17,15 +17,34 @@
  */
 class SQLitePreparedInsertBuilder
 {
+    private const SHAPE_CACHE_LIMIT = 32;
+
+    /** @var list<array{table: string, chunks: list<string>, values: list<array<string, mixed>>, base64_indexes: list<int>}> */
+    private static array $shape_cache = [];
+
     /**
      * @param callable|null $rewrite_value Optional callback:
      *        fn(string $value, string $table, ?string $column): string
+     * @param callable|null $should_rewrite_value Optional callback:
+     *        fn(string $encoded_value, string $decoded_value): bool. When omitted,
+     *        $rewrite_value is applied to every decoded value. The decoded value
+     *        is passed as a second argument so callers can avoid re-scanning the
+     *        base64 text when the decoded payload is already available.
      * @return array{sql: string, params: list<string>}|null
      */
-    public static function build(string $sql, ?callable $rewrite_value = null): ?array
+    public static function build(
+        string $sql,
+        ?callable $rewrite_value = null,
+        ?callable $should_rewrite_value = null
+    ): ?array
     {
         if (strpos($sql, 'FROM_BASE64(') === false) {
             return null;
+        }
+
+        $cached = self::build_from_cached_shape($sql, $rewrite_value, $should_rewrite_value);
+        if ($cached !== null) {
+            return $cached;
         }
 
         $fast = FastInsertScanner::scan($sql);
@@ -33,6 +52,27 @@ class SQLitePreparedInsertBuilder
             return null;
         }
 
+        self::remember_shape($sql, $fast);
+
+        return self::build_from_scan($sql, $fast, $rewrite_value, $should_rewrite_value);
+    }
+
+    /**
+     * @param array{
+     *   table: string,
+     *   column_map: list<array{int, int, string}>,
+     *   base64_entries: list<array{expr_start: int, expr_length: int, quote_start: int, quote_length: int, encoded_value: string, value: ?string, new_value: ?string, column?: string}>
+     * } $fast
+     * @param callable|null $rewrite_value
+     * @param callable|null $should_rewrite_value
+     * @return array{sql: string, params: list<string>}|null
+     */
+    private static function build_from_scan(
+        string $sql,
+        array $fast,
+        ?callable $rewrite_value,
+        ?callable $should_rewrite_value
+    ): ?array {
         $parts = [];
         $params = [];
         $cursor = 0;
@@ -43,9 +83,16 @@ class SQLitePreparedInsertBuilder
             }
 
             $decoded = base64_decode($entry['encoded_value'], true);
-            $value = $decoded !== false ? $decoded : '';
-            if ($rewrite_value !== null) {
-                $column = self::find_column_at_offset($fast['column_map'], $entry['expr_start']);
+            if ($decoded === false) {
+                return null;
+            }
+            $value = $decoded;
+            if (
+                $rewrite_value !== null
+                && ($should_rewrite_value === null || $should_rewrite_value($entry['encoded_value'], $value))
+            ) {
+                $column = $entry['column']
+                    ?? self::find_column_at_offset($fast['column_map'], $entry['expr_start']);
                 $value = $rewrite_value($value, $fast['table'], $column);
             }
 
@@ -61,6 +108,253 @@ class SQLitePreparedInsertBuilder
             'sql' => implode('', $parts),
             'params' => $params,
         ];
+    }
+
+    /**
+     * @param array{
+     *   table: string,
+     *   value_entries: list<array{start: int, length: int, kind: string, column: string, quote_start?: int, quote_length?: int, encoded_value?: string}>
+     * } $fast
+     */
+    private static function remember_shape(string $sql, array $fast): void
+    {
+        if (empty($fast['value_entries'])) {
+            return;
+        }
+
+        $chunks = [];
+        $values = [];
+        $base64_indexes = [];
+        $cursor = 0;
+
+        foreach ($fast['value_entries'] as $index => $entry) {
+            $start = $entry['start'];
+            $end = $start + $entry['length'];
+            $chunks[] = substr($sql, $cursor, $start - $cursor);
+
+            $shape_entry = [
+                'kind' => $entry['kind'],
+                'column' => $entry['column'],
+            ];
+
+            if ($entry['kind'] === 'base64') {
+                $quote_start = $entry['quote_start'];
+                $quote_end = $quote_start + $entry['quote_length'];
+                $payload_start = $quote_start + 1;
+                $payload_end = $quote_end - 1;
+
+                $shape_entry['prefix'] = substr($sql, $start, $payload_start - $start);
+                $shape_entry['suffix'] = substr($sql, $payload_end, $end - $payload_end);
+                $base64_indexes[] = $index;
+            } elseif ($entry['kind'] !== 'number') {
+                $shape_entry['literal'] = substr($sql, $start, $entry['length']);
+            }
+
+            $values[] = $shape_entry;
+            $cursor = $end;
+        }
+
+        $chunks[] = substr($sql, $cursor);
+
+        self::$shape_cache[] = [
+            'table' => $fast['table'],
+            'chunks' => $chunks,
+            'values' => $values,
+            'base64_indexes' => $base64_indexes,
+        ];
+
+        if (count(self::$shape_cache) > self::SHAPE_CACHE_LIMIT) {
+            array_shift(self::$shape_cache);
+        }
+    }
+
+    /**
+     * @param callable|null $rewrite_value
+     * @param callable|null $should_rewrite_value
+     * @return array{sql: string, params: list<string>}|null
+     */
+    private static function build_from_cached_shape(
+        string $sql,
+        ?callable $rewrite_value,
+        ?callable $should_rewrite_value
+    ): ?array {
+        $count = count(self::$shape_cache);
+        for ($i = $count - 1; $i >= 0; $i--) {
+            $matched = self::match_shape(self::$shape_cache[$i], $sql, $rewrite_value, $should_rewrite_value);
+            if ($matched === null) {
+                continue;
+            }
+
+            if ($i !== $count - 1) {
+                $shape = self::$shape_cache[$i];
+                array_splice(self::$shape_cache, $i, 1);
+                self::$shape_cache[] = $shape;
+            }
+
+            return $matched;
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array{table: string, chunks: list<string>, values: list<array<string, mixed>>, base64_indexes: list<int>} $shape
+     * @param callable|null $rewrite_value
+     * @param callable|null $should_rewrite_value
+     * @return array{sql: string, params: list<string>}|null
+     */
+    private static function match_shape(
+        array $shape,
+        string $sql,
+        ?callable $rewrite_value,
+        ?callable $should_rewrite_value
+    ): ?array {
+        $pos = 0;
+        $sql_len = strlen($sql);
+        $value_ranges = [];
+        $encoded_by_index = [];
+
+        $first_chunk = $shape['chunks'][0];
+        if (!self::consume_literal($sql, $sql_len, $pos, $first_chunk)) {
+            return null;
+        }
+
+        foreach ($shape['values'] as $index => $entry) {
+            $value_start = $pos;
+            if ($entry['kind'] === 'base64') {
+                $prefix = $entry['prefix'];
+                if (!self::consume_literal($sql, $sql_len, $pos, $prefix)) {
+                    return null;
+                }
+                $payload_start = $pos;
+                $quote = strpos($sql, "'", $payload_start);
+                if ($quote === false) {
+                    return null;
+                }
+                $encoded = substr($sql, $payload_start, $quote - $payload_start);
+                if (!self::is_base64_payload($encoded)) {
+                    return null;
+                }
+                $pos = $quote;
+                if (!self::consume_literal($sql, $sql_len, $pos, $entry['suffix'])) {
+                    return null;
+                }
+                $encoded_by_index[$index] = $encoded;
+            } elseif ($entry['kind'] === 'number') {
+                if (!self::consume_number($sql, $sql_len, $pos)) {
+                    return null;
+                }
+            } else {
+                if (!self::consume_literal($sql, $sql_len, $pos, $entry['literal'])) {
+                    return null;
+                }
+            }
+
+            $value_ranges[$index] = [$value_start, $pos];
+            if (!self::consume_literal($sql, $sql_len, $pos, $shape['chunks'][$index + 1])) {
+                return null;
+            }
+        }
+
+        if ($pos !== $sql_len) {
+            return null;
+        }
+
+        $parts = [];
+        $params = [];
+        $cursor = 0;
+
+        foreach ($shape['base64_indexes'] as $index) {
+            [$value_start, $value_end] = $value_ranges[$index];
+            if ($value_start < $cursor || $value_end <= $value_start) {
+                return null;
+            }
+
+            $encoded = $encoded_by_index[$index];
+            $decoded = base64_decode($encoded, true);
+            if ($decoded === false) {
+                return null;
+            }
+            $value = $decoded;
+            if (
+                $rewrite_value !== null
+                && ($should_rewrite_value === null || $should_rewrite_value($encoded, $value))
+            ) {
+                $value = $rewrite_value($value, $shape['table'], $shape['values'][$index]['column']);
+            }
+
+            $parts[] = substr($sql, $cursor, $value_start - $cursor);
+            $parts[] = '?';
+            $params[] = $value;
+            $cursor = $value_end;
+        }
+
+        $parts[] = substr($sql, $cursor);
+
+        return [
+            'sql' => implode('', $parts),
+            'params' => $params,
+        ];
+    }
+
+    private static function is_base64_payload(string $payload): bool
+    {
+        return $payload === '' || preg_match('/\A[A-Za-z0-9+\/=]*\z/', $payload) === 1;
+    }
+
+    private static function consume_literal(string $sql, int $sql_len, int &$pos, string $literal): bool
+    {
+        $length = strlen($literal);
+        if ($pos + $length > $sql_len || substr_compare($sql, $literal, $pos, $length) !== 0) {
+            return false;
+        }
+
+        $pos += $length;
+        return true;
+    }
+
+    private static function consume_number(string $sql, int $sql_len, int &$pos): bool
+    {
+        $start = $pos;
+        if ($pos < $sql_len && ($sql[$pos] === '+' || $sql[$pos] === '-')) {
+            $pos++;
+        }
+        $digit_start = $pos;
+        while ($pos < $sql_len && $sql[$pos] >= '0' && $sql[$pos] <= '9') {
+            $pos++;
+        }
+        $digits_before_decimal = $pos > $digit_start;
+        if ($pos < $sql_len && $sql[$pos] === '.') {
+            $pos++;
+            $fraction_start = $pos;
+            while ($pos < $sql_len && $sql[$pos] >= '0' && $sql[$pos] <= '9') {
+                $pos++;
+            }
+            if (!$digits_before_decimal && $pos === $fraction_start) {
+                $pos = $start;
+                return false;
+            }
+        }
+        if (!$digits_before_decimal && $pos === $digit_start) {
+            $pos = $start;
+            return false;
+        }
+        if ($pos < $sql_len && ($sql[$pos] === 'e' || $sql[$pos] === 'E')) {
+            $exponent_start = $pos;
+            $pos++;
+            if ($pos < $sql_len && ($sql[$pos] === '+' || $sql[$pos] === '-')) {
+                $pos++;
+            }
+            $exponent_digits_start = $pos;
+            while ($pos < $sql_len && $sql[$pos] >= '0' && $sql[$pos] <= '9') {
+                $pos++;
+            }
+            if ($pos === $exponent_digits_start) {
+                $pos = $exponent_start;
+            }
+        }
+
+        return true;
     }
 
     /**

--- a/tests/UrlRewriting/SQLitePreparedInsertBuilderTest.php
+++ b/tests/UrlRewriting/SQLitePreparedInsertBuilderTest.php
@@ -7,6 +7,19 @@ require_once __DIR__ . '/../../packages/reprint-importer/src/lib/url-rewrite/loa
 
 class SQLitePreparedInsertBuilderTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        self::clearShapeCache();
+    }
+
+    private static function clearShapeCache(): void
+    {
+        $reflection = new ReflectionClass(SQLitePreparedInsertBuilder::class);
+        $property = $reflection->getProperty('shape_cache');
+        $property->setAccessible(true);
+        $property->setValue(null, []);
+    }
+
     public function testBuildsPreparedInsertForArbitraryBytes(): void
     {
         $bytes = '';
@@ -66,6 +79,104 @@ class SQLitePreparedInsertBuilderTest extends TestCase
 
         $this->assertNotNull($prepared);
         $this->assertSame(['after'], $prepared['params']);
+    }
+
+    public function testRewriteCallbackCanBePrefilteredByEncodedPayload(): void
+    {
+        $sql = sprintf(
+            "INSERT INTO `wp_options` (`option_name`, `option_value`) VALUES(FROM_BASE64('%s'), FROM_BASE64('%s'));",
+            base64_encode('plain value'),
+            base64_encode('http://old-site.example.com')
+        );
+        $calls = 0;
+
+        $prepared = SQLitePreparedInsertBuilder::build(
+            $sql,
+            function (string $value, string $table, ?string $column) use (&$calls): string {
+                $calls++;
+                return str_replace('old-site', 'new-site', $value);
+            },
+            function (string $encoded_value): bool {
+                return strpos($encoded_value, 'aHR0') !== false;
+            }
+        );
+
+        $this->assertNotNull($prepared);
+        $this->assertSame(1, $calls);
+        $this->assertSame(
+            ['plain value', 'http://new-site.example.com'],
+            $prepared['params']
+        );
+    }
+
+    public function testRewritePrefilterReceivesDecodedPayloadOnCachedShape(): void
+    {
+        $make_sql = static function (string $first, string $second): string {
+            return sprintf(
+                "INSERT INTO `wp_options` (`option_name`, `option_value`) VALUES(FROM_BASE64('%s'), FROM_BASE64('%s'));",
+                base64_encode($first),
+                base64_encode($second)
+            );
+        };
+
+        SQLitePreparedInsertBuilder::build($make_sql('seed', 'seed'));
+
+        $calls = 0;
+        $seen_decoded = [];
+        $prepared = SQLitePreparedInsertBuilder::build(
+            $make_sql('plain value', 'http://old-site.example.com'),
+            function (string $value, string $table, ?string $column) use (&$calls): string {
+                $calls++;
+                return str_replace('old-site', 'new-site', $value);
+            },
+            function (string $encoded_value, string $decoded_value) use (&$seen_decoded): bool {
+                unset($encoded_value);
+                $seen_decoded[] = $decoded_value;
+                return strpos($decoded_value, 'http') !== false;
+            }
+        );
+
+        $this->assertNotNull($prepared);
+        $this->assertSame(['plain value', 'http://old-site.example.com'], $seen_decoded);
+        $this->assertSame(1, $calls);
+        $this->assertSame(
+            ['plain value', 'http://new-site.example.com'],
+            $prepared['params']
+        );
+    }
+
+    public function testCachedShapeRejectsPayloadThatFastScannerWouldReject(): void
+    {
+        $valid_sql = sprintf(
+            "INSERT INTO `wp_options` (`option_name`, `option_value`) VALUES(FROM_BASE64('%s'), FROM_BASE64('%s'));",
+            base64_encode('seed'),
+            base64_encode('value')
+        );
+        SQLitePreparedInsertBuilder::build($valid_sql);
+
+        $invalid_sql = "INSERT INTO `wp_options` (`option_name`, `option_value`) VALUES(FROM_BASE64('valid'), FROM_BASE64('not-valid!'));";
+
+        $this->assertNull(SQLitePreparedInsertBuilder::build($invalid_sql));
+    }
+
+    public function testUncachedShapeRejectsInvalidBase64PaddingInsteadOfBindingEmptyString(): void
+    {
+        $sql = "INSERT INTO `wp_options` (`option_value`) VALUES(FROM_BASE64('valid'));";
+
+        $this->assertNull(SQLitePreparedInsertBuilder::build($sql));
+    }
+
+    public function testCachedShapeRejectsInvalidBase64PaddingInsteadOfBindingEmptyString(): void
+    {
+        $valid_sql = sprintf(
+            "INSERT INTO `wp_options` (`option_value`) VALUES(FROM_BASE64('%s'));",
+            base64_encode('seed')
+        );
+        SQLitePreparedInsertBuilder::build($valid_sql);
+
+        $invalid_sql = "INSERT INTO `wp_options` (`option_value`) VALUES(FROM_BASE64('valid'));";
+
+        $this->assertNull(SQLitePreparedInsertBuilder::build($invalid_sql));
     }
 
     public function testUnknownInsertShapeReturnsNull(): void


### PR DESCRIPTION
## What it does

Caches the parsed value layout for producer-shaped SQLite prepared `INSERT` statements. Repeated batches with the same table/column/value shape can skip the full `FastInsertScanner` pass and rebuild prepared SQL from cached chunks.

## Rationale

The accepted gate is the full `playground-sqlite-db-apply` phase, not method-level timing. The prior stack included #235, but a fresh full-stage audit showed #235 does not improve db-apply. This PR has been rebased directly onto `trunk` and is the surviving db-apply speedup.

Full-stage evidence:

- fresh `trunk` audit: `73.86s`
- this PR rebased on `trunk`: `65.03s`

Both timings are full `BENCH_STAGES=playground-sqlite-db-apply` runs on `large-directory` with 320,007 posts / 720,015 postmeta, PHP 8.3 wasm runner, `PLAYGROUND_PHP_USE_WASM_RUNNER=1`, and native `wp_mysql_parser` verified. The PR run printed the completed full-stage table, then exited nonzero only because `.context/` did not exist for the JSON output path.

## Implementation

- Adds a bounded static shape cache to `SQLitePreparedInsertBuilder`.
- Stores literal chunks, static value kinds, base64 positions, table name, and column names from known-good producer-shaped inserts.
- Revalidates cached matches against the whole SQL string before using them.
- Adds a decoded-payload rewrite prefilter so non-URL payloads avoid the rewrite callback.
- Hardens invalid base64 handling so cached and uncached paths both fall back instead of binding empty strings.

## Testing instructions

```bash
vendor/bin/phpunit --configuration tests/phpunit.xml tests/UrlRewriting
mkdir -p .context
BENCH_STAGES=playground-sqlite-db-apply \
BENCH_LABEL=pr239-shape-on-trunk \
BENCH_JSON_OUT=.context/pr239-shape-on-trunk.json \
BENCH_MD_OUT=.context/pr239-shape-on-trunk.md \
WP_MYSQL_PARSER_EXTENSION_MANIFEST=https://wordpress.github.io/sqlite-database-integration/wp_mysql_parser-wasm-extension/latest/manifest.json \
PLAYGROUND_PHP_USE_WASM_RUNNER=1 \
PLAYGROUND_PHP_VERSION=8.3 \
node tests/e2e/benchmark/bench-pull.mjs
```

Observed URL-rewrite suite on the rebased branch: `225 tests`, `2303 assertions`, `7 skipped`.
Observed full db-apply result on the rebased branch: `65.03s`, native parser verified.
