### PR TITLE
Cache SQLite prepared INSERT shapes

### DIFF
--- a/packages/reprint-importer/src/lib/url-rewrite/class-fast-insert-scanner.php
+++ b/packages/reprint-importer/src/lib/url-rewrite/class-fast-insert-scanner.php
@@ -37,7 +37,8 @@ class FastInsertScanner
      * @return array{
      *   table: string,
      *   column_map: list<array{int, int, string}>,
-     *   base64_entries: list<array{expr_start: int, expr_length: int, quote_start: int, quote_length: int, encoded_value: string, value: ?string, new_value: ?string}>
+     *   base64_entries: list<array{expr_start: int, expr_length: int, quote_start: int, quote_length: int, encoded_value: string, value: ?string, new_value: ?string}>,
+     *   value_entries: list<array{start: int, length: int, kind: string, column: string, quote_start?: int, quote_length?: int, encoded_value?: string}>
      * }|null
      *   Null when the SQL doesn't match the recognised shape.
      */
@@ -93,6 +94,7 @@ class FastInsertScanner
 
         $column_map = [];
         $base64_entries = [];
+        $value_entries = [];
 
         $cursor = $values_end;
         $sql_len = strlen($sql);
@@ -149,6 +151,22 @@ class FastInsertScanner
                         'value' => null,
                         'new_value' => null,
                     ];
+                    $value_entries[] = [
+                        'start' => $value_start,
+                        'length' => $value_end - $value_start,
+                        'kind' => 'base64',
+                        'column' => $columns[$col_idx],
+                        'quote_start' => $value_kind[2],
+                        'quote_length' => $value_kind[3],
+                        'encoded_value' => $value_kind[4],
+                    ];
+                } else {
+                    $value_entries[] = [
+                        'start' => $value_start,
+                        'length' => $value_end - $value_start,
+                        'kind' => self::classify_static_value($sql, $value_start, $value_end),
+                        'column' => $columns[$col_idx],
+                    ];
                 }
 
                 while ($cursor < $sql_len && self::is_ws($sql[$cursor])) {
@@ -194,7 +212,25 @@ class FastInsertScanner
             'table' => $table,
             'column_map' => $column_map,
             'base64_entries' => $base64_entries,
+            'value_entries' => $value_entries,
         ];
