### PR TITLE
Batch SQLite db-apply work between state checkpoints

### DIFF
--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -5135,7 +5135,7 @@ class ImportClient
             if (!$use_sqlite_apply_transactions || $sqlite_apply_transaction_active) {
                 return;
             }
-            if (method_exists($pdo, 'inTransaction') && $pdo->inTransaction()) {
+            if ($pdo->inTransaction()) {
                 return;
             }
             $pdo->beginTransaction();
@@ -5149,7 +5149,7 @@ class ImportClient
             if (!$use_sqlite_apply_transactions || !$sqlite_apply_transaction_active) {
                 return;
             }
-            if (method_exists($pdo, 'inTransaction') && $pdo->inTransaction()) {
+            if ($pdo->inTransaction()) {
                 $pdo->commit();
             }
             $sqlite_apply_transaction_active = false;
@@ -5162,7 +5162,7 @@ class ImportClient
             if (!$use_sqlite_apply_transactions || !$sqlite_apply_transaction_active) {
                 return;
             }
-            if (method_exists($pdo, 'inTransaction') && $pdo->inTransaction()) {
+            if ($pdo->inTransaction()) {
                 $pdo->rollBack();
             }
             $sqlite_apply_transaction_active = false;

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -5125,6 +5125,48 @@ class ImportClient
         ) {
             $sqlite_prepared_pdo = $pdo->get_connection()->get_pdo();
         }
+        $use_sqlite_apply_transactions = $sqlite_prepared_pdo !== null;
+        $sqlite_apply_transaction_active = false;
+        $begin_sqlite_apply_transaction = function () use (
+            $pdo,
+            $use_sqlite_apply_transactions,
+            &$sqlite_apply_transaction_active
+        ): void {
+            if (!$use_sqlite_apply_transactions || $sqlite_apply_transaction_active) {
+                return;
+            }
+            if (method_exists($pdo, 'inTransaction') && $pdo->inTransaction()) {
+                return;
+            }
+            $pdo->beginTransaction();
+            $sqlite_apply_transaction_active = true;
+        };
+        $commit_sqlite_apply_transaction = function () use (
+            $pdo,
+            $use_sqlite_apply_transactions,
+            &$sqlite_apply_transaction_active
+        ): void {
+            if (!$use_sqlite_apply_transactions || !$sqlite_apply_transaction_active) {
+                return;
+            }
+            if (method_exists($pdo, 'inTransaction') && $pdo->inTransaction()) {
+                $pdo->commit();
+            }
+            $sqlite_apply_transaction_active = false;
+        };
+        $rollback_sqlite_apply_transaction = function () use (
+            $pdo,
+            $use_sqlite_apply_transactions,
+            &$sqlite_apply_transaction_active
+        ): void {
+            if (!$use_sqlite_apply_transactions || !$sqlite_apply_transaction_active) {
+                return;
+            }
+            if (method_exists($pdo, 'inTransaction') && $pdo->inTransaction()) {
+                $pdo->rollBack();
+            }
+            $sqlite_apply_transaction_active = false;
+        };
 
         $this->audit_log(
             "CONNECTED | {$connection_label}",
@@ -5201,6 +5243,7 @@ class ImportClient
 
         try {
             $chunk_size = 64 * 1024; // 64KB read chunks
+            $begin_sqlite_apply_transaction();
 
             while (!feof($sql_handle)) {
                 // Check shutdown
@@ -5264,9 +5307,11 @@ class ImportClient
                     // formed a complete query yet. This ensures resumption starts at
                     // the exact boundary between executed and un-executed queries.
                     if ($stmts_since_save >= $save_every) {
+                        $commit_sqlite_apply_transaction();
                         $this->state["apply"]["statements_executed"] = $statements_executed;
                         $this->state["apply"]["bytes_read"] = $seek_offset + $query_stream->get_bytes_consumed();
                         $this->save_state($this->state);
+                        $begin_sqlite_apply_transaction();
                         $stmts_since_save = 0;
 
                         // Progress output
@@ -5338,6 +5383,7 @@ class ImportClient
 
             if ($this->shutdown_requested) {
                 // Save partial progress
+                $commit_sqlite_apply_transaction();
                 $this->state["apply"]["statements_executed"] = $statements_executed;
                 $this->state["apply"]["bytes_read"] = $seek_offset + $query_stream->get_bytes_consumed();
                 $this->state["status"] = "partial";
@@ -5366,6 +5412,7 @@ class ImportClient
                 // We skip deactivate_plugins() because the plugin files will
                 // be gone by the time WordPress boots — firing deactivation
                 // hooks into absent code is pointless.
+                $commit_sqlite_apply_transaction();
                 $deactivated = $this->deactivate_host_plugins($pdo);
                 foreach ($deactivated as $basename) {
                     $this->audit_log("DB-APPLY | deactivated plugin {$basename} (host-specific)");
@@ -5410,6 +5457,9 @@ class ImportClient
                 }
                 $this->progress->show_lifecycle_line("db-apply complete ({$statements_executed} statements executed)\n");
             }
+        } catch (Throwable $e) {
+            $rollback_sqlite_apply_transaction();
+            throw $e;
         } finally {
             fclose($sql_handle);
         }

--- a/tests/Import/NewSiteUrlSqliteTest.php
+++ b/tests/Import/NewSiteUrlSqliteTest.php
@@ -369,4 +369,91 @@ class NewSiteUrlSqliteTest extends TestCase
         $this->assertCount(1, $rows);
         $this->assertSame(strtoupper(bin2hex($bytes)), $rows[0]['hex_value']);
     }
+
+    public function testSqliteDbApplyRollsBackOnlyUncheckpointedWindowAndCanResume(): void
+    {
+        $sqlitePath = $this->tempDir . '/database/wordpress.sqlite';
+        $buildDump = function (string $tailStatement): string {
+            $stmts = [];
+            $stmts[] = "CREATE TABLE `wp_txn_window` ("
+                . "`id` int NOT NULL, "
+                . "`payload` longtext NOT NULL, "
+                . "PRIMARY KEY (`id`)"
+                . ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;";
+            for ($i = 1; $i <= 104; $i++) {
+                $stmts[] = sprintf(
+                    "INSERT INTO `wp_txn_window` (`id`, `payload`) VALUES (%d, FROM_BASE64('%s'));",
+                    $i,
+                    base64_encode("row-{$i}")
+                );
+            }
+            $stmts[] = $tailStatement;
+
+            return implode("\n", $stmts) . "\n";
+        };
+
+        file_put_contents(
+            $this->tempDir . '/db.sql',
+            $buildDump("INSERT INTO `wp_missing_table` (`id`) VALUES (1);")
+        );
+        $this->writeState();
+
+        $client = new \ImportClient(
+            'https://old-site.example.com/?reprint-api',
+            $this->tempDir,
+            $this->tempDir . '/fs-root',
+        );
+        $options = [
+            'command' => 'db-apply',
+            'abort' => false,
+            'verbose' => false,
+            'secret' => null,
+            'tuning_config' => [],
+            'target_engine' => 'sqlite',
+            'target_sqlite_path' => $sqlitePath,
+            'target_db' => 'wp_test',
+        ];
+
+        try {
+            $client->run($options);
+            $this->fail('Expected db-apply to fail after the first checkpoint.');
+        } catch (\RuntimeException $e) {
+            $this->assertStringContainsString('wp_missing_table', $e->getMessage());
+        }
+
+        $state = json_decode(file_get_contents($this->tempDir . '/.import-state.json'), true);
+        $this->assertSame('in_progress', $state['status']);
+        $this->assertSame(100, $state['apply']['statements_executed']);
+
+        $rowsAfterFailure = $this->querySqlite(
+            $sqlitePath,
+            "SELECT COUNT(*) AS c, MAX(id) AS max_id FROM wp_txn_window",
+            'wp_test',
+        );
+        $this->assertSame(99, (int) $rowsAfterFailure[0]['c']);
+        $this->assertSame(99, (int) $rowsAfterFailure[0]['max_id']);
+
+        file_put_contents(
+            $this->tempDir . '/db.sql',
+            $buildDump("INSERT INTO `wp_txn_window` (`id`, `payload`) VALUES (105, FROM_BASE64('" . base64_encode('row-105') . "'));")
+        );
+
+        $client = new \ImportClient(
+            'https://old-site.example.com/?reprint-api',
+            $this->tempDir,
+            $this->tempDir . '/fs-root',
+        );
+        $client->run($options);
+
+        $rowsAfterResume = $this->querySqlite(
+            $sqlitePath,
+            "SELECT COUNT(*) AS c, MAX(id) AS max_id FROM wp_txn_window",
+            'wp_test',
+        );
+        $this->assertSame(105, (int) $rowsAfterResume[0]['c']);
+        $this->assertSame(105, (int) $rowsAfterResume[0]['max_id']);
+
+        $state = json_decode(file_get_contents($this->tempDir . '/.import-state.json'), true);
+        $this->assertSame('complete', $state['status']);
+    }
 }


### PR DESCRIPTION
## What it does

Batches SQLite `db-apply` work inside explicit SQLite transactions aligned with the existing 100-statement state checkpoints.

## Rationale

`SET AUTOCOMMIT=0` in the dump only updates MySQL-on-SQLite session state; it does not keep the SQLite connection in one write transaction. The existing state-save boundary is the durability boundary this code can safely resume from.

## Implementation

- Starts a SQLite transaction before applying a checkpoint window.
- Commits before each periodic `save_state()` checkpoint, then starts the next window.
- Commits before graceful partial state saves and before final plugin deactivation/state completion.
- Rolls back the current uncheckpointed window on apply errors so resume replays from the last committed byte boundary.

## Full db-apply evidence

Performance Report run: https://github.com/adamziel/reprint/actions/runs/26226894929/job/77176319597

`large-directory` benchmark, with 10,000 posts, 25,000 postmeta rows, 2,000+ files, PHP 8.5.6 runner, and Playground PHP.wasm 8.3:

- PR `playground-sqlite-db-apply`: `3.67 s`, `1` resume attempt, status `✓`.
- Trunk `playground-sqlite-db-apply`: `3.82 s`, `1` resume attempt, status `✓`.
- Details: `condition=db-apply to SQLite in PHP.wasm`, `wp_mysql_parser=enabled`, `mode=parser`, `native_lexer=verified`, `native_parser=verified`, `native_ast=WP_MySQL_Native_Parser_Node`, `sqlite_driver_parser=verified`.

## Transaction/resume risk

This changes SQLite `db-apply` durability from statement-by-statement autocommit to checkpoint-sized transactions. A failure inside a checkpoint window rolls back that window and resume replays from the last saved SQL byte offset. A crash after SQLite commit but before the state file is saved can still leave committed database work ahead of the saved resume offset, so commit and state save are not atomic across storage layers.
