### PR TITLE
Speed up SQLite prepared insert templates

### DIFF
--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -959,6 +959,7 @@ class ImportClient
 
     private const SAVE_STATE_EVERY_N_CHUNKS = 50;
     private const STATE_PATH_ENCODING_PREFIX = "base64:";
+    private const SQLITE_PREPARED_INSERT_CACHE_MAX = 128;
 
     /**
      * Maximum number of consecutive cURL timeouts with no cursor progress
@@ -5119,6 +5120,8 @@ class ImportClient
 
         [$pdo, $connection_label] = $this->create_target_db_apply_connection($options);
         $sqlite_prepared_pdo = null;
+        $sqlite_prepared_statement_cache = [];
+        $sqlite_prepared_statement_cache_order = [];
         if (
             strtolower((string) ($options["target_engine"] ?? "mysql")) === "sqlite"
             && method_exists($pdo, 'get_connection')
@@ -5237,6 +5240,8 @@ class ImportClient
                             $query,
                             $stmt_rewriter,
                             $sqlite_prepared_pdo,
+                            $sqlite_prepared_statement_cache,
+                            $sqlite_prepared_statement_cache_order,
                             $executed_query,
                         );
                     } catch (PDOException $e) {
@@ -5315,6 +5320,8 @@ class ImportClient
                         $query,
                         $stmt_rewriter,
                         $sqlite_prepared_pdo,
+                        $sqlite_prepared_statement_cache,
+                        $sqlite_prepared_statement_cache_order,
                         $executed_query,
                     );
                 } catch (PDOException $e) {
@@ -5420,6 +5427,8 @@ class ImportClient
         string $query,
         ?SqlStatementRewriter $stmt_rewriter,
         ?PDO $sqlite_prepared_pdo,
+        array &$sqlite_prepared_statement_cache,
+        array &$sqlite_prepared_statement_cache_order,
         string &$executed_query
     ): void {
         $executed_query = $query;
@@ -5431,13 +5440,31 @@ class ImportClient
 
             if ($prepared_insert !== null) {
                 $executed_query = $prepared_insert['sql'];
-                $statement = $sqlite_prepared_pdo->prepare($prepared_insert['sql']);
-                if ($statement === false) {
-                    throw new PDOException('Failed to prepare SQLite INSERT statement.');
+                $statement = $sqlite_prepared_statement_cache[$prepared_insert['sql']] ?? null;
+                if (!$statement instanceof PDOStatement) {
+                    $statement = $sqlite_prepared_pdo->prepare($prepared_insert['sql']);
+                    if ($statement === false) {
+                        throw new PDOException('Failed to prepare SQLite INSERT statement.');
+                    }
+
+                    $sqlite_prepared_statement_cache[$prepared_insert['sql']] = $statement;
+                    $sqlite_prepared_statement_cache_order[] = $prepared_insert['sql'];
+                    if (count($sqlite_prepared_statement_cache_order) > self::SQLITE_PREPARED_INSERT_CACHE_MAX) {
+                        $oldest_sql = array_shift($sqlite_prepared_statement_cache_order);
+                        if (is_string($oldest_sql)) {
+                            unset($sqlite_prepared_statement_cache[$oldest_sql]);
+                        }
+                    }
+                } else {
+                    $statement->closeCursor();
                 }
 
                 foreach ($prepared_insert['params'] as $index => $value) {
-                    $statement->bindValue($index + 1, $value, PDO::PARAM_STR);
+                    $statement->bindValue(
+                        $index + 1,
+                        $value,
+                        $prepared_insert['param_types'][$index] ?? PDO::PARAM_STR
+                    );
                 }
 
                 if ($statement->execute() === false) {

--- a/packages/reprint-importer/src/lib/url-rewrite/class-fast-insert-scanner.php
+++ b/packages/reprint-importer/src/lib/url-rewrite/class-fast-insert-scanner.php
@@ -36,12 +36,14 @@ class FastInsertScanner
      *
      * @return array{
      *   table: string,
+     *   columns: list<string>,
      *   column_map: list<array{int, int, string}>,
-     *   base64_entries: list<array{expr_start: int, expr_length: int, quote_start: int, quote_length: int, encoded_value: string, value: ?string, new_value: ?string}>
+     *   base64_entries: list<array{expr_start: int, expr_length: int, quote_start: int, quote_length: int, encoded_value: string, value: ?string, new_value: ?string}>,
+     *   value_entries: list<array{kind: string, start: int, end: int, column: string, raw?: string, expr_start?: int, expr_length?: int, quote_start?: int, quote_length?: int, encoded_value?: string}>
      * }|null
      *   Null when the SQL doesn't match the recognised shape.
      */
-    public static function scan(string $sql): ?array
+    public static function scan(string $sql, bool $include_column_map = true): ?array
     {
         // Header: optional leading whitespace, INSERT (no priority/IGNORE
         // modifiers — producer never emits those), INTO, backticked table,
@@ -93,6 +95,7 @@ class FastInsertScanner
 
         $column_map = [];
         $base64_entries = [];
+        $value_entries = [];
 
         $cursor = $values_end;
         $sql_len = strlen($sql);
@@ -136,16 +139,21 @@ class FastInsertScanner
                     return null;
                 }
                 $value_end = $cursor;
-                $column_map[] = [$value_start, $value_end, $columns[$col_idx]];
+                if ($include_column_map) {
+                    $column_map[] = [$value_start, $value_end, $columns[$col_idx]];
+                }
+                $value_kind['start'] = $value_start;
+                $value_kind['end'] = $value_end;
+                $value_kind['column'] = $columns[$col_idx];
+                $value_entries[] = $value_kind;
 
