### PR TITLE
Speed up MySQL query stream statement scanning

### DIFF
--- a/packages/reprint-importer/src/lib/mysql-query-stream/class-wp-mysql-fast-query-stream.php
+++ b/packages/reprint-importer/src/lib/mysql-query-stream/class-wp-mysql-fast-query-stream.php
@@ -373,6 +373,14 @@ class WP_MySQL_FastQueryStream {
 			}
 
 			if ( $c === '-' ) {
+				if ( $i + 1 >= $buf_len ) {
+					if ( ! $this->input_complete ) {
+						$this->scan_cursor = $i;
+						return false;
+					}
+					$i++;
+					continue;
+				}
 				if ( $i + 1 < $buf_len && $buf[$i + 1] === '-' ) {
 					if ( $i + 2 >= $buf_len ) {
 						$this->scan_cursor = $i;
@@ -404,6 +412,14 @@ class WP_MySQL_FastQueryStream {
 			}
 
 			if ( $c === '/' ) {
+				if ( $i + 1 >= $buf_len ) {
+					if ( ! $this->input_complete ) {
+						$this->scan_cursor = $i;
+						return false;
+					}
+					$i++;
+					continue;
+				}
 				if ( $i + 1 < $buf_len && $buf[$i + 1] === '*' ) {
 					$end = strpos( $buf, '*/', $i + 2 );
 					if ( $end === false ) {
@@ -439,31 +455,35 @@ class WP_MySQL_FastQueryStream {
 	private function skip_string( string $buf, int $buf_len, int $start, string $quote ) {
 		$i = $start + 1;
 		while ( $i < $buf_len ) {
-			// Fast-skip over the bulk of the string body. Inside a
-			// quoted literal only `\` and the matching $quote can end
-			// the run; a strcspn over those two bytes lets PHP's libc
-			// devour 4 KB blocks of base64 payload in microseconds.
-			$skip = strcspn( $buf, "\\" . $quote, $i );
-			$i += $skip;
-			if ( $i >= $buf_len ) {
+			// Fast-skip over the bulk of the string body. Only the
+			// matching quote can close the literal; backslashes only
+			// matter when they immediately precede that candidate quote.
+			$pos = strpos( $buf, $quote, $i );
+			if ( $pos === false ) {
 				return false;
 			}
-			$c = $buf[$i];
-			if ( $c === '\\' ) {
-				if ( $i + 1 >= $buf_len ) {
-					return false;
-				}
-				$i += 2; // skip the backslash + escaped byte
+
+			if ( $this->is_quote_escaped_by_backslashes( $buf, $start, $pos ) ) {
+				$i = $pos + 1;
 				continue;
 			}
+
 			// Found the matching $quote. Doubled-quote escape: keep going.
-			if ( $i + 1 < $buf_len && $buf[$i + 1] === $quote ) {
-				$i += 2;
+			if ( $pos + 1 < $buf_len && $buf[$pos + 1] === $quote ) {
+				$i = $pos + 2;
 				continue;
 			}
-			return $i + 1;
+			return $pos + 1;
 		}
 		return false;
+	}
+
+	private function is_quote_escaped_by_backslashes( string $buf, int $string_start, int $quote_pos ): bool {
+		$slashes = 0;
+		for ( $i = $quote_pos - 1; $i > $string_start && $buf[$i] === '\\'; $i-- ) {
+			$slashes++;
+		}
+		return ( $slashes % 2 ) === 1;
 	}
 
 	/**

--- a/tests/FastQueryStreamTest.php
+++ b/tests/FastQueryStreamTest.php
@@ -197,4 +197,80 @@ SQL;
         $this->assertSame($naive['queries'], $fast_queries);
         $this->assertFalse($fast->has_fallen_back());
     }
+
+    private function adversarialBoundaryFixture(): string
+    {
+        $multi_byte = "\xE2\x98\x83 text; \xF0\x9F\x98\x80";
+        $base64_payload = base64_encode(str_repeat(
+            "semicolon; quote ' double \" backslash \\ multibyte {$multi_byte}\n",
+            8
+        ));
+
+        return <<<'SQL'
+-- line comment with ; and 'quotes'
+/* block comment with ; and "quotes" */
+INSERT INTO t (a, b, c) VALUES ('semi;colon', "double;colon", 'doubled '' quote; still string');
+INSERT INTO t (a, b, c) VALUES ('escaped quote \' and semicolon; still string', 'two backslashes before close \\', 'odd backslashes before quote \\\' and semicolon; still string');
+# hash comment with ; and `ticks`
+INSERT INTO `semi;table` (`weird``name`, `plain`) VALUES ('value', '/* not comment; */');
+SQL
+            . "INSERT INTO t (a) VALUES ('{$multi_byte}');\n"
+            . "INSERT INTO t (a) VALUES (FROM_BASE64('{$base64_payload}'));\n"
+            . "SELECT 'final; statement without trailing semicolon'";
+    }
+
+    public function testAdversarialStatementBoundariesMatchNaive(): void
+    {
+        $sql = $this->adversarialBoundaryFixture();
+        $fast  = $this->drain(new WP_MySQL_FastQueryStream(), $sql);
+        $naive = $this->drain(new WP_MySQL_Naive_Query_Stream(), $sql);
+
+        $this->assertSame($naive['queries'], $fast['queries']);
+        $this->assertSame($naive['bytes_consumed'], $fast['bytes_consumed']);
+        $this->assertCount(6, $fast['queries']);
+    }
+
+    public function testAdversarialStatementBoundariesAcrossSmallChunks(): void
+    {
+        $sql = $this->adversarialBoundaryFixture();
+        $expected = $this->drain(new WP_MySQL_Naive_Query_Stream(), $sql);
+
+        foreach ([1, 3, 17, 64] as $chunk_size) {
+            $fast = new WP_MySQL_FastQueryStream();
+            $queries = [];
+
+            for ($i = 0, $len = strlen($sql); $i < $len; $i += $chunk_size) {
+                $fast->append_sql(substr($sql, $i, $chunk_size));
+                while ($fast->next_query()) {
+                    $queries[] = $fast->get_query();
+                }
+            }
+
+            $fast->mark_input_complete();
+            while ($fast->next_query()) {
+                $queries[] = $fast->get_query();
+            }
+
+            $this->assertSame($expected['queries'], $queries, "chunk size {$chunk_size}");
+            $this->assertSame($expected['bytes_consumed'], $fast->get_bytes_consumed(), "chunk size {$chunk_size}");
+            $this->assertFalse($fast->has_fallen_back(), "chunk size {$chunk_size}");
+        }
+    }
+
+    public function testFinalUnterminatedStringWithTrailingBackslashFallsBack(): void
+    {
+        $fast = new WP_MySQL_FastQueryStream();
+        $errors = [];
+        $fast->set_error_logger(function (array $err) use (&$errors) {
+            $errors[] = $err;
+        });
+
+        $fast->append_sql("SELECT 'unterminated\\");
+        $fast->mark_input_complete();
+        $fast->next_query();
+
+        $this->assertTrue($fast->has_fallen_back());
+        $this->assertCount(1, $errors);
+        $this->assertSame('input complete but parser paused', $errors[0]['reason']);
+    }
 }


### PR DESCRIPTION
## Summary

Speeds up `WP_MySQL_FastQueryStream` string scanning by jumping between candidate quote bytes instead of treating every backslash as a stop point. This keeps the existing fallback behavior and adds adversarial statement-boundary coverage for semicolons in strings/comments, escaped quotes/backslashes, multibyte text, final unterminated buffers, and `FROM_BASE64` payloads.

## Full db-apply benchmark

Command:

```bash
BENCH_STAGES=playground-sqlite-db-apply \
WP_MYSQL_PARSER_EXTENSION_MANIFEST=https://wordpress.github.io/sqlite-database-integration/wp_mysql_parser-wasm-extension/latest/manifest.json \
PLAYGROUND_PHP_USE_WASM_RUNNER=1 \
PLAYGROUND_PHP_VERSION=8.3 \
node tests/e2e/benchmark/bench-pull.mjs
```

Result: `playground-sqlite-db-apply` completed in `49.46s`.

Native parser evidence:

```text
wp_mysql_parser=enabled
mode=parser
native_lexer=verified
native_token_stream=WP_MySQL_Native_Token_Stream
native_parser=verified
native_ast=WP_MySQL_Native_Parser_Node
sqlite_driver_parser=verified
```

Comparison:

- `5.94s` faster than PR #244's `55.40s`
- `12.05s` faster than trunk's `61.51s`
- Slower than coalesce PR #245's `43.79s`

## Tests

```bash
vendor/bin/phpunit -c tests/phpunit.xml tests/FastQueryStreamTest.php
```

No microbenchmarks were used.