### PR TITLE
Clear cached SQLite bound values after execute

### DIFF
--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -5467,16 +5467,31 @@ class ImportClient
                     $statement->closeCursor();
                 }
 
-                foreach ($prepared_insert['params'] as $index => $value) {
-                    $statement->bindValue(
-                        $index + 1,
-                        $value,
-                        $prepared_insert['param_types'][$index] ?? PDO::PARAM_STR
-                    );
-                }
+                $param_count = count($prepared_insert['params']);
+                $primary_error = null;
+                try {
+                    foreach ($prepared_insert['params'] as $index => $value) {
+                        $statement->bindValue(
+                            $index + 1,
+                            $value,
+                            $prepared_insert['param_types'][$index] ?? PDO::PARAM_STR
+                        );
+                    }
 
-                if ($statement->execute() === false) {
-                    throw new PDOException('Failed to execute SQLite INSERT statement.');
+                    if ($statement->execute() === false) {
+                        throw new PDOException('Failed to execute SQLite INSERT statement.');
+                    }
+                } catch (Throwable $e) {
+                    $primary_error = $e;
+                    throw $e;
+                } finally {
+                    try {
+                        $this->clear_sqlite_prepared_statement_values($statement, $param_count);
+                    } catch (Throwable $clear_error) {
+                        if ($primary_error === null) {
+                            throw $clear_error;
+                        }
+                    }
                 }
                 return;
             }
@@ -5487,6 +5502,14 @@ class ImportClient
         }
 
         $pdo->exec($executed_query);