-                if (is_array($value_kind)) {
-                    // FROM_BASE64 payload: kind = [expr_start, expr_length, quote_start, quote_length, encoded_value]
+                if ($value_kind['kind'] === 'base64') {
                     $base64_entries[] = [
-                        'expr_start' => $value_kind[0],
-                        'expr_length' => $value_kind[1],
-                        'quote_start' => $value_kind[2],
-                        'quote_length' => $value_kind[3],
-                        'encoded_value' => $value_kind[4],
+                        'expr_start' => $value_kind['expr_start'],
+                        'expr_length' => $value_kind['expr_length'],
+                        'quote_start' => $value_kind['quote_start'],
+                        'quote_length' => $value_kind['quote_length'],
+                        'encoded_value' => $value_kind['encoded_value'],
                         'value' => null,
                         'new_value' => null,
                     ];
@@ -192,18 +200,18 @@ class FastInsertScanner
 
         return [
             'table' => $table,
+            'columns' => $columns,
             'column_map' => $column_map,
             'base64_entries' => $base64_entries,
+            'value_entries' => $value_entries,
         ];
     }
 
     /**
      * Scan one value in producer's tuple shape, advancing $cursor past it.
      *
-     * @return null|true|array{int,int,int,int,string}
+     * @return null|array{kind: string, raw?: string, expr_start?: int, expr_length?: int, quote_start?: int, quote_length?: int, encoded_value?: string}
      *   null = unrecognized shape (caller bails)
-     *   true = recognised, no FROM_BASE64 entry to record
-     *   array = FROM_BASE64 payload, [expr_start, expr_length, quote_start, quote_length, encoded]
      */
     private static function scan_value(string $sql, int $sql_len, int &$cursor)
     {
@@ -219,13 +227,13 @@ class FastInsertScanner
             && substr_compare($sql, 'NULL', $cursor, 4, true) === 0
         ) {
             $cursor += 4;
-            return true;
+            return ['kind' => 'null'];
         }
 
         // Empty string literal
         if ($c === "'" && $cursor + 1 < $sql_len && $sql[$cursor + 1] === "'") {
             $cursor += 2;
-            return true;
+            return ['kind' => 'empty_string'];
         }
 
         // FROM_BASE64('…')
@@ -236,7 +244,18 @@ class FastInsertScanner
         ) {
             $expr_start = $cursor;
             $cursor += 12; // step past "FROM_BASE64("
-            return self::consume_base64_call($sql, $sql_len, $cursor, $expr_start);
+            $entry = self::consume_base64_call($sql, $sql_len, $cursor, $expr_start);
+            if ($entry === null) {
+                return null;
+            }
+            return [
+                'kind' => 'base64',
+                'expr_start' => $entry[0],
+                'expr_length' => $entry[1],
+                'quote_start' => $entry[2],
+                'quote_length' => $entry[3],
+                'encoded_value' => $entry[4],
+            ];
         }
 
         // CONVERT(FROM_BASE64('…') USING utf8mb4)
@@ -258,7 +277,7 @@ class FastInsertScanner
             }
             $cursor += 12;
             $entry = self::consume_base64_call($sql, $sql_len, $cursor, $expr_start);
-            if (!is_array($entry)) {
+            if ($entry === null) {
                 return null;
             }
             // Expect: USING utf8mb4 )
@@ -284,7 +303,14 @@ class FastInsertScanner
             }
             $cursor++;
             $entry[1] = $cursor - $expr_start;
-            return $entry;
+            return [
+                'kind' => 'base64',
+                'expr_start' => $entry[0],
+                'expr_length' => $entry[1],
+                'quote_start' => $entry[2],
+                'quote_length' => $entry[3],
+                'encoded_value' => $entry[4],
+            ];
         }
 
         // Numeric literal: optional sign, digits, optional fraction, optional exponent.
@@ -303,19 +329,27 @@ class FastInsertScanner
             }
         }
         if ($cursor < $sql_len && ($sql[$cursor] === 'e' || $sql[$cursor] === 'E')) {
+            $exponent_start = $cursor;
             $cursor++;
             if ($cursor < $sql_len && ($sql[$cursor] === '+' || $sql[$cursor] === '-')) {
                 $cursor++;
             }
+            $exponent_digit_start = $cursor;
             while ($cursor < $sql_len && $sql[$cursor] >= '0' && $sql[$cursor] <= '9') {
                 $cursor++;
+            }
+            if ($cursor === $exponent_digit_start) {
+                $cursor = $exponent_start;
             }
         }
         if ($cursor === $digit_start) {
             $cursor = $start;
             return null;
         }
-        return true;
+        return [
+            'kind' => 'numeric',
+            'raw' => substr($sql, $start, $cursor - $start),
+        ];
     }
 
     /**

--- a/packages/reprint-importer/src/lib/url-rewrite/class-sql-statement-rewriter.php
+++ b/packages/reprint-importer/src/lib/url-rewrite/class-sql-statement-rewriter.php
@@ -164,7 +164,7 @@ class SqlStatementRewriter
      * statement shapes return null so callers can fall back to the normal
      * MySQL-on-SQLite execution path.
      *
-     * @return array{sql: string, params: list<string>}|null
+     * @return array{sql: string, params: list<mixed>, param_types: list<int>}|null
      */
     public function build_sqlite_prepared_insert(string $sql): ?array
     {

--- a/packages/reprint-importer/src/lib/url-rewrite/class-sqlite-prepared-insert-builder.php
+++ b/packages/reprint-importer/src/lib/url-rewrite/class-sqlite-prepared-insert-builder.php
@@ -143,9 +143,7 @@ class SQLitePreparedInsertBuilder
             $parts[] = strlen($column) . ':' . $column;
         }
         foreach ($fast['value_entries'] as $entry) {
-            $parts[] = $entry['kind'] === 'numeric'
-                ? self::numeric_placeholder_sql($entry['raw'])
-                : '?';
+            $parts[] = self::shape_marker_for_value($entry);
         }
 
         return implode('|', $parts);
@@ -175,10 +173,7 @@ class SQLitePreparedInsertBuilder
         for ($offset = 0; $offset < $value_count; $offset += $column_count) {
             $placeholders = [];
             for ($i = 0; $i < $column_count; $i++) {
-                $entry = $fast['value_entries'][$offset + $i];
-                $placeholders[] = $entry['kind'] === 'numeric'
-                    ? self::numeric_placeholder_sql($entry['raw'])
-                    : '?';
+                $placeholders[] = self::placeholder_sql_for_value($fast['value_entries'][$offset + $i]);
             }
             $rows[] = '(' . implode(', ', $placeholders) . ')';
         }
@@ -188,6 +183,26 @@ class SQLitePreparedInsertBuilder
             . ' (' . implode(', ', $quoted_columns) . ') VALUES'
             . implode(',', $rows)
             . ';';
