### PR TITLE
Stream SQLite prepared insert shape data

### DIFF
--- a/packages/reprint-importer/src/lib/url-rewrite/class-fast-insert-scanner.php
+++ b/packages/reprint-importer/src/lib/url-rewrite/class-fast-insert-scanner.php
@@ -40,11 +40,20 @@ class FastInsertScanner
      *   column_map: list<array{int, int, string}>,
      *   has_base64: bool,
      *   base64_entries: list<array{expr_start: int, expr_length: int, quote_start: int, quote_length: int, encoded_value: string, value: ?string, new_value: ?string}>,
-     *   value_entries: list<array{kind: string, column: string, start?: int, end?: int, raw?: string, expr_start?: int, expr_length?: int, quote_start?: int, quote_length?: int, encoded_value?: string}>
+     *   value_entries: list<array{kind: string, column: string, start?: int, end?: int, raw?: string, expr_start?: int, expr_length?: int, quote_start?: int, quote_length?: int, encoded_value?: string}>,
+     *   value_count?: int,
+     *   value_codes?: string,
+     *   value_shape_codes?: string,
+     *   value_payloads?: list<string>
      * }|null
      *   Null when the SQL doesn't match the recognised shape.
      */
-    public static function scan(string $sql, bool $include_column_map = true, bool $include_base64_entries = true): ?array
+    public static function scan(
+        string $sql,
+        bool $include_column_map = true,
+        bool $include_base64_entries = true,
+        bool $compact_values = false
+    ): ?array
     {
         // Header: optional leading whitespace, INSERT (no priority/IGNORE
         // modifiers — producer never emits those), INTO, backticked table,
@@ -97,6 +106,10 @@ class FastInsertScanner
         $column_map = [];
         $base64_entries = [];
         $value_entries = [];
+        $value_payloads = [];
+        $value_codes = '';
+        $value_shape_codes = '';
+        $value_count = 0;
         $has_base64 = false;
 
         $cursor = $values_end;
@@ -143,11 +156,45 @@ class FastInsertScanner
                 $value_end = $cursor;
                 if ($include_column_map) {
                     $column_map[] = [$value_start, $value_end, $columns[$col_idx]];
-                    $value_kind['start'] = $value_start;
-                    $value_kind['end'] = $value_end;
+                    if (!$compact_values) {
+                        $value_kind['start'] = $value_start;
+                        $value_kind['end'] = $value_end;
+                    }
                 }
-                $value_kind['column'] = $columns[$col_idx];
-                $value_entries[] = $value_kind;
+
+                if ($compact_values) {
+                    $value_count++;
+                    switch ($value_kind['kind']) {
+                        case 'null':
+                            $value_codes .= 'n';
+                            $value_shape_codes .= 's';
+                            break;
+
+                        case 'empty_string':
+                            $value_codes .= 'e';
+                            $value_shape_codes .= 's';
+                            break;
+
+                        case 'numeric':
+                            $is_real = strpbrk($value_kind['raw'], '.eE') !== false;
+                            $value_codes .= $is_real ? 'r' : 'i';
+                            $value_shape_codes .= $is_real ? 'r' : 'i';
+                            $value_payloads[] = $value_kind['raw'];
+                            break;
+
+                        case 'base64':
+                            $value_codes .= 'b';
+                            $value_shape_codes .= 's';
+                            $value_payloads[] = $value_kind['encoded_value'];
+                            break;
+
+                        default:
+                            return null;
+                    }
+                } else {
+                    $value_kind['column'] = $columns[$col_idx];
+                    $value_entries[] = $value_kind;
+                }
 
                 if ($value_kind['kind'] === 'base64') {
                     $has_base64 = true;
@@ -210,6 +257,10 @@ class FastInsertScanner
             'has_base64' => $has_base64,
             'base64_entries' => $base64_entries,
             'value_entries' => $value_entries,
+            'value_count' => $value_count,
+            'value_codes' => $value_codes,
+            'value_shape_codes' => $value_shape_codes,
+            'value_payloads' => $value_payloads,
         ];
     }
 