+    }
+
+    private function clear_sqlite_prepared_statement_values(PDOStatement $statement, int $param_count): void
+    {
+        $statement->closeCursor();
+        for ($index = 1; $index <= $param_count; $index++) {
+            $statement->bindValue($index, null, PDO::PARAM_NULL);
+        }
     }
 
     /**

--- a/tests/Import/SqlitePreparedStatementBoundValuesTest.php
+++ b/tests/Import/SqlitePreparedStatementBoundValuesTest.php
@@ -1,0 +1,209 @@
+<?php
+
+namespace ImportTests;
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../importer/import.php';
+
+class RecordingSqlitePreparedStatement extends \PDOStatement
+{
+    /** @var array<int|string, array{value: mixed, type: int}> */
+    public array $current_bindings = [];
+
+    /** @var list<array<int|string, array{is_null: bool, length: ?int, hash: ?string, value: mixed, type: int}>> */
+    public array $execute_snapshots = [];
+
+    /** @var list<array{param: int|string, is_null: bool, length: ?int, hash: ?string, value: mixed, type: int}> */
+    public array $bind_log = [];
+
+    public int $close_cursor_calls = 0;
+
+    protected function __construct()
+    {
+    }
+
+    public static function create(): self
+    {
+        $reflection = new \ReflectionClass(self::class);
+        /** @var self $statement */
+        $statement = $reflection->newInstanceWithoutConstructor();
+        return $statement;
+    }
+
+    #[\ReturnTypeWillChange]
+    public function bindValue($param, $value, $type = \PDO::PARAM_STR)
+    {
+        $this->current_bindings[$param] = [
+            'value' => $value,
+            'type' => $type,
+        ];
+        $this->bind_log[] = $this->describe_binding($param, $value, $type);
+        return true;
+    }
+
+    #[\ReturnTypeWillChange]
+    public function execute($params = null)
+    {
+        $snapshot = [];
+        foreach ($this->current_bindings as $param => $binding) {
+            $snapshot[$param] = $this->describe_binding($param, $binding['value'], $binding['type']);
+        }
+        $this->execute_snapshots[] = $snapshot;
+        return true;
+    }
+
+    #[\ReturnTypeWillChange]
+    public function closeCursor()
+    {
+        $this->close_cursor_calls++;
+        return true;
+    }
+
+    /**
+     * @return array{param: int|string, is_null: bool, length: ?int, hash: ?string, value: mixed, type: int}
+     */
+    private function describe_binding($param, $value, int $type): array
+    {
+        return [
+            'param' => $param,
+            'is_null' => $value === null,
+            'length' => is_string($value) ? strlen($value) : null,
+            'hash' => is_string($value) ? sha1($value) : null,
+            'value' => is_string($value) && strlen($value) <= 128 ? $value : null,
+            'type' => $type,
+        ];
+    }
+}
+
+class RecordingSqlitePdo extends \PDO
+{
+    /** @var list<string> */
+    public array $prepared_sql = [];
+
+    /** @var array<string, RecordingSqlitePreparedStatement> */
+    public array $statements_by_sql = [];
+
+    public function __construct()
+    {
+    }
+
+    #[\ReturnTypeWillChange]
+    public function prepare($query, $options = [])
+    {
+        $this->prepared_sql[] = $query;
+        $statement = RecordingSqlitePreparedStatement::create();
+        $this->statements_by_sql[$query] = $statement;
+        return $statement;
+    }
+}
+
+class SqlitePreparedStatementBoundValuesTest extends TestCase
+{
+    public function testSqlitePreparedInsertClearsLargeBoundValuesAfterExecute(): void
+    {
+        $large_value = str_repeat('large-bound-value-', 128 * 1024);
+        $query = $this->buildInsertQuery(1, 'large_payload', $large_value);
+
+        $pdo = new RecordingSqlitePdo();
+        $cache = [];
+        $cache_order = [];
+        $executed_query = '';
+
+        $this->executePreparedPath($pdo, $query, $cache, $cache_order, $executed_query);
+
+        $this->assertCount(1, $pdo->prepared_sql);
+        $statement = $pdo->statements_by_sql[$pdo->prepared_sql[0]];
+        $this->assertSame($pdo->prepared_sql[0], $executed_query);
+        $this->assertCount(1, $statement->execute_snapshots);
+        $this->assertSame(strlen($large_value), $statement->execute_snapshots[0][3]['length']);
+        $this->assertSame(sha1($large_value), $statement->execute_snapshots[0][3]['hash']);
+
+        $this->assertBoundValuesCleared($statement, 3);
+    }
+
+    public function testCachedSqlitePreparedInsertRebindsValuesAfterClearing(): void
+    {
+        $first_value = str_repeat('first-row-', 96 * 1024);
+        $second_value = 'second row payload';
+        $first_query = $this->buildInsertQuery(1, 'first_payload', $first_value);
+        $second_query = $this->buildInsertQuery(2, 'second_payload', $second_value);
+
+        $pdo = new RecordingSqlitePdo();
+        $cache = [];
+        $cache_order = [];
+        $executed_query = '';
+
+        $this->executePreparedPath($pdo, $first_query, $cache, $cache_order, $executed_query);
+        $first_executed_query = $executed_query;
+        $this->executePreparedPath($pdo, $second_query, $cache, $cache_order, $executed_query);
+
+        $this->assertSame($first_executed_query, $executed_query);
+        $this->assertCount(1, $pdo->prepared_sql, 'same INSERT shape should reuse one cached statement');
+        $this->assertCount(1, $cache);
+
+        $statement = $pdo->statements_by_sql[$pdo->prepared_sql[0]];
+        $this->assertCount(2, $statement->execute_snapshots);
+        $this->assertSame(strlen($first_value), $statement->execute_snapshots[0][3]['length']);
+        $this->assertSame(sha1($first_value), $statement->execute_snapshots[0][3]['hash']);
+        $this->assertSame($second_value, $statement->execute_snapshots[1][3]['value']);
+        $this->assertSame(\PDO::PARAM_STR, $statement->execute_snapshots[1][3]['type']);
+
+        $this->assertBoundValuesCleared($statement, 3);
+    }
+
+    /**
+     * @param array<string, \PDOStatement> $cache
+     * @param list<string> $cache_order
+     */
+    private function executePreparedPath(
+        \PDO $pdo,
+        string $query,
+        array &$cache,
+        array &$cache_order,
+        string &$executed_query
+    ): void {
+        $client_reflection = new \ReflectionClass(\ImportClient::class);
+        $client = $client_reflection->newInstanceWithoutConstructor();
+        $method = $client_reflection->getMethod('execute_db_apply_query');
+        $method->setAccessible(true);
+
+        $method->invokeArgs($client, [
+            $pdo,
+            $query,
+            null,
+            $pdo,
+            &$cache,
+            &$cache_order,
+            &$executed_query,
+        ]);
+    }
+
+    private function buildInsertQuery(int $id, string $name, string $value): string
+    {
+        return sprintf(
+            "INSERT INTO `wp_options` (`option_id`, `option_name`, `option_value`) VALUES " .
+            "(%d, FROM_BASE64('%s'), FROM_BASE64('%s'));",
+            $id,
+            base64_encode($name),
+            base64_encode($value),
+        );
+    }
+
+    private function assertBoundValuesCleared(RecordingSqlitePreparedStatement $statement, int $param_count): void
+    {
+        for ($index = 1; $index <= $param_count; $index++) {
+            $this->assertArrayHasKey($index, $statement->current_bindings);
+            $this->assertNull($statement->current_bindings[$index]['value']);
+            $this->assertSame(\PDO::PARAM_NULL, $statement->current_bindings[$index]['type']);
+        }
+
+        $this->assertGreaterThanOrEqual(1, $statement->close_cursor_calls);
+        $clear_binds = array_slice($statement->bind_log, -$param_count);
+        $this->assertCount($param_count, $clear_binds);
+        foreach ($clear_binds as $clear_bind) {
+            $this->assertTrue($clear_bind['is_null']);
+            $this->assertSame(\PDO::PARAM_NULL, $clear_bind['type']);
+        }
+    }
+}