+    }
+
+    /**
+     * @param array{kind: string, raw?: string} $entry
+     */
+    private static function placeholder_sql_for_value(array $entry): string
+    {
+        return $entry['kind'] === 'numeric'
+            ? self::numeric_placeholder_sql($entry['raw'])
+            : '?';
+    }
+
+    /**
+     * @param array{kind: string, raw?: string} $entry
+     */
+    private static function shape_marker_for_value(array $entry): string
+    {
+        return $entry['kind'] === 'numeric'
+            ? self::numeric_placeholder_sql($entry['raw'])
+            : '?';
     }
 
     private static function quote_identifier(string $identifier): string

--- a/packages/reprint-importer/src/lib/url-rewrite/class-sqlite-prepared-insert-builder.php
+++ b/packages/reprint-importer/src/lib/url-rewrite/class-sqlite-prepared-insert-builder.php
@@ -4,23 +4,34 @@
  * Builds SQLite prepared INSERT statements for MySQLDumpProducer-shaped SQL.
  *
  * This is deliberately narrower than SqlStatementRewriter: it only accepts
- * INSERT statements that FastInsertScanner fully recognises. Every complete
- * FROM_BASE64(...) expression is replaced with a positional placeholder and
- * its decoded bytes are returned as a bound PHP string. Values that do not
- * match the producer shape return null so db-apply can fall back to the normal
- * MySQL-on-SQLite execution path.
+ * INSERT statements that FastInsertScanner fully recognises and that contain
+ * at least one FROM_BASE64(...) expression. Every tuple value is replaced with
+ * a positional placeholder (integer-looking numeric literals use
+ * CAST(? AS NUMERIC), dotted/exponent literals use CAST(? AS REAL)), so repeated
+ * dump batches for the same table/column/row-count shape compile to the same
+ * SQLite SQL template. Values that do not match the producer shape return null
+ * so db-apply can fall back to the normal MySQL-on-SQLite execution path.
  *
  * The important property is that decoded payload bytes never become SQL text.
  * That avoids quoting, escaping, UTF-8, and "garbage codepoint" questions: the
  * SQL parser sees only `?`, and SQLite receives the exact PHP string through
