### PR TITLE
Speed up SQLite prepared insert builder

### DIFF
--- a/packages/reprint-importer/src/lib/url-rewrite/class-fast-insert-scanner.php
+++ b/packages/reprint-importer/src/lib/url-rewrite/class-fast-insert-scanner.php
@@ -38,12 +38,13 @@ class FastInsertScanner
      *   table: string,
      *   columns: list<string>,
      *   column_map: list<array{int, int, string}>,
+     *   has_base64: bool,
      *   base64_entries: list<array{expr_start: int, expr_length: int, quote_start: int, quote_length: int, encoded_value: string, value: ?string, new_value: ?string}>,
-     *   value_entries: list<array{kind: string, start: int, end: int, column: string, raw?: string, expr_start?: int, expr_length?: int, quote_start?: int, quote_length?: int, encoded_value?: string}>
+     *   value_entries: list<array{kind: string, column: string, start?: int, end?: int, raw?: string, expr_start?: int, expr_length?: int, quote_start?: int, quote_length?: int, encoded_value?: string}>
      * }|null
      *   Null when the SQL doesn't match the recognised shape.
      */
-    public static function scan(string $sql, bool $include_column_map = true): ?array
+    public static function scan(string $sql, bool $include_column_map = true, bool $include_base64_entries = true): ?array
     {
         // Header: optional leading whitespace, INSERT (no priority/IGNORE
         // modifiers — producer never emits those), INTO, backticked table,
@@ -96,6 +97,7 @@ class FastInsertScanner
         $column_map = [];
         $base64_entries = [];
         $value_entries = [];
+        $has_base64 = false;
 
         $cursor = $values_end;
         $sql_len = strlen($sql);
@@ -134,29 +136,32 @@ class FastInsertScanner
                     $cursor++;
                 }
                 $value_start = $cursor;
-                $value_kind = self::scan_value($sql, $sql_len, $cursor);
+                $value_kind = self::scan_value($sql, $sql_len, $cursor, $include_base64_entries);
                 if ($value_kind === null) {
                     return null;
                 }
                 $value_end = $cursor;
                 if ($include_column_map) {
                     $column_map[] = [$value_start, $value_end, $columns[$col_idx]];
+                    $value_kind['start'] = $value_start;
+                    $value_kind['end'] = $value_end;
                 }
-                $value_kind['start'] = $value_start;
-                $value_kind['end'] = $value_end;
                 $value_kind['column'] = $columns[$col_idx];
                 $value_entries[] = $value_kind;
 
                 if ($value_kind['kind'] === 'base64') {
-                    $base64_entries[] = [
-                        'expr_start' => $value_kind['expr_start'],
-                        'expr_length' => $value_kind['expr_length'],
-                        'quote_start' => $value_kind['quote_start'],
-                        'quote_length' => $value_kind['quote_length'],
-                        'encoded_value' => $value_kind['encoded_value'],
-                        'value' => null,
-                        'new_value' => null,
-                    ];
+                    $has_base64 = true;
+                    if ($include_base64_entries) {
+                        $base64_entries[] = [
+                            'expr_start' => $value_kind['expr_start'],
+                            'expr_length' => $value_kind['expr_length'],
+                            'quote_start' => $value_kind['quote_start'],
+                            'quote_length' => $value_kind['quote_length'],
+                            'encoded_value' => $value_kind['encoded_value'],
+                            'value' => null,
+                            'new_value' => null,
+                        ];
+                    }
                 }
 
                 while ($cursor < $sql_len && self::is_ws($sql[$cursor])) {
@@ -202,6 +207,7 @@ class FastInsertScanner
             'table' => $table,
             'columns' => $columns,
             'column_map' => $column_map,
+            'has_base64' => $has_base64,
             'base64_entries' => $base64_entries,
             'value_entries' => $value_entries,
         ];
@@ -213,7 +219,7 @@ class FastInsertScanner
      * @return null|array{kind: string, raw?: string, expr_start?: int, expr_length?: int, quote_start?: int, quote_length?: int, encoded_value?: string}
      *   null = unrecognized shape (caller bails)
      */
