### PR TITLE
Set SQLite import pragmas during db-apply

### DIFF
--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -5124,6 +5124,14 @@ class ImportClient
             && method_exists($pdo, 'get_connection')
         ) {
             $sqlite_prepared_pdo = $pdo->get_connection()->get_pdo();
+            // These are connection-local import hints. Avoid journal/sync/locking
+            // PRAGMAs because they alter durability or observable database state.
+            $sqlite_prepared_pdo->exec('PRAGMA temp_store = MEMORY');
+            $sqlite_prepared_pdo->exec('PRAGMA cache_size = -32768');
+            $this->audit_log(
+                'SQLite db-apply PRAGMAs | temp_store=MEMORY | cache_size=32768 KiB',
+                false,
+            );
         }
 
         $this->audit_log(

--- a/tests/Import/NewSiteUrlSqliteTest.php
+++ b/tests/Import/NewSiteUrlSqliteTest.php
@@ -369,4 +369,49 @@ class NewSiteUrlSqliteTest extends TestCase
         $this->assertCount(1, $rows);
         $this->assertSame(strtoupper(bin2hex($bytes)), $rows[0]['hex_value']);
     }
+
+    public function testSqliteImportPragmasDoNotChangeProgressCounters(): void
+    {
+        $sqlitePath = $this->tempDir . '/database/wordpress.sqlite';
+        $drop = "DROP TABLE IF EXISTS `wp_options`;";
+        $create = "CREATE TABLE `wp_options` ("
+            . "`option_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT, "
+            . "`option_name` varchar(191) NOT NULL DEFAULT '', "
+            . "`option_value` longtext NOT NULL, "
+            . "`autoload` varchar(20) NOT NULL DEFAULT 'yes', "
+            . "PRIMARY KEY (`option_id`)"
+            . ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;";
+        $insert = sprintf(
+            "INSERT INTO `wp_options` (`option_id`, `option_name`, `option_value`, `autoload`) VALUES "
+            . "(1, FROM_BASE64('%s'), FROM_BASE64('%s'), FROM_BASE64('%s'));",
+            base64_encode('siteurl'),
+            base64_encode('https://example.com'),
+            base64_encode('yes')
+        );
+        $sql = implode("\n", [$drop, $create, $insert]);
+
+        file_put_contents($this->tempDir . '/db.sql', $sql);
+        $this->writeState();
+
+        $client = new \ImportClient(
+            'https://old-site.example.com/?reprint-api',
+            $this->tempDir,
+            $this->tempDir . '/fs-root',
+        );
+        $client->run([
+            'command' => 'db-apply',
+            'abort' => false,
+            'verbose' => false,
+            'secret' => null,
+            'tuning_config' => [],
+            'target_engine' => 'sqlite',
+            'target_sqlite_path' => $sqlitePath,
+            'target_db' => 'wp_test',
+        ]);
+
+        $state = json_decode(file_get_contents($this->tempDir . '/.import-state.json'), true);
+        $this->assertSame('complete', $state['status']);
+        $this->assertSame(3, $state['apply']['statements_executed']);
+        $this->assertSame(strlen($sql), $state['apply']['bytes_read']);
+    }
 }


### PR DESCRIPTION
## Summary

Sets two connection-local SQLite PRAGMAs for the `db-apply` target connection:

```sql
PRAGMA temp_store = MEMORY;
PRAGMA cache_size = -32768;
```

This is intentionally session-only. The SQLite PDO is created for the apply command, so there is no restore wrapper. The PR still avoids persistent or durability-sensitive settings such as `journal_mode`, `synchronous`, and locking.

## Full db-apply benchmark

Command:

```bash
BENCH_STAGES=playground-sqlite-db-apply \
WP_MYSQL_PARSER_EXTENSION_MANIFEST=https://wordpress.github.io/sqlite-database-integration/wp_mysql_parser-wasm-extension/latest/manifest.json \
PLAYGROUND_PHP_USE_WASM_RUNNER=1 \
PLAYGROUND_PHP_VERSION=8.3 \
node tests/e2e/benchmark/bench-pull.mjs
```

Result on the simplified branch rebased onto `trunk`: `playground-sqlite-db-apply` completed in `58.41s`.

Native parser evidence:

```text
wp_mysql_parser=enabled
mode=parser
native_lexer=verified
native_token_stream=WP_MySQL_Native_Token_Stream
native_parser=verified
native_ast=WP_MySQL_Native_Parser_Node
sqlite_driver_parser=verified
```

Comparison:

- `3.10s` faster than trunk's `61.51s`
- Slower than PR #244's `55.40s`, because this PR is now standalone and no longer stacked on #244

## Tests

```bash
vendor/bin/phpunit -c tests/phpunit.xml tests/Import/NewSiteUrlSqliteTest.php --filter 'SqliteImportPragmas|NewSiteUrlRewritesSiteurlAndHomeInSqlite|SqliteDbApplyPreservesArbitraryBase64Bytes'
```

No microbenchmarks were used.