- * PDO binding.
+ * PDO binding. Numeric literals stay numeric through SQLite's NUMERIC cast,
+ * including large values that cannot be represented as PHP integers.
  */
 class SQLitePreparedInsertBuilder
 {
+    private const TEMPLATE_CACHE_MAX = 256;
+
+    /** @var array<string, string> */
+    private static array $template_sql_cache = [];
+
+    /** @var string[] */
+    private static array $template_sql_cache_order = [];
+
     /**
      * @param callable|null $rewrite_value Optional callback:
      *        fn(string $value, string $table, ?string $column): string
-     * @return array{sql: string, params: list<string>}|null
+     * @return array{sql: string, params: list<mixed>, param_types: list<int>}|null
      */
     public static function build(string $sql, ?callable $rewrite_value = null): ?array
     {
@@ -28,63 +39,191 @@ class SQLitePreparedInsertBuilder
             return null;
         }
 
-        $fast = FastInsertScanner::scan($sql);
-        if ($fast === null || empty($fast['base64_entries'])) {
+        $fast = FastInsertScanner::scan($sql, false);
+        if ($fast === null || empty($fast['base64_entries']) || empty($fast['value_entries'])) {
             return null;
         }
 
-        $parts = [];
-        $params = [];
-        $cursor = 0;
-
-        foreach ($fast['base64_entries'] as $entry) {
-            if ($entry['expr_start'] < $cursor || $entry['expr_length'] <= 0) {
-                return null;
-            }
-
-            $decoded = base64_decode($entry['encoded_value'], true);
-            if ($decoded === false) {
-                return null;
-            }
-            $value = $decoded;
-            if ($rewrite_value !== null) {
-                $column = self::find_column_at_offset($fast['column_map'], $entry['expr_start']);
-                $value = $rewrite_value($value, $fast['table'], $column);
-            }
-
-            $parts[] = substr($sql, $cursor, $entry['expr_start'] - $cursor);
-            $parts[] = '?';
-            $params[] = $value;
-            $cursor = $entry['expr_start'] + $entry['expr_length'];
+        $template_sql = self::get_template_sql($fast);
+        if ($template_sql === null) {
+            return null;
         }
 
-        $parts[] = substr($sql, $cursor);
+        $params = [];
+        $param_types = [];
+
+        foreach ($fast['value_entries'] as $entry) {
+            switch ($entry['kind']) {
+                case 'null':
+                    $params[] = null;
+                    $param_types[] = PDO::PARAM_NULL;
+                    break;
+
+                case 'empty_string':
+                    $params[] = '';
+                    $param_types[] = PDO::PARAM_STR;
+                    break;
+
+                case 'numeric':
+                    $params[] = $entry['raw'];
+                    $param_types[] = PDO::PARAM_STR;
+                    break;
+
+                case 'base64':
+                    $decoded = base64_decode($entry['encoded_value'], true);
+                    if ($decoded === false) {
+                        return null;
+                    }
+                    $value = $decoded;
+                    if ($rewrite_value !== null) {
+                        $value = $rewrite_value($value, $fast['table'], $entry['column']);
+                    }
+                    $params[] = $value;
+                    $param_types[] = PDO::PARAM_STR;
+                    break;
+
+                default:
+                    return null;
+            }
+        }
 
         return [
-            'sql' => implode('', $parts),
+            'sql' => $template_sql,
             'params' => $params,
+            'param_types' => $param_types,
         ];
     }
 
     /**
-     * @param list<array{int, int, string}> $column_map
+     * @param array{
+     *   table: string,
+     *   columns: list<string>,
+     *   value_entries: list<array{kind: string, raw?: string}>
+     * } $fast
      */
-    private static function find_column_at_offset(array $column_map, int $offset): ?string
+    private static function get_template_sql(array $fast): ?string
     {
-        $low = 0;
-        $high = count($column_map) - 1;
-        while ($low <= $high) {
-            $mid = ($low + $high) >> 1;
-            $entry = $column_map[$mid];
-            if ($offset < $entry[0]) {
-                $high = $mid - 1;
-            } elseif ($offset >= $entry[1]) {
-                $low = $mid + 1;
-            } else {
-                return $entry[2];
+        $shape_key = self::shape_key($fast);
+        $cached = self::$template_sql_cache[$shape_key] ?? null;
+        if ($cached !== null) {
+            return $cached;
+        }
+
+        $template_sql = self::build_template_sql($fast);
+        if ($template_sql === null) {
+            return null;
+        }
+
+        self::$template_sql_cache[$shape_key] = $template_sql;
+        self::$template_sql_cache_order[] = $shape_key;
+        if (count(self::$template_sql_cache_order) > self::TEMPLATE_CACHE_MAX) {
+            $oldest_key = array_shift(self::$template_sql_cache_order);
+            if (is_string($oldest_key)) {
+                unset(self::$template_sql_cache[$oldest_key]);
             }
         }
 
-        return null;
+        return $template_sql;
     }
+
+    /**
+     * @param array{
+     *   table: string,
+     *   columns: list<string>,
+     *   value_entries: list<array{kind: string, raw?: string}>
+     * } $fast
+     */
+    private static function shape_key(array $fast): string
+    {
+        $parts = [
+            strlen($fast['table']) . ':' . $fast['table'],
+            (string) count($fast['columns']),
+        ];
+        foreach ($fast['columns'] as $column) {
+            $parts[] = strlen($column) . ':' . $column;
+        }
+        foreach ($fast['value_entries'] as $entry) {
+            $parts[] = self::shape_marker_for_value($entry);
+        }
+
+        return implode('|', $parts);
+    }
+
+    /**
+     * @param array{
+     *   table: string,
+     *   columns: list<string>,
+     *   value_entries: list<array{kind: string, raw?: string}>
+     * } $fast
+     */
+    private static function build_template_sql(array $fast): ?string
+    {
+        $column_count = count($fast['columns']);
+        $value_count = count($fast['value_entries']);
+        if ($column_count === 0 || $value_count === 0 || $value_count % $column_count !== 0) {
+            return null;
+        }
+
+        $quoted_columns = [];
+        foreach ($fast['columns'] as $column) {
+            $quoted_columns[] = self::quote_identifier($column);
+        }
+
+        $rows = [];
+        for ($offset = 0; $offset < $value_count; $offset += $column_count) {
+            $placeholders = [];
+            for ($i = 0; $i < $column_count; $i++) {
+                $placeholders[] = self::placeholder_sql_for_value($fast['value_entries'][$offset + $i]);
+            }
+            $rows[] = '(' . implode(', ', $placeholders) . ')';
+        }
+
+        return 'INSERT INTO '
+            . self::quote_identifier($fast['table'])
+            . ' (' . implode(', ', $quoted_columns) . ') VALUES'
+            . implode(',', $rows)
+            . ';';
+    }
+
+    /**
+     * @param array{kind: string, raw?: string} $entry
+     */
+    private static function placeholder_sql_for_value(array $entry): string
+    {
+        return $entry['kind'] === 'numeric'
+            ? self::numeric_placeholder_sql($entry['raw'])
+            : '?';
+    }
+
+    /**
+     * @param array{kind: string, raw?: string} $entry
+     */
+    private static function shape_marker_for_value(array $entry): string
+    {
+        return $entry['kind'] === 'numeric'
+            ? self::numeric_placeholder_sql($entry['raw'])
+            : '?';
+    }
+
+    private static function quote_identifier(string $identifier): string
+    {
+        return '`' . str_replace('`', '``', $identifier) . '`';
+    }
+
+    /**
+     * Preserve SQLite's own numeric-literal storage class where it matters.
+     *
+     * SQLite parses dotted and exponent literals as REAL even when their
+     * numeric value is integral (`1.`, `1e2`, `-3.5e+2`). Plain integer
+     * literals are INTEGER until they overflow into REAL. CAST(? AS NUMERIC)
+     * matches the latter behavior, but would collapse exact dotted/exponent
+     * values to INTEGER, so those use REAL explicitly.
+     */
+    private static function numeric_placeholder_sql(string $raw): string
+    {
+        return strpbrk($raw, '.eE') === false
+            ? 'CAST(? AS NUMERIC)'
+            : 'CAST(? AS REAL)';
+    }
+
 }

--- a/packages/reprint-importer/src/lib/url-rewrite/class-sqlite-prepared-insert-builder.php
+++ b/packages/reprint-importer/src/lib/url-rewrite/class-sqlite-prepared-insert-builder.php
@@ -44,9 +44,68 @@ class SQLitePreparedInsertBuilder
             return null;
         }
 
-        $template_sql = self::get_template_sql($fast);
-        if ($template_sql === null) {
+        $column_count = count($fast['columns']);
+        $value_count = count($fast['value_entries']);
+        if ($column_count === 0 || $value_count === 0 || $value_count % $column_count !== 0) {
             return null;
+        }
+
+        $shape_key_parts = [
+            strlen($fast['table']) . ':' . $fast['table'],
+            (string) $column_count,
+        ];
+        foreach ($fast['columns'] as $column) {
+            $shape_key_parts[] = strlen($column) . ':' . $column;
+        }
+        foreach ($fast['value_entries'] as $entry) {
+            if ($entry['kind'] === 'numeric') {
+                $shape_key_parts[] = strpbrk($entry['raw'], '.eE') === false
+                    ? 'CAST(? AS NUMERIC)'
+                    : 'CAST(? AS REAL)';
+            } else {
+                $shape_key_parts[] = '?';
+            }
+        }
+
+        $shape_key = implode('|', $shape_key_parts);
+        $template_sql = self::$template_sql_cache[$shape_key] ?? null;
+        if ($template_sql === null) {
+            $quoted_columns = [];
+            foreach ($fast['columns'] as $column) {
+                $quoted_columns[] = self::quote_identifier($column);
+            }
+
+            $rows = [];
+            for ($offset = 0; $offset < $value_count; $offset += $column_count) {
+                $placeholders = [];
+                for ($i = 0; $i < $column_count; $i++) {
+                    $entry = $fast['value_entries'][$offset + $i];
+                    if ($entry['kind'] === 'numeric') {
+                        // Dotted/exponent literals need REAL to match SQLite's literal typing.
+                        $placeholders[] = strpbrk($entry['raw'], '.eE') === false
+                            ? 'CAST(? AS NUMERIC)'
+                            : 'CAST(? AS REAL)';
+                    } else {
+                        $placeholders[] = '?';
+                    }
+                }
+                $rows[] = '(' . implode(', ', $placeholders) . ')';
+            }
+
+            $template_sql = 'INSERT INTO '
+                . self::quote_identifier($fast['table'])
+                . ' (' . implode(', ', $quoted_columns) . ') VALUES'
+                . implode(',', $rows)
+                . ';';
+
+            self::$template_sql_cache[$shape_key] = $template_sql;
+            self::$template_sql_cache_order[] = $shape_key;
+            if (count(self::$template_sql_cache_order) > self::TEMPLATE_CACHE_MAX) {
+                $oldest_key = array_shift(self::$template_sql_cache_order);
+                if (is_string($oldest_key)) {
+                    unset(self::$template_sql_cache[$oldest_key]);
+                }
+            }
         }
 
         $params = [];
@@ -94,136 +153,9 @@ class SQLitePreparedInsertBuilder
         ];
     }
 
-    /**
-     * @param array{
-     *   table: string,
-     *   columns: list<string>,
-     *   value_entries: list<array{kind: string, raw?: string}>
-     * } $fast
-     */
-    private static function get_template_sql(array $fast): ?string
-    {
-        $shape_key = self::shape_key($fast);
-        $cached = self::$template_sql_cache[$shape_key] ?? null;
-        if ($cached !== null) {
-            return $cached;
-        }
-
-        $template_sql = self::build_template_sql($fast);
-        if ($template_sql === null) {
-            return null;
-        }
-
-        self::$template_sql_cache[$shape_key] = $template_sql;
-        self::$template_sql_cache_order[] = $shape_key;
-        if (count(self::$template_sql_cache_order) > self::TEMPLATE_CACHE_MAX) {
-            $oldest_key = array_shift(self::$template_sql_cache_order);
-            if (is_string($oldest_key)) {
-                unset(self::$template_sql_cache[$oldest_key]);
-            }
-        }
-
-        return $template_sql;
-    }
-
-    /**
-     * @param array{
-     *   table: string,
-     *   columns: list<string>,
-     *   value_entries: list<array{kind: string, raw?: string}>
-     * } $fast
-     */
-    private static function shape_key(array $fast): string
-    {
-        $parts = [
-            strlen($fast['table']) . ':' . $fast['table'],
-            (string) count($fast['columns']),
-        ];
-        foreach ($fast['columns'] as $column) {
-            $parts[] = strlen($column) . ':' . $column;
-        }
-        foreach ($fast['value_entries'] as $entry) {
-            $parts[] = self::shape_marker_for_value($entry);
-        }
-
-        return implode('|', $parts);
-    }
-
-    /**
-     * @param array{
-     *   table: string,
-     *   columns: list<string>,
-     *   value_entries: list<array{kind: string, raw?: string}>
-     * } $fast
-     */
-    private static function build_template_sql(array $fast): ?string
-    {
-        $column_count = count($fast['columns']);
-        $value_count = count($fast['value_entries']);
-        if ($column_count === 0 || $value_count === 0 || $value_count % $column_count !== 0) {
-            return null;
-        }
-
-        $quoted_columns = [];
-        foreach ($fast['columns'] as $column) {
-            $quoted_columns[] = self::quote_identifier($column);
-        }
-
-        $rows = [];
-        for ($offset = 0; $offset < $value_count; $offset += $column_count) {
-            $placeholders = [];
-            for ($i = 0; $i < $column_count; $i++) {
-                $placeholders[] = self::placeholder_sql_for_value($fast['value_entries'][$offset + $i]);
-            }
-            $rows[] = '(' . implode(', ', $placeholders) . ')';
-        }
-
-        return 'INSERT INTO '
-            . self::quote_identifier($fast['table'])
-            . ' (' . implode(', ', $quoted_columns) . ') VALUES'
-            . implode(',', $rows)
-            . ';';
-    }
-
-    /**
-     * @param array{kind: string, raw?: string} $entry
-     */
-    private static function placeholder_sql_for_value(array $entry): string
-    {
-        return $entry['kind'] === 'numeric'
-            ? self::numeric_placeholder_sql($entry['raw'])
-            : '?';
-    }
-
-    /**
-     * @param array{kind: string, raw?: string} $entry
-     */
-    private static function shape_marker_for_value(array $entry): string
-    {
-        return $entry['kind'] === 'numeric'
-            ? self::numeric_placeholder_sql($entry['raw'])
-            : '?';
-    }
-
     private static function quote_identifier(string $identifier): string
     {
         return '`' . str_replace('`', '``', $identifier) . '`';
-    }
-
-    /**
-     * Preserve SQLite's own numeric-literal storage class where it matters.
-     *
-     * SQLite parses dotted and exponent literals as REAL even when their
-     * numeric value is integral (`1.`, `1e2`, `-3.5e+2`). Plain integer
-     * literals are INTEGER until they overflow into REAL. CAST(? AS NUMERIC)
-     * matches the latter behavior, but would collapse exact dotted/exponent
-     * values to INTEGER, so those use REAL explicitly.
-     */
-    private static function numeric_placeholder_sql(string $raw): string
-    {
-        return strpbrk($raw, '.eE') === false
-            ? 'CAST(? AS NUMERIC)'
-            : 'CAST(? AS REAL)';
     }
 
 }