-    private static function scan_value(string $sql, int $sql_len, int &$cursor)
+    private static function scan_value(string $sql, int $sql_len, int &$cursor, bool $include_base64_offsets = true)
     {
         if ($cursor >= $sql_len) {
             return null;
@@ -248,12 +254,18 @@ class FastInsertScanner
             if ($entry === null) {
                 return null;
             }
+            if ($include_base64_offsets) {
+                return [
+                    'kind' => 'base64',
+                    'expr_start' => $entry[0],
+                    'expr_length' => $entry[1],
+                    'quote_start' => $entry[2],
+                    'quote_length' => $entry[3],
+                    'encoded_value' => $entry[4],
+                ];
+            }
             return [
                 'kind' => 'base64',
-                'expr_start' => $entry[0],
-                'expr_length' => $entry[1],
-                'quote_start' => $entry[2],
-                'quote_length' => $entry[3],
                 'encoded_value' => $entry[4],
             ];
         }
@@ -303,12 +315,18 @@ class FastInsertScanner
             }
             $cursor++;
             $entry[1] = $cursor - $expr_start;
+            if ($include_base64_offsets) {
+                return [
+                    'kind' => 'base64',
+                    'expr_start' => $entry[0],
+                    'expr_length' => $entry[1],
+                    'quote_start' => $entry[2],
+                    'quote_length' => $entry[3],
+                    'encoded_value' => $entry[4],
+                ];
+            }
             return [
                 'kind' => 'base64',
-                'expr_start' => $entry[0],
-                'expr_length' => $entry[1],
-                'quote_start' => $entry[2],
-                'quote_length' => $entry[3],
                 'encoded_value' => $entry[4],
             ];
         }

--- a/packages/reprint-importer/src/lib/url-rewrite/class-sqlite-prepared-insert-builder.php
+++ b/packages/reprint-importer/src/lib/url-rewrite/class-sqlite-prepared-insert-builder.php
@@ -39,8 +39,18 @@ class SQLitePreparedInsertBuilder
             return null;
         }
 