@@ -254,18 +305,18 @@ class FastInsertScanner
             if ($entry === null) {
                 return null;
             }
-            if ($include_base64_offsets) {
+            if (!$include_base64_offsets) {
                 return [
                     'kind' => 'base64',
-                    'expr_start' => $entry[0],
-                    'expr_length' => $entry[1],
-                    'quote_start' => $entry[2],
-                    'quote_length' => $entry[3],
                     'encoded_value' => $entry[4],
                 ];
             }
             return [
                 'kind' => 'base64',
+                'expr_start' => $entry[0],
+                'expr_length' => $entry[1],
+                'quote_start' => $entry[2],
+                'quote_length' => $entry[3],
                 'encoded_value' => $entry[4],
             ];
         }
@@ -315,18 +366,18 @@ class FastInsertScanner
             }
             $cursor++;
             $entry[1] = $cursor - $expr_start;
-            if ($include_base64_offsets) {
+            if (!$include_base64_offsets) {
                 return [
                     'kind' => 'base64',
-                    'expr_start' => $entry[0],
-                    'expr_length' => $entry[1],
-                    'quote_start' => $entry[2],
-                    'quote_length' => $entry[3],
                     'encoded_value' => $entry[4],
                 ];
             }
             return [
                 'kind' => 'base64',
+                'expr_start' => $entry[0],
+                'expr_length' => $entry[1],
+                'quote_start' => $entry[2],
+                'quote_length' => $entry[3],
                 'encoded_value' => $entry[4],
             ];
         }