--- a/packages/reprint-importer/src/lib/url-rewrite/class-sqlite-prepared-insert-builder.php
+++ b/packages/reprint-importer/src/lib/url-rewrite/class-sqlite-prepared-insert-builder.php
@@ -50,19 +50,34 @@ class SQLitePreparedInsertBuilder
             return null;
         }
 
+        // Describe the prepared SQL template, not the concrete bound values.
+        // The cache key must change when the generated SQL text changes, but
+        // must stay stable across batches that only differ by decoded payloads
+        // or numeric literal values.
         $shape_key_parts = [
+            // Table names are emitted into the SQL template, so they are part
+            // of the shape. Length-prefixing prevents separator collisions.
             strlen($fast['table']) . ':' . $fast['table'],
+            // The number of columns determines tuple width and avoids treating
+            // a prefix of one column list as the same shape as a shorter list.
             (string) $column_count,
         ];
         foreach ($fast['columns'] as $column) {
+            // Column order is part of INSERT semantics and of the generated SQL
+            // text, so each quoted identifier contributes to the template key.
             $shape_key_parts[] = strlen($column) . ':' . $column;
         }
         foreach ($fast['value_entries'] as $entry) {
             if ($entry['kind'] === 'numeric') {
+                // Numeric values are bound, not embedded. Only SQLite's target
+                // storage class affects the template: dotted/exponent literals
+                // need REAL while integer-looking literals use NUMERIC.
                 $shape_key_parts[] = strpbrk($entry['raw'], '.eE') === false
                     ? 'CAST(? AS NUMERIC)'
                     : 'CAST(? AS REAL)';
             } else {
+                // NULL, empty strings, and decoded base64 payloads all compile
+                // to the same bare placeholder; their values are supplied later.
                 $shape_key_parts[] = '?';
             }
         }
