### PR TITLE
Reuse insert shape plans during db-pull domain scan

### DIFF
--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -7702,12 +7702,20 @@ class ImportClient
             if ($statements_counted !== null) {
                 $statements_counted++;
             }
-            // Only scan INSERT statements (they contain data values).
-            if (!self::sql_starts_with_token($query, \WP_MySQL_Lexer::INSERT_SYMBOL)) {
-                continue;
-            }
             // Only scan statements with base64 values
             if (strpos($query, "FROM_BASE64(") === false) {
+                continue;
+            }
+
+            $fast_insert = \FastInsertScanner::scan_with_reusable_plan($query, false);
+            if ($fast_insert !== null && $this->drain_fast_insert_for_domains($fast_insert, $domain_collector)) {
+                continue;
+            }
+
+            // Only scan INSERT statements (they contain data values). The
+            // producer-shaped INSERT path above already proved its statement
+            // shape, so the lexer check is only needed for fallback.
+            if (!self::sql_starts_with_token($query, \WP_MySQL_Lexer::INSERT_SYMBOL)) {
                 continue;
             }
 
@@ -7755,6 +7763,147 @@ class ImportClient
                 }
             }
         }
+    }
+
+    /**
+     * Scan a FastInsertScanner-proven INSERT shape using its reusable plan.
+     *
+     * @param array{
+     *   table: string,
+     *   columns: list<string>,
+     *   value_entries: list<array{kind: string, start: int, end: int, column: string, raw?: string, expr_start?: int, expr_length?: int, quote_start?: int, quote_length?: int, encoded_value?: string}>,
+     *   shape_plan: array{
+     *     table: string,
+     *     columns: list<string>,
+     *     column_count: int,
+     *     row_count: int,
+     *     base64_value_indexes: list<int>,
+     *     option_name_value_indexes: list<int|null>,
+     *     row_identifier_value_indexes: list<int>
+     *   }
+     * } $fast_insert
+     */
+    private function drain_fast_insert_for_domains(
+        array $fast_insert,
+        \DomainCollector $domain_collector
+    ): bool {
+        $plan = $fast_insert['shape_plan'];
+        $value_entries = $fast_insert['value_entries'];
+        $table = $plan['table'];
+        $column_count = $plan['column_count'];
+        if ($column_count <= 0) {
+            return false;
+        }
+
+        $is_options_table = substr($table, -8) === '_options';
+        if ($is_options_table) {
+            foreach ($plan['option_name_value_indexes'] as $option_name_value_index) {
+                if ($option_name_value_index === null) {
+                    return false;
+                }
+            }
+        }
+
+        foreach ($plan['base64_value_indexes'] as $value_index) {
+            if (!isset($value_entries[$value_index])) {
+                return false;
+            }
+            $entry = $value_entries[$value_index];
+            if (!isset($entry['encoded_value'])) {
+                return false;
+            }
+
+            $row_index = intdiv($value_index, $column_count);
+            $option_name = null;
+            if ($is_options_table) {
+                $option_name_value_index = $plan['option_name_value_indexes'][$row_index] ?? null;
+                if ($option_name_value_index === null || !isset($value_entries[$option_name_value_index])) {
+                    return false;
+                }
+                $option_name = self::fast_insert_value_as_string($value_entries[$option_name_value_index], 80);
+                if ($option_name !== null && (
+                    strpos($option_name, '_transient') === 0 ||
+                    strpos($option_name, '_site_transient') === 0
+                )) {
+                    continue;
+                }
+            }
+
+            $decoded = base64_decode($entry['encoded_value'], true);
+            $new_domains = $domain_collector->scan($decoded === false ? '' : $decoded);
+            if (!empty($new_domains)) {
+                $row_identifier_value_index = $plan['row_identifier_value_indexes'][$row_index] ?? null;
+                $row_id = is_int($row_identifier_value_index) && isset($value_entries[$row_identifier_value_index])
+                    ? self::fast_insert_row_identifier($value_entries[$row_identifier_value_index])
+                    : 'offset=?';
+
+                $option_ctx = '';
+                if ($option_name !== null) {
+                    $option_ctx = ' option=' . $option_name;
+                }
+
+                foreach ($new_domains as $domain) {
+                    $this->audit_log(
+                        sprintf(
+                            "NEW DOMAIN | %s | table=%s %s%s",
+                            $domain,
+                            $table,
+                            $row_id,
+                            $option_ctx,
+                        ),
+                        false,
+                    );
+                }
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param array{kind: string, raw?: string, encoded_value?: string} $entry
+     */
+    private static function fast_insert_value_as_string(array $entry, int $max_length): ?string
+    {
+        switch ($entry['kind']) {
+            case 'base64':
+                if (!isset($entry['encoded_value'])) {
+                    return null;
+                }
+                $decoded = base64_decode($entry['encoded_value'], true);
+                return $decoded === false ? null : substr($decoded, 0, $max_length);
+
+            case 'empty_string':
+                return '';
+
+            case 'numeric':
+                return $entry['raw'] ?? null;
+
+            case 'null':
+                return null;
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array{kind: string, raw?: string} $entry
+     */
+    private static function fast_insert_row_identifier(array $entry): string
+    {
+        switch ($entry['kind']) {
+            case 'numeric':
+                $raw = $entry['raw'] ?? '';
+                return preg_match('/^-?\d+$/', $raw) ? 'pk=' . $raw : 'offset=?';
+
+            case 'empty_string':
+                return 'pk=';
+
+            case 'null':
+                return 'pk=NULL';
+        }
+
+        return 'offset=?';
     }
 
     /**

--- a/packages/reprint-importer/src/lib/url-rewrite/class-fast-insert-scanner.php
+++ b/packages/reprint-importer/src/lib/url-rewrite/class-fast-insert-scanner.php
@@ -31,6 +31,26 @@
  */
 class FastInsertScanner
 {
+    private const SHAPE_PLAN_CACHE_MAX = 256;
+
+    /**
+     * Reusable plans keyed by table, column order, row count, and value kinds.
+     *
+     * @var array<string, array{
+     *   table: string,
+     *   columns: list<string>,
+     *   column_count: int,
+     *   row_count: int,
+     *   base64_value_indexes: list<int>,
+     *   option_name_value_indexes: list<int|null>,
+     *   row_identifier_value_indexes: list<int>
+     * }>
+     */
+    private static array $shape_plan_cache = [];
+
+    /** @var string[] */
+    private static array $shape_plan_cache_order = [];
+
     /**
      * Try to scan a producer-shape INSERT statement.
      *
@@ -44,6 +64,64 @@ class FastInsertScanner
      *   Null when the SQL doesn't match the recognised shape.
      */
     public static function scan(string $sql, bool $include_column_map = true): ?array
+    {
+        return self::scan_internal($sql, $include_column_map, false);
+    }
+
+    /**
+     * Try to scan a producer-shape INSERT and attach a reusable shape plan.
+     *
+     * The current SQL is still parsed first; only successfully recognised
+     * producer INSERTs can enter the cache. That keeps unsupported SQL on the
+     * caller's existing fallback path while avoiding repeated planning for
+     * recurring table/column/value shapes.
+     *
+     * @return array{
+     *   table: string,
+     *   columns: list<string>,
+     *   column_map: list<array{int, int, string}>,
+     *   base64_entries: list<array{expr_start: int, expr_length: int, quote_start: int, quote_length: int, encoded_value: string, value: ?string, new_value: ?string}>,
+     *   value_entries: list<array{kind: string, start: int, end: int, column: string, raw?: string, expr_start?: int, expr_length?: int, quote_start?: int, quote_length?: int, encoded_value?: string}>,
+     *   shape_key: string,
+     *   shape_plan_cache_hit: bool,
+     *   shape_plan: array{
+     *     table: string,
+     *     columns: list<string>,
+     *     column_count: int,
+     *     row_count: int,
+     *     base64_value_indexes: list<int>,
+     *     option_name_value_indexes: list<int|null>,
+     *     row_identifier_value_indexes: list<int>
+     *   }
+     * }|null
+     *   Null when the SQL doesn't match the recognised shape.
+     */
+    public static function scan_with_reusable_plan(string $sql, bool $include_column_map = true): ?array
+    {
+        return self::scan_internal($sql, $include_column_map, true);
+    }
+
+    /**
+     * @return array{
+     *   table: string,
+     *   columns: list<string>,
+     *   column_map: list<array{int, int, string}>,
+     *   base64_entries: list<array{expr_start: int, expr_length: int, quote_start: int, quote_length: int, encoded_value: string, value: ?string, new_value: ?string}>,
+     *   value_entries: list<array{kind: string, start: int, end: int, column: string, raw?: string, expr_start?: int, expr_length?: int, quote_start?: int, quote_length?: int, encoded_value?: string}>,
+     *   shape_key?: string,
+     *   shape_plan_cache_hit?: bool,
+     *   shape_plan?: array{
+     *     table: string,
+     *     columns: list<string>,
+     *     column_count: int,
+     *     row_count: int,
+     *     base64_value_indexes: list<int>,
+     *     option_name_value_indexes: list<int|null>,
+     *     row_identifier_value_indexes: list<int>
+     *   }
+     * }|null
+     */
+    private static function scan_internal(string $sql, bool $include_column_map, bool $include_shape_plan): ?array
     {
         // Header: optional leading whitespace, INSERT (no priority/IGNORE
         // modifiers — producer never emits those), INTO, backticked table,
@@ -198,13 +276,36 @@ class FastInsertScanner
             // Either ';' or end-of-string (or whitespace then either) loops back.
         }
 
-        return [
+        $result = [
             'table' => $table,
             'columns' => $columns,
             'column_map' => $column_map,
             'base64_entries' => $base64_entries,
             'value_entries' => $value_entries,
         ];
+
+        if ($include_shape_plan) {
+            $shape_key = self::shape_key($table, $columns, $value_entries);
+            $shape_plan = self::$shape_plan_cache[$shape_key] ?? null;
+            $cache_hit = $shape_plan !== null;
+            if ($shape_plan === null) {
+                $shape_plan = self::build_shape_plan($table, $columns, $value_entries);
+                self::$shape_plan_cache[$shape_key] = $shape_plan;
+                self::$shape_plan_cache_order[] = $shape_key;
+                if (count(self::$shape_plan_cache_order) > self::SHAPE_PLAN_CACHE_MAX) {
+                    $oldest_key = array_shift(self::$shape_plan_cache_order);
+                    if (is_string($oldest_key)) {
+                        unset(self::$shape_plan_cache[$oldest_key]);
+                    }
+                }
+            }
+
+            $result['shape_key'] = $shape_key;
+            $result['shape_plan_cache_hit'] = $cache_hit;
+            $result['shape_plan'] = $shape_plan;
+        }
+
+        return $result;
     }
 
     /**
@@ -399,5 +500,86 @@ class FastInsertScanner
     private static function is_ws(string $c): bool
     {
         return $c === ' ' || $c === "\t" || $c === "\n" || $c === "\r";
+    }
+
+    /**
+     * @param list<string> $columns
+     * @param list<array{kind: string, start: int, end: int, column: string, raw?: string, expr_start?: int, expr_length?: int, quote_start?: int, quote_length?: int, encoded_value?: string}> $value_entries
+     */
+    private static function shape_key(string $table, array $columns, array $value_entries): string
+    {
+        $parts = [
+            strlen($table) . ':' . $table,
+            (string) count($columns),
+        ];
+        foreach ($columns as $column) {
+            $parts[] = strlen($column) . ':' . $column;
+        }
+        $parts[] = (string) count($value_entries);
+        foreach ($value_entries as $entry) {
+            $kind = $entry['kind'];
+            if ($kind === 'numeric') {
+                $kind .= isset($entry['raw']) && strpbrk($entry['raw'], '.eE') === false
+                    ? ':integer'
+                    : ':real';
+            }
+            $parts[] = $kind;
+        }
+
+        return implode('|', $parts);
+    }
+
+    /**
+     * @param list<string> $columns
+     * @param list<array{kind: string, start: int, end: int, column: string, raw?: string, expr_start?: int, expr_length?: int, quote_start?: int, quote_length?: int, encoded_value?: string}> $value_entries
+     * @return array{
+     *   table: string,
+     *   columns: list<string>,
+     *   column_count: int,
+     *   row_count: int,
+     *   base64_value_indexes: list<int>,
+     *   option_name_value_indexes: list<int|null>,
+     *   row_identifier_value_indexes: list<int>
+     * }
+     */
+    private static function build_shape_plan(string $table, array $columns, array $value_entries): array
+    {
+        $column_count = count($columns);
+        $value_count = count($value_entries);
+        $row_count = $column_count > 0 ? (int) ($value_count / $column_count) : 0;
+        $option_name_column_index = null;
+        foreach ($columns as $index => $column) {
+            if ($column === 'option_name') {
+                $option_name_column_index = $index;
+                break;
+            }
+        }
+
+        $base64_value_indexes = [];
+        foreach ($value_entries as $index => $entry) {
+            if ($entry['kind'] === 'base64') {
+                $base64_value_indexes[] = $index;
+            }
+        }
+
+        $option_name_value_indexes = [];
+        $row_identifier_value_indexes = [];
+        for ($row = 0; $row < $row_count; $row++) {
+            $row_start = $row * $column_count;
+            $row_identifier_value_indexes[] = $row_start;
+            $option_name_value_indexes[] = $option_name_column_index === null
+                ? null
+                : $row_start + $option_name_column_index;
+        }
+
+        return [
+            'table' => $table,
+            'columns' => $columns,
+            'column_count' => $column_count,
+            'row_count' => $row_count,
+            'base64_value_indexes' => $base64_value_indexes,
+            'option_name_value_indexes' => $option_name_value_indexes,
+            'row_identifier_value_indexes' => $row_identifier_value_indexes,
+        ];
     }
 }

--- a/tests/Import/DbPullDomainShapePlanTest.php
+++ b/tests/Import/DbPullDomainShapePlanTest.php
@@ -1,0 +1,106 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../packages/reprint-importer/src/import.php';
+
+class DbPullDomainShapePlanTest extends TestCase
+{
+    private string $temp_dir;
+
+    protected function setUp(): void
+    {
+        $this->temp_dir = sys_get_temp_dir() . '/reprint-domain-plan-' . bin2hex(random_bytes(6));
+        mkdir($this->temp_dir, 0777, true);
+        mkdir($this->temp_dir . '/fs', 0777, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeTree($this->temp_dir);
+    }
+
+    private function removeTree(string $path): void
+    {
+        if (!is_dir($path)) {
+            return;
+        }
+        $entries = scandir($path);
+        if ($entries === false) {
+            return;
+        }
+        foreach ($entries as $entry) {
+            if ($entry === '.' || $entry === '..') {
+                continue;
+            }
+            $child = $path . '/' . $entry;
+            if (is_dir($child) && !is_link($child)) {
+                $this->removeTree($child);
+            } else {
+                unlink($child);
+            }
+        }
+        rmdir($path);
+    }
+
+    /**
+     * @return array{domains: list<string>, statements: int}
+     */
+    private function collectDomainsFromSql(string $sql): array
+    {
+        $client = new ImportClient('https://source.example', $this->temp_dir, $this->temp_dir . '/fs');
+        $stream = new WP_MySQL_Naive_Query_Stream();
+        $collector = new DomainCollector();
+
+        $stream->append_sql($sql);
+        $stream->mark_input_complete();
+
+        $statements = 0;
+        $reflection = new ReflectionClass(ImportClient::class);
+        $method = $reflection->getMethod('drain_query_stream_for_domains');
+        $method->setAccessible(true);
+        $args = [$stream, $collector, &$statements];
+        $method->invokeArgs($client, $args);
+
+        return [
+            'domains' => $collector->get_domains(),
+            'statements' => $statements,
+        ];
+    }
+
+    private function b64(string $value): string
+    {
+        return base64_encode($value);
+    }
+
+    public function testPlannedOptionsShapeUsesColumnNamesForTransientSkip(): void
+    {
+        $sql = sprintf(
+            "INSERT INTO `shape_options` (`option_value`, `option_id`, `option_name`) VALUES" .
+            "(FROM_BASE64('%s'), 1, FROM_BASE64('%s'))," .
+            "(FROM_BASE64('%s'), 2, FROM_BASE64('%s'));",
+            $this->b64('https://transient-media.example/image.jpg'),
+            $this->b64('_transient_cached_media'),
+            $this->b64('<img src="https://content-media.example/image.jpg">'),
+            $this->b64('regular_media')
+        );
+
+        $result = $this->collectDomainsFromSql($sql);
+
+        $this->assertSame(1, $result['statements']);
+        $this->assertSame(['https://content-media.example'], $result['domains']);
+    }
+
+    public function testUnsupportedInsertShapeFallsBackToLexerScanner(): void
+    {
+        $sql = sprintf(
+            "INSERT LOW_PRIORITY IGNORE INTO `shape_postmeta` (`meta_id`, `meta_value`) VALUES(1, FROM_BASE64('%s'));",
+            $this->b64('https://fallback.example/path')
+        );
+
+        $result = $this->collectDomainsFromSql($sql);
+
+        $this->assertSame(1, $result['statements']);
+        $this->assertSame(['https://fallback.example'], $result['domains']);
+    }
+}

--- a/tests/UrlRewriting/FastInsertScannerShapePlanTest.php
+++ b/tests/UrlRewriting/FastInsertScannerShapePlanTest.php
@@ -1,0 +1,175 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../vendor/autoload.php';
+require_once __DIR__ . '/../../packages/reprint-importer/src/lib/url-rewrite/load.php';
+
+class FastInsertScannerShapePlanTest extends TestCase
+{
+    private function b64(string $value): string
+    {
+        return base64_encode($value);
+    }
+
+    /**
+     * @return array{
+     *   table: string,
+     *   columns: list<string>,
+     *   column_map: list<array{int, int, string}>,
+     *   base64_entries: list<array{expr_start: int, expr_length: int, quote_start: int, quote_length: int, encoded_value: string, value: ?string, new_value: ?string}>,
+     *   value_entries: list<array{kind: string, start: int, end: int, column: string, raw?: string, expr_start?: int, expr_length?: int, quote_start?: int, quote_length?: int, encoded_value?: string}>,
+     *   shape_key: string,
+     *   shape_plan_cache_hit: bool,
+     *   shape_plan: array{
+     *     table: string,
+     *     columns: list<string>,
+     *     column_count: int,
+     *     row_count: int,
+     *     base64_value_indexes: list<int>,
+     *     option_name_value_indexes: list<int|null>,
+     *     row_identifier_value_indexes: list<int>
+     *   }
+     * }
+     */
+    private function scan(string $sql): array
+    {
+        $scan = FastInsertScanner::scan_with_reusable_plan($sql, false);
+        $this->assertNotNull($scan);
+        return $scan;
+    }
+
+    public function testReusesPlanForSameTableColumnAndValueShape(): void
+    {
+        $sql_a = sprintf(
+            "INSERT INTO `shape_reuse_posts` (`ID`, `post_content`) VALUES(1, FROM_BASE64('%s')), (2, FROM_BASE64('%s'));",
+            $this->b64('alpha'),
+            $this->b64('bravo')
+        );
+        $sql_b = sprintf(
+            "INSERT INTO `shape_reuse_posts` (`ID`, `post_content`) VALUES(10, FROM_BASE64('%s')), (20, FROM_BASE64('%s'));",
+            $this->b64('charlie'),
+            $this->b64('delta')
+        );
+
+        $first = $this->scan($sql_a);
+        $second = $this->scan($sql_b);
+
+        $this->assertFalse($first['shape_plan_cache_hit']);
+        $this->assertTrue($second['shape_plan_cache_hit']);
+        $this->assertSame($first['shape_key'], $second['shape_key']);
+        $this->assertSame([1, 3], $second['shape_plan']['base64_value_indexes']);
+        $this->assertSame([0, 2], $second['shape_plan']['row_identifier_value_indexes']);
+    }
+
+    public function testDifferentTablesDoNotReusePlan(): void
+    {
+        $sql_a = sprintf(
+            "INSERT INTO `shape_table_a` (`id`, `payload`) VALUES(1, FROM_BASE64('%s'));",
+            $this->b64('alpha')
+        );
+        $sql_b = sprintf(
+            "INSERT INTO `shape_table_b` (`id`, `payload`) VALUES(1, FROM_BASE64('%s'));",
+            $this->b64('bravo')
+        );
+
+        $first = $this->scan($sql_a);
+        $second = $this->scan($sql_b);
+
+        $this->assertFalse($first['shape_plan_cache_hit']);
+        $this->assertFalse($second['shape_plan_cache_hit']);
+        $this->assertNotSame($first['shape_key'], $second['shape_key']);
+    }
+
+    public function testDifferentColumnListsAndOrdersDoNotReusePlan(): void
+    {
+        $sql_a = sprintf(
+            "INSERT INTO `shape_column_order` (`id`, `payload`) VALUES(1, FROM_BASE64('%s'));",
+            $this->b64('alpha')
+        );
+        $sql_b = sprintf(
+            "INSERT INTO `shape_column_order` (`payload`, `id`) VALUES(FROM_BASE64('%s'), 1);",
+            $this->b64('alpha')
+        );
+
+        $first = $this->scan($sql_a);
+        $second = $this->scan($sql_b);
+
+        $this->assertFalse($first['shape_plan_cache_hit']);
+        $this->assertFalse($second['shape_plan_cache_hit']);
+        $this->assertNotSame($first['shape_key'], $second['shape_key']);
+        $this->assertSame([0], $second['shape_plan']['base64_value_indexes']);
+        $this->assertSame([0], $second['shape_plan']['row_identifier_value_indexes']);
+    }
+
+    public function testDifferentValueKindsDoNotReusePlan(): void
+    {
+        $sql_a = sprintf(
+            "INSERT INTO `shape_value_kinds` (`id`, `payload`, `flag`) VALUES(1, FROM_BASE64('%s'), NULL);",
+            $this->b64('alpha')
+        );
+        $sql_b = sprintf(
+            "INSERT INTO `shape_value_kinds` (`id`, `payload`, `flag`) VALUES(1, FROM_BASE64('%s'), '');",
+            $this->b64('alpha')
+        );
+
+        $first = $this->scan($sql_a);
+        $second = $this->scan($sql_b);
+
+        $this->assertFalse($first['shape_plan_cache_hit']);
+        $this->assertFalse($second['shape_plan_cache_hit']);
+        $this->assertNotSame($first['shape_key'], $second['shape_key']);
+    }
+
+    public function testEscapedIdentifiersArePartOfReusablePlan(): void
+    {
+        $sql_a = sprintf(
+            "INSERT INTO `shape``escaped` (`id`, `weird``payload`) VALUES(1, FROM_BASE64('%s'));",
+            $this->b64('alpha')
+        );
+        $sql_b = sprintf(
+            "INSERT INTO `shape``escaped` (`id`, `weird``payload`) VALUES(2, FROM_BASE64('%s'));",
+            $this->b64('bravo')
+        );
+
+        $first = $this->scan($sql_a);
+        $second = $this->scan($sql_b);
+
+        $this->assertSame('shape`escaped', $first['shape_plan']['table']);
+        $this->assertSame(['id', 'weird`payload'], $first['shape_plan']['columns']);
+        $this->assertFalse($first['shape_plan_cache_hit']);
+        $this->assertTrue($second['shape_plan_cache_hit']);
+        $this->assertSame($first['shape_key'], $second['shape_key']);
+    }
+
+    public function testOptionsColumnOrderSelectsOptionNameFromPlan(): void
+    {
+        $sql = sprintf(
+            "INSERT INTO `shape_options` (`option_value`, `option_name`, `option_id`) VALUES(FROM_BASE64('%s'), FROM_BASE64('%s'), 1);",
+            $this->b64('https://example.test'),
+            $this->b64('_transient_cached')
+        );
+
+        $scan = $this->scan($sql);
+
+        $this->assertSame([0, 1], $scan['shape_plan']['base64_value_indexes']);
+        $this->assertSame([1], $scan['shape_plan']['option_name_value_indexes']);
+    }
+
+    public function testUnsupportedShapeStillReturnsNullForFallback(): void
+    {
+        $supported = sprintf(
+            "INSERT INTO `shape_fallback` (`id`, `payload`) VALUES(1, FROM_BASE64('%s'));",
+            $this->b64('alpha')
+        );
+        $unsupported_without_columns = sprintf(
+            "INSERT INTO `shape_fallback` VALUES(1, FROM_BASE64('%s'));",
+            $this->b64('bravo')
+        );
+        $unsupported_literal = "INSERT INTO `shape_fallback` (`id`, `payload`) VALUES(1, 'literal');";
+
+        $this->assertNotNull(FastInsertScanner::scan_with_reusable_plan($supported, false));
+        $this->assertNull(FastInsertScanner::scan_with_reusable_plan($unsupported_without_columns, false));
+        $this->assertNull(FastInsertScanner::scan_with_reusable_plan($unsupported_literal, false));
+    }
+}


### PR DESCRIPTION
## What it does

Caches reusable `FastInsertScanner` shape plans for producer-shaped `INSERT` statements and uses them during `db-pull` domain discovery. Canonical dump `INSERT`s skip the extra lexer-only statement check and `Base64ValueScanner` pass; unsupported statements still fall back to the existing lexer scanner.

## Rationale

`db-pull` scans the SQL stream to collect domains while writing `db.sql`. For recurring dumped `INSERT` batches, it repeatedly re-derived table, column, row, and `option_name` context even after the constrained scanner could already prove the table, column order, row count, and value kinds.

## Implementation

- Added `FastInsertScanner::scan_with_reusable_plan()` with a bounded plan cache keyed by table, column order, row count, and value kinds.
- Updated the `db-pull` domain drain to use the plan for row and `option_name` context, including non-standard `wp_options` column order.
- Preserved the current trunk scanner contract for `has_base64` and optional base64 offset collection; `db-pull` uses the no-offset reusable-plan mode.
- Kept unsupported shapes on the existing fallback path; no regex or URL/domain shortcut replaces the structured scanners.
- Added adversarial coverage for reuse, invalidation, escaped identifiers, value-kind changes, options column order, no-offset reusable plans, and unsupported fallback.

## Testing instructions

```bash
php -l packages/reprint-importer/src/lib/url-rewrite/class-fast-insert-scanner.php
php -l packages/reprint-importer/src/import.php
php -l tests/UrlRewriting/FastInsertScannerShapePlanTest.php
php -l tests/Import/DbPullDomainShapePlanTest.php
vendor/bin/phpunit --configuration tests/phpunit.xml tests/Import/DbPullDomainShapePlanTest.php tests/UrlRewriting/FastInsertScannerShapePlanTest.php tests/UrlRewriting/SQLitePreparedInsertBuilderTest.php tests/UrlRewriting/SqlStatementRewriterTest.php tests/UrlRewriting/SqlStatementRewriterLexerWalkerTest.php tests/UrlRewriting/SqlStatementRewriterPrefilterTest.php
vendor/bin/phpstan analyze --memory-limit=1G packages/reprint-importer/src/lib/url-rewrite/class-fast-insert-scanner.php packages/reprint-importer/src/import.php
git diff --check
git diff --cached --check
```

Locked benchmark command shape:

```bash
flock /tmp/reprint-bench.lock -c 'BENCH_STAGES=playground-sqlite-db-pull,playground-sqlite-db-apply BENCH_LABEL=<label> BENCH_JSON_OUT=/tmp/reprint-bench-<label>.json BENCH_MD_OUT=/tmp/reprint-bench-<label>.md node tests/e2e/benchmark/bench-pull.mjs'
```

Benchmark results after review:

| Stage | branch | trunk | delta |
|---|---:|---:|---:|
| `playground-sqlite-db-pull` | 371.61 s | 420.99 s | -49.38 s (-11.7%) |
| `playground-sqlite-db-apply` | 92.52 s | 90.66 s | +1.86 s (+2.1%) |
| Total | 464.13 s | 511.65 s | -47.52 s (-9.3%) |

Benchmark note: the local rerun used the workflow seed env (`BENCH_SEED_POSTS=10000`, `BENCH_SEED_POSTMETA=25000`) but the existing `large-directory` source DB was already seeded with 400,011 posts, so both PR and trunk reused that larger fixture. The trunk `db-pull` number is from the full trunk run stdout; the trunk `db-apply` number is from a follow-up apply-only run after the full trunk session exited during `db-apply` before writing artifacts. The apply stage still regresses slightly; total time remains improved because the pull win is larger.