+    }
+
+    private static function classify_static_value(string $sql, int $start, int $end): string
+    {
+        if ($start >= $end) {
+            return 'unknown';
+        }
+
+        $c = $sql[$start];
+        if ($c === "'") {
+            return 'empty';
+        }
+        if ($c === 'N' || $c === 'n') {
+            return 'null';
+        }
+
+        return 'number';
     }
 
     /**

--- a/packages/reprint-importer/src/lib/url-rewrite/class-sqlite-prepared-insert-builder.php
+++ b/packages/reprint-importer/src/lib/url-rewrite/class-sqlite-prepared-insert-builder.php
@@ -17,6 +17,11 @@
  */
 class SQLitePreparedInsertBuilder
 {
+    private const SHAPE_CACHE_LIMIT = 32;
+
+    /** @var list<array{table: string, chunks: list<string>, values: list<array<string, mixed>>, base64_indexes: list<int>}> */
+    private static array $shape_cache = [];
+
     /**
      * @param callable|null $rewrite_value Optional callback:
      *        fn(string $value, string $table, ?string $column): string
@@ -28,11 +33,32 @@ class SQLitePreparedInsertBuilder
             return null;
         }
 
+        $cached = self::build_from_cached_shape($sql, $rewrite_value);
+        if ($cached !== null) {
+            return $cached;
+        }
+
         $fast = FastInsertScanner::scan($sql);
         if ($fast === null || empty($fast['base64_entries'])) {
             return null;
         }
 
+        self::remember_shape($sql, $fast);
+
+        return self::build_from_scan($sql, $fast, $rewrite_value);
+    }
+
+    /**
+     * @param array{
+     *   table: string,
+     *   column_map: list<array{int, int, string}>,
+     *   base64_entries: list<array{expr_start: int, expr_length: int, quote_start: int, quote_length: int, encoded_value: string, value: ?string, new_value: ?string}>
+     * } $fast
+     * @param callable|null $rewrite_value
+     * @return array{sql: string, params: list<string>}|null
+     */
+    private static function build_from_scan(string $sql, array $fast, ?callable $rewrite_value): ?array
+    {
         $parts = [];
         $params = [];
         $cursor = 0;
@@ -61,6 +87,230 @@ class SQLitePreparedInsertBuilder
             'sql' => implode('', $parts),
             'params' => $params,
         ];
+    }
+
+    /**
+     * @param array{
+     *   table: string,
+     *   value_entries: list<array{start: int, length: int, kind: string, column: string, quote_start?: int, quote_length?: int, encoded_value?: string}>
+     * } $fast
+     */
+    private static function remember_shape(string $sql, array $fast): void
+    {
+        if (empty($fast['value_entries'])) {
+            return;
+        }
+
+        $chunks = [];
+        $values = [];
+        $base64_indexes = [];
+        $cursor = 0;
+
+        foreach ($fast['value_entries'] as $index => $entry) {
+            $start = $entry['start'];
+            $end = $start + $entry['length'];
+            $chunks[] = substr($sql, $cursor, $start - $cursor);
+
+            $shape_entry = [
+                'kind' => $entry['kind'],
+                'column' => $entry['column'],
+            ];
+
+            if ($entry['kind'] === 'base64') {
+                $quote_start = $entry['quote_start'];
+                $quote_end = $quote_start + $entry['quote_length'];
+                $payload_start = $quote_start + 1;
+                $payload_end = $quote_end - 1;
+
+                $shape_entry['prefix'] = substr($sql, $start, $payload_start - $start);
+                $shape_entry['suffix'] = substr($sql, $payload_end, $end - $payload_end);
+                $base64_indexes[] = $index;
+            } elseif ($entry['kind'] !== 'number') {
+                $shape_entry['literal'] = substr($sql, $start, $entry['length']);
+            }
+
+            $values[] = $shape_entry;
+            $cursor = $end;
+        }
+
+        $chunks[] = substr($sql, $cursor);
+
+        self::$shape_cache[] = [
+            'table' => $fast['table'],
+            'chunks' => $chunks,
+            'values' => $values,
+            'base64_indexes' => $base64_indexes,
+        ];
+
+        if (count(self::$shape_cache) > self::SHAPE_CACHE_LIMIT) {
+            array_shift(self::$shape_cache);
+        }
+    }
+
+    /**
+     * @param callable|null $rewrite_value
+     * @return array{sql: string, params: list<string>}|null
+     */
+    private static function build_from_cached_shape(string $sql, ?callable $rewrite_value): ?array
+    {
+        $count = count(self::$shape_cache);
+        for ($i = $count - 1; $i >= 0; $i--) {
+            $matched = self::match_shape(self::$shape_cache[$i], $sql, $rewrite_value);
+            if ($matched === null) {
+                continue;
+            }
+
+            if ($i !== $count - 1) {
+                $shape = self::$shape_cache[$i];
+                array_splice(self::$shape_cache, $i, 1);
+                self::$shape_cache[] = $shape;
+            }
+
+            return $matched;
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array{table: string, chunks: list<string>, values: list<array<string, mixed>>, base64_indexes: list<int>} $shape
+     * @param callable|null $rewrite_value
+     * @return array{sql: string, params: list<string>}|null
+     */
+    private static function match_shape(array $shape, string $sql, ?callable $rewrite_value): ?array
+    {
+        $pos = 0;
+        $sql_len = strlen($sql);
+        $value_ranges = [];
+        $encoded_by_index = [];
+
+        $first_chunk = $shape['chunks'][0];
+        if (!self::consume_literal($sql, $sql_len, $pos, $first_chunk)) {
+            return null;
+        }
+
+        foreach ($shape['values'] as $index => $entry) {
+            $value_start = $pos;
+            if ($entry['kind'] === 'base64') {
+                $prefix = $entry['prefix'];
+                if (!self::consume_literal($sql, $sql_len, $pos, $prefix)) {
+                    return null;
+                }
+
+                $payload_start = $pos;
+                $quote = strpos($sql, "'", $payload_start);
+                if ($quote === false) {
+                    return null;
+                }
+
+                $encoded = substr($sql, $payload_start, $quote - $payload_start);
+                if (!self::is_base64_payload($encoded)) {
+                    return null;
+                }
+
+                $pos = $quote;
+                if (!self::consume_literal($sql, $sql_len, $pos, $entry['suffix'])) {
+                    return null;
+                }
+                $encoded_by_index[$index] = $encoded;
+            } elseif ($entry['kind'] === 'number') {
+                if (!self::consume_number($sql, $sql_len, $pos)) {
+                    return null;
+                }
+            } else {
+                if (!self::consume_literal($sql, $sql_len, $pos, $entry['literal'])) {
+                    return null;
+                }
+            }
+
+            $value_ranges[$index] = [$value_start, $pos];
+            if (!self::consume_literal($sql, $sql_len, $pos, $shape['chunks'][$index + 1])) {
+                return null;
+            }
+        }
+
+        if ($pos !== $sql_len) {
+            return null;
+        }
+
+        $parts = [];
+        $params = [];
+        $cursor = 0;
+
+        foreach ($shape['base64_indexes'] as $index) {
+            [$value_start, $value_end] = $value_ranges[$index];
+            if ($value_start < $cursor || $value_end <= $value_start) {
+                return null;
+            }
+
+            $decoded = base64_decode($encoded_by_index[$index], true);
+            $value = $decoded !== false ? $decoded : '';
+            if ($rewrite_value !== null) {
+                $value = $rewrite_value($value, $shape['table'], $shape['values'][$index]['column']);
+            }
+
+            $parts[] = substr($sql, $cursor, $value_start - $cursor);
+            $parts[] = '?';
+            $params[] = $value;
+            $cursor = $value_end;
+        }
+
+        $parts[] = substr($sql, $cursor);
+
+        return [
+            'sql' => implode('', $parts),
+            'params' => $params,
+        ];
+    }
+
+    private static function is_base64_payload(string $payload): bool
+    {
+        return $payload === '' || preg_match('/\A[A-Za-z0-9+\/=]*\z/', $payload) === 1;
+    }
+
+    private static function consume_literal(string $sql, int $sql_len, int &$pos, string $literal): bool
+    {
+        $length = strlen($literal);
+        if ($pos + $length > $sql_len || substr_compare($sql, $literal, $pos, $length) !== 0) {
+            return false;
+        }
+
+        $pos += $length;
+        return true;
+    }
+
+    private static function consume_number(string $sql, int $sql_len, int &$pos): bool
+    {
+        $start = $pos;
+        if ($pos < $sql_len && ($sql[$pos] === '+' || $sql[$pos] === '-')) {
+            $pos++;
+        }
+
+        $digit_start = $pos;
+        while ($pos < $sql_len && $sql[$pos] >= '0' && $sql[$pos] <= '9') {
+            $pos++;
+        }
+        if ($pos < $sql_len && $sql[$pos] === '.') {
+            $pos++;
+            while ($pos < $sql_len && $sql[$pos] >= '0' && $sql[$pos] <= '9') {
+                $pos++;
+            }
+        }
+        if ($pos < $sql_len && ($sql[$pos] === 'e' || $sql[$pos] === 'E')) {
+            $pos++;
+            if ($pos < $sql_len && ($sql[$pos] === '+' || $sql[$pos] === '-')) {
+                $pos++;
+            }
+            while ($pos < $sql_len && $sql[$pos] >= '0' && $sql[$pos] <= '9') {
+                $pos++;
+            }
+        }
+        if ($pos === $digit_start) {
+            $pos = $start;
+            return false;
+        }
+
+        return true;
     }
 
     /**

--- a/tests/UrlRewriting/SQLitePreparedInsertBuilderTest.php
+++ b/tests/UrlRewriting/SQLitePreparedInsertBuilderTest.php
@@ -7,6 +7,28 @@ require_once __DIR__ . '/../../packages/reprint-importer/src/lib/url-rewrite/loa
 
 class SQLitePreparedInsertBuilderTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        self::clearShapeCache();
+    }
+
+    private static function clearShapeCache(): void
+    {
+        $reflection = new ReflectionClass(SQLitePreparedInsertBuilder::class);
+        $property = $reflection->getProperty('shape_cache');
+        $property->setAccessible(true);
+        $property->setValue(null, []);
+    }
+
+    private static function shapeCacheCount(): int
+    {
+        $reflection = new ReflectionClass(SQLitePreparedInsertBuilder::class);
+        $property = $reflection->getProperty('shape_cache');
+        $property->setAccessible(true);
+
+        return count($property->getValue());
+    }
+
     public function testBuildsPreparedInsertForArbitraryBytes(): void
     {
         $bytes = '';
@@ -66,6 +88,116 @@ class SQLitePreparedInsertBuilderTest extends TestCase
 
         $this->assertNotNull($prepared);
         $this->assertSame(['after'], $prepared['params']);
+    }
+
+    public function testCachedShapeReusesProducerLayoutWithChangedNumbersAndPayloads(): void
+    {
+        $make_sql = static function (
+            string $first_id,
+            string $first_score,
+            string $first_key,
+            string $first_value,
+            string $second_id,
+            string $second_score,
+            string $second_key,
+            string $second_value
+        ): string {
+            return sprintf(
+                "INSERT INTO `wp_shape` (`id`, `score`, `empty_value`, `maybe_null`, `meta_key`, `meta_value`) VALUES(%s, %s, '', NULL, FROM_BASE64('%s'), CONVERT(FROM_BASE64('%s') USING utf8mb4)),(%s, %s, '', NULL, FROM_BASE64('%s'), CONVERT(FROM_BASE64('%s') USING utf8mb4));",
+                $first_id,
+                $first_score,
+                base64_encode($first_key),
+                base64_encode($first_value),
+                $second_id,
+                $second_score,
+                base64_encode($second_key),
+                base64_encode($second_value)
+            );
+        };
+
+        $seed = $make_sql('1', '-2.5', 'alpha', 'http://old.example/alpha', '2', '3e4', 'beta', 'http://old.example/beta');
+        $this->assertNotNull(SQLitePreparedInsertBuilder::build($seed));
+        $this->assertSame(1, self::shapeCacheCount());
+
+        $sql = $make_sql('1000000', '-4.25e+6', 'third', 'http://old.example/third', '22', '.5', 'fourth', 'http://old.example/fourth');
+        $prepared = SQLitePreparedInsertBuilder::build($sql);
+
+        $this->assertNotNull($prepared);
+        $this->assertSame(
+            "INSERT INTO `wp_shape` (`id`, `score`, `empty_value`, `maybe_null`, `meta_key`, `meta_value`) VALUES(1000000, -4.25e+6, '', NULL, ?, ?),(22, .5, '', NULL, ?, ?);",
+            $prepared['sql']
+        );
+        $this->assertSame(
+            ['third', 'http://old.example/third', 'fourth', 'http://old.example/fourth'],
+            $prepared['params']
+        );
+        $this->assertSame(1, self::shapeCacheCount(), 'matching layout should be served from the existing cache entry');
+    }
+
+    public function testCachedShapeKeepsColumnAwareRewriteContext(): void
+    {
+        $make_sql = static function (string $value): string {
+            return sprintf(
+                "INSERT INTO `wp_posts` (`ID`, `post_content`) VALUES(1, FROM_BASE64('%s'));",
+                base64_encode($value)
+            );
+        };
+
+        $this->assertNotNull(SQLitePreparedInsertBuilder::build($make_sql('seed')));
+        $this->assertSame(1, self::shapeCacheCount());
+
+        $seen = [];
+        $prepared = SQLitePreparedInsertBuilder::build(
+            $make_sql('before'),
+            function (string $value, string $table, ?string $column) use (&$seen): string {
+                $seen[] = [$value, $table, $column];
+                return 'after';
+            }
+        );
+
+        $this->assertNotNull($prepared);
+        $this->assertSame([['before', 'wp_posts', 'post_content']], $seen);
+        $this->assertSame(['after'], $prepared['params']);
+        $this->assertSame(1, self::shapeCacheCount(), 'matching layout should not add a duplicate shape');
+    }
+
+    public function testCachedShapeMismatchFallsBackToFreshScan(): void
+    {
+        $seed = sprintf(
+            "INSERT INTO `wp_options` (`option_id`, `autoload`, `option_value`) VALUES(1, NULL, FROM_BASE64('%s'));",
+            base64_encode('seed')
+        );
+        $this->assertNotNull(SQLitePreparedInsertBuilder::build($seed));
+        $this->assertSame(1, self::shapeCacheCount());
+
+        $sql = sprintf(
+            "INSERT INTO `wp_options` (`option_id`, `autoload`, `option_value`) VALUES(2, '', FROM_BASE64('%s'));",
+            base64_encode('value')
+        );
+        $prepared = SQLitePreparedInsertBuilder::build($sql);
+
+        $this->assertNotNull($prepared);
+        $this->assertSame(
+            "INSERT INTO `wp_options` (`option_id`, `autoload`, `option_value`) VALUES(2, '', ?);",
+            $prepared['sql']
+        );
+        $this->assertSame(['value'], $prepared['params']);
+        $this->assertSame(2, self::shapeCacheCount(), 'different literal layout should miss cache and be rescanned');
+    }
+
+    public function testCachedShapeRejectsPayloadThatFastScannerWouldReject(): void
+    {
+        $seed = sprintf(
+            "INSERT INTO `wp_options` (`option_id`, `option_value`) VALUES(1, FROM_BASE64('%s'));",
+            base64_encode('seed')
+        );
+        $this->assertNotNull(SQLitePreparedInsertBuilder::build($seed));
+        $this->assertSame(1, self::shapeCacheCount());
+
+        $invalid_sql = "INSERT INTO `wp_options` (`option_id`, `option_value`) VALUES(2, FROM_BASE64('not-valid!'));";
+
+        $this->assertNull(SQLitePreparedInsertBuilder::build($invalid_sql));
+        $this->assertSame(1, self::shapeCacheCount());
     }
 
     public function testUnknownInsertShapeReturnsNull(): void


### PR DESCRIPTION
## What it does

Caches repeated MySQLDumpProducer-shaped SQLite prepared `INSERT` layouts in `SQLitePreparedInsertBuilder`.

## Rationale

SQLite `db-apply` receives many producer-shaped `INSERT` statements that repeat the same table, column, and value layout while only scalar payloads change. Reusing the recognised shape avoids rescanning the full statement on repeated layouts while leaving changed or unknown shapes on the existing fallback path.

## Implementation

`FastInsertScanner` exposes value-layout metadata for producer-shaped `INSERT` statements. `SQLitePreparedInsertBuilder` stores a bounded cache of successful shapes and reuses a shape only when the surrounding SQL chunks and value kinds still match.

## Full playground-sqlite-db-apply evidence

```bash
BENCH_STAGES=playground-sqlite-db-apply \
BENCH_SEED_POSTS=10000 \
BENCH_SEED_POSTMETA=25000 \
BENCH_PLAYGROUND_PHP_BINARY=/home/claude/reprint-shape-cache-pr239/tests/e2e/ci/playground-php.sh \
PLAYGROUND_PHP_USE_WASM_RUNNER=1 \
PLAYGROUND_PHP_VERSION=8.3 \
WP_MYSQL_PARSER_EXTENSION_MANIFEST=https://wordpress.github.io/sqlite-database-integration/wp_mysql_parser-wasm-extension/latest/manifest.json \
node benchmark/bench-pull.mjs
```

The local `large-directory` source DB was already above the requested seed threshold, so the benchmark skipped reseeding down; both branch and `origin/trunk` used the same source DB.

Results for `playground-sqlite-db-apply` with PHP.wasm 8.3 and native parser verification enabled on both sides:

- This branch: `72.66 s`
- `origin/trunk`: `109.92 s`