@@ -70,6 +85,9 @@ class SQLitePreparedInsertBuilder
         $shape_key = implode('|', $shape_key_parts);
         $template_sql = self::$template_sql_cache[$shape_key] ?? null;
         if ($template_sql === null) {
+            // Cache misses are the only time we build SQL text. Payload bytes
+            // and numeric literals still never become SQL; this only emits
+            // identifiers and placeholders for the producer-recognised shape.
             $quoted_columns = [];
             foreach ($fast['columns'] as $column) {
                 $quoted_columns[] = self::quote_identifier($column);
@@ -92,6 +110,8 @@ class SQLitePreparedInsertBuilder
                 $rows[] = '(' . implode(', ', $placeholders) . ')';
             }
 
+            // Preserve one reusable SQL string per table/column/value-shape so
+            // PDO and SQLite can reuse the compiled statement across dump rows.
             $template_sql = 'INSERT INTO '
                 . self::quote_identifier($fast['table'])
                 . ' (' . implode(', ', $quoted_columns) . ') VALUES'
@@ -101,6 +121,8 @@ class SQLitePreparedInsertBuilder
             self::$template_sql_cache[$shape_key] = $template_sql;
             self::$template_sql_cache_order[] = $shape_key;
             if (count(self::$template_sql_cache_order) > self::TEMPLATE_CACHE_MAX) {
+                // Bound cache growth: large imports can touch many plugin
+                // tables, but old shapes are cheap to rebuild if seen again.
                 $oldest_key = array_shift(self::$template_sql_cache_order);
                 if (is_string($oldest_key)) {
                     unset(self::$template_sql_cache[$oldest_key]);
@@ -108,6 +130,9 @@ class SQLitePreparedInsertBuilder
             }
         }
 
+        // Build the bound values after the template is selected. This keeps
+        // untrusted decoded bytes out of SQL text while still allowing URL
+        // rewriting to use table/column context for structured data.
         $params = [];
         $param_types = [];
 

--- a/packages/reprint-importer/src/lib/url-rewrite/class-sqlite-prepared-insert-builder.php
+++ b/packages/reprint-importer/src/lib/url-rewrite/class-sqlite-prepared-insert-builder.php
@@ -143,7 +143,9 @@ class SQLitePreparedInsertBuilder
             $parts[] = strlen($column) . ':' . $column;
         }
         foreach ($fast['value_entries'] as $entry) {
-            $parts[] = self::shape_marker_for_value($entry);
+            $parts[] = $entry['kind'] === 'numeric'
+                ? self::numeric_placeholder_sql($entry['raw'])
+                : '?';
         }
 
         return implode('|', $parts);
@@ -173,7 +175,10 @@ class SQLitePreparedInsertBuilder
         for ($offset = 0; $offset < $value_count; $offset += $column_count) {
             $placeholders = [];
             for ($i = 0; $i < $column_count; $i++) {
-                $placeholders[] = self::placeholder_sql_for_value($fast['value_entries'][$offset + $i]);
+                $entry = $fast['value_entries'][$offset + $i];
+                $placeholders[] = $entry['kind'] === 'numeric'
+                    ? self::numeric_placeholder_sql($entry['raw'])
+                    : '?';
             }
             $rows[] = '(' . implode(', ', $placeholders) . ')';
         }
@@ -183,26 +188,6 @@ class SQLitePreparedInsertBuilder
             . ' (' . implode(', ', $quoted_columns) . ') VALUES'
             . implode(',', $rows)
             . ';';
-    }
-
-    /**
-     * @param array{kind: string, raw?: string} $entry
-     */
-    private static function placeholder_sql_for_value(array $entry): string
-    {
-        return $entry['kind'] === 'numeric'
-            ? self::numeric_placeholder_sql($entry['raw'])
-            : '?';
-    }
-
-    /**
-     * @param array{kind: string, raw?: string} $entry
-     */
-    private static function shape_marker_for_value(array $entry): string
-    {
-        return $entry['kind'] === 'numeric'
-            ? self::numeric_placeholder_sql($entry['raw'])
-            : '?';
     }
 
     private static function quote_identifier(string $identifier): string

--- a/tests/UrlRewriting/SQLitePreparedInsertBuilderTest.php
+++ b/tests/UrlRewriting/SQLitePreparedInsertBuilderTest.php
@@ -7,6 +7,32 @@ require_once __DIR__ . '/../../packages/reprint-importer/src/lib/url-rewrite/loa
 
 class SQLitePreparedInsertBuilderTest extends TestCase
 {
+    /**
+     * @return string[]
+     */
+    private function collectValues(string $sql): array
+    {
+        $values = [];
+        $scanner = new Base64ValueScanner($sql);
+        while ($scanner->next_value()) {
+            $values[] = $scanner->get_value();
+        }
+        return $values;
+    }
+
+    /**
+     * @param array{sql: string, params: list<mixed>, param_types: list<int>} $prepared
+     */
+    private function executePrepared(PDO $pdo, array $prepared): void
+    {
+        $statement = $pdo->prepare($prepared['sql']);
+        $this->assertInstanceOf(PDOStatement::class, $statement);
+        foreach ($prepared['params'] as $index => $value) {
+            $statement->bindValue($index + 1, $value, $prepared['param_types'][$index]);
+        }
+        $this->assertTrue($statement->execute());
+    }
+
     public function testBuildsPreparedInsertForArbitraryBytes(): void
     {
         $bytes = '';
@@ -23,10 +49,24 @@ class SQLitePreparedInsertBuilderTest extends TestCase
 
         $this->assertNotNull($prepared);
         $this->assertSame(
-            "INSERT INTO `wp_options` (`option_id`, `option_value`) VALUES(1, ?);",
+            "INSERT INTO `wp_options` (`option_id`, `option_value`) VALUES(CAST(? AS NUMERIC), ?);",
             $prepared['sql']
         );
-        $this->assertSame([$bytes], $prepared['params']);
+        $this->assertSame(['1', $bytes], $prepared['params']);
+        $this->assertSame([PDO::PARAM_STR, PDO::PARAM_STR], $prepared['param_types']);
+
+        if (!extension_loaded('pdo_sqlite')) {
+            $this->markTestSkipped('pdo_sqlite is required for binary round-trip coverage.');
+        }
+
+        $pdo = new PDO('sqlite::memory:');
+        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $pdo->exec('CREATE TABLE `wp_options` (`option_id` INTEGER, `option_value` BLOB)');
+        $this->executePrepared($pdo, $prepared);
+
+        $row = $pdo->query('SELECT option_id, option_value FROM `wp_options`')->fetch(PDO::FETCH_ASSOC);
+        $this->assertSame(1, $row['option_id']);
+        $this->assertSame($bytes, $row['option_value']);
     }
 
     public function testBuildsPreparedInsertForConvertWrappedPayload(): void
@@ -65,7 +105,59 @@ class SQLitePreparedInsertBuilderTest extends TestCase
         );
 
         $this->assertNotNull($prepared);
-        $this->assertSame(['after'], $prepared['params']);
+        $this->assertSame(['1', 'after'], $prepared['params']);
+    }
+
+    public function testRepeatedShapesCompileToSameTemplateWithDifferentValues(): void
+    {
+        $sql_a = sprintf(
+            "INSERT INTO `wp_posts` (`ID`, `post_content`, `post_excerpt`, `menu_order`) VALUES" .
+            "(1, FROM_BASE64('%s'), '', NULL)," .
+            "(2, CONVERT(FROM_BASE64('%s') USING utf8mb4), FROM_BASE64('%s'), -3.5e+2);",
+            base64_encode('alpha'),
+            base64_encode('{"url":"https://example.test/a"}'),
+            base64_encode('excerpt-a')
+        );
+        $sql_b = sprintf(
+            "INSERT INTO `wp_posts` (`ID`, `post_content`, `post_excerpt`, `menu_order`) VALUES" .
+            "(10, FROM_BASE64('%s'), '', NULL)," .
+            "(20, CONVERT(FROM_BASE64('%s') USING utf8mb4), FROM_BASE64('%s'), 4.25);",
+            base64_encode('bravo'),
+            base64_encode('{"url":"https://example.test/b"}'),
+            base64_encode('excerpt-b')
+        );
+
+        $prepared_a = SQLitePreparedInsertBuilder::build($sql_a);
+        $prepared_b = SQLitePreparedInsertBuilder::build($sql_b);
+
+        $this->assertNotNull($prepared_a);
+        $this->assertNotNull($prepared_b);
+        $expected_sql = "INSERT INTO `wp_posts` (`ID`, `post_content`, `post_excerpt`, `menu_order`) VALUES" .
+            "(CAST(? AS NUMERIC), ?, ?, ?)," .
+            "(CAST(? AS NUMERIC), ?, ?, CAST(? AS REAL));";
+        $this->assertSame($expected_sql, $prepared_a['sql']);
+        $this->assertSame($prepared_a['sql'], $prepared_b['sql']);
+        $this->assertSame(
+            ['1', 'alpha', '', null, '2', '{"url":"https://example.test/a"}', 'excerpt-a', '-3.5e+2'],
+            $prepared_a['params']
+        );
+        $this->assertSame(
+            ['10', 'bravo', '', null, '20', '{"url":"https://example.test/b"}', 'excerpt-b', '4.25'],
+            $prepared_b['params']
+        );
+        $this->assertSame(
+            [
+                PDO::PARAM_STR,
+                PDO::PARAM_STR,
+                PDO::PARAM_STR,
+                PDO::PARAM_NULL,
+                PDO::PARAM_STR,
+                PDO::PARAM_STR,
+                PDO::PARAM_STR,
+                PDO::PARAM_STR,
+            ],
+            $prepared_a['param_types']
+        );
     }
 
     public function testRejectsMalformedBase64InsteadOfBindingEmptyString(): void
@@ -121,6 +213,68 @@ class SQLitePreparedInsertBuilderTest extends TestCase
         $this->assertNull(SQLitePreparedInsertBuilder::build($sql));
     }
 