### PR DESCRIPTION
## What it does

Clears cached SQLite prepared-statement bindings after each db-apply prepared `INSERT` execute.

The SQLite prepared statement cache still keeps the compiled `PDOStatement`, but its placeholder slots are rebound to `NULL` after execution so decoded row payloads do not remain attached to the cached statement.

## Rationale

`execute_db_apply_query()` caches `PDOStatement` objects by generated SQLite `INSERT` template. Each row binds decoded `FROM_BASE64(...)` values with `bindValue()`, executes, then leaves the statement in the cache for reuse.

If PDO SQLite keeps those bound zvals on the statement, a cached statement can retain large PHP strings until the template is reused, evicted, or the import exits. Clearing the slots after execute preserves the cache while releasing row payload references. Reuse remains safe because the db-apply path binds every placeholder before each execute.

## Implementation

- Wrap the prepared `INSERT` bind/execute path in `try`/`finally`.
- Rebind every placeholder to `NULL` with `PDO::PARAM_NULL` after execute.
- Keep the original SQL/bind exception if clearing also fails, so cleanup cannot mask the real db-apply error.
- Add direct importer tests with a recording `PDOStatement` to assert:
  - a large bound value is present during execute and cleared afterward
  - a reused cached statement executes with the second row's values after the first row was cleared

## Testing instructions

Focused checks run:

```bash
php -l packages/reprint-importer/src/import.php
php -l tests/Import/SqlitePreparedStatementBoundValuesTest.php
vendor/bin/phpunit --configuration tests/phpunit.xml tests/Import/SqlitePreparedStatementBoundValuesTest.php
vendor/bin/phpunit --configuration tests/phpunit.xml tests/Import/NewSiteUrlSqliteTest.php tests/UrlRewriting/SQLitePreparedInsertBuilderTest.php
composer analyze
```

Benchmark command, run separately for `origin/trunk` and this branch under `flock /tmp/reprint-bench.lock -c '...'`:

```bash
BENCH_STAGES=playground-sqlite-db-apply node tests/e2e/benchmark/bench-pull.mjs
```

| Ref | Stage | Wall time | Delta |
|---|---:|---:|---:|
| `origin/trunk` | `playground-sqlite-db-apply` | 77.46 s | baseline |
| `codex/opt-clear-bound-values-20260522015014` | `playground-sqlite-db-apply` | 75.58 s | -1.89 s (-2.44%) |
