### PR TITLE
Harden invalid base64 prepared inserts

### DIFF
--- a/packages/reprint-importer/src/lib/url-rewrite/class-sqlite-prepared-insert-builder.php
+++ b/packages/reprint-importer/src/lib/url-rewrite/class-sqlite-prepared-insert-builder.php
@@ -43,7 +43,10 @@ class SQLitePreparedInsertBuilder
             }
 
             $decoded = base64_decode($entry['encoded_value'], true);
-            $value = $decoded !== false ? $decoded : '';
+            if ($decoded === false) {
+                return null;
+            }
+            $value = $decoded;
             if ($rewrite_value !== null) {
                 $column = self::find_column_at_offset($fast['column_map'], $entry['expr_start']);
                 $value = $rewrite_value($value, $fast['table'], $column);

--- a/tests/UrlRewriting/SQLitePreparedInsertBuilderTest.php
+++ b/tests/UrlRewriting/SQLitePreparedInsertBuilderTest.php
@@ -68,6 +68,49 @@ class SQLitePreparedInsertBuilderTest extends TestCase
         $this->assertSame(['after'], $prepared['params']);
     }
 
+    public function testRejectsMalformedBase64InsteadOfBindingEmptyString(): void
+    {
+        $sql = "INSERT INTO `wp_options` (`option_value`) VALUES(FROM_BASE64('valid'));";
+
+        $this->assertNull(SQLitePreparedInsertBuilder::build($sql));
+    }
+
+    public function testRejectsMalformedBase64AfterSameShapeWasBuilt(): void
+    {
+        $valid_sql = sprintf(
+            "INSERT INTO `wp_options` (`option_name`, `option_value`) VALUES(FROM_BASE64('%s'), FROM_BASE64('%s'));",
+            base64_encode('name'),
+            base64_encode('value')
+        );
+        $this->assertNotNull(SQLitePreparedInsertBuilder::build($valid_sql));
+
+        // Guards both the current rescan path and any future same-shape cache.
+        $invalid_sql = sprintf(
+            "INSERT INTO `wp_options` (`option_name`, `option_value`) VALUES(FROM_BASE64('%s'), FROM_BASE64('valid'));",
+            base64_encode('name')
+        );
+
+        $this->assertNull(SQLitePreparedInsertBuilder::build($invalid_sql));
+    }
+
+    public function testRejectsNonAlphabetPayloadAfterSameShapeWasBuilt(): void
+    {
+        $valid_sql = sprintf(
+            "INSERT INTO `wp_options` (`option_name`, `option_value`) VALUES(FROM_BASE64('%s'), FROM_BASE64('%s'));",
+            base64_encode('name'),
+            base64_encode('value')
+        );
+        $this->assertNotNull(SQLitePreparedInsertBuilder::build($valid_sql));
+
+        // Guards both the current rescan path and any future same-shape cache.
+        $invalid_sql = sprintf(
+            "INSERT INTO `wp_options` (`option_name`, `option_value`) VALUES(FROM_BASE64('%s'), FROM_BASE64('not-valid!'));",
+            base64_encode('name')
+        );
+
+        $this->assertNull(SQLitePreparedInsertBuilder::build($invalid_sql));
+    }
+
     public function testUnknownInsertShapeReturnsNull(): void
     {
         $sql = sprintf(


### PR DESCRIPTION
## What it does

Makes `SQLitePreparedInsertBuilder` abandon the prepared insert fast path when strict `FROM_BASE64()` decoding fails.

Invalid payloads now return `null` from `build()`, so the caller keeps the existing SQL execution path instead of binding an empty string.

## Rationale

Prepared inserts should only bind bytes that were decoded successfully. Treating malformed base64 as `''` can change imported data, so this PR keeps malformed statements out of the prepared path.

This is a correctness-only draft. It makes no speed claim and does not include the shape-cache work from #239.

## Implementation

`base64_decode(..., true)` failures now stop prepared insert construction instead of substituting an empty string.

The tests cover malformed alphabet-only payloads, same-shape reuse after a valid statement, and payloads with non-base64 characters.

## Testing instructions

Ran:

```bash
vendor/bin/phpunit --configuration tests/phpunit.xml tests/UrlRewriting/SQLitePreparedInsertBuilderTest.php
vendor/bin/phpunit --configuration tests/phpunit.xml tests/UrlRewriting
```

Results:

- `SQLitePreparedInsertBuilderTest.php`: OK, 8 tests, 20 assertions
- `tests/UrlRewriting`: OK, 223 tests, 2298 assertions, 7 skipped