+    public function testMalformedProducerShapesReturnNull(): void
+    {
+        $encoded = base64_encode('value');
+
+        $this->assertNull(SQLitePreparedInsertBuilder::build(
+            "INSERT INTO `wp_options` (`option_id`, `option_value`) VALUES(1e, FROM_BASE64('{$encoded}'));"
+        ));
+        $this->assertNull(SQLitePreparedInsertBuilder::build(
+            "INSERT INTO `wp_options` (`option_id`, `option_value`) VALUES(1, FROM_BASE64('{$encoded}'),);"
+        ));
+        $this->assertNull(SQLitePreparedInsertBuilder::build(
+            "INSERT INTO `wp_options` (`option_id`, `option_value`) VALUES(1, 'literal');"
+        ));
+    }
+
+    public function testNumericLiteralStorageClassesMatchSQLiteLiteralSemantics(): void
+    {
+        if (!extension_loaded('pdo_sqlite')) {
+            $this->markTestSkipped('pdo_sqlite is required for numeric storage-class coverage.');
+        }
+
+        $pdo = new PDO('sqlite::memory:');
+        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $cases = ['1', '-3.5e+2', '4.25', '18446744073709551615', '1.', '1e2'];
+
+        foreach ($cases as $index => $literal) {
+            $table = 't' . $index;
+            $pdo->exec("CREATE TABLE `{$table}` (`n`, `payload`)");
+            $sql = sprintf(
+                "INSERT INTO `{$table}` (`n`, `payload`) VALUES({$literal}, FROM_BASE64('%s'));",
+                base64_encode('value')
+            );
+            $prepared = SQLitePreparedInsertBuilder::build($sql);
+            $this->assertNotNull($prepared);
+            $this->executePrepared($pdo, $prepared);
+
+            $expected_type = $pdo->query("SELECT typeof({$literal})")->fetchColumn();
+            $actual_type = $pdo->query("SELECT typeof(`n`) FROM `{$table}`")->fetchColumn();
+            $this->assertSame($expected_type, $actual_type, "literal {$literal}");
+        }
+    }
+
+    public function testUnsupportedPreparedShapeCanStillFallBackToSqlRewriter(): void
+    {
+        $rewriter = new SqlStatementRewriter(
+            new StructuredDataUrlRewriter([
+                'https://old-site.com' => 'https://new-site.com',
+            ])
+        );
+        $sql = sprintf(
+            "INSERT LOW_PRIORITY IGNORE INTO `wp_posts` (`ID`, `post_content`) VALUES(1, FROM_BASE64('%s'));",
+            base64_encode('<a href="https://old-site.com/page">Link</a>')
+        );
+
+        $this->assertNull($rewriter->build_sqlite_prepared_insert($sql));
+
+        $rewritten = $rewriter->rewrite($sql);
+        $values = $this->collectValues($rewritten);
+        $this->assertCount(1, $values);
+        $this->assertSame('<a href="https://new-site.com/page">Link</a>', $values[0]);
+    }
+
     public function testSqlStatementRewriterBuildsPreparedInsertWithRewrittenParam(): void
     {
         $rewriter = new SqlStatementRewriter(
@@ -137,9 +291,35 @@ class SQLitePreparedInsertBuilderTest extends TestCase
 
         $this->assertNotNull($prepared);
         $this->assertSame(
-            "INSERT INTO `wp_posts` (`ID`, `post_content`) VALUES(1, ?);",
+            "INSERT INTO `wp_posts` (`ID`, `post_content`) VALUES(CAST(? AS NUMERIC), ?);",
             $prepared['sql']
         );
-        $this->assertSame('<a href="https://new-site.com/page">Link</a>', $prepared['params'][0]);
+        $this->assertSame('1', $prepared['params'][0]);
+        $this->assertSame('<a href="https://new-site.com/page">Link</a>', $prepared['params'][1]);
+    }
+
+    public function testSqlStatementRewriterUsesColumnOrderWhenCompilingTemplate(): void
+    {
+        $rewriter = new SqlStatementRewriter(
+            new StructuredDataUrlRewriter([
+                'https://old-site.com' => 'https://new-site.com',
+            ])
+        );
+        $sql = sprintf(
+            "INSERT INTO `wp_posts` (`ID`, `post_title`, `post_content`) VALUES(7, FROM_BASE64('%s'), FROM_BASE64('%s'));",
+            base64_encode('Title https://old-site.com/title'),
+            base64_encode('<a href="https://old-site.com/body">Body</a>')
+        );
+
+        $prepared = $rewriter->build_sqlite_prepared_insert($sql);
+
+        $this->assertNotNull($prepared);
+        $this->assertSame(
+            "INSERT INTO `wp_posts` (`ID`, `post_title`, `post_content`) VALUES(CAST(? AS NUMERIC), ?, ?);",
+            $prepared['sql']
+        );
+        $this->assertSame('7', $prepared['params'][0]);
+        $this->assertSame('Title https://new-site.com/title', $prepared['params'][1]);
+        $this->assertSame('<a href="https://new-site.com/body">Body</a>', $prepared['params'][2]);
     }
 }


### PR DESCRIPTION
## What it does

Speeds up SQLite `db-apply` by making producer-shaped INSERTs compile to reusable prepared SQL templates.

Instead of rebuilding SQLite SQL around only `FROM_BASE64(...)` values on every statement, the prepared-insert path now:

- treats every tuple value as a bound parameter
- emits stable templates for repeated table/column/row-count shapes
- caches those generated templates
- reuses prepared SQLite `PDOStatement`s by template SQL

## Rationale

The full db-apply profile showed the real bottleneck was not query streaming or a small helper call. It was the SQLite prepared INSERT build path:

```text
sqlite_build=33.527s
sqlite_execute=13.936s
sqlite_prepare=5.122s
next_query=4.652s
```

This patch targets that hot path directly. It does not use microbenchmarks or value-substring URL shortcuts.

Full benchmark result, current environment:

```text
trunk:     61.51s
this PR:   57.66s
impact:   -3.85s / -6.3%
```

Both runs used `BENCH_STAGES=playground-sqlite-db-apply`, PHP.wasm 8.3, and the native MySQL parser manifest. Native parser proof was verified in the benchmark output.

## Implementation

`FastInsertScanner` now records structured value entries for producer-shaped INSERTs, including `NULL`, empty strings, numeric literals, and `FROM_BASE64(...)` payloads.

`SQLitePreparedInsertBuilder` uses those entries to build a shape-stable SQL template, with numeric literals bound through SQLite casts so storage class behavior matches literal execution. The importer then caches prepared statements for those stable templates with a bounded LRU-style cache.

Unsupported or malformed shapes still return `null`, so `db-apply` falls back to the existing MySQL-on-SQLite execution path.

## Testing instructions

Focused verification:

```bash
php -l packages/reprint-importer/src/import.php
php -l packages/reprint-importer/src/lib/url-rewrite/class-fast-insert-scanner.php
php -l packages/reprint-importer/src/lib/url-rewrite/class-sqlite-prepared-insert-builder.php
php -l packages/reprint-importer/src/lib/url-rewrite/class-sql-statement-rewriter.php
php -l tests/UrlRewriting/SQLitePreparedInsertBuilderTest.php
vendor/bin/phpunit -c tests/phpunit.xml tests/UrlRewriting/SQLitePreparedInsertBuilderTest.php --testdox
git diff --check
```

Full performance gate:

```bash
BENCH_STAGES=playground-sqlite-db-apply \
WP_MYSQL_PARSER_EXTENSION_MANIFEST=https://wordpress.github.io/sqlite-database-integration/wp_mysql_parser-wasm-extension/latest/manifest.json \
PLAYGROUND_PHP_USE_WASM_RUNNER=1 \
PLAYGROUND_PHP_VERSION=8.3 \
node tests/e2e/benchmark/bench-pull.mjs
```