--- a/packages/reprint-importer/src/lib/url-rewrite/class-sqlite-prepared-insert-builder.php
+++ b/packages/reprint-importer/src/lib/url-rewrite/class-sqlite-prepared-insert-builder.php
@@ -35,7 +35,7 @@ class SQLitePreparedInsertBuilder
      */
     public static function build(string $sql, ?callable $rewrite_value = null): ?array
     {
-        if (strpos($sql, 'FROM_BASE64(') === false) {
+        if (stripos($sql, 'FROM_BASE64(') === false) {
             return null;
         }
 
@@ -49,69 +49,31 @@ class SQLitePreparedInsertBuilder
      */
     private static function build_with_fast_insert_scanner(string $sql, ?callable $rewrite_value): ?array
     {
-        $fast = FastInsertScanner::scan($sql, false, false);
-        if ($fast === null || empty($fast['has_base64']) || empty($fast['value_entries'])) {
+        $fast = FastInsertScanner::scan($sql, false, false, true);
+        if ($fast === null || empty($fast['has_base64'])) {
+            return null;
+        }
+
+        $value_count = $fast['value_count'] ?? 0;
+        $value_codes = $fast['value_codes'] ?? '';
+        $value_shape_codes = $fast['value_shape_codes'] ?? '';
+        $value_payloads = $fast['value_payloads'] ?? [];
+        if ($value_codes === '') {
             return null;
         }
 
         $column_count = count($fast['columns']);
-        $value_count = count($fast['value_entries']);
-        if ($column_count === 0 || $value_count === 0 || $value_count % $column_count !== 0) {
+        if (
+            $column_count === 0
+            || $value_count === 0
+            || $value_count % $column_count !== 0
+            || strlen($value_codes) !== $value_count
+            || strlen($value_shape_codes) !== $value_count
+        ) {
             return null;
         }
 
-        // Describe the prepared SQL template, not the concrete bound values.
-        // The cache key must change when the generated SQL text changes, but
-        // must stay stable across batches that only differ by decoded payloads
-        // or numeric literal values.
-        $shape_value_codes = '';
-        $params = [];
-        $param_types = [];
-        foreach ($fast['value_entries'] as $entry) {
-            switch ($entry['kind']) {
-                case 'null':
-                    // NULL, empty strings, and decoded base64 payloads all compile
-                    // to the same bare placeholder; their values are supplied later.
-                    $shape_value_codes .= 's';
-                    $params[] = null;
-                    $param_types[] = PDO::PARAM_NULL;
-                    break;
-
-                case 'empty_string':
-                    $shape_value_codes .= 's';
-                    $params[] = '';
-                    $param_types[] = PDO::PARAM_STR;
-                    break;
-
-                case 'numeric':
-                    // Numeric values are bound, not embedded. Only SQLite's target
-                    // storage class affects the template: dotted/exponent literals
-                    // need REAL while integer-looking literals use NUMERIC.
-                    $shape_value_codes .= strpbrk($entry['raw'], '.eE') === false ? 'i' : 'r';
-                    $params[] = $entry['raw'];
-                    $param_types[] = PDO::PARAM_STR;
-                    break;
-
-                case 'base64':
-                    $shape_value_codes .= 's';
-                    $decoded = base64_decode($entry['encoded_value'], true);
-                    if ($decoded === false) {
-                        return null;
-                    }
-                    $value = $decoded;
-                    if ($rewrite_value !== null) {
-                        $value = $rewrite_value($value, $fast['table'], $entry['column']);
-                    }
-                    $params[] = $value;
-                    $param_types[] = PDO::PARAM_STR;
-                    break;
-
-                default:
-                    return null;
-            }
-        }
-
-        $shape_key = self::compact_shape_key($fast['table'], $fast['columns'], $shape_value_codes);
+        $shape_key = self::compact_shape_key($fast['table'], $fast['columns'], $value_shape_codes);
         $template_sql = self::$template_sql_cache[$shape_key] ?? null;
         if ($template_sql === null) {
             // Cache misses are the only time we build SQL text. Payload bytes
@@ -119,7 +81,7 @@ class SQLitePreparedInsertBuilder
             // identifiers and placeholders for the producer-recognised shape.
             // Preserve one reusable SQL string per table/column/value-shape so
             // PDO and SQLite can reuse the compiled statement across dump rows.
-            $template_sql = self::template_sql_from_shape($fast['table'], $fast['columns'], $shape_value_codes);
+            $template_sql = self::template_sql_from_shape($fast['table'], $fast['columns'], $value_shape_codes);
 
             self::$template_sql_cache[$shape_key] = $template_sql;
             self::$template_sql_cache_order[] = $shape_key;
@@ -131,6 +93,61 @@ class SQLitePreparedInsertBuilder
                     unset(self::$template_sql_cache[$oldest_key]);
                 }
             }
+        }
+
+        // Build the bound values after the template is selected. This keeps
+        // untrusted decoded bytes out of SQL text while still allowing URL
+        // rewriting to use table/column context for structured data.
+        $params = [];
+        $param_types = [];
+        $payload_index = 0;
+
+        for ($i = 0; $i < $value_count; $i++) {
+            switch ($value_codes[$i]) {
+                case 'n':
+                    $params[] = null;
+                    $param_types[] = PDO::PARAM_NULL;
+                    break;
+
+                case 'e':
+                    $params[] = '';
+                    $param_types[] = PDO::PARAM_STR;
+                    break;
+
+                case 'i':
+                case 'r':
+                    if (!array_key_exists($payload_index, $value_payloads)) {
+                        return null;
+                    }
+                    $params[] = $value_payloads[$payload_index];
+                    $payload_index++;
+                    $param_types[] = PDO::PARAM_STR;
+                    break;
+
+                case 'b':
+                    if (!array_key_exists($payload_index, $value_payloads)) {
+                        return null;
+                    }
+                    $decoded = base64_decode($value_payloads[$payload_index], true);
+                    $payload_index++;
+                    if ($decoded === false) {
+                        return null;
+                    }
+                    $value = $decoded;
+                    if ($rewrite_value !== null) {
+                        $value = $rewrite_value($value, $fast['table'], $fast['columns'][$i % $column_count]);
+                    }
+                    $params[] = $value;
+                    $param_types[] = PDO::PARAM_STR;
+                    break;
+
+                default:
+                    return null;
+            }
+        }
+
+        if ($payload_index !== count($value_payloads)) {
+            return null;
         }
 
         return [
@@ -145,7 +162,9 @@ class SQLitePreparedInsertBuilder
      */
     private static function compact_shape_key(string $table, array $columns, string $shape_value_codes): string
     {
-        $key = 'compact|' . strlen($table) . ':' . $table . '|' . count($columns);
+        // Describe the prepared SQL template, not the concrete bound values.
+        // Length-prefixing identifiers prevents separator collisions.
+        $key = 'stream1|' . strlen($table) . ':' . $table . '|' . count($columns);
         foreach ($columns as $column) {
             $key .= '|' . strlen($column) . ':' . $column;
         }
@@ -157,38 +176,51 @@ class SQLitePreparedInsertBuilder
      */
     private static function template_sql_from_shape(string $table, array $columns, string $shape_value_codes): string
     {
-        $quoted_columns = [];
-        foreach ($columns as $column) {
-            $quoted_columns[] = self::quote_identifier($column);
-        }
-
         $column_count = count($columns);
         $value_count = strlen($shape_value_codes);
-        $rows = [];
-        for ($offset = 0; $offset < $value_count; $offset += $column_count) {
-            $placeholders = [];
-            for ($i = 0; $i < $column_count; $i++) {
-                $code = $shape_value_codes[$offset + $i];
-                if ($code === 'i') {
-                    $placeholders[] = 'CAST(? AS NUMERIC)';
-                } elseif ($code === 'r') {
-                    $placeholders[] = 'CAST(? AS REAL)';
-                } else {
-                    $placeholders[] = '?';
-                }
+
+        $template_sql = 'INSERT INTO ' . self::quote_identifier($table) . ' (';
+        foreach ($columns as $index => $column) {
+            if ($index > 0) {
+                $template_sql .= ', ';
             }
-            $rows[] = '(' . implode(', ', $placeholders) . ')';
+            $template_sql .= self::quote_identifier($column);
+        }
+        $template_sql .= ') VALUES';
+
+        for ($offset = 0; $offset < $value_count; $offset += $column_count) {
+            if ($offset > 0) {
+                $template_sql .= ',';
+            }
+            $template_sql .= '(';
+            for ($i = 0; $i < $column_count; $i++) {
+                if ($i > 0) {
+                    $template_sql .= ', ';
+                }
+                $template_sql .= self::placeholder_for_shape_code($shape_value_codes[$offset + $i]);
+            }
+            $template_sql .= ')';
         }
 
-        return 'INSERT INTO '
-            . self::quote_identifier($table)
-            . ' (' . implode(', ', $quoted_columns) . ') VALUES'
-            . implode(',', $rows)
-            . ';';
+        return $template_sql . ';';
+    }
+
+    private static function placeholder_for_shape_code(string $code): string
+    {
+        if ($code === 'i') {
+            return 'CAST(? AS NUMERIC)';
+        }
+        if ($code === 'r') {
+            return 'CAST(? AS REAL)';
+        }
+        return '?';
     }
 
     private static function quote_identifier(string $identifier): string
     {
+        if (strpos($identifier, '`') === false) {
+            return '`' . $identifier . '`';
+        }
         return '`' . str_replace('`', '``', $identifier) . '`';
     }
 

--- a/tests/UrlRewriting/SQLitePreparedInsertBuilderTest.php
+++ b/tests/UrlRewriting/SQLitePreparedInsertBuilderTest.php
@@ -87,6 +87,23 @@ class SQLitePreparedInsertBuilderTest extends TestCase
         $this->assertSame([$value], $prepared['params']);
     }
 
+    public function testBuildsPreparedInsertForLowercaseFromBase64Function(): void
+    {
+        $sql = sprintf(
+            "INSERT INTO `wp_options` (`option_id`, `option_value`) VALUES(1, from_base64('%s'));",
+            base64_encode('value')
+        );
+
+        $prepared = SQLitePreparedInsertBuilder::build($sql);
+
+        $this->assertNotNull($prepared);
+        $this->assertSame(
+            "INSERT INTO `wp_options` (`option_id`, `option_value`) VALUES(CAST(? AS NUMERIC), ?);",
+            $prepared['sql']
+        );
+        $this->assertSame(['1', 'value'], $prepared['params']);
+    }
+
     public function testRewriteCallbackReceivesTableAndColumn(): void
     {
         $sql = sprintf(
@@ -180,6 +197,53 @@ class SQLitePreparedInsertBuilderTest extends TestCase
             ],
             $prepared_a['param_types']
         );
+    }
+
+    public function testBuildsPreparedInsertForEscapedIdentifiersAndMixedCasts(): void
+    {
+        $value = "payload\nbytes";
+        $sql = sprintf(
+            "INSERT INTO `wp``odd` (`id``num`, `ratio`, `content``bytes`, `empty_value`, `missing_value`) VALUES(+42, -1.25E+3, FROM_BASE64('%s'), '', NULL);",
+            base64_encode($value)
+        );
+
+        $prepared = SQLitePreparedInsertBuilder::build($sql);
+
+        $this->assertNotNull($prepared);
+        $this->assertSame(
+            "INSERT INTO `wp``odd` (`id``num`, `ratio`, `content``bytes`, `empty_value`, `missing_value`) VALUES(CAST(? AS NUMERIC), CAST(? AS REAL), ?, ?, ?);",
+            $prepared['sql']
+        );
+        $this->assertSame(['+42', '-1.25E+3', $value, '', null], $prepared['params']);
+        $this->assertSame(
+            [PDO::PARAM_STR, PDO::PARAM_STR, PDO::PARAM_STR, PDO::PARAM_STR, PDO::PARAM_NULL],
+            $prepared['param_types']
+        );
+    }
+
+    public function testPlaceholderShapeStaysStableAcrossNullEmptyAndBase64Values(): void
+    {
+        $sql_a = sprintf(
+            "INSERT INTO `wp_options` (`option_id`, `option_name`, `option_value`) VALUES(1, FROM_BASE64('%s'), NULL);",
+            base64_encode('alpha')
+        );
+        $sql_b = sprintf(
+            "INSERT INTO `wp_options` (`option_id`, `option_name`, `option_value`) VALUES(999, '', FROM_BASE64('%s'));",
+            base64_encode('bravo')
+        );
+
+        $prepared_a = SQLitePreparedInsertBuilder::build($sql_a);
+        $prepared_b = SQLitePreparedInsertBuilder::build($sql_b);
+
+        $this->assertNotNull($prepared_a);
+        $this->assertNotNull($prepared_b);
+        $this->assertSame(
+            "INSERT INTO `wp_options` (`option_id`, `option_name`, `option_value`) VALUES(CAST(? AS NUMERIC), ?, ?);",
+            $prepared_a['sql']
+        );
+        $this->assertSame($prepared_a['sql'], $prepared_b['sql']);
+        $this->assertSame(['1', 'alpha', null], $prepared_a['params']);
+        $this->assertSame(['999', '', 'bravo'], $prepared_b['params']);
     }
 
     public function testRejectsMalformedBase64InsteadOfBindingEmptyString(): void
@@ -349,6 +413,27 @@ class SQLitePreparedInsertBuilderTest extends TestCase
         );
         $this->assertSame('1', $prepared['params'][0]);
         $this->assertSame('<a href="https://new-site.com/page">Link</a>', $prepared['params'][1]);
+    }
+
+    public function testCommentsAndStringLiteralShapesUseStatementFallback(): void
+    {
+        $rewriter = new SqlStatementRewriter(
+            new StructuredDataUrlRewriter([
+                'https://old-site.com' => 'https://new-site.com',
+            ])
+        );
+        $sql = sprintf(
+            "/* dump comment */ INSERT INTO `wp_posts` (`ID`, `post_title`, `post_content`) VALUES (1, 'literal ''FROM_BASE64(''fake'')''', FROM_BASE64('%s'));",
+            base64_encode('<a href="https://old-site.com/page">Link</a>')
+        );
+
+        $this->assertNull($rewriter->build_sqlite_prepared_insert($sql));
+
+        $rewritten = $rewriter->rewrite($sql);
+        $this->assertStringContainsString("'literal ''FROM_BASE64(''fake'')'''", $rewritten);
+        $values = $this->collectValues($rewritten);
+        $this->assertCount(1, $values);
+        $this->assertSame('<a href="https://new-site.com/page">Link</a>', $values[0]);
     }
 
     public function testSqlStatementRewriterUsesColumnOrderWhenCompilingTemplate(): void


### PR DESCRIPTION
## What it does

Streams SQLite prepared-insert shape data through `FastInsertScanner` instead of building full per-value entry arrays for the prepared-builder path.

## Rationale

PR #249 already landed the reusable prepared-template cache on `trunk`. This PR keeps that behavior and removes another hot-path allocation layer: the prepared builder only needs the SQL shape, raw numeric literals, and encoded payloads, not offset-rich scanner entries.

## Implementation

`FastInsertScanner::scan()` now has a compact mode that emits `value_codes`, `value_shape_codes`, and a flat `value_payloads` list while preserving the existing structured scanner/fallback path for rewriting.

`SQLitePreparedInsertBuilder` builds template cache keys directly from compact shape codes, streams template SQL generation, binds params in scanner order, validates payload counts, and keeps decoded `FROM_BASE64()` bytes out of SQL text. The initial `FROM_BASE64(` guard is now case-insensitive to match the scanner.

## Testing instructions

Run:

```bash
php -l packages/reprint-importer/src/lib/url-rewrite/class-fast-insert-scanner.php
php -l packages/reprint-importer/src/lib/url-rewrite/class-sqlite-prepared-insert-builder.php
php -l tests/UrlRewriting/SQLitePreparedInsertBuilderTest.php
vendor/bin/phpunit --configuration tests/phpunit.xml tests/UrlRewriting/SQLitePreparedInsertBuilderTest.php
vendor/bin/phpunit --configuration tests/phpunit.xml tests/UrlRewriting
vendor/bin/phpstan analyze --memory-limit=1G packages/reprint-importer/src/lib/url-rewrite/class-fast-insert-scanner.php packages/reprint-importer/src/lib/url-rewrite/class-sqlite-prepared-insert-builder.php
vendor/bin/phpstan analyze --memory-limit=1G
git diff --check
```

Benchmarks were run with `flock /tmp/reprint-bench.lock -c 'BENCH_STAGES=playground-sqlite-db-apply ... node tests/e2e/benchmark/bench-pull.mjs'`, `BENCH_SEED_POSTS=10000`, `BENCH_SEED_POSTMETA=25000`, PHP `8.2.29`, PHP.wasm `8.3`, and the native MySQL parser manifest enabled. The runner log reported the source DB was already seeded with `400011` posts and skipped reseeding downward.

| Ref | Commit | Stage | Time | Delta |
|---|---|---|---:|---:|
| `origin/trunk` | `27c5f25` | `playground-sqlite-db-apply` | 93.10 s | baseline |
| this branch | `116aa2d` | `playground-sqlite-db-apply` | 90.48 s | -2.62 s / -2.8% |
