### PR TITLE
Add structured SQLite insert row streaming

### DIFF
--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -5119,6 +5119,7 @@ class ImportClient
 
         [$pdo, $connection_label] = $this->create_target_db_apply_connection($options);
         $sqlite_prepared_pdo = null;
+        $sqlite_prepared_statement_cache = [];
         if (
             strtolower((string) ($options["target_engine"] ?? "mysql")) === "sqlite"
             && method_exists($pdo, 'get_connection')
@@ -5245,6 +5246,7 @@ class ImportClient
                             $query,
                             $stmt_rewriter,
                             $sqlite_prepared_pdo,
+                            $sqlite_prepared_statement_cache,
                             $executed_query,
                         );
                     } catch (PDOException $e) {
@@ -5323,6 +5325,7 @@ class ImportClient
                         $query,
                         $stmt_rewriter,
                         $sqlite_prepared_pdo,
+                        $sqlite_prepared_statement_cache,
                         $executed_query,
                     );
                 } catch (PDOException $e) {
@@ -5428,11 +5431,45 @@ class ImportClient
         string $query,
         ?SqlStatementRewriter $stmt_rewriter,
         ?PDO $sqlite_prepared_pdo,
+        array &$sqlite_prepared_statement_cache,
         string &$executed_query
     ): void {
         $executed_query = $query;
 
         if ($sqlite_prepared_pdo !== null) {
+            $structured_insert = $stmt_rewriter !== null
+                ? $stmt_rewriter->build_sqlite_structured_insert($query)
+                : SQLitePreparedInsertBuilder::build_structured($query);
+
+            if ($structured_insert !== null) {
+                $executed_query = $structured_insert['sql'];
+                $statement = $sqlite_prepared_statement_cache[$structured_insert['sql']] ?? null;
+                if ($statement === null) {
+                    $statement = $sqlite_prepared_pdo->prepare($structured_insert['sql']);
+                    if ($statement === false) {
+                        throw new PDOException('Failed to prepare structured SQLite INSERT statement.');
+                    }
+
+                    if (count($sqlite_prepared_statement_cache) < 64) {
+                        $sqlite_prepared_statement_cache[$structured_insert['sql']] = $statement;
+                    }
+                }
+
+                foreach ($structured_insert['params'] as $index => $value) {
+                    $statement->bindValue(
+                        $index + 1,
+                        $value,
+                        $structured_insert['param_types'][$index] ?? PDO::PARAM_STR
+                    );
+                }
+
+                if ($statement->execute() === false) {
+                    throw new PDOException('Failed to execute structured SQLite INSERT statement.');
+                }
+                $statement->closeCursor();
+                return;
+            }
+
             $prepared_insert = $stmt_rewriter !== null
                 ? $stmt_rewriter->build_sqlite_prepared_insert($query)
                 : SQLitePreparedInsertBuilder::build($query);

--- a/packages/reprint-importer/src/lib/url-rewrite/class-sql-statement-rewriter.php
+++ b/packages/reprint-importer/src/lib/url-rewrite/class-sql-statement-rewriter.php
@@ -176,12 +176,27 @@ class SqlStatementRewriter
         );
     }
 
+    /**
+     * Build a fully parameterized SQLite INSERT for producer-shaped rows.
+     *
+     * This keeps the same URL-rewrite semantics as build_sqlite_prepared_insert()
+     * while producing a stable statement shape that callers can cache. Unknown
+     * shapes return null so the caller can fall back to the legacy SQL-text path.
+     *
+     * @return array{sql: string, params: list<mixed>, param_types: list<int>, table: string, columns: list<string>, row_count: int}|null
+     */
+    public function build_sqlite_structured_insert(string $sql): ?array
+    {
+        return SQLitePreparedInsertBuilder::build_structured(
+            $sql,
+            function (string $value, string $table, ?string $column): string {
+                return $this->rewrite_value_for_column($value, $table, $column);
+            }
+        );
+    }
+
     private function rewrite_value_for_column(string $value, string $table, ?string $column): string
     {
-        if (strpos($value, 'http') === false) {
-            return $value;
-        }
-
         if (!$this->url_rewriter->value_might_contain_source_domain($value)) {
             return $value;
         }

--- a/packages/reprint-importer/src/lib/url-rewrite/class-sqlite-prepared-insert-builder.php
+++ b/packages/reprint-importer/src/lib/url-rewrite/class-sqlite-prepared-insert-builder.php
@@ -38,60 +38,72 @@ class SQLitePreparedInsertBuilder
             return null;
         }
 
