### PR TITLE
Coalesce structured SQLite inserts during db-apply

### DIFF
--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -5119,7 +5119,7 @@ class ImportClient
 
         [$pdo, $connection_label] = $this->create_target_db_apply_connection($options);
         $sqlite_prepared_pdo = null;
-        $sqlite_prepared_statement_cache = [];
+        $sqlite_insert_coalescer = null;
         if (
             strtolower((string) ($options["target_engine"] ?? "mysql")) === "sqlite"
             && method_exists($pdo, 'get_connection')
@@ -5133,6 +5133,7 @@ class ImportClient
                 'SQLite db-apply PRAGMAs | temp_store=MEMORY | cache_size=32768 KiB',
                 false,
             );
+            $sqlite_insert_coalescer = new SQLitePreparedInsertCoalescer($sqlite_prepared_pdo);
         }
 
         $this->audit_log(
@@ -5175,6 +5176,19 @@ class ImportClient
         $skipped = 0;
         $save_every = 100;
         $stmts_since_save = 0;
+        $last_applied_bytes_read = $bytes_read;
+        $record_apply_result = function (array $result) use (&$statements_executed, &$stmts_since_save, &$last_applied_bytes_read): void {
+            $count = (int) ($result['statements_executed'] ?? 0);
+            if ($count <= 0) {
+                return;
+            }
+
+            $statements_executed += $count;
+            $stmts_since_save += $count;
+            if (isset($result['bytes_read'])) {
+                $last_applied_bytes_read = (int) $result['bytes_read'];
+            }
+        };
 
         // Load pre-computed statement count from db-pull for progress reporting
         $sql_stats_file = $this->state_dir . "/.import-sql-stats.json";
@@ -5235,20 +5249,32 @@ class ImportClient
                     // Skip already-executed statements on resume
                     if ($stmts_to_skip > 0) {
                         $stmts_to_skip--;
+                        $last_applied_bytes_read = $seek_offset + $query_stream->get_bytes_consumed();
                         continue;
                     }
 
                     // Execute against target database
                     $executed_query = $query;
+                    $statement_end_offset = $seek_offset + $query_stream->get_bytes_consumed();
                     try {
-                        $this->execute_db_apply_query(
-                            $pdo,
-                            $query,
-                            $stmt_rewriter,
-                            $sqlite_prepared_pdo,
-                            $sqlite_prepared_statement_cache,
-                            $executed_query,
+                        $record_apply_result(
+                            $this->execute_db_apply_query(
+                                $pdo,
+                                $query,
+                                $stmt_rewriter,
+                                $sqlite_prepared_pdo,
+                                $sqlite_insert_coalescer,
+                                $statement_end_offset,
+                                $executed_query,
+                            )
                         );
+                        if (
+                            $sqlite_insert_coalescer !== null
+                            && $sqlite_insert_coalescer->pending_statement_count() > 0
+                            && $stmts_since_save + $sqlite_insert_coalescer->pending_statement_count() >= $save_every
+                        ) {
+                            $record_apply_result($sqlite_insert_coalescer->flush($executed_query));
+                        }
                     } catch (PDOException $e) {
                         $this->audit_log(
                             sprintf(
@@ -5265,9 +5291,6 @@ class ImportClient
                         );
                     }
 
-                    $statements_executed++;
-                    $stmts_since_save++;
-
                     // Save state periodically. bytes_read is the file offset
                     // right after the last extracted query — NOT total_bytes_read,
                     // which includes bytes buffered in the query stream that haven't
@@ -5275,7 +5298,7 @@ class ImportClient
                     // the exact boundary between executed and un-executed queries.
                     if ($stmts_since_save >= $save_every) {
                         $this->state["apply"]["statements_executed"] = $statements_executed;
-                        $this->state["apply"]["bytes_read"] = $seek_offset + $query_stream->get_bytes_consumed();
+                        $this->state["apply"]["bytes_read"] = $last_applied_bytes_read;
                         $this->save_state($this->state);
                         $stmts_since_save = 0;
 
@@ -5315,18 +5338,23 @@ class ImportClient
 
                 if ($stmts_to_skip > 0) {
                     $stmts_to_skip--;
+                    $last_applied_bytes_read = $seek_offset + $query_stream->get_bytes_consumed();
                     continue;
                 }
 
                 $executed_query = $query;
+                $statement_end_offset = $seek_offset + $query_stream->get_bytes_consumed();
                 try {
-                    $this->execute_db_apply_query(
-                        $pdo,
-                        $query,
-                        $stmt_rewriter,
-                        $sqlite_prepared_pdo,
-                        $sqlite_prepared_statement_cache,
-                        $executed_query,
+                    $record_apply_result(
+                        $this->execute_db_apply_query(
+                            $pdo,
+                            $query,
+                            $stmt_rewriter,
+                            $sqlite_prepared_pdo,
+                            $sqlite_insert_coalescer,
+                            $statement_end_offset,
+                            $executed_query,
+                        )
                     );
                 } catch (PDOException $e) {
                     $this->audit_log(
@@ -5343,14 +5371,33 @@ class ImportClient
                         $e->getMessage(),
                     );
                 }
+            }
 
-                $statements_executed++;
+            if ($sqlite_insert_coalescer !== null && $sqlite_insert_coalescer->pending_statement_count() > 0) {
+                $executed_query = '(coalesced SQLite INSERT flush)';
+                try {
+                    $record_apply_result($sqlite_insert_coalescer->flush($executed_query));
+                } catch (PDOException $e) {
+                    $this->audit_log(
+                        sprintf(
+                            "SQL ERROR | stmt=%d | %s | query=%.200s",
+                            $stmt_count,
+                            $e->getMessage(),
+                            $executed_query,
+                        ),
+                        true,
+                    );
+                    throw new RuntimeException(
+                        "SQL execution error at statement {$stmt_count}: " .
+                        $e->getMessage(),
+                    );
+                }
             }
 
             if ($this->shutdown_requested) {
                 // Save partial progress
                 $this->state["apply"]["statements_executed"] = $statements_executed;
-                $this->state["apply"]["bytes_read"] = $seek_offset + $query_stream->get_bytes_consumed();
+                $this->state["apply"]["bytes_read"] = $last_applied_bytes_read;
                 $this->state["status"] = "partial";
                 $this->save_state($this->state);
                 $this->audit_log(
@@ -5395,7 +5442,7 @@ class ImportClient
 
                 // Mark complete
                 $this->state["apply"]["statements_executed"] = $statements_executed;
-                $this->state["apply"]["bytes_read"] = $seek_offset + $query_stream->get_bytes_consumed();
+                $this->state["apply"]["bytes_read"] = $last_applied_bytes_read;
                 $this->state["status"] = "complete";
                 $this->save_state($this->state);
 
@@ -5431,10 +5478,15 @@ class ImportClient
         string $query,
         ?SqlStatementRewriter $stmt_rewriter,
         ?PDO $sqlite_prepared_pdo,
-        array &$sqlite_prepared_statement_cache,
+        ?SQLitePreparedInsertCoalescer $sqlite_insert_coalescer,
+        int $statement_end_offset,
         string &$executed_query
-    ): void {
+    ): array {
         $executed_query = $query;
+        $result = [
+            'statements_executed' => 0,
+            'bytes_read' => null,
+        ];
 
         if ($sqlite_prepared_pdo !== null) {
             $structured_insert = $stmt_rewriter !== null
@@ -5442,32 +5494,22 @@ class ImportClient
                 : SQLitePreparedInsertBuilder::build_structured($query);
 
             if ($structured_insert !== null) {
-                $executed_query = $structured_insert['sql'];
-                $statement = $sqlite_prepared_statement_cache[$structured_insert['sql']] ?? null;
-                if ($statement === null) {
-                    $statement = $sqlite_prepared_pdo->prepare($structured_insert['sql']);
-                    if ($statement === false) {
-                        throw new PDOException('Failed to prepare structured SQLite INSERT statement.');
-                    }
+                if ($sqlite_insert_coalescer === null) {
+                    $one_off_coalescer = new SQLitePreparedInsertCoalescer($sqlite_prepared_pdo);
+                    $append_result = $one_off_coalescer->append($structured_insert, $statement_end_offset, $executed_query);
+                    $flush_result = $one_off_coalescer->flush($executed_query);
 
-                    if (count($sqlite_prepared_statement_cache) < 64) {
-                        $sqlite_prepared_statement_cache[$structured_insert['sql']] = $statement;
-                    }
+                    return [
+                        'statements_executed' => (int) $append_result['statements_executed'] + (int) $flush_result['statements_executed'],
+                        'bytes_read' => $flush_result['bytes_read'] ?? $append_result['bytes_read'],
+                    ];
                 }
+                return $sqlite_insert_coalescer->append($structured_insert, $statement_end_offset, $executed_query);
+            }
 
-                foreach ($structured_insert['params'] as $index => $value) {
-                    $statement->bindValue(
-                        $index + 1,
-                        $value,
-                        $structured_insert['param_types'][$index] ?? PDO::PARAM_STR
-                    );
-                }
-
-                if ($statement->execute() === false) {
-                    throw new PDOException('Failed to execute structured SQLite INSERT statement.');
-                }
-                $statement->closeCursor();
-                return;
+            if ($sqlite_insert_coalescer !== null && $sqlite_insert_coalescer->pending_statement_count() > 0) {
+                $result = $sqlite_insert_coalescer->flush($executed_query);
+                $executed_query = $query;
             }
 
             $prepared_insert = $stmt_rewriter !== null
@@ -5488,7 +5530,9 @@ class ImportClient
                 if ($statement->execute() === false) {
                     throw new PDOException('Failed to execute SQLite INSERT statement.');
                 }
-                return;
+                $result['statements_executed']++;
+                $result['bytes_read'] = $statement_end_offset;
+                return $result;
             }
         }
 
@@ -5497,6 +5541,9 @@ class ImportClient
         }
 
         $pdo->exec($executed_query);
+        $result['statements_executed']++;
+        $result['bytes_read'] = $statement_end_offset;
+        return $result;
     }
 
     /**

--- a/packages/reprint-importer/src/lib/url-rewrite/class-sqlite-prepared-insert-coalescer.php
+++ b/packages/reprint-importer/src/lib/url-rewrite/class-sqlite-prepared-insert-coalescer.php
@@ -1,0 +1,335 @@
+<?php
+
+/**
+ * Buffers adjacent PR #244 structured SQLite INSERTs and executes them as
+ * larger prepared multi-row INSERTs without letting decoded values become SQL.
+ */
+class SQLitePreparedInsertCoalescer
+{
+    private const DEFAULT_MAX_PARAMETERS = 999;
+    private const CACHE_LIMIT = 64;
+
+    private PDO $pdo;
+    private int $max_parameters;
+
+    /** @var array<string, PDOStatement> */
+    private array $statement_cache = [];
+
+    /**
+     * @var array{
+     *     table: string,
+     *     columns: list<string>,
+     *     params: list<mixed>,
+     *     param_types: list<int>,
+     *     row_count: int,
+     *     statement_count: int,
+     *     last_statement_end_offset: int
+     * }|null
+     */
+    private ?array $buffer = null;
+
+    public function __construct(PDO $pdo, ?int $max_parameters = null)
+    {
+        $this->pdo = $pdo;
+        $this->max_parameters = max(1, $max_parameters ?? self::detect_max_parameters($pdo));
+    }
+
+    public static function detect_max_parameters(PDO $pdo): int
+    {
+        $limit = null;
+
+        try {
+            $rows = $pdo->query('PRAGMA compile_options');
+            if ($rows !== false) {
+                while (($option = $rows->fetchColumn()) !== false) {
+                    if (
+                        is_string($option)
+                        && preg_match('/\AMAX_VARIABLE_NUMBER=(\d+)\z/', $option, $m)
+                    ) {
+                        $limit = (int) $m[1];
+                        break;
+                    }
+                }
+            }
+        } catch (Throwable $e) {
+            $limit = null;
+        }
+
+        if ($limit === null) {
+            try {
+                $version = $pdo->query('SELECT sqlite_version()')->fetchColumn();
+                if (is_string($version) && version_compare($version, '3.32.0', '>=')) {
+                    $limit = 32766;
+                }
+            } catch (Throwable $e) {
+                $limit = null;
+            }
+        }
+
+        return max(1, min($limit ?? self::DEFAULT_MAX_PARAMETERS, 32766));
+    }
+
+    public function get_max_parameters(): int
+    {
+        return $this->max_parameters;
+    }
+
+    public function pending_statement_count(): int
+    {
+        return (int) ($this->buffer['statement_count'] ?? 0);
+    }
+
+    /**
+     * @param array{
+     *     table: string,
+     *     columns: list<string>,
+     *     params: list<mixed>,
+     *     param_types: list<int>,
+     *     row_count: int
+     * } $structured_insert
+     * @return array{statements_executed: int, bytes_read: ?int}
+     */
+    public function append(array $structured_insert, int $statement_end_offset, string &$executed_query): array
+    {
+        $this->assert_valid_insert($structured_insert);
+
+        $result = self::empty_result();
+        if (
+            $this->buffer !== null
+            && (
+                !$this->is_compatible($structured_insert)
+                || $this->would_exceed_parameter_limit($structured_insert)
+            )
+        ) {
+            $result = self::merge_results($result, $this->flush($executed_query));
+        }
+
+        $this->append_to_buffer($structured_insert, $statement_end_offset);
+
+        if ($this->buffer !== null && $this->buffer_parameter_count() >= $this->max_parameters) {
+            $result = self::merge_results($result, $this->flush($executed_query));
+        }
+
+        return $result;
+    }
+
+    /**
+     * @return array{statements_executed: int, bytes_read: ?int}
+     */
+    public function flush(string &$executed_query): array
+    {
+        if ($this->buffer === null) {
+            return self::empty_result();
+        }
+
+        $buffer = $this->buffer;
+        $this->buffer = null;
+
+        $this->execute_buffer($buffer, $executed_query);
+
+        return [
+            'statements_executed' => $buffer['statement_count'],
+            'bytes_read' => $buffer['last_statement_end_offset'],
+        ];
+    }
+
+    /**
+     * @param array{columns: list<string>, params: list<mixed>, param_types: list<int>, row_count: int} $structured_insert
+     */
+    private function assert_valid_insert(array $structured_insert): void
+    {
+        $column_count = count($structured_insert['columns']);
+        $row_count = (int) $structured_insert['row_count'];
+        $param_count = count($structured_insert['params']);
+
+        if ($column_count <= 0 || $row_count <= 0) {
+            throw new InvalidArgumentException('Structured SQLite INSERT must have columns and rows.');
+        }
+        if ($param_count !== $column_count * $row_count) {
+            throw new InvalidArgumentException('Structured SQLite INSERT parameter count does not match its shape.');
+        }
+        if (count($structured_insert['param_types']) !== $param_count) {
+            throw new InvalidArgumentException('Structured SQLite INSERT parameter type count does not match its parameters.');
+        }
+    }
+
+    /**
+     * @param array{table: string, columns: list<string>} $structured_insert
+     */
+    private function is_compatible(array $structured_insert): bool
+    {
+        return $this->buffer !== null
+            && $this->buffer['table'] === $structured_insert['table']
+            && $this->buffer['columns'] === $structured_insert['columns'];
+    }
+
+    /**
+     * @param array{params: list<mixed>} $structured_insert
+     */
+    private function would_exceed_parameter_limit(array $structured_insert): bool
+    {
+        return $this->buffer !== null
+            && $this->buffer_parameter_count() > 0
+            && $this->buffer_parameter_count() + count($structured_insert['params']) > $this->max_parameters;
+    }
+
+    /**
+     * @param array{
+     *     table: string,
+     *     columns: list<string>,
+     *     params: list<mixed>,
+     *     param_types: list<int>,
+     *     row_count: int
+     * } $structured_insert
+     */
+    private function append_to_buffer(array $structured_insert, int $statement_end_offset): void
+    {
+        if ($this->buffer === null) {
+            $this->buffer = [
+                'table' => $structured_insert['table'],
+                'columns' => $structured_insert['columns'],
+                'params' => $structured_insert['params'],
+                'param_types' => $structured_insert['param_types'],
+                'row_count' => (int) $structured_insert['row_count'],
+                'statement_count' => 1,
+                'last_statement_end_offset' => $statement_end_offset,
+            ];
+            return;
+        }
+
+        array_push($this->buffer['params'], ...$structured_insert['params']);
+        array_push($this->buffer['param_types'], ...$structured_insert['param_types']);
+        $this->buffer['row_count'] += (int) $structured_insert['row_count'];
+        $this->buffer['statement_count']++;
+        $this->buffer['last_statement_end_offset'] = $statement_end_offset;
+    }
+
+    private function buffer_parameter_count(): int
+    {
+        return $this->buffer === null ? 0 : count($this->buffer['params']);
+    }
+
+    /**
+     * @param array{
+     *     table: string,
+     *     columns: list<string>,
+     *     params: list<mixed>,
+     *     param_types: list<int>,
+     *     row_count: int
+     * } $buffer
+     */
+    private function execute_buffer(array $buffer, string &$executed_query): void
+    {
+        $column_count = count($buffer['columns']);
+        $rows_per_statement = max(1, intdiv($this->max_parameters, $column_count));
+        $rows_remaining = $buffer['row_count'];
+        $row_offset = 0;
+
+        $this->pdo->exec('SAVEPOINT reprint_insert_coalesce');
+        try {
+            while ($rows_remaining > 0) {
+                $rows_in_chunk = min($rows_remaining, $rows_per_statement);
+                $this->execute_chunk($buffer, $row_offset, $rows_in_chunk, $executed_query);
+                $row_offset += $rows_in_chunk;
+                $rows_remaining -= $rows_in_chunk;
+            }
+            $this->pdo->exec('RELEASE SAVEPOINT reprint_insert_coalesce');
+        } catch (Throwable $e) {
+            try {
+                $this->pdo->exec('ROLLBACK TO SAVEPOINT reprint_insert_coalesce');
+            } catch (Throwable $rollback_error) {
+            }
+            try {
+                $this->pdo->exec('RELEASE SAVEPOINT reprint_insert_coalesce');
+            } catch (Throwable $release_error) {
+            }
+            throw $e;
+        }
+    }
+
+    /**
+     * @param array{
+     *     table: string,
+     *     columns: list<string>,
+     *     params: list<mixed>,
+     *     param_types: list<int>
+     * } $buffer
+     */
+    private function execute_chunk(array $buffer, int $row_offset, int $row_count, string &$executed_query): void
+    {
+        $column_count = count($buffer['columns']);
+        $param_offset = $row_offset * $column_count;
+        $param_count = $row_count * $column_count;
+        $sql = $this->build_sql($buffer['table'], $buffer['columns'], $row_count);
+        $executed_query = $sql;
+
+        $statement = $this->statement_cache[$sql] ?? null;
+        if ($statement === null) {
+            $statement = $this->pdo->prepare($sql);
+            if ($statement === false) {
+                throw new PDOException('Failed to prepare coalesced SQLite INSERT statement.');
+            }
+            if (count($this->statement_cache) < self::CACHE_LIMIT) {
+                $this->statement_cache[$sql] = $statement;
+            }
+        }
+
+        for ($i = 0; $i < $param_count; $i++) {
+            $statement->bindValue(
+                $i + 1,
+                $buffer['params'][$param_offset + $i],
+                $buffer['param_types'][$param_offset + $i] ?? PDO::PARAM_STR
+            );
+        }
+
+        if ($statement->execute() === false) {
+            throw new PDOException('Failed to execute coalesced SQLite INSERT statement.');
+        }
+        $statement->closeCursor();
+    }
+
+    /**
+     * @param list<string> $columns
+     */
+    private function build_sql(string $table, array $columns, int $row_count): string
+    {
+        $quoted_columns = array_map([self::class, 'quote_identifier'], $columns);
+        $tuple = '(' . implode(',', array_fill(0, count($columns), '?')) . ')';
+
+        return sprintf(
+            'INSERT INTO %s (%s) VALUES %s;',
+            self::quote_identifier($table),
+            implode(',', $quoted_columns),
+            implode(',', array_fill(0, $row_count, $tuple))
+        );
+    }
+
+    private static function quote_identifier(string $identifier): string
+    {
+        return '`' . str_replace('`', '``', $identifier) . '`';
+    }
+
+    /**
+     * @return array{statements_executed: int, bytes_read: ?int}
+     */
+    private static function empty_result(): array
+    {
+        return [
+            'statements_executed' => 0,
+            'bytes_read' => null,
+        ];
+    }
+
+    /**
+     * @param array{statements_executed: int, bytes_read: ?int} $left
+     * @param array{statements_executed: int, bytes_read: ?int} $right
+     * @return array{statements_executed: int, bytes_read: ?int}
+     */
+    private static function merge_results(array $left, array $right): array
+    {
+        return [
+            'statements_executed' => $left['statements_executed'] + $right['statements_executed'],
+            'bytes_read' => $right['bytes_read'] ?? $left['bytes_read'],
+        ];
+    }
+}

--- a/packages/reprint-importer/src/lib/url-rewrite/load.php
+++ b/packages/reprint-importer/src/lib/url-rewrite/load.php
@@ -22,3 +22,6 @@ require_once __DIR__ . '/class-domain-collector.php';
 
 // Depends on StructuredDataUrlRewriter + Base64ValueScanner
 require_once __DIR__ . '/class-sql-statement-rewriter.php';
+
+// Depends on PR #244 structured prepared INSERT arrays.
+require_once __DIR__ . '/class-sqlite-prepared-insert-coalescer.php';

--- a/tests/Import/SQLiteInsertCoalescingApplyTest.php
+++ b/tests/Import/SQLiteInsertCoalescingApplyTest.php
@@ -1,0 +1,280 @@
+<?php
+
+namespace ImportTests;
+
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+
+require_once __DIR__ . '/../../importer/import.php';
+
+class SQLiteInsertCoalescingApplyTest extends TestCase
+{
+    private \PDO $pdo;
+    private string $tempDir;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (!extension_loaded('pdo_sqlite')) {
+            $this->markTestSkipped('pdo_sqlite extension required');
+        }
+
+        $this->pdo = new \PDO('sqlite::memory:');
+        $this->pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+
+        $this->tempDir = sys_get_temp_dir() . '/import-sqlite-coalesce-' . uniqid();
+        mkdir($this->tempDir, 0777, true);
+        mkdir($this->tempDir . '/fs-root', 0777, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->recursiveDelete($this->tempDir);
+        parent::tearDown();
+    }
+
+    private function recursiveDelete(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        foreach (scandir($dir) as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $path = $dir . '/' . $item;
+            if (is_dir($path) && !is_link($path)) {
+                $this->recursiveDelete($path);
+            } else {
+                unlink($path);
+            }
+        }
+        rmdir($dir);
+    }
+
+    private function structuredInsert(string $sql, ?\SqlStatementRewriter $rewriter = null): array
+    {
+        $insert = $rewriter !== null
+            ? $rewriter->build_sqlite_structured_insert($sql)
+            : \SQLitePreparedInsertBuilder::build_structured($sql);
+
+        $this->assertNotNull($insert, $sql);
+        return $insert;
+    }
+
+    private function insertSql(string $table, int $id, string $value): string
+    {
+        return sprintf(
+            "INSERT INTO `%s` (`id`, `value`) VALUES (%d, FROM_BASE64('%s'));",
+            $table,
+            $id,
+            base64_encode($value)
+        );
+    }
+
+    public function testShapeMismatchFlushesBufferedInsertBeforeNextShape(): void
+    {
+        $this->pdo->exec('CREATE TABLE first_table (id INTEGER PRIMARY KEY, value TEXT)');
+        $this->pdo->exec('CREATE TABLE second_table (id INTEGER PRIMARY KEY, value TEXT)');
+
+        $coalescer = new \SQLitePreparedInsertCoalescer($this->pdo, 999);
+        $executed = '';
+        $result = $coalescer->append($this->structuredInsert($this->insertSql('first_table', 1, 'one')), 10, $executed);
+        $this->assertSame(0, $result['statements_executed']);
+
+        $result = $coalescer->append($this->structuredInsert($this->insertSql('second_table', 2, 'two')), 20, $executed);
+        $this->assertSame(1, $result['statements_executed']);
+        $this->assertSame(10, $result['bytes_read']);
+        $this->assertSame(1, (int) $this->pdo->query('SELECT COUNT(*) FROM first_table')->fetchColumn());
+        $this->assertSame(0, (int) $this->pdo->query('SELECT COUNT(*) FROM second_table')->fetchColumn());
+
+        $result = $coalescer->flush($executed);
+        $this->assertSame(1, $result['statements_executed']);
+        $this->assertSame(20, $result['bytes_read']);
+        $this->assertSame(1, (int) $this->pdo->query('SELECT COUNT(*) FROM second_table')->fetchColumn());
+    }
+
+    public function testParameterLimitSplitsBufferedStatements(): void
+    {
+        $this->pdo->exec('CREATE TABLE items (id INTEGER PRIMARY KEY, value TEXT)');
+        $coalescer = new \SQLitePreparedInsertCoalescer($this->pdo, 4);
+        $executed = '';
+
+        $this->assertSame(
+            0,
+            $coalescer->append($this->structuredInsert($this->insertSql('items', 1, 'one')), 10, $executed)['statements_executed']
+        );
+
+        $result = $coalescer->append($this->structuredInsert($this->insertSql('items', 2, 'two')), 20, $executed);
+        $this->assertSame(2, $result['statements_executed']);
+        $this->assertSame(20, $result['bytes_read']);
+        $this->assertSame(2, (int) $this->pdo->query('SELECT COUNT(*) FROM items')->fetchColumn());
+
+        $result = $coalescer->append($this->structuredInsert($this->insertSql('items', 3, 'three')), 30, $executed);
+        $this->assertSame(0, $result['statements_executed']);
+        $this->assertSame(2, (int) $this->pdo->query('SELECT COUNT(*) FROM items')->fetchColumn());
+
+        $coalescer->flush($executed);
+        $this->assertSame(3, (int) $this->pdo->query('SELECT COUNT(*) FROM items')->fetchColumn());
+    }
+
+    public function testApplyFlushesCoalescedInsertBeforeDdlFallback(): void
+    {
+        $this->pdo->exec('CREATE TABLE source_rows (id INTEGER PRIMARY KEY, value TEXT)');
+
+        $client = new \ImportClient('https://old.example/?reprint-api', $this->tempDir, $this->tempDir . '/fs-root');
+        $method = new ReflectionMethod(\ImportClient::class, 'execute_db_apply_query');
+        $method->setAccessible(true);
+
+        $coalescer = new \SQLitePreparedInsertCoalescer($this->pdo, 999);
+        $executed = '';
+        $insert = $this->insertSql('source_rows', 1, 'before-ddl');
+        $result = $method->invokeArgs($client, [
+            $this->pdo,
+            $insert,
+            null,
+            $this->pdo,
+            $coalescer,
+            strlen($insert),
+            &$executed,
+        ]);
+        $this->assertSame(0, $result['statements_executed']);
+
+        $ddl = 'CREATE TABLE copied_rows AS SELECT * FROM source_rows;';
+        $result = $method->invokeArgs($client, [
+            $this->pdo,
+            $ddl,
+            null,
+            $this->pdo,
+            $coalescer,
+            strlen($insert) + strlen($ddl),
+            &$executed,
+        ]);
+        $this->assertSame(2, $result['statements_executed']);
+        $this->assertSame('before-ddl', $this->pdo->query('SELECT value FROM copied_rows WHERE id = 1')->fetchColumn());
+    }
+
+    public function testApplyExecutesStructuredInsertImmediatelyWithoutSharedCoalescer(): void
+    {
+        $this->pdo->exec('CREATE TABLE immediate_rows (id INTEGER PRIMARY KEY, value TEXT)');
+
+        $client = new \ImportClient('https://old.example/?reprint-api', $this->tempDir, $this->tempDir . '/fs-root');
+        $method = new ReflectionMethod(\ImportClient::class, 'execute_db_apply_query');
+        $method->setAccessible(true);
+
+        $executed = '';
+        $insert = $this->insertSql('immediate_rows', 1, 'one-off');
+        $result = $method->invokeArgs($client, [
+            $this->pdo,
+            $insert,
+            null,
+            $this->pdo,
+            null,
+            strlen($insert),
+            &$executed,
+        ]);
+
+        $this->assertSame(1, $result['statements_executed']);
+        $this->assertSame(strlen($insert), $result['bytes_read']);
+        $this->assertSame('one-off', $this->pdo->query('SELECT value FROM immediate_rows WHERE id = 1')->fetchColumn());
+    }
+
+    public function testErrorRollsBackWholeCoalescedFlushAcrossParameterSplits(): void
+    {
+        $this->pdo->exec('CREATE TABLE unique_items (id INTEGER PRIMARY KEY, value TEXT)');
+        $coalescer = new \SQLitePreparedInsertCoalescer($this->pdo, 5);
+        $executed = '';
+        $sql = sprintf(
+            "INSERT INTO `unique_items` (`id`, `value`) VALUES "
+            . "(1, FROM_BASE64('%s')),"
+            . "(2, FROM_BASE64('%s')),"
+            . "(1, FROM_BASE64('%s'));",
+            base64_encode('one'),
+            base64_encode('two'),
+            base64_encode('duplicate')
+        );
+
+        try {
+            $coalescer->append($this->structuredInsert($sql), 30, $executed);
+            $this->fail('Expected duplicate primary key failure.');
+        } catch (\PDOException $e) {
+            $this->assertStringContainsString('UNIQUE', strtoupper($e->getMessage()));
+        }
+
+        $this->assertSame(0, (int) $this->pdo->query('SELECT COUNT(*) FROM unique_items')->fetchColumn());
+    }
+
+    public function testCoalescedFlushSavepointStaysInsideExistingTransaction(): void
+    {
+        $this->pdo->exec('CREATE TABLE transaction_rows (id INTEGER PRIMARY KEY, value TEXT)');
+        $coalescer = new \SQLitePreparedInsertCoalescer($this->pdo, 999);
+        $executed = '';
+
+        $this->pdo->beginTransaction();
+        $coalescer->append($this->structuredInsert($this->insertSql('transaction_rows', 1, 'inside')), 10, $executed);
+        $coalescer->append($this->structuredInsert($this->insertSql('transaction_rows', 2, 'transaction')), 20, $executed);
+        $result = $coalescer->flush($executed);
+
+        $this->assertSame(2, $result['statements_executed']);
+        $this->assertSame(2, (int) $this->pdo->query('SELECT COUNT(*) FROM transaction_rows')->fetchColumn());
+
+        $this->pdo->rollBack();
+        $this->assertSame(0, (int) $this->pdo->query('SELECT COUNT(*) FROM transaction_rows')->fetchColumn());
+    }
+
+    public function testCoalescedInsertPreservesRowOrder(): void
+    {
+        $this->pdo->exec('CREATE TABLE ordered_log (label TEXT)');
+        $coalescer = new \SQLitePreparedInsertCoalescer($this->pdo, 999);
+        $executed = '';
+
+        foreach (['first', 'second', 'third'] as $index => $label) {
+            $sql = sprintf(
+                "INSERT INTO `ordered_log` (`label`) VALUES (FROM_BASE64('%s'));",
+                base64_encode($label)
+            );
+            $coalescer->append($this->structuredInsert($sql), ($index + 1) * 10, $executed);
+        }
+        $coalescer->flush($executed);
+
+        $rows = $this->pdo->query('SELECT label FROM ordered_log ORDER BY rowid')->fetchAll(\PDO::FETCH_COLUMN);
+        $this->assertSame(['first', 'second', 'third'], $rows);
+    }
+
+    public function testCoalescedStructuredInsertsKeepUrlRewriteSemantics(): void
+    {
+        $this->pdo->exec('CREATE TABLE wp_posts (ID INTEGER PRIMARY KEY, post_content TEXT, post_title TEXT)');
+        $rewriter = new \SqlStatementRewriter(
+            new \StructuredDataUrlRewriter([
+                'https://old-site.com' => 'https://new-site.com',
+            ])
+        );
+        $coalescer = new \SQLitePreparedInsertCoalescer($this->pdo, 999);
+        $executed = '';
+
+        $values = [
+            '<a href="HTTPS://OLD-SITE.COM/case-only">Case</a>',
+            '<!-- wp:image {"src":"https:\/\/old-site.com\/escaped.jpg"} -->',
+        ];
+        foreach ($values as $index => $value) {
+            $sql = sprintf(
+                "INSERT INTO `wp_posts` (`ID`, `post_content`, `post_title`) VALUES "
+                . "(%d, FROM_BASE64('%s'), FROM_BASE64('%s'));",
+                $index + 1,
+                base64_encode($value),
+                base64_encode('Title')
+            );
+            $coalescer->append($this->structuredInsert($sql, $rewriter), ($index + 1) * 10, $executed);
+        }
+        $coalescer->flush($executed);
+
+        $contents = $this->pdo
+            ->query('SELECT post_content FROM wp_posts ORDER BY ID')
+            ->fetchAll(\PDO::FETCH_COLUMN);
+
+        $this->assertStringContainsString('https://new-site.com/case-only', $contents[0]);
+        $this->assertStringContainsString('https:\/\/new-site.com\/escaped.jpg', $contents[1]);
+        $this->assertStringNotContainsString('old-site.com', strtolower(implode("\n", $contents)));
+    }
+}


### PR DESCRIPTION
## What it does

Coalesces adjacent PR #244 structured SQLite `INSERT`s during `db-apply` into prepared multi-row SQLite `INSERT`s. Buffered inserts flush when the table/column shape changes, a non-structured statement needs to run, or the SQLite parameter limit would be exceeded.

## Rationale

PR #244 streams structured rows, but applying each structured `INSERT` separately leaves per-statement overhead in PHP.wasm. Coalescing keeps decoded values bound as parameters while reducing SQLite apply time.

## Implementation

Adds `SQLitePreparedInsertCoalescer`, loaded with the URL rewrite/import helpers. `ImportClient::execute_db_apply_query()` now returns applied statement counts and byte offsets so resume state advances only after buffered statements flush. Flushes use a savepoint so split multi-chunk coalesced inserts roll back together.

## Testing instructions

Focused PHPUnit passed:

- `vendor/bin/phpunit -c tests/phpunit.xml --testdox tests/Import/SQLiteInsertCoalescingApplyTest.php tests/UrlRewriting/SQLitePreparedInsertBuilderTest.php` — passed, 21 tests / 114 assertions.
- `vendor/bin/phpunit -c tests/phpunit.xml --testdox tests/Import/NewSiteUrlSqliteTest.php --filter 'NewSiteUrl|Resume'` — passed, 5 tests / 18 assertions.

Full benchmark command:

```bash
BENCH_STAGES=playground-sqlite-db-apply WP_MYSQL_PARSER_EXTENSION_MANIFEST=https://wordpress.github.io/sqlite-database-integration/wp_mysql_parser-wasm-extension/latest/manifest.json PLAYGROUND_PHP_USE_WASM_RUNNER=1 PLAYGROUND_PHP_VERSION=8.3 node tests/e2e/benchmark/bench-pull.mjs
```

Result: `playground-sqlite-db-apply` 43.79s, status pass.

Native evidence: `wp_mysql_parser=enabled`; `mode=parser`; `native_lexer=verified`; `native_token_stream=WP_MySQL_Native_Token_Stream`; `native_parser=verified`; `native_ast=WP_MySQL_Native_Parser_Node`; `sqlite_driver_parser=verified`.

Comparison: 11.61s faster than PR #244's 55.40s; 17.72s faster than trunk's 61.51s.