-        $fast = FastInsertScanner::scan($sql, false);
-        if ($fast === null || empty($fast['base64_entries']) || empty($fast['value_entries'])) {
+        return self::build_with_fast_insert_scanner($sql, $rewrite_value);
+    }
+
+    /**
+     * @param callable|null $rewrite_value Optional callback:
+     *        fn(string $value, string $table, ?string $column): string
+     * @return array{sql: string, params: list<mixed>, param_types: list<int>}|null
+     */
+    private static function build_with_fast_insert_scanner(string $sql, ?callable $rewrite_value): ?array
+    {
+        $fast = FastInsertScanner::scan($sql, false, false);
+        if ($fast === null || empty($fast['has_base64']) || empty($fast['value_entries'])) {
             return null;
         }
 
@@ -54,106 +64,36 @@ class SQLitePreparedInsertBuilder
         // The cache key must change when the generated SQL text changes, but
         // must stay stable across batches that only differ by decoded payloads
         // or numeric literal values.
-        $shape_key_parts = [
-            // Table names are emitted into the SQL template, so they are part
-            // of the shape. Length-prefixing prevents separator collisions.
-            strlen($fast['table']) . ':' . $fast['table'],
-            // The number of columns determines tuple width and avoids treating
-            // a prefix of one column list as the same shape as a shorter list.
-            (string) $column_count,
-        ];
-        foreach ($fast['columns'] as $column) {
-            // Column order is part of INSERT semantics and of the generated SQL
-            // text, so each quoted identifier contributes to the template key.
-            $shape_key_parts[] = strlen($column) . ':' . $column;
-        }
-        foreach ($fast['value_entries'] as $entry) {
-            if ($entry['kind'] === 'numeric') {
-                // Numeric values are bound, not embedded. Only SQLite's target
-                // storage class affects the template: dotted/exponent literals
-                // need REAL while integer-looking literals use NUMERIC.
-                $shape_key_parts[] = strpbrk($entry['raw'], '.eE') === false
-                    ? 'CAST(? AS NUMERIC)'
-                    : 'CAST(? AS REAL)';
-            } else {
-                // NULL, empty strings, and decoded base64 payloads all compile
-                // to the same bare placeholder; their values are supplied later.
-                $shape_key_parts[] = '?';
-            }
-        }
-
-        $shape_key = implode('|', $shape_key_parts);
-        $template_sql = self::$template_sql_cache[$shape_key] ?? null;
-        if ($template_sql === null) {
-            // Cache misses are the only time we build SQL text. Payload bytes
-            // and numeric literals still never become SQL; this only emits
-            // identifiers and placeholders for the producer-recognised shape.
-            $quoted_columns = [];
-            foreach ($fast['columns'] as $column) {
-                $quoted_columns[] = self::quote_identifier($column);
-            }
-
-            $rows = [];
-            for ($offset = 0; $offset < $value_count; $offset += $column_count) {
-                $placeholders = [];
-                for ($i = 0; $i < $column_count; $i++) {
-                    $entry = $fast['value_entries'][$offset + $i];
-                    if ($entry['kind'] === 'numeric') {
-                        // Dotted/exponent literals need REAL to match SQLite's literal typing.
-                        $placeholders[] = strpbrk($entry['raw'], '.eE') === false
-                            ? 'CAST(? AS NUMERIC)'
-                            : 'CAST(? AS REAL)';
-                    } else {
-                        $placeholders[] = '?';
-                    }
-                }
-                $rows[] = '(' . implode(', ', $placeholders) . ')';
-            }
-
-            // Preserve one reusable SQL string per table/column/value-shape so
-            // PDO and SQLite can reuse the compiled statement across dump rows.
-            $template_sql = 'INSERT INTO '
-                . self::quote_identifier($fast['table'])
-                . ' (' . implode(', ', $quoted_columns) . ') VALUES'
-                . implode(',', $rows)
-                . ';';
-
-            self::$template_sql_cache[$shape_key] = $template_sql;
-            self::$template_sql_cache_order[] = $shape_key;
-            if (count(self::$template_sql_cache_order) > self::TEMPLATE_CACHE_MAX) {
-                // Bound cache growth: large imports can touch many plugin
-                // tables, but old shapes are cheap to rebuild if seen again.
-                $oldest_key = array_shift(self::$template_sql_cache_order);
-                if (is_string($oldest_key)) {
-                    unset(self::$template_sql_cache[$oldest_key]);
-                }
-            }
-        }
-
-        // Build the bound values after the template is selected. This keeps
-        // untrusted decoded bytes out of SQL text while still allowing URL
-        // rewriting to use table/column context for structured data.
+        $shape_value_codes = '';
         $params = [];
         $param_types = [];
-
         foreach ($fast['value_entries'] as $entry) {
             switch ($entry['kind']) {
                 case 'null':
+                    // NULL, empty strings, and decoded base64 payloads all compile
+                    // to the same bare placeholder; their values are supplied later.
+                    $shape_value_codes .= 's';
                     $params[] = null;
                     $param_types[] = PDO::PARAM_NULL;
                     break;
 
                 case 'empty_string':
+                    $shape_value_codes .= 's';
                     $params[] = '';
                     $param_types[] = PDO::PARAM_STR;
                     break;
 
                 case 'numeric':
+                    // Numeric values are bound, not embedded. Only SQLite's target
+                    // storage class affects the template: dotted/exponent literals
+                    // need REAL while integer-looking literals use NUMERIC.
+                    $shape_value_codes .= strpbrk($entry['raw'], '.eE') === false ? 'i' : 'r';
                     $params[] = $entry['raw'];
                     $param_types[] = PDO::PARAM_STR;
                     break;
 
                 case 'base64':
+                    $shape_value_codes .= 's';
                     $decoded = base64_decode($entry['encoded_value'], true);
                     if ($decoded === false) {
                         return null;
@@ -171,11 +111,80 @@ class SQLitePreparedInsertBuilder
             }
         }
 
+        $shape_key = self::compact_shape_key($fast['table'], $fast['columns'], $shape_value_codes);
+        $template_sql = self::$template_sql_cache[$shape_key] ?? null;
+        if ($template_sql === null) {
+            // Cache misses are the only time we build SQL text. Payload bytes
+            // and numeric literals still never become SQL; this only emits
+            // identifiers and placeholders for the producer-recognised shape.
+            // Preserve one reusable SQL string per table/column/value-shape so
+            // PDO and SQLite can reuse the compiled statement across dump rows.
+            $template_sql = self::template_sql_from_shape($fast['table'], $fast['columns'], $shape_value_codes);
+
+            self::$template_sql_cache[$shape_key] = $template_sql;
+            self::$template_sql_cache_order[] = $shape_key;
+            if (count(self::$template_sql_cache_order) > self::TEMPLATE_CACHE_MAX) {
+                // Bound cache growth: large imports can touch many plugin
+                // tables, but old shapes are cheap to rebuild if seen again.
+                $oldest_key = array_shift(self::$template_sql_cache_order);
+                if (is_string($oldest_key)) {
+                    unset(self::$template_sql_cache[$oldest_key]);
+                }
+            }
+        }
+
         return [
             'sql' => $template_sql,
             'params' => $params,
             'param_types' => $param_types,
         ];
+    }
+
+    /**
+     * @param list<string> $columns
+     */
+    private static function compact_shape_key(string $table, array $columns, string $shape_value_codes): string
+    {
+        $key = 'compact|' . strlen($table) . ':' . $table . '|' . count($columns);
+        foreach ($columns as $column) {
+            $key .= '|' . strlen($column) . ':' . $column;
+        }
+        return $key . '|' . $shape_value_codes;
+    }
+
+    /**
+     * @param list<string> $columns
+     */
+    private static function template_sql_from_shape(string $table, array $columns, string $shape_value_codes): string
+    {
+        $quoted_columns = [];
+        foreach ($columns as $column) {
+            $quoted_columns[] = self::quote_identifier($column);
+        }
+
+        $column_count = count($columns);
+        $value_count = strlen($shape_value_codes);
+        $rows = [];
+        for ($offset = 0; $offset < $value_count; $offset += $column_count) {
+            $placeholders = [];
+            for ($i = 0; $i < $column_count; $i++) {
+                $code = $shape_value_codes[$offset + $i];
+                if ($code === 'i') {
+                    $placeholders[] = 'CAST(? AS NUMERIC)';
+                } elseif ($code === 'r') {
+                    $placeholders[] = 'CAST(? AS REAL)';
+                } else {
+                    $placeholders[] = '?';
+                }
+            }
+            $rows[] = '(' . implode(', ', $placeholders) . ')';
+        }
+
+        return 'INSERT INTO '
+            . self::quote_identifier($table)
+            . ' (' . implode(', ', $quoted_columns) . ') VALUES'
+            . implode(',', $rows)
+            . ';';
     }
 
     private static function quote_identifier(string $identifier): string

--- a/tests/UrlRewriting/SQLitePreparedInsertBuilderTest.php
+++ b/tests/UrlRewriting/SQLitePreparedInsertBuilderTest.php
@@ -108,6 +108,28 @@ class SQLitePreparedInsertBuilderTest extends TestCase
         $this->assertSame(['1', 'after'], $prepared['params']);
     }
 
+    public function testBuildsPreparedInsertForEscapedIdentifiersAndMixedParams(): void
+    {
+        $payload = "\x00https://example.com/value\xff";
+        $sql = sprintf(
+            "INSERT INTO `wp``options` (`id`, `empty`, `nullable`, `ratio`, `payload``blob`) VALUES(+7, '', NULL, -3.5e+2, FROM_BASE64('%s'));",
+            base64_encode($payload)
+        );
+
+        $prepared = SQLitePreparedInsertBuilder::build($sql);
+
+        $this->assertNotNull($prepared);
+        $this->assertSame(
+            "INSERT INTO `wp``options` (`id`, `empty`, `nullable`, `ratio`, `payload``blob`) VALUES(CAST(? AS NUMERIC), ?, ?, CAST(? AS REAL), ?);",
+            $prepared['sql']
+        );
+        $this->assertSame(['+7', '', null, '-3.5e+2', $payload], $prepared['params']);
+        $this->assertSame(
+            [PDO::PARAM_STR, PDO::PARAM_STR, PDO::PARAM_NULL, PDO::PARAM_STR, PDO::PARAM_STR],
+            $prepared['param_types']
+        );
+    }
+
     public function testRepeatedShapesCompileToSameTemplateWithDifferentValues(): void
     {
         $sql_a = sprintf(
@@ -211,6 +233,37 @@ class SQLitePreparedInsertBuilderTest extends TestCase
         );
 
         $this->assertNull(SQLitePreparedInsertBuilder::build($sql));
+    }
+
+    public function testRejectsFromBase64InsideStringLiteral(): void
+    {
+        $sql = "INSERT INTO `wp_options` (`option_value`) VALUES('FROM_BASE64(''dmFsdWU='')');";
+
+        $this->assertNull(SQLitePreparedInsertBuilder::build($sql));
+    }
+
+    public function testRejectsFromBase64InsideComment(): void
+    {
+        $sql = "INSERT INTO `wp_options` (`option_id`, `option_value`) VALUES(/* FROM_BASE64('dmFsdWU=') */ 1, '');";
+
+        $this->assertNull(SQLitePreparedInsertBuilder::build($sql));
+    }
+
+    public function testFastInsertScannerHeaderWhitespaceStillBuildsPreparedInsert(): void
+    {
+        $sql = sprintf(
+            "INSERT\fINTO `wp_options` (`option_id`, `option_value`) VALUES(1, FROM_BASE64('%s'));",
+            base64_encode('value')
+        );
+
+        $prepared = SQLitePreparedInsertBuilder::build($sql);
+
+        $this->assertNotNull($prepared);
+        $this->assertSame(
+            "INSERT INTO `wp_options` (`option_id`, `option_value`) VALUES(CAST(? AS NUMERIC), ?);",
+            $prepared['sql']
+        );
+        $this->assertSame(['1', 'value'], $prepared['params']);
     }
 
     public function testMalformedProducerShapesReturnNull(): void


### PR DESCRIPTION
## What it does

Speeds up `SQLitePreparedInsertBuilder::build()` for producer-shaped INSERT batches that contain `FROM_BASE64(...)` values.

The prepared insert path now asks `FastInsertScanner` for only the metadata it needs: table, columns, value kinds, decoded base64 payloads, and column names. It skips column offset maps and base64 replacement offsets that are only needed by the SQL rewrite path.

## Rationale

The SQLite db-apply hot path spends substantial time building prepared INSERT templates before PDO/SQLite execution. The previous prepared builder still paid for scanner metadata that it never consumed, and it built template cache keys from full placeholder strings.

This keeps the same constrained producer-shape parser and same fallback behavior, but removes avoidable per-value array fields and string work.

## Implementation

- Added optional `FastInsertScanner::scan()` flags for base64 replacement entries and column maps.
- Added `has_base64` so callers can cheaply distinguish "recognized INSERT without base64" from "recognized INSERT with base64 entries omitted."
- Changed `SQLitePreparedInsertBuilder` to call `FastInsertScanner::scan($sql, false, false)`.
- Replaced verbose shape-key placeholder strings with compact value codes:
  - `i` = `CAST(? AS NUMERIC)`
  - `r` = `CAST(? AS REAL)`
  - `s` = plain `?`
- Kept all decoded payload bytes bound through PDO params; payloads still never become SQL text.

## Testing instructions

Focused checks run:

```bash
php -l packages/reprint-importer/src/lib/url-rewrite/class-fast-insert-scanner.php
php -l packages/reprint-importer/src/lib/url-rewrite/class-sqlite-prepared-insert-builder.php
php -l tests/UrlRewriting/SQLitePreparedInsertBuilderTest.php
git diff --check
(cd tests && ../vendor/bin/phpunit --testdox UrlRewriting/SQLitePreparedInsertBuilderTest.php)
(cd tests && ../vendor/bin/phpunit --testdox UrlRewriting)
vendor/bin/phpstan analyze packages/reprint-importer/src/lib/url-rewrite/class-fast-insert-scanner.php packages/reprint-importer/src/lib/url-rewrite/class-sqlite-prepared-insert-builder.php --memory-limit=1G
```

Locked benchmark commands run from this worktree after checking out each ref:

```bash
flock /tmp/reprint-bench.lock -c 'BENCH_LABEL=trunk BENCH_STAGES=playground-sqlite-db-apply BENCH_JSON_OUT=.context/bench-trunk.json BENCH_MD_OUT=.context/bench-trunk.md node tests/e2e/benchmark/bench-pull.mjs' > .context/benchmark-trunk.log 2>&1
flock /tmp/reprint-bench.lock -c 'BENCH_LABEL=branch BENCH_STAGES=playground-sqlite-db-apply BENCH_JSON_OUT=.context/bench-branch.json BENCH_MD_OUT=.context/bench-branch.md node tests/e2e/benchmark/bench-pull.mjs' > .context/benchmark-branch.log 2>&1
```

Both benchmark logs reported `Source DB already seeded with 400011 posts; skipping seed`, so the before/after runs used the same shared source fixture state.

| Ref | Stage | Wall time | Attempts | Status | Details |
|---|---|---:|---:|---|---|
| `origin/trunk` (`b63206e`) | `playground-sqlite-db-apply` | 82.42 s | 1 | pass | PHP.wasm 8.3, `wp_mysql_parser=disabled` |
| branch (`d4ece7d`) | `playground-sqlite-db-apply` | 67.65 s | 1 | pass | PHP.wasm 8.3, `wp_mysql_parser=disabled` |

Delta: `-14.77 s` (`17.9%` lower wall time, `1.218x` speedup).