-        if (!preg_match(
-            '/\A\s*INSERT\s+INTO\s+`((?:[^`]|``)+)`\s*\(([^)]+)\)\s*VALUES\b/i',
-            $sql,
-            $m,
-            PREG_OFFSET_CAPTURE
-        )) {
+        $tokens = self::significant_tokens($sql);
+        $token_count = count($tokens);
+        $cursor = 0;
+
+        if (
+            $token_count < 8
+            || $tokens[$cursor]->id !== WP_MySQL_Lexer::INSERT_SYMBOL
+        ) {
+            return null;
+        }
+        $cursor++;
+
+        if ($cursor >= $token_count || $tokens[$cursor]->id !== WP_MySQL_Lexer::INTO_SYMBOL) {
+            return null;
+        }
+        $cursor++;
+
+        if ($cursor >= $token_count) {
             return null;
         }
 
-        $table = str_replace('``', '`', $m[1][0]);
-        $columns = self::parse_column_list($m[2][0]);
+        $table = self::identifier_token_value($tokens[$cursor]);
+        if ($table === null) {
+            return null;
+        }
+        $cursor++;
+
+        if ($cursor < $token_count && $tokens[$cursor]->id === WP_MySQL_Lexer::DOT_SYMBOL) {
+            return null;
+        }
+
+        $columns = self::consume_column_list($tokens, $token_count, $cursor);
         if ($columns === null || empty($columns)) {
             return null;
         }
 
-        $column_count = count($columns);
-        $cursor = $m[0][1] + strlen($m[0][0]);
-        $sql_len = strlen($sql);
+        if (
+            $cursor >= $token_count
+            || (
+                $tokens[$cursor]->id !== WP_MySQL_Lexer::VALUES_SYMBOL
+                && $tokens[$cursor]->id !== WP_MySQL_Lexer::VALUE_SYMBOL
+            )
+        ) {
+            return null;
+        }
+        $cursor++;
+
         $params = [];
         $param_types = [];
+        $column_count = count($columns);
         $row_count = 0;
         $saw_base64 = false;
 
-        while (true) {
-            while ($cursor < $sql_len && self::is_ws($sql[$cursor])) {
+        while ($cursor < $token_count) {
+            if ($tokens[$cursor]->id === WP_MySQL_Lexer::SEMICOLON_SYMBOL) {
                 $cursor++;
-            }
-
-            if ($cursor >= $sql_len) {
                 break;
             }
 
-            if ($sql[$cursor] === ';') {
-                $cursor++;
-                while ($cursor < $sql_len && self::is_ws($sql[$cursor])) {
-                    $cursor++;
-                }
-                if ($cursor !== $sql_len) {
-                    return null;
-                }
-                break;
-            }
-
-            if ($sql[$cursor] !== '(') {
+            if ($tokens[$cursor]->id !== WP_MySQL_Lexer::OPEN_PAR_SYMBOL) {
                 return null;
             }
             $cursor++;
 
             for ($col_idx = 0; $col_idx < $column_count; $col_idx++) {
-                while ($cursor < $sql_len && self::is_ws($sql[$cursor])) {
-                    $cursor++;
-                }
-
-                $value = self::scan_structured_value($sql, $sql_len, $cursor);
+                $value = self::consume_structured_value($tokens, $token_count, $cursor, $sql);
                 if ($value === null) {
                     return null;
                 }
@@ -114,15 +126,11 @@ class SQLitePreparedInsertBuilder
                     $param_types[] = $value['pdo_type'];
                 }
 
-                while ($cursor < $sql_len && self::is_ws($sql[$cursor])) {
-                    $cursor++;
-                }
-
-                if ($cursor >= $sql_len) {
+                if ($cursor >= $token_count) {
                     return null;
                 }
 
-                if ($sql[$cursor] === ',') {
+                if ($tokens[$cursor]->id === WP_MySQL_Lexer::COMMA_SYMBOL) {
                     if ($col_idx === $column_count - 1) {
                         return null;
                     }
@@ -130,7 +138,7 @@ class SQLitePreparedInsertBuilder
                     continue;
                 }
 
-                if ($sql[$cursor] === ')') {
+                if ($tokens[$cursor]->id === WP_MySQL_Lexer::CLOSE_PAR_SYMBOL) {
                     if ($col_idx !== $column_count - 1) {
                         return null;
                     }
@@ -140,40 +148,30 @@ class SQLitePreparedInsertBuilder
                 return null;
             }
 
-            if ($cursor >= $sql_len || $sql[$cursor] !== ')') {
+            if ($cursor >= $token_count || $tokens[$cursor]->id !== WP_MySQL_Lexer::CLOSE_PAR_SYMBOL) {
                 return null;
             }
             $cursor++;
             $row_count++;
 
-            while ($cursor < $sql_len && self::is_ws($sql[$cursor])) {
-                $cursor++;
-            }
-
-            if ($cursor < $sql_len && $sql[$cursor] === ',') {
+            if ($cursor < $token_count && $tokens[$cursor]->id === WP_MySQL_Lexer::COMMA_SYMBOL) {
                 $cursor++;
                 continue;
             }
 
-            if ($cursor < $sql_len && $sql[$cursor] === ';') {
+            if ($cursor < $token_count && $tokens[$cursor]->id === WP_MySQL_Lexer::SEMICOLON_SYMBOL) {
                 $cursor++;
-                while ($cursor < $sql_len && self::is_ws($sql[$cursor])) {
-                    $cursor++;
-                }
-                if ($cursor !== $sql_len) {
-                    return null;
-                }
                 break;
             }
 
-            if ($cursor >= $sql_len) {
+            if ($cursor >= $token_count) {
                 break;
             }
 
             return null;
         }
 
-        if ($row_count === 0 || !$saw_base64) {
+        if ($cursor !== $token_count || $row_count === 0 || !$saw_base64) {
             return null;
         }
 
@@ -267,46 +265,18 @@ class SQLitePreparedInsertBuilder
     }
 
     /**
-     * @return list<string>|null
-     */
-    private static function parse_column_list(string $columns_body): ?array
-    {
-        $columns = [];
-        if (!preg_match_all(
-            '/\s*`((?:[^`]|``)+)`\s*(,|$)/A',
-            $columns_body,
-            $matches,
-            PREG_SET_ORDER
-        )) {
-            return null;
-        }
-
-        $offset = 0;
-        foreach ($matches as $match) {
-            $columns[] = str_replace('``', '`', $match[1]);
-            $offset += strlen($match[0]);
-        }
-
-        return $offset === strlen($columns_body) ? $columns : null;
-    }
-
-    /**
      * @return array{kind: string, value?: mixed, pdo_type?: int, encoded_value?: string}|null
      */
-    private static function scan_structured_value(string $sql, int $sql_len, int &$cursor): ?array
+    private static function consume_structured_value(array $tokens, int $token_count, int &$cursor, string $sql): ?array
     {
-        if ($cursor >= $sql_len) {
+        if ($cursor >= $token_count) {
             return null;
         }
 
-        $c = $sql[$cursor];
+        $token = $tokens[$cursor];
 
-        if (
-            ($c === 'N' || $c === 'n')
-            && $cursor + 4 <= $sql_len
-            && substr_compare($sql, 'NULL', $cursor, 4, true) === 0
-        ) {
-            $cursor += 4;
+        if ($token->id === WP_MySQL_Lexer::NULL_SYMBOL) {
+            $cursor++;
             return [
                 'kind' => 'null',
                 'value' => null,
@@ -314,8 +284,14 @@ class SQLitePreparedInsertBuilder
             ];
         }
 
-        if ($c === "'" && $cursor + 1 < $sql_len && $sql[$cursor + 1] === "'") {
-            $cursor += 2;
+        if (
+            (
+                $token->id === WP_MySQL_Lexer::SINGLE_QUOTED_TEXT
+                || $token->id === WP_MySQL_Lexer::DOUBLE_QUOTED_TEXT
+            )
+            && $token->get_value() === ''
+        ) {
+            $cursor++;
             return [
                 'kind' => 'empty',
                 'value' => '',
@@ -323,13 +299,8 @@ class SQLitePreparedInsertBuilder
             ];
         }
 
-        if (
-            ($c === 'F' || $c === 'f')
-            && $cursor + 13 <= $sql_len
-            && substr_compare($sql, 'FROM_BASE64(', $cursor, 12, true) === 0
-        ) {
-            $cursor += 12;
-            $encoded = self::consume_base64_payload($sql, $sql_len, $cursor);
+        if (self::is_from_base64_token($token)) {
+            $encoded = self::consume_base64_call($tokens, $token_count, $cursor);
             return $encoded === null
                 ? null
                 : [
@@ -338,45 +309,32 @@ class SQLitePreparedInsertBuilder
                 ];
         }
 
-        if (
-            ($c === 'C' || $c === 'c')
-            && $cursor + 8 <= $sql_len
-            && substr_compare($sql, 'CONVERT(', $cursor, 8, true) === 0
-        ) {
-            $cursor += 8;
-            while ($cursor < $sql_len && self::is_ws($sql[$cursor])) {
-                $cursor++;
-            }
-            if (
-                $cursor + 12 > $sql_len
-                || substr_compare($sql, 'FROM_BASE64(', $cursor, 12, true) !== 0
-            ) {
+        if ($token->id === WP_MySQL_Lexer::CONVERT_SYMBOL) {
+            $cursor++;
+            if ($cursor >= $token_count || $tokens[$cursor]->id !== WP_MySQL_Lexer::OPEN_PAR_SYMBOL) {
                 return null;
             }
-            $cursor += 12;
-            $encoded = self::consume_base64_payload($sql, $sql_len, $cursor);
+            $cursor++;
+
+            if ($cursor >= $token_count || !self::is_from_base64_token($tokens[$cursor])) {
+                return null;
+            }
+            $encoded = self::consume_base64_call($tokens, $token_count, $cursor);
             if ($encoded === null) {
                 return null;
             }
 
-            while ($cursor < $sql_len && self::is_ws($sql[$cursor])) {
-                $cursor++;
-            }
-            if ($cursor + 5 > $sql_len || substr_compare($sql, 'USING', $cursor, 5, true) !== 0) {
+            if ($cursor >= $token_count || $tokens[$cursor]->id !== WP_MySQL_Lexer::USING_SYMBOL) {
                 return null;
             }
-            $cursor += 5;
-            while ($cursor < $sql_len && self::is_ws($sql[$cursor])) {
-                $cursor++;
-            }
-            if ($cursor + 7 > $sql_len || substr_compare($sql, 'utf8mb4', $cursor, 7, true) !== 0) {
+            $cursor++;
+
+            if ($cursor >= $token_count || strcasecmp($tokens[$cursor]->get_value(), 'utf8mb4') !== 0) {
                 return null;
             }
-            $cursor += 7;
-            while ($cursor < $sql_len && self::is_ws($sql[$cursor])) {
-                $cursor++;
-            }
-            if ($cursor >= $sql_len || $sql[$cursor] !== ')') {
+            $cursor++;
+
+            if ($cursor >= $token_count || $tokens[$cursor]->id !== WP_MySQL_Lexer::CLOSE_PAR_SYMBOL) {
                 return null;
             }
             $cursor++;
@@ -387,81 +345,99 @@ class SQLitePreparedInsertBuilder
             ];
         }
 
-        $start = $cursor;
-        if ($c === '+' || $c === '-') {
+        $first_token = $token;
+        if (
+            $token->id === WP_MySQL_Lexer::PLUS_OPERATOR
+            || $token->id === WP_MySQL_Lexer::MINUS_OPERATOR
+        ) {
             $cursor++;
-        }
-
-        $digits_before_decimal = 0;
-        while ($cursor < $sql_len && $sql[$cursor] >= '0' && $sql[$cursor] <= '9') {
-            $cursor++;
-            $digits_before_decimal++;
-        }
-
-        $digits_after_decimal = 0;
-        if ($cursor < $sql_len && $sql[$cursor] === '.') {
-            $cursor++;
-            while ($cursor < $sql_len && $sql[$cursor] >= '0' && $sql[$cursor] <= '9') {
-                $cursor++;
-                $digits_after_decimal++;
-            }
-        }
-
-        if ($digits_before_decimal === 0 && $digits_after_decimal === 0) {
-            $cursor = $start;
-            return null;
-        }
-
-        if ($cursor < $sql_len && ($sql[$cursor] === 'e' || $sql[$cursor] === 'E')) {
-            $cursor++;
-            if ($cursor < $sql_len && ($sql[$cursor] === '+' || $sql[$cursor] === '-')) {
-                $cursor++;
-            }
-
-            $exponent_start = $cursor;
-            while ($cursor < $sql_len && $sql[$cursor] >= '0' && $sql[$cursor] <= '9') {
-                $cursor++;
-            }
-
-            if ($cursor === $exponent_start) {
-                $cursor = $start;
+            if (
+                $cursor >= $token_count
+                || !self::is_numeric_token($tokens[$cursor])
+                || $first_token->start + $first_token->length !== $tokens[$cursor]->start
+            ) {
                 return null;
             }
+            $token = $tokens[$cursor];
+        } elseif (!self::is_numeric_token($token)) {
+            return null;
         }
+        $cursor++;
 
         return [
             'kind' => 'numeric',
-            'value' => substr($sql, $start, $cursor - $start),
+            'value' => substr($sql, $first_token->start, ($token->start + $token->length) - $first_token->start),
             'pdo_type' => PDO::PARAM_STR,
         ];
     }
 
-    private static function consume_base64_payload(string $sql, int $sql_len, int &$cursor): ?string
+    /**
+     * @param WP_MySQL_Token[] $tokens
+     * @return list<string>|null
+     */
+    private static function consume_column_list(array $tokens, int $token_count, int &$cursor): ?array
     {
-        while ($cursor < $sql_len && self::is_ws($sql[$cursor])) {
-            $cursor++;
-        }
-        if ($cursor >= $sql_len || $sql[$cursor] !== "'") {
+        if ($cursor >= $token_count || $tokens[$cursor]->id !== WP_MySQL_Lexer::OPEN_PAR_SYMBOL) {
             return null;
         }
-
         $cursor++;
-        $payload_start = $cursor;
-        $close = strpos($sql, "'", $cursor);
-        if ($close === false) {
-            return null;
+
+        $columns = [];
+        while ($cursor < $token_count && $tokens[$cursor]->id !== WP_MySQL_Lexer::CLOSE_PAR_SYMBOL) {
+            $column = self::identifier_token_value($tokens[$cursor]);
+            if ($column === null) {
+                return null;
+            }
+            $columns[] = $column;
+            $cursor++;
+
+            if ($cursor < $token_count && $tokens[$cursor]->id === WP_MySQL_Lexer::COMMA_SYMBOL) {
+                $cursor++;
+                continue;
+            }
+            break;
         }
 
-        $payload = substr($sql, $payload_start, $close - $payload_start);
+        if ($cursor >= $token_count || $tokens[$cursor]->id !== WP_MySQL_Lexer::CLOSE_PAR_SYMBOL) {
+            return null;
+        }
+        $cursor++;
+
+        return $columns;
+    }
+
+    /**
+     * @param WP_MySQL_Token[] $tokens
+     */
+    private static function consume_base64_call(array $tokens, int $token_count, int &$cursor): ?string
+    {
+        if ($cursor >= $token_count || !self::is_from_base64_token($tokens[$cursor])) {
+            return null;
+        }
+        $cursor++;
+
+        if ($cursor >= $token_count || $tokens[$cursor]->id !== WP_MySQL_Lexer::OPEN_PAR_SYMBOL) {
+            return null;
+        }
+        $cursor++;
+
+        if (
+            $cursor >= $token_count
+            || (
+                $tokens[$cursor]->id !== WP_MySQL_Lexer::SINGLE_QUOTED_TEXT
+                && $tokens[$cursor]->id !== WP_MySQL_Lexer::DOUBLE_QUOTED_TEXT
+            )
+        ) {
+            return null;
+        }
+        $payload = $tokens[$cursor]->get_value();
+        $cursor++;
+
         if ($payload !== '' && !preg_match('/\A[A-Za-z0-9+\/=]*\z/', $payload)) {
             return null;
         }
 
-        $cursor = $close + 1;
-        while ($cursor < $sql_len && self::is_ws($sql[$cursor])) {
-            $cursor++;
-        }
-        if ($cursor >= $sql_len || $sql[$cursor] !== ')') {
+        if ($cursor >= $token_count || $tokens[$cursor]->id !== WP_MySQL_Lexer::CLOSE_PAR_SYMBOL) {
             return null;
         }
         $cursor++;
@@ -474,8 +450,44 @@ class SQLitePreparedInsertBuilder
         return '`' . str_replace('`', '``', $identifier) . '`';
     }
 
-    private static function is_ws(string $c): bool
+    private static function identifier_token_value(WP_MySQL_Token $token): ?string
     {
-        return $c === ' ' || $c === "\t" || $c === "\n" || $c === "\r";
+        return (
+            $token->id === WP_MySQL_Lexer::BACK_TICK_QUOTED_ID
+            || $token->id === WP_MySQL_Lexer::IDENTIFIER
+        )
+            ? $token->get_value()
+            : null;
+    }
+
+    private static function is_from_base64_token(WP_MySQL_Token $token): bool
+    {
+        return $token->id === WP_MySQL_Lexer::IDENTIFIER
+            && strcasecmp($token->get_value(), 'FROM_BASE64') === 0;
+    }
+
+    private static function is_numeric_token(WP_MySQL_Token $token): bool
+    {
+        return $token->id === WP_MySQL_Lexer::INT_NUMBER
+            || $token->id === WP_MySQL_Lexer::LONG_NUMBER
+            || $token->id === WP_MySQL_Lexer::ULONGLONG_NUMBER
+            || $token->id === WP_MySQL_Lexer::DECIMAL_NUMBER
+            || $token->id === WP_MySQL_Lexer::FLOAT_NUMBER;
+    }
+
+    /**
+     * @return WP_MySQL_Token[]
+     */
+    private static function significant_tokens(string $sql): array
+    {
+        $lexer = new WP_MySQL_Lexer($sql);
+        $tokens = $lexer->remaining_tokens();
+        if (
+            !empty($tokens)
+            && end($tokens)->id === WP_MySQL_Lexer::EOF
+        ) {
+            array_pop($tokens);
+        }
+        return $tokens;
     }
 }

--- a/packages/reprint-importer/src/lib/url-rewrite/class-sqlite-prepared-insert-builder.php
+++ b/packages/reprint-importer/src/lib/url-rewrite/class-sqlite-prepared-insert-builder.php
@@ -18,6 +18,184 @@
 class SQLitePreparedInsertBuilder
 {
     /**
+     * Build a fully parameterized producer-shape INSERT.
+     *
+     * Unlike build(), this treats the INSERT as structured rows rather than as
+     * SQL text with only FROM_BASE64(...) holes. Every producer value becomes a
+     * positional placeholder, so the generated SQL is stable for the same
+     * table/column/row-count shape and callers can cache the PDOStatement.
+     *
+     * Unknown shapes return null so db-apply can fall back to the legacy
+     * MySQL-on-SQLite path.
+     *
+     * @param callable|null $rewrite_value Optional callback:
+     *        fn(string $value, string $table, ?string $column): string
+     * @return array{sql: string, params: list<mixed>, param_types: list<int>, table: string, columns: list<string>, row_count: int}|null
+     */
+    public static function build_structured(string $sql, ?callable $rewrite_value = null): ?array
+    {
+        if (stripos($sql, 'FROM_BASE64(') === false) {
+            return null;
+        }
+
+        if (!preg_match(
+            '/\A\s*INSERT\s+INTO\s+`((?:[^`]|``)+)`\s*\(([^)]+)\)\s*VALUES\b/i',
+            $sql,
+            $m,
+            PREG_OFFSET_CAPTURE
+        )) {
+            return null;
+        }
+
+        $table = str_replace('``', '`', $m[1][0]);
+        $columns = self::parse_column_list($m[2][0]);
+        if ($columns === null || empty($columns)) {
+            return null;
+        }
+
+        $column_count = count($columns);
+        $cursor = $m[0][1] + strlen($m[0][0]);
+        $sql_len = strlen($sql);
+        $params = [];
+        $param_types = [];
+        $row_count = 0;
+        $saw_base64 = false;
+
+        while (true) {
+            while ($cursor < $sql_len && self::is_ws($sql[$cursor])) {
+                $cursor++;
+            }
+
+            if ($cursor >= $sql_len) {
+                break;
+            }
+
+            if ($sql[$cursor] === ';') {
+                $cursor++;
+                while ($cursor < $sql_len && self::is_ws($sql[$cursor])) {
+                    $cursor++;
+                }
+                if ($cursor !== $sql_len) {
+                    return null;
+                }
+                break;
+            }
+
+            if ($sql[$cursor] !== '(') {
+                return null;
+            }
+            $cursor++;
+
+            for ($col_idx = 0; $col_idx < $column_count; $col_idx++) {
+                while ($cursor < $sql_len && self::is_ws($sql[$cursor])) {
+                    $cursor++;
+                }
+
+                $value = self::scan_structured_value($sql, $sql_len, $cursor);
+                if ($value === null) {
+                    return null;
+                }
+
+                if ($value['kind'] === 'base64') {
+                    $saw_base64 = true;
+                    $decoded = base64_decode($value['encoded_value'], true);
+                    if ($decoded === false) {
+                        return null;
+                    }
+
+                    if ($rewrite_value !== null) {
+                        $decoded = $rewrite_value($decoded, $table, $columns[$col_idx]);
+                    }
+
+                    $params[] = $decoded;
+                    $param_types[] = PDO::PARAM_STR;
+                } else {
+                    $params[] = $value['value'];
+                    $param_types[] = $value['pdo_type'];
+                }
+
+                while ($cursor < $sql_len && self::is_ws($sql[$cursor])) {
+                    $cursor++;
+                }
+
+                if ($cursor >= $sql_len) {
+                    return null;
+                }
+
+                if ($sql[$cursor] === ',') {
+                    if ($col_idx === $column_count - 1) {
+                        return null;
+                    }
+                    $cursor++;
+                    continue;
+                }
+
+                if ($sql[$cursor] === ')') {
+                    if ($col_idx !== $column_count - 1) {
+                        return null;
+                    }
+                    break;
+                }
+
+                return null;
+            }
+
+            if ($cursor >= $sql_len || $sql[$cursor] !== ')') {
+                return null;
+            }
+            $cursor++;
+            $row_count++;
+
+            while ($cursor < $sql_len && self::is_ws($sql[$cursor])) {
+                $cursor++;
+            }
+
+            if ($cursor < $sql_len && $sql[$cursor] === ',') {
+                $cursor++;
+                continue;
+            }
+
+            if ($cursor < $sql_len && $sql[$cursor] === ';') {
+                $cursor++;
+                while ($cursor < $sql_len && self::is_ws($sql[$cursor])) {
+                    $cursor++;
+                }
+                if ($cursor !== $sql_len) {
+                    return null;
+                }
+                break;
+            }
+
+            if ($cursor >= $sql_len) {
+                break;
+            }
+
+            return null;
+        }
+
+        if ($row_count === 0 || !$saw_base64) {
+            return null;
+        }
+
+        $quoted_columns = array_map([self::class, 'quote_identifier'], $columns);
+        $tuple = '(' . implode(',', array_fill(0, $column_count, '?')) . ')';
+
+        return [
+            'sql' => sprintf(
+                'INSERT INTO %s (%s) VALUES %s;',
+                self::quote_identifier($table),
+                implode(',', $quoted_columns),
+                implode(',', array_fill(0, $row_count, $tuple))
+            ),
+            'params' => $params,
+            'param_types' => $param_types,
+            'table' => $table,
+            'columns' => $columns,
+            'row_count' => $row_count,
+        ];
+    }
+
+    /**
      * @param callable|null $rewrite_value Optional callback:
      *        fn(string $value, string $table, ?string $column): string
      * @return array{sql: string, params: list<string>}|null
@@ -86,5 +264,218 @@ class SQLitePreparedInsertBuilder
         }
 
         return null;
+    }
+
+    /**
+     * @return list<string>|null
+     */
+    private static function parse_column_list(string $columns_body): ?array
+    {
+        $columns = [];
+        if (!preg_match_all(
+            '/\s*`((?:[^`]|``)+)`\s*(,|$)/A',
+            $columns_body,
+            $matches,
+            PREG_SET_ORDER
+        )) {
+            return null;
+        }
+
+        $offset = 0;
+        foreach ($matches as $match) {
+            $columns[] = str_replace('``', '`', $match[1]);
+            $offset += strlen($match[0]);
+        }
+
+        return $offset === strlen($columns_body) ? $columns : null;
+    }
+
+    /**
+     * @return array{kind: string, value?: mixed, pdo_type?: int, encoded_value?: string}|null
+     */
+    private static function scan_structured_value(string $sql, int $sql_len, int &$cursor): ?array
+    {
+        if ($cursor >= $sql_len) {
+            return null;
+        }
+
+        $c = $sql[$cursor];
+
+        if (
+            ($c === 'N' || $c === 'n')
+            && $cursor + 4 <= $sql_len
+            && substr_compare($sql, 'NULL', $cursor, 4, true) === 0
+        ) {
+            $cursor += 4;
+            return [
+                'kind' => 'null',
+                'value' => null,
+                'pdo_type' => PDO::PARAM_NULL,
+            ];
+        }
+
+        if ($c === "'" && $cursor + 1 < $sql_len && $sql[$cursor + 1] === "'") {
+            $cursor += 2;
+            return [
+                'kind' => 'empty',
+                'value' => '',
+                'pdo_type' => PDO::PARAM_STR,
+            ];
+        }
+
+        if (
+            ($c === 'F' || $c === 'f')
+            && $cursor + 13 <= $sql_len
+            && substr_compare($sql, 'FROM_BASE64(', $cursor, 12, true) === 0
+        ) {
+            $cursor += 12;
+            $encoded = self::consume_base64_payload($sql, $sql_len, $cursor);
+            return $encoded === null
+                ? null
+                : [
+                    'kind' => 'base64',
+                    'encoded_value' => $encoded,
+                ];
+        }
+
+        if (
+            ($c === 'C' || $c === 'c')
+            && $cursor + 8 <= $sql_len
+            && substr_compare($sql, 'CONVERT(', $cursor, 8, true) === 0
+        ) {
+            $cursor += 8;
+            while ($cursor < $sql_len && self::is_ws($sql[$cursor])) {
+                $cursor++;
+            }
+            if (
+                $cursor + 12 > $sql_len
+                || substr_compare($sql, 'FROM_BASE64(', $cursor, 12, true) !== 0
+            ) {
+                return null;
+            }
+            $cursor += 12;
+            $encoded = self::consume_base64_payload($sql, $sql_len, $cursor);
+            if ($encoded === null) {
+                return null;
+            }
+
+            while ($cursor < $sql_len && self::is_ws($sql[$cursor])) {
+                $cursor++;
+            }
+            if ($cursor + 5 > $sql_len || substr_compare($sql, 'USING', $cursor, 5, true) !== 0) {
+                return null;
+            }
+            $cursor += 5;
+            while ($cursor < $sql_len && self::is_ws($sql[$cursor])) {
+                $cursor++;
+            }
+            if ($cursor + 7 > $sql_len || substr_compare($sql, 'utf8mb4', $cursor, 7, true) !== 0) {
+                return null;
+            }
+            $cursor += 7;
+            while ($cursor < $sql_len && self::is_ws($sql[$cursor])) {
+                $cursor++;
+            }
+            if ($cursor >= $sql_len || $sql[$cursor] !== ')') {
+                return null;
+            }
+            $cursor++;
+
+            return [
+                'kind' => 'base64',
+                'encoded_value' => $encoded,
+            ];
+        }
+
+        $start = $cursor;
+        if ($c === '+' || $c === '-') {
+            $cursor++;
+        }
+
+        $digits_before_decimal = 0;
+        while ($cursor < $sql_len && $sql[$cursor] >= '0' && $sql[$cursor] <= '9') {
+            $cursor++;
+            $digits_before_decimal++;
+        }
+
+        $digits_after_decimal = 0;
+        if ($cursor < $sql_len && $sql[$cursor] === '.') {
+            $cursor++;
+            while ($cursor < $sql_len && $sql[$cursor] >= '0' && $sql[$cursor] <= '9') {
+                $cursor++;
+                $digits_after_decimal++;
+            }
+        }
+
+        if ($digits_before_decimal === 0 && $digits_after_decimal === 0) {
+            $cursor = $start;
+            return null;
+        }
+
+        if ($cursor < $sql_len && ($sql[$cursor] === 'e' || $sql[$cursor] === 'E')) {
+            $cursor++;
+            if ($cursor < $sql_len && ($sql[$cursor] === '+' || $sql[$cursor] === '-')) {
+                $cursor++;
+            }
+
+            $exponent_start = $cursor;
+            while ($cursor < $sql_len && $sql[$cursor] >= '0' && $sql[$cursor] <= '9') {
+                $cursor++;
+            }
+
+            if ($cursor === $exponent_start) {
+                $cursor = $start;
+                return null;
+            }
+        }
+
+        return [
+            'kind' => 'numeric',
+            'value' => substr($sql, $start, $cursor - $start),
+            'pdo_type' => PDO::PARAM_STR,
+        ];
+    }
+
+    private static function consume_base64_payload(string $sql, int $sql_len, int &$cursor): ?string
+    {
+        while ($cursor < $sql_len && self::is_ws($sql[$cursor])) {
+            $cursor++;
+        }
+        if ($cursor >= $sql_len || $sql[$cursor] !== "'") {
+            return null;
+        }
+
+        $cursor++;
+        $payload_start = $cursor;
+        $close = strpos($sql, "'", $cursor);
+        if ($close === false) {
+            return null;
+        }
+
+        $payload = substr($sql, $payload_start, $close - $payload_start);
+        if ($payload !== '' && !preg_match('/\A[A-Za-z0-9+\/=]*\z/', $payload)) {
+            return null;
+        }
+
+        $cursor = $close + 1;
+        while ($cursor < $sql_len && self::is_ws($sql[$cursor])) {
+            $cursor++;
+        }
+        if ($cursor >= $sql_len || $sql[$cursor] !== ')') {
+            return null;
+        }
+        $cursor++;
+
+        return $payload;
+    }
+
+    private static function quote_identifier(string $identifier): string
+    {
+        return '`' . str_replace('`', '``', $identifier) . '`';
+    }
+
+    private static function is_ws(string $c): bool
+    {
+        return $c === ' ' || $c === "\t" || $c === "\n" || $c === "\r";
     }
 }

--- a/tests/Import/NewSiteUrlSqliteTest.php
+++ b/tests/Import/NewSiteUrlSqliteTest.php
@@ -135,7 +135,7 @@ class NewSiteUrlSqliteTest extends TestCase
             return $data === null ? null : base64_decode($data);
         });
 
-        return $pdo->query($sql)->fetchAll();
+        return $pdo->query($sql)->fetchAll(\PDO::FETCH_ASSOC);
     }
 
     /**
@@ -413,5 +413,106 @@ class NewSiteUrlSqliteTest extends TestCase
         $this->assertSame('complete', $state['status']);
         $this->assertSame(3, $state['apply']['statements_executed']);
         $this->assertSame(strlen($sql), $state['apply']['bytes_read']);
+    }
+
+    public function testSqliteDbApplyResumeCountsStructuredInsertStatementsNotRows(): void
+    {
+        $sqlitePath = $this->tempDir . '/database/wordpress.sqlite';
+        mkdir(dirname($sqlitePath), 0777, true);
+
+        $drop = "DROP TABLE IF EXISTS `wp_options`;";
+        $create = "CREATE TABLE `wp_options` ("
+            . "`option_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT, "
+            . "`option_name` varchar(191) NOT NULL DEFAULT '', "
+            . "`option_value` longtext NOT NULL, "
+            . "`autoload` varchar(20) NOT NULL DEFAULT 'yes', "
+            . "PRIMARY KEY (`option_id`)"
+            . ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;";
+        $insert1 = sprintf(
+            "INSERT INTO `wp_options` (`option_id`, `option_name`, `option_value`, `autoload`) VALUES "
+            . "(1, FROM_BASE64('%s'), FROM_BASE64('%s'), FROM_BASE64('%s')), "
+            . "(2, FROM_BASE64('%s'), FROM_BASE64('%s'), FROM_BASE64('%s'));",
+            base64_encode('first'),
+            base64_encode('one'),
+            base64_encode('yes'),
+            base64_encode('second'),
+            base64_encode('two'),
+            base64_encode('yes')
+        );
+        $insert2 = sprintf(
+            "INSERT INTO `wp_options` (`option_id`, `option_name`, `option_value`, `autoload`) VALUES "
+            . "(3, FROM_BASE64('%s'), FROM_BASE64('%s'), FROM_BASE64('%s')), "
+            . "(4, FROM_BASE64('%s'), FROM_BASE64('%s'), FROM_BASE64('%s'));",
+            base64_encode('third'),
+            base64_encode('three'),
+            base64_encode('yes'),
+            base64_encode('fourth'),
+            base64_encode('four'),
+            base64_encode('yes')
+        );
+
+        $prefix = $drop . "\n" . $create . "\n" . $insert1 . "\n";
+        file_put_contents($this->tempDir . '/db.sql', $prefix . $insert2 . "\n");
+
+        $pdo = new \PDO('sqlite:' . $sqlitePath);
+        $pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+        $pdo->exec(
+            "CREATE TABLE wp_options ("
+            . "option_id INTEGER PRIMARY KEY, "
+            . "option_name TEXT NOT NULL, "
+            . "option_value BLOB NOT NULL, "
+            . "autoload TEXT NOT NULL"
+            . ")"
+        );
+        $seed = $pdo->prepare(
+            "INSERT INTO wp_options (option_id, option_name, option_value, autoload) VALUES (?, ?, ?, ?)"
+        );
+        $seed->execute([1, 'first', 'one', 'yes']);
+        $seed->execute([2, 'second', 'two', 'yes']);
+
+        $this->writeState([
+            'command' => 'db-apply',
+            'status' => 'in_progress',
+            'apply' => [
+                'statements_executed' => 3,
+                'bytes_read' => strlen($prefix),
+            ],
+        ]);
+
+        $client = new \ImportClient(
+            'https://old-site.example.com/?reprint-api',
+            $this->tempDir,
+            $this->tempDir . '/fs-root',
+        );
+        $client->run([
+            'command' => 'db-apply',
+            'abort' => false,
+            'verbose' => false,
+            'secret' => null,
+            'tuning_config' => [],
+            'target_engine' => 'sqlite',
+            'target_sqlite_path' => $sqlitePath,
+            'target_db' => 'wp_test',
+        ]);
+
+        $rows = $this->querySqlite(
+            $sqlitePath,
+            "SELECT option_id, option_name, option_value FROM wp_options ORDER BY option_id",
+            'wp_test',
+        );
+        $this->assertSame(
+            [
+                ['option_id' => 1, 'option_name' => 'first', 'option_value' => 'one'],
+                ['option_id' => 2, 'option_name' => 'second', 'option_value' => 'two'],
+                ['option_id' => 3, 'option_name' => 'third', 'option_value' => 'three'],
+                ['option_id' => 4, 'option_name' => 'fourth', 'option_value' => 'four'],
+            ],
+            $rows
+        );
+
+        $state = json_decode(file_get_contents($this->tempDir . '/.import-state.json'), true);
+        $this->assertSame('complete', $state['status']);
+        $this->assertSame(4, $state['apply']['statements_executed']);
+        $this->assertGreaterThanOrEqual(strlen($prefix), $state['apply']['bytes_read']);
     }
 }

--- a/tests/UrlRewriting/SQLitePreparedInsertBuilderTest.php
+++ b/tests/UrlRewriting/SQLitePreparedInsertBuilderTest.php
@@ -107,6 +107,70 @@ class SQLitePreparedInsertBuilderTest extends TestCase
         $this->assertSame(['999', '888', 'second_key', 'second_value'], $prepared_b['params']);
     }
 
+    public function testStructuredInsertTokenizesCommentsAndEscapedIdentifiers(): void
+    {
+        $sql = sprintf(
+            "/* leading FROM_BASE64('ignored') */ INSERT INTO `wp``odd` (`id`, `meta``key`, `value`) "
+            . "VALUES /* tuple */ (1, FROM_BASE64('%s'), CONVERT(FROM_BASE64('%s') USING utf8mb4));",
+            base64_encode('key'),
+            base64_encode('value')
+        );
+
+        $calls = [];
+        $prepared = SQLitePreparedInsertBuilder::build_structured(
+            $sql,
+            function (string $value, string $table, ?string $column) use (&$calls): string {
+                $calls[] = [$value, $table, $column];
+                return $value;
+            }
+        );
+
+        $this->assertNotNull($prepared);
+        $this->assertSame(
+            "INSERT INTO `wp``odd` (`id`,`meta``key`,`value`) VALUES (?,?,?);",
+            $prepared['sql']
+        );
+        $this->assertSame(['1', 'key', 'value'], $prepared['params']);
+        $this->assertSame(
+            [
+                ['key', 'wp`odd', 'meta`key'],
+                ['value', 'wp`odd', 'value'],
+            ],
+            $calls
+        );
+    }
+
+    public function testStructuredInsertDoesNotTreatStringLiteralsAsSqlShape(): void
+    {
+        $sql = sprintf(
+            "INSERT INTO `wp_options` (`option_id`, `option_name`, `option_value`) VALUES "
+            . "(1, '', FROM_BASE64('%s'));",
+            base64_encode("literal text with ),( and FROM_BASE64('ignored') inside")
+        );
+
+        $prepared = SQLitePreparedInsertBuilder::build_structured($sql);
+
+        $this->assertNotNull($prepared);
+        $this->assertSame(
+            ['1', '', "literal text with ),( and FROM_BASE64('ignored') inside"],
+            $prepared['params']
+        );
+    }
+
+    public function testStructuredInsertRejectsNestedExpressionsFallbackSafely(): void
+    {
+        $cases = [
+            "INSERT INTO `wp_options` (`option_id`, `option_value`) VALUES((1 + 2), FROM_BASE64('" . base64_encode('value') . "'));",
+            "INSERT INTO `wp_options` (`option_id`, `option_value`) VALUES(ABS(-1), FROM_BASE64('" . base64_encode('value') . "'));",
+            "INSERT INTO `wp_options` (`option_id`, `option_value`) VALUES(1, CONCAT(FROM_BASE64('" . base64_encode('value') . "'), 'x'));",
+            "INSERT INTO `wp_options` (`option_id`, `option_value`) VALUES(1, CONVERT('plain' USING utf8mb4));",
+        ];
+
+        foreach ($cases as $case) {
+            $this->assertNull(SQLitePreparedInsertBuilder::build_structured($case), $case);
+        }
+    }
+
     public function testStructuredUrlRewriteReceivesColumnContextForEveryBase64Value(): void
     {
         $sql = sprintf(

--- a/tests/UrlRewriting/SQLitePreparedInsertBuilderTest.php
+++ b/tests/UrlRewriting/SQLitePreparedInsertBuilderTest.php
@@ -7,6 +7,15 @@ require_once __DIR__ . '/../../packages/reprint-importer/src/lib/url-rewrite/loa
 
 class SQLitePreparedInsertBuilderTest extends TestCase
 {
+    private function createStatementRewriter(?array $mapping = null): SqlStatementRewriter
+    {
+        return new SqlStatementRewriter(
+            new StructuredDataUrlRewriter($mapping ?? [
+                'https://old-site.com' => 'https://new-site.com',
+            ])
+        );
+    }
+
     public function testBuildsPreparedInsertForArbitraryBytes(): void
     {
         $bytes = '';
@@ -27,6 +36,163 @@ class SQLitePreparedInsertBuilderTest extends TestCase
             $prepared['sql']
         );
         $this->assertSame([$bytes], $prepared['params']);
+    }
+
+    public function testStructuredInsertPreservesBinaryNullAndEmptyValues(): void
+    {
+        $bytes = '';
+        for ($i = 0; $i <= 255; $i++) {
+            $bytes .= chr($i);
+        }
+        $json = '{"null":null,"empty":""}';
+
+        $sql = sprintf(
+            "INSERT INTO `wp_options` (`option_id`, `option_name`, `option_value`, `autoload`) VALUES "
+            . "(1, FROM_BASE64('%s'), '', NULL),"
+            . "(2, CONVERT(FROM_BASE64('%s') USING utf8mb4), FROM_BASE64('%s'), '');",
+            base64_encode('binary_payload'),
+            base64_encode($json),
+            base64_encode($bytes)
+        );
+
+        $prepared = SQLitePreparedInsertBuilder::build_structured($sql);
+
+        $this->assertNotNull($prepared);
+        $this->assertSame(
+            "INSERT INTO `wp_options` (`option_id`,`option_name`,`option_value`,`autoload`) VALUES (?,?,?,?),(?,?,?,?);",
+            $prepared['sql']
+        );
+        $this->assertSame(
+            ['1', 'binary_payload', '', null, '2', $json, $bytes, ''],
+            $prepared['params']
+        );
+        $this->assertSame(
+            [
+                PDO::PARAM_STR,
+                PDO::PARAM_STR,
+                PDO::PARAM_STR,
+                PDO::PARAM_NULL,
+                PDO::PARAM_STR,
+                PDO::PARAM_STR,
+                PDO::PARAM_STR,
+                PDO::PARAM_STR,
+            ],
+            $prepared['param_types']
+        );
+        $this->assertSame(2, $prepared['row_count']);
+    }
+
+    public function testStructuredInsertShapeIsStableAcrossLiteralValues(): void
+    {
+        $sql_a = sprintf(
+            "INSERT INTO `wp_postmeta` (`meta_id`, `post_id`, `meta_key`, `meta_value`) VALUES "
+            . "(1, 10, FROM_BASE64('%s'), FROM_BASE64('%s'));",
+            base64_encode('first_key'),
+            base64_encode('first_value')
+        );
+        $sql_b = sprintf(
+            "INSERT INTO `wp_postmeta` (`meta_id`, `post_id`, `meta_key`, `meta_value`) VALUES "
+            . "(999, 888, FROM_BASE64('%s'), FROM_BASE64('%s'));",
+            base64_encode('second_key'),
+            base64_encode('second_value')
+        );
+
+        $prepared_a = SQLitePreparedInsertBuilder::build_structured($sql_a);
+        $prepared_b = SQLitePreparedInsertBuilder::build_structured($sql_b);
+
+        $this->assertNotNull($prepared_a);
+        $this->assertNotNull($prepared_b);
+        $this->assertSame($prepared_a['sql'], $prepared_b['sql']);
+        $this->assertSame(['1', '10', 'first_key', 'first_value'], $prepared_a['params']);
+        $this->assertSame(['999', '888', 'second_key', 'second_value'], $prepared_b['params']);
+    }
+
+    public function testStructuredUrlRewriteReceivesColumnContextForEveryBase64Value(): void
+    {
+        $sql = sprintf(
+            "INSERT INTO `wp_posts` (`ID`, `post_content`, `post_title`) VALUES "
+            . "(1, FROM_BASE64('%s'), FROM_BASE64('%s'));",
+            base64_encode('<a href="https://old-site.example/page">Link</a>'),
+            base64_encode('Plain title')
+        );
+
+        $calls = [];
+        $prepared = SQLitePreparedInsertBuilder::build_structured(
+            $sql,
+            function (string $value, string $table, ?string $column) use (&$calls): string {
+                $calls[] = [$value, $table, $column];
+                return str_replace('old-site.example', 'new-site.example', $value);
+            }
+        );
+
+        $this->assertNotNull($prepared);
+        $this->assertSame(
+            [
+                ['<a href="https://old-site.example/page">Link</a>', 'wp_posts', 'post_content'],
+                ['Plain title', 'wp_posts', 'post_title'],
+            ],
+            $calls
+        );
+        $this->assertSame(
+            ['1', '<a href="https://new-site.example/page">Link</a>', 'Plain title'],
+            $prepared['params']
+        );
+    }
+
+    public function testStructuredSqliteInsertMatchesPreparedRewriteSemanticsForSupportedUrlSpellings(): void
+    {
+        $cases = [
+            'lowercase_url' => [
+                'mapping' => ['https://old-site.com' => 'https://new-site.com'],
+                'value' => '<a href="https://old-site.com/lowercase">Lowercase</a>',
+                'expected' => '<a href="https://new-site.com/lowercase">Lowercase</a>',
+                'forbidden' => 'old-site.com',
+            ],
+            'uppercase_scheme_and_host' => [
+                'mapping' => ['https://old-site.com' => 'https://new-site.com'],
+                'value' => '<a href="HTTPS://OLD-SITE.COM/case-only">Case</a>',
+                'expected' => '<a href="https://new-site.com/case-only">Case</a>',
+                'forbidden' => 'old-site.com',
+            ],
+            'json_escaped_block_attribute' => [
+                'mapping' => ['https://old-site.com' => 'https://new-site.com'],
+                'value' => '<!-- wp:image {"src":"https:\/\/old-site.com\/escaped.jpg"} -->',
+                'expected' => 'https:\/\/new-site.com\/escaped.jpg',
+                'forbidden' => 'old-site.com',
+            ],
+            'serialized_php' => [
+                'mapping' => ['https://old-site.com' => 'https://new-site.com'],
+                'value' => serialize(['html' => '<a href="https://old-site.com/serialized">Serialized</a>']),
+                'expected' => serialize(['html' => '<a href="https://new-site.com/serialized">Serialized</a>']),
+                'forbidden' => 'old-site.com',
+            ],
+            'punycode_idn_host' => [
+                'mapping' => ['https://xn--bcher-kva.example' => 'https://new.example'],
+                'value' => '<a href="https://xn--bcher-kva.example/punycode">Punycode</a>',
+                'expected' => '<a href="https://new.example/punycode">Punycode</a>',
+                'forbidden' => 'xn--bcher-kva.example',
+            ],
+        ];
+
+        foreach ($cases as $label => $case) {
+            $rewriter = $this->createStatementRewriter($case['mapping']);
+            $sql = sprintf(
+                "INSERT INTO `wp_posts` (`ID`, `post_content`, `post_title`) VALUES "
+                . "(1, FROM_BASE64('%s'), FROM_BASE64('%s'));",
+                base64_encode($case['value']),
+                base64_encode('Title without URLs')
+            );
+
+            $legacy = $rewriter->build_sqlite_prepared_insert($sql);
+            $structured = $rewriter->build_sqlite_structured_insert($sql);
+
+            $this->assertNotNull($legacy, $label);
+            $this->assertNotNull($structured, $label);
+            $this->assertSame($legacy['params'][0], $structured['params'][1], $label);
+            $this->assertStringContainsString($case['expected'], $structured['params'][1], $label);
+            $this->assertStringNotContainsString($case['forbidden'], strtolower($structured['params'][1]), $label);
+            $this->assertSame('Title without URLs', $structured['params'][2], $label);
+        }
     }
 
     public function testBuildsPreparedInsertForConvertWrappedPayload(): void
@@ -91,6 +257,29 @@ class SQLitePreparedInsertBuilderTest extends TestCase
         );
 
         $this->assertNull(SQLitePreparedInsertBuilder::build($invalid_sql));
+    }
+
+    public function testStructuredInsertRejectsFallbackBoundaries(): void
+    {
+        $valid_sql = sprintf(
+            "INSERT INTO `wp_options` (`option_id`, `option_value`) VALUES(1, FROM_BASE64('%s'));",
+            base64_encode('value')
+        );
+        $this->assertNotNull(SQLitePreparedInsertBuilder::build_structured($valid_sql));
+
+        $cases = [
+            "INSERT INTO `wp_options` VALUES(1, FROM_BASE64('" . base64_encode('value') . "'));",
+            "INSERT INTO `wp_options` (`option_id`, `option_value`) VALUES(1);",
+            "INSERT INTO `wp_options` (`option_id`, `option_value`) VALUES(1, FROM_BASE64('not-valid!'));",
+            "INSERT INTO `wp_options` (`option_id`, `option_value`) VALUES(1, FROM_BASE64('valid'));",
+            "INSERT INTO `wp_options` (`option_id`, `option_value`) VALUES(1e, FROM_BASE64('" . base64_encode('value') . "'));",
+            "INSERT INTO `wp_options` (`option_id`, `option_value`) VALUES(1, 'literal');",
+            "INSERT INTO `wp_options` (`option_id`, `option_value`) VALUES(1, FROM_BASE64('" . base64_encode('value') . "')) ON DUPLICATE KEY UPDATE `option_value` = VALUES(`option_value`);",
+        ];
+
+        foreach ($cases as $case) {
+            $this->assertNull(SQLitePreparedInsertBuilder::build_structured($case), $case);
+        }
     }
 
     public function testRejectsNonAlphabetPayloadAfterSameShapeWasBuilt(): void


### PR DESCRIPTION
## What it does

Adds a structured SQLite `INSERT` path for producer-shaped row streams. Supported rows are parsed into a stable, fully parameterized SQLite statement, then executed through a small prepared-statement cache during `db-apply`.

Unsupported shapes still return `null` and use the existing SQL-text fallback.

## Tokenizer cleanup

The structured SQLite insert builder now uses `WP_MySQL_Lexer` tokens for the supported SQL shape instead of regex/manual SQL-shape parsing. The token walk handles table names, column lists, row tuples, numeric literals, empty strings, `NULL`, `FROM_BASE64(...)`, and `CONVERT(FROM_BASE64(...) USING utf8mb4)` as structured tokens.

Correctness remains the priority: unsupported or ambiguous shapes fall back safely rather than being guessed from raw string positions. The structured path still calls the rewrite callback for accepted base64 values with table and column context.

## Adversarial coverage

Added/kept focused tests for:

- comments containing fake `FROM_BASE64(...)` before and inside the statement
- escaped backtick identifiers in table and column names
- string payloads containing `),(` and fake `FROM_BASE64(...)` text
- `CONVERT(FROM_BASE64(...) USING utf8mb4)` values
- malformed/non-base64 payloads
- nested expressions such as `(1 + 2)`, `ABS(-1)`, `CONCAT(FROM_BASE64(...), ...)`
- unsupported `CONVERT('plain' USING utf8mb4)` fallback
- unsupported shapes continuing to return `null`

## Benchmark

Preliminary full db-apply benchmark from the tokenizer-cleanup worktree:

```bash
BENCH_STAGES=playground-sqlite-db-apply \
WP_MYSQL_PARSER_EXTENSION_MANIFEST=https://wordpress.github.io/sqlite-database-integration/wp_mysql_parser-wasm-extension/latest/manifest.json \
PLAYGROUND_PHP_USE_WASM_RUNNER=1 \
PLAYGROUND_PHP_VERSION=8.3 \
node tests/e2e/benchmark/bench-pull.mjs
```

Result:

- `playground-sqlite-db-apply`: **96.96s**, attempts: 1, status: ok
- Runtime: `php.wasm 8.3`
- Native parser evidence: `wp_mysql_parser=enabled`, native lexer/parser verified, SQLite driver native parser verified

Caveat: this timing is preliminary only. The run overlapped active #243/#245/#246 benchmark processes, so it should not be used as a clean performance comparison. Re-run in a quiet window before making performance claims.

## Testing

Focused verification after tokenizer cleanup:

```bash
php -l packages/reprint-importer/src/lib/url-rewrite/class-sqlite-prepared-insert-builder.php
php -l tests/UrlRewriting/SQLitePreparedInsertBuilderTest.php
./vendor/bin/phpunit tests/UrlRewriting/SQLitePreparedInsertBuilderTest.php
./vendor/bin/phpunit tests/UrlRewriting
```

Results:

- `SQLitePreparedInsertBuilderTest`: 16 tests, 81 assertions
- `tests/UrlRewriting`: 231 tests, 2359 assertions, 7 skipped
