### PR TITLE
Validate db-pull SQL metadata side channel

### DIFF
--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -1943,12 +1943,17 @@ class ImportClient
                         "FILE DELETE | {$tables_file} | abort db-pull",
                     );
                 }
-                $domains_file = $this->state_dir . "/.import-domains.json";
-                if (file_exists($domains_file)) {
-                    unlink($domains_file);
-                    $this->audit_log(
-                        "FILE DELETE | {$domains_file} | abort db-pull",
-                    );
+                foreach ([
+                    SqlPullMetadata::path($this->state_dir),
+                    SqlPullMetadata::legacy_domains_path($this->state_dir),
+                    SqlPullMetadata::legacy_stats_path($this->state_dir),
+                ] as $metadata_file) {
+                    if (file_exists($metadata_file)) {
+                        unlink($metadata_file);
+                        $this->audit_log(
+                            "FILE DELETE | {$metadata_file} | abort db-pull",
+                        );
+                    }
                 }
                 break;
 
@@ -3515,6 +3520,16 @@ class ImportClient
             $this->state["stage"] = "db-index";
             $this->state["diff"] = $this->default_state()["diff"];
             $this->state["db_index"] = $this->default_state()["db_index"];
+            $this->state["sql_statements_counted"] = 0;
+            foreach ([
+                SqlPullMetadata::path($this->state_dir),
+                SqlPullMetadata::legacy_domains_path($this->state_dir),
+                SqlPullMetadata::legacy_stats_path($this->state_dir),
+            ] as $metadata_file) {
+                if (file_exists($metadata_file)) {
+                    @unlink($metadata_file);
+                }
+            }
             $this->save_state($this->state);
 
             $this->audit_log("START db-pull", true);
@@ -3614,56 +3629,18 @@ class ImportClient
      */
     private function run_db_domains(): void
     {
-        $domains_file = $this->state_dir . "/.import-domains.json";
         $sql_file = $this->state_dir . "/db.sql";
+        $metadata = $this->load_valid_sql_pull_metadata($sql_file);
 
-        if (file_exists($domains_file)) {
-            // Fast path: domains were already discovered during db-pull
-            $domains = json_decode(file_get_contents($domains_file), true);
-            if (!is_array($domains)) {
-                throw new RuntimeException(
-                    "Failed to parse {$domains_file}",
-                );
-            }
+        if ($metadata !== null) {
+            $domains = $metadata['domains'];
         } elseif (file_exists($sql_file)) {
-            // Scan db.sql for domains using the same pipeline as db-pull
-            $query_stream = new \WP_MySQL_Naive_Query_Stream();
-            $domain_collector = new \DomainCollector();
-
-            $sql_handle = fopen($sql_file, "r");
-            if (!$sql_handle) {
-                throw new RuntimeException("Cannot open SQL file: {$sql_file}");
-            }
-
-            try {
-                $chunk_size = 64 * 1024;
-                while (!feof($sql_handle)) {
-                    $data = fread($sql_handle, $chunk_size);
-                    if ($data === false || $data === '') {
-                        break;
-                    }
-                    $query_stream->append_sql($data);
-                    $this->drain_query_stream_for_domains(
-                        $query_stream,
-                        $domain_collector,
-                    );
-                }
-
-                $query_stream->mark_input_complete();
-                $this->drain_query_stream_for_domains(
-                    $query_stream,
-                    $domain_collector,
-                );
-            } finally {
-                fclose($sql_handle);
-            }
-
-            $domains = $domain_collector->get_domains();
-
-            // Save for future calls
-            file_put_contents(
-                $domains_file,
-                json_encode($domains, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . "\n",
+            $scanned = $this->scan_sql_file_for_pull_metadata($sql_file);
+            $domains = $scanned['domains'];
+            $this->write_sql_pull_metadata(
+                $sql_file,
+                $domains,
+                $scanned['statements_total'],
             );
         } else {
             throw new RuntimeException(
@@ -3675,6 +3652,92 @@ class ImportClient
         foreach ($domains as $domain) {
             echo $domain . "\n";
         }
+    }
+
+    /**
+     * @return array{domains: list<string>, statements_total: int}
+     */
+    private function scan_sql_file_for_pull_metadata(string $sql_file): array
+    {
+        $query_stream = new \WP_MySQL_Naive_Query_Stream();
+        $domain_collector = new \DomainCollector();
+        $statements_total = 0;
+
+        $sql_handle = fopen($sql_file, "r");
+        if (!$sql_handle) {
+            throw new RuntimeException("Cannot open SQL file: {$sql_file}");
+        }
+
+        try {
+            $chunk_size = 64 * 1024;
+            while (!feof($sql_handle)) {
+                $data = fread($sql_handle, $chunk_size);
+                if ($data === false || $data === '') {
+                    break;
+                }
+                $query_stream->append_sql($data);
+                $this->drain_query_stream_for_domains(
+                    $query_stream,
+                    $domain_collector,
+                    $statements_total,
+                );
+            }
+
+            $query_stream->mark_input_complete();
+            $this->drain_query_stream_for_domains(
+                $query_stream,
+                $domain_collector,
+                $statements_total,
+            );
+        } finally {
+            fclose($sql_handle);
+        }
+
+        return [
+            'domains' => $domain_collector->get_domains(),
+            'statements_total' => $statements_total,
+        ];
+    }
+
+    /**
+     * @return array{domains: list<string>, statements_total: int}|null
+     */
+    private function load_valid_sql_pull_metadata(string $sql_file): ?array
+    {
+        $metadata_file = SqlPullMetadata::path($this->state_dir);
+        $reason = null;
+        $metadata = SqlPullMetadata::read_complete($metadata_file, $sql_file, $reason);
+        if ($metadata === null && file_exists($metadata_file)) {
+            $this->audit_log(
+                "SQL METADATA ignored | {$reason}",
+                false,
+            );
+        }
+        return $metadata;
+    }
+
+    /**
+     * @param string[] $domains
+     */
+    private function write_sql_pull_metadata(
+        string $sql_file,
+        array $domains,
+        int $statements_total
+    ): void {
+        SqlPullMetadata::write_complete(
+            SqlPullMetadata::path($this->state_dir),
+            $sql_file,
+            $domains,
+            $statements_total,
+        );
+        SqlPullMetadata::write_legacy_domains(
+            SqlPullMetadata::legacy_domains_path($this->state_dir),
+            $domains,
+        );
+        SqlPullMetadata::write_legacy_stats(
+            SqlPullMetadata::legacy_stats_path($this->state_dir),
+            $statements_total,
+        );
     }
 
     /**
@@ -5010,31 +5073,32 @@ class ImportClient
             }
         }
 
-        // Show discovered domains if available
-        $domains_file = $this->state_dir . "/.import-domains.json";
-        if (file_exists($domains_file)) {
-            $domains = json_decode(file_get_contents($domains_file), true);
-            if (is_array($domains) && !empty($domains)) {
-                $this->audit_log(
-                    sprintf("DISCOVERED DOMAINS | %s", implode(", ", $domains)),
-                    false,
-                );
-                $this->progress->show_lifecycle_line("Discovered domains in SQL dump:\n");
-                foreach ($domains as $domain) {
-                    $mapped = isset($url_mapping[$domain]) ? " => {$url_mapping[$domain]}" : " (not mapped)";
-                    $this->progress->show_lifecycle_line("  {$domain}{$mapped}\n");
-                }
-                $this->progress->show_lifecycle_line("\n");
-                $domain_map = [];
-                foreach ($domains as $domain) {
-                    $domain_map[$domain] = $url_mapping[$domain] ?? null;
-                }
-                $this->output_progress([
-                    "type" => "domains_discovered",
-                    "domains" => $domain_map,
-                    "message" => "Discovered " . count($domains) . " domain(s) in SQL dump",
-                ], true);
+        $sql_pull_metadata = $this->load_valid_sql_pull_metadata($sql_file);
+
+        // Show discovered domains only when the db-pull metadata validates
+        // against the current db.sql. Stale or malformed side-channel data is
+        // advisory and ignored; db-apply remains correct without it.
+        if ($sql_pull_metadata !== null && !empty($sql_pull_metadata['domains'])) {
+            $domains = $sql_pull_metadata['domains'];
+            $this->audit_log(
+                sprintf("DISCOVERED DOMAINS | %s", implode(", ", $domains)),
+                false,
+            );
+            $this->progress->show_lifecycle_line("Discovered domains in SQL dump:\n");
+            foreach ($domains as $domain) {
+                $mapped = isset($url_mapping[$domain]) ? " => {$url_mapping[$domain]}" : " (not mapped)";
+                $this->progress->show_lifecycle_line("  {$domain}{$mapped}\n");
             }
+            $this->progress->show_lifecycle_line("\n");
+            $domain_map = [];
+            foreach ($domains as $domain) {
+                $domain_map[$domain] = $url_mapping[$domain] ?? null;
+            }
+            $this->output_progress([
+                "type" => "domains_discovered",
+                "domains" => $domain_map,
+                "message" => "Discovered " . count($domains) . " domain(s) in SQL dump",
+            ], true);
         }
 
         // Check state for resume
@@ -5178,15 +5242,10 @@ class ImportClient
         $save_every = 100;
         $stmts_since_save = 0;
 
-        // Load pre-computed statement count from db-pull for progress reporting
-        $sql_stats_file = $this->state_dir . "/.import-sql-stats.json";
-        $statements_total = null;
-        if (file_exists($sql_stats_file)) {
-            $stats = json_decode(file_get_contents($sql_stats_file), true);
-            if (is_array($stats) && isset($stats["statements_total"])) {
-                $statements_total = (int) $stats["statements_total"];
-            }
-        }
+        // Load pre-computed statement count from validated db-pull metadata
+        // for progress reporting. When absent/stale, progress falls back to
+        // executed statement count only.
+        $statements_total = $sql_pull_metadata['statements_total'] ?? null;
 
         // If resuming, seek to saved position. bytes_read is the byte offset
         // right after the last successfully executed query (tracked via
@@ -7146,6 +7205,7 @@ class ImportClient
         $cursor = $this->state["cursor"] ?? null;
         $complete = false;
         $mode = $this->sql_output_mode;
+        $sql_file = $this->state_dir . "/db.sql";
 
         // ── Set up write strategy based on output mode ──────────────
 
@@ -7156,8 +7216,6 @@ class ImportClient
         $sql_buffer = "";
 
         if ($mode === "file") {
-            $sql_file = $this->state_dir . "/db.sql";
-
             // Crash recovery: if SQL file is larger than expected, truncate it.
             // This happens if we crashed after writing but before saving the new cursor.
             $tracked_bytes = $this->state["sql_bytes"] ?? null;
@@ -7180,7 +7238,7 @@ class ImportClient
                 }
             }
 
-            $sql_bytes_written = file_exists($sql_file) ? filesize($sql_file) : 0;
+            $sql_bytes_written = $cursor && file_exists($sql_file) ? (int) filesize($sql_file) : 0;
 
             // Open in write mode if no cursor (starting fresh), append mode if resuming
             $sql_handle = fopen($sql_file, $cursor ? "a" : "w");
@@ -7251,13 +7309,14 @@ class ImportClient
         $domain_collector = class_exists('DomainCollector')
             ? new \DomainCollector()
             : null;
-        $domains_file = $this->state_dir . "/.import-domains.json";
-        $sql_stats_file = $this->state_dir . "/.import-sql-stats.json";
+        $metadata_file = SqlPullMetadata::path($this->state_dir);
+        $domains_file = SqlPullMetadata::legacy_domains_path($this->state_dir);
+        $sql_stats_file = SqlPullMetadata::legacy_stats_path($this->state_dir);
         $sql_statements_counted = (int) ($this->state["sql_statements_counted"] ?? 0);
 
-        // Auto-detect the source site domain from the export URL so it
-        // always appears in .import-domains.json even if the SQL dump
-        // hasn't been fully scanned yet.
+        // Auto-detect the source site domain from the export URL so it is
+        // present in partial metadata even if the SQL dump has not been
+        // fully scanned yet.
         if ($domain_collector) {
             $parsed_url = parse_url($this->remote_url);
             if ($parsed_url && isset($parsed_url['scheme'], $parsed_url['host'])) {
@@ -7269,10 +7328,15 @@ class ImportClient
             }
         }
 
-        // Load previously discovered domains (from earlier partial downloads)
-        if ($domain_collector && file_exists($domains_file)) {
-            $prev = json_decode(file_get_contents($domains_file), true);
-            if (is_array($prev)) {
+        // Load previously discovered domains (from earlier partial downloads).
+        // Prefer the versioned metadata envelope, then accept a validated
+        // legacy list only for resume migration.
+        if ($domain_collector && ($cursor !== null || $sql_statements_counted > 0)) {
+            $prev = SqlPullMetadata::read_resume_domains($metadata_file);
+            if (empty($prev)) {
+                $prev = SqlPullMetadata::read_legacy_domains($domains_file);
+            }
+            if (!empty($prev)) {
                 $domain_collector->merge($prev);
             }
         }
@@ -7312,6 +7376,7 @@ class ImportClient
                     $context,
                     $query_stream,
                     $domain_collector,
+                    $metadata_file,
                     $domains_file,
                     &$sql_statements_counted,
                     &$chunks_since_save
@@ -7352,12 +7417,13 @@ class ImportClient
                         // earlier data would be lost without periodic saves.
                         if ($domain_collector) {
                             $domains = $domain_collector->get_domains();
-                            if (!empty($domains)) {
-                                file_put_contents(
-                                    $domains_file,
-                                    json_encode($domains, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . "\n",
-                                );
-                            }
+                            SqlPullMetadata::write_partial(
+                                $metadata_file,
+                                $domains,
+                                $sql_statements_counted,
+                                $sql_bytes_written,
+                            );
+                            SqlPullMetadata::write_legacy_domains($domains_file, $domains);
                         }
                     }
 
@@ -7512,6 +7578,16 @@ class ImportClient
                     $this->state["sql_statements_counted"] = $sql_statements_counted;
                     $this->state["status"] = "partial";
                     $this->save_state($this->state);
+                    if ($domain_collector) {
+                        $domains = $domain_collector->get_domains();
+                        SqlPullMetadata::write_partial(
+                            $metadata_file,
+                            $domains,
+                            $sql_statements_counted,
+                            $sql_bytes_written,
+                        );
+                        SqlPullMetadata::write_legacy_domains($domains_file, $domains);
+                    }
                     // Discard any pending SQL buffer — it's incomplete and
                     // will be re-fetched on the next invocation. Setting
                     // this to "" also prevents the finally block from
@@ -7563,6 +7639,16 @@ class ImportClient
                         $this->state["sql_statements_counted"] = $sql_statements_counted;
                         $this->state["status"] = "partial";
                         $this->save_state($this->state);
+                        if ($domain_collector) {
+                            $domains = $domain_collector->get_domains();
+                            SqlPullMetadata::write_partial(
+                                $metadata_file,
+                                $domains,
+                                $sql_statements_counted,
+                                $sql_bytes_written,
+                            );
+                            SqlPullMetadata::write_legacy_domains($domains_file, $domains);
+                        }
                         $curl_timed_out = true;
                         break;
                     }
@@ -7584,6 +7670,7 @@ class ImportClient
                 $this->state["cursor"] = $cursor;
                 // Clear sql_bytes when complete, otherwise save current position
                 $this->state["sql_bytes"] = $complete ? null : $sql_bytes_written;
+                $this->state["sql_statements_counted"] = $sql_statements_counted;
                 $this->save_state($this->state);
             }
 
@@ -7598,26 +7685,30 @@ class ImportClient
 
                 // Save discovered domains
                 $domains = $domain_collector->get_domains();
-                if (!empty($domains)) {
-                    file_put_contents(
-                        $domains_file,
-                        json_encode($domains, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . "\n",
+                if ($mode === "file") {
+                    if ($sql_handle) {
+                        fflush($sql_handle);
+                    }
+                    $this->write_sql_pull_metadata(
+                        $sql_file,
+                        $domains,
+                        $sql_statements_counted,
                     );
                     $this->audit_log(
                         sprintf(
-                            "DOMAINS DISCOVERED | %d unique domains saved to .import-domains.json",
+                            "SQL METADATA | %d domains and %d statements saved to .import-sql-metadata.json",
                             count($domains),
+                            $sql_statements_counted,
                         ),
                         false,
                     );
+                } elseif (!empty($domains)) {
+                    SqlPullMetadata::write_legacy_domains($domains_file, $domains);
                 }
 
                 // Save statement count for db-apply progress reporting
                 if ($sql_statements_counted > 0) {
-                    file_put_contents(
-                        $sql_stats_file,
-                        json_encode(["statements_total" => $sql_statements_counted]) . "\n",
-                    );
+                    SqlPullMetadata::write_legacy_stats($sql_stats_file, $sql_statements_counted);
                     $this->audit_log(
                         sprintf(
                             "SQL STATS | %d statements counted during download",
@@ -10257,6 +10348,7 @@ class ImportClient
             "current_file_bytes" => null,  // Expected bytes written so far
             // Crash recovery: track SQL file size
             "sql_bytes" => null,           // Expected SQL file size
+            "sql_statements_counted" => 0, // Complete SQL statements counted during db-pull
             // db-apply state
             "apply" => [
                 "statements_executed" => 0,
@@ -11870,7 +11962,8 @@ if (
                 "Indexes remote tables, then streams the full SQL dump into\n" .
                 "--state-dir/db.sql (default), to stdout, or directly into a\n" .
                 "MySQL connection. Resumes from the last cursor if interrupted.\n" .
-                "Discovered domains are cached for later use by db-apply.\n",
+                "Validated domain and statement-count metadata is cached for later\n" .
+                "use by db-apply.\n",
             "extra" =>
                 "Output modes:\n" .
                 "  file    Write to --state-dir/db.sql (default)\n" .
@@ -11894,9 +11987,9 @@ if (
             "description" =>
                 "Prints domains found in the SQL dump, one per line.\n" .
                 "\n" .
-                "If .import-domains.json exists (cached by db-pull), it is read\n" .
-                "directly. Otherwise, db.sql is scanned and the result is cached\n" .
-                "for future calls. No network calls.\n" .
+                "If validated .import-sql-metadata.json exists (cached by db-pull),\n" .
+                "it is read directly. Otherwise, db.sql is scanned and the result\n" .
+                "is cached for future calls. No network calls.\n" .
                 "\n" .
                 "Example:\n" .
                 "  reprint db-domains - --state-dir=/path/to/state\n",

--- a/packages/reprint-importer/src/lib/pull/class-pull.php
+++ b/packages/reprint-importer/src/lib/pull/class-pull.php
@@ -421,7 +421,9 @@ class Pull
 
         foreach ([
             $state_dir . "/db.sql",
+            $state_dir . "/.import-sql-metadata.json",
             $state_dir . "/.import-domains.json",
+            $state_dir . "/.import-sql-stats.json",
             $state_dir . "/.import-remote-index.jsonl",
             $state_dir . "/.import-download-list.jsonl",
             $state_dir . "/.import-download-list-skipped.jsonl",

--- a/packages/reprint-importer/src/lib/url-rewrite/class-sql-pull-metadata.php
+++ b/packages/reprint-importer/src/lib/url-rewrite/class-sql-pull-metadata.php
@@ -1,0 +1,374 @@
+<?php
+
+/**
+ * Versioned side-channel metadata learned while streaming db-pull SQL.
+ *
+ * The metadata is advisory: db-apply may use it for domain display and
+ * statement-count progress only after the envelope and db.sql fingerprint
+ * validate. Invalid, stale, or absent metadata must be ignored.
+ */
+class SqlPullMetadata
+{
+    private const KIND = 'reprint.sql-pull-metadata';
+    private const VERSION = 1;
+
+    public const FILENAME = '.import-sql-metadata.json';
+    public const LEGACY_DOMAINS_FILENAME = '.import-domains.json';
+    public const LEGACY_STATS_FILENAME = '.import-sql-stats.json';
+
+    public static function path(string $state_dir): string
+    {
+        return rtrim($state_dir, '/') . '/' . self::FILENAME;
+    }
+
+    public static function legacy_domains_path(string $state_dir): string
+    {
+        return rtrim($state_dir, '/') . '/' . self::LEGACY_DOMAINS_FILENAME;
+    }
+
+    public static function legacy_stats_path(string $state_dir): string
+    {
+        return rtrim($state_dir, '/') . '/' . self::LEGACY_STATS_FILENAME;
+    }
+
+    /**
+     * @param string[] $domains
+     */
+    public static function write_complete(
+        string $metadata_file,
+        string $sql_file,
+        array $domains,
+        int $statements_total
+    ): void {
+        if (!is_file($sql_file)) {
+            throw new RuntimeException("Cannot write SQL metadata: db.sql not found at {$sql_file}");
+        }
+        if ($statements_total < 0) {
+            throw new InvalidArgumentException('Statement count cannot be negative.');
+        }
+
+        $hash = hash_file('sha256', $sql_file);
+        if (!is_string($hash)) {
+            throw new RuntimeException("Cannot hash SQL file: {$sql_file}");
+        }
+
+        self::write_payload($metadata_file, [
+            'kind' => self::KIND,
+            'version' => self::VERSION,
+            'complete' => true,
+            'generated_at' => gmdate('c'),
+            'sql' => [
+                'file' => basename($sql_file),
+                'bytes' => filesize($sql_file),
+                'sha256' => $hash,
+            ],
+            'statements' => [
+                'total' => $statements_total,
+                'counter' => 'WP_MySQL_Naive_Query_Stream',
+            ],
+            'domains' => [
+                'origins' => self::normalize_domains($domains),
+                'collector' => 'Base64ValueScanner+DomainCollector',
+            ],
+        ]);
+    }
+
+    /**
+     * Persist crash-resumable partial discoveries. Partial metadata is valid
+     * only for resuming db-pull discovery; db-apply requires complete metadata
+     * with a matching db.sql hash.
+     *
+     * @param string[] $domains
+     */
+    public static function write_partial(
+        string $metadata_file,
+        array $domains,
+        int $statements_counted,
+        int $bytes_written
+    ): void {
+        if ($statements_counted < 0 || $bytes_written < 0) {
+            throw new InvalidArgumentException('Partial SQL metadata counters cannot be negative.');
+        }
+
+        self::write_payload($metadata_file, [
+            'kind' => self::KIND,
+            'version' => self::VERSION,
+            'complete' => false,
+            'generated_at' => gmdate('c'),
+            'sql' => [
+                'file' => 'db.sql',
+                'bytes' => $bytes_written,
+                'sha256' => null,
+            ],
+            'statements' => [
+                'total' => $statements_counted,
+                'counter' => 'WP_MySQL_Naive_Query_Stream',
+            ],
+            'domains' => [
+                'origins' => self::normalize_domains($domains),
+                'collector' => 'Base64ValueScanner+DomainCollector',
+            ],
+        ]);
+    }
+
+    /**
+     * @return array{domains: list<string>, statements_total: int}|null
+     */
+    public static function read_complete(string $metadata_file, string $sql_file, ?string &$reason = null): ?array
+    {
+        $payload = self::read_payload($metadata_file, $reason);
+        if ($payload === null) {
+            return null;
+        }
+
+        $validated = self::validate_payload($payload, true, $reason);
+        if ($validated === null) {
+            return null;
+        }
+
+        if (!is_file($sql_file)) {
+            $reason = 'sql file missing';
+            return null;
+        }
+
+        $sql = $payload['sql'] ?? null;
+        if (!is_array($sql)) {
+            $reason = 'sql fingerprint missing';
+            return null;
+        }
+
+        $expected_bytes = $sql['bytes'] ?? null;
+        $actual_bytes = filesize($sql_file);
+        if (!is_int($expected_bytes) || $actual_bytes !== $expected_bytes) {
+            $reason = 'sql file size mismatch';
+            return null;
+        }
+
+        $expected_hash = $sql['sha256'] ?? null;
+        if (!is_string($expected_hash) || !preg_match('/\A[a-f0-9]{64}\z/', $expected_hash)) {
+            $reason = 'invalid sql hash';
+            return null;
+        }
+
+        $actual_hash = hash_file('sha256', $sql_file);
+        if (!is_string($actual_hash) || !hash_equals($expected_hash, $actual_hash)) {
+            $reason = 'sql file hash mismatch';
+            return null;
+        }
+
+        return $validated;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public static function read_resume_domains(string $metadata_file): array
+    {
+        $reason = null;
+        $payload = self::read_payload($metadata_file, $reason);
+        if ($payload === null) {
+            return [];
+        }
+
+        $validated = self::validate_payload($payload, false, $reason);
+        return $validated['domains'] ?? [];
+    }
+
+    /**
+     * @param string[] $domains
+     */
+    public static function write_legacy_domains(string $domains_file, array $domains): void
+    {
+        self::write_payload(
+            $domains_file,
+            self::normalize_domains($domains),
+            JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES
+        );
+    }
+
+    public static function write_legacy_stats(string $stats_file, int $statements_total): void
+    {
+        if ($statements_total < 0) {
+            throw new InvalidArgumentException('Statement count cannot be negative.');
+        }
+        self::write_payload($stats_file, ['statements_total' => $statements_total]);
+    }
+
+    /**
+     * Validate a legacy .import-domains.json array for resume migration only.
+     *
+     * @return list<string>
+     */
+    public static function read_legacy_domains(string $domains_file): array
+    {
+        $reason = null;
+        $payload = self::read_payload($domains_file, $reason);
+        if (!is_array($payload)) {
+            return [];
+        }
+
+        try {
+            return self::normalize_domains($payload);
+        } catch (InvalidArgumentException $e) {
+            return [];
+        }
+    }
+
+    /**
+     * @return array<mixed>|null
+     */
+    private static function read_payload(string $path, ?string &$reason = null): ?array
+    {
+        if (!is_file($path)) {
+            $reason = 'metadata file missing';
+            return null;
+        }
+
+        $contents = file_get_contents($path);
+        if (!is_string($contents)) {
+            $reason = 'metadata file unreadable';
+            return null;
+        }
+
+        $payload = json_decode($contents, true);
+        if (!is_array($payload)) {
+            $reason = 'metadata json invalid';
+            return null;
+        }
+
+        return $payload;
+    }
+
+    /**
+     * @param array<mixed> $payload
+     * @return array{domains: list<string>, statements_total: int}|null
+     */
+    private static function validate_payload(array $payload, bool $require_complete, ?string &$reason = null): ?array
+    {
+        if (($payload['kind'] ?? null) !== self::KIND) {
+            $reason = 'metadata kind mismatch';
+            return null;
+        }
+        if (($payload['version'] ?? null) !== self::VERSION) {
+            $reason = 'metadata version mismatch';
+            return null;
+        }
+        if ($require_complete && (($payload['complete'] ?? null) !== true)) {
+            $reason = 'metadata incomplete';
+            return null;
+        }
+
+        $statements = $payload['statements'] ?? null;
+        if (!is_array($statements) || !isset($statements['total']) || !is_int($statements['total'])) {
+            $reason = 'statement count missing';
+            return null;
+        }
+        if ($statements['total'] < 0) {
+            $reason = 'statement count negative';
+            return null;
+        }
+
+        $domains = $payload['domains'] ?? null;
+        $origins = is_array($domains) ? ($domains['origins'] ?? null) : null;
+        if (!is_array($origins)) {
+            $reason = 'domains missing';
+            return null;
+        }
+
+        try {
+            $normalized_domains = self::normalize_domains($origins);
+        } catch (InvalidArgumentException $e) {
+            $reason = 'domain list invalid';
+            return null;
+        }
+
+        return [
+            'domains' => $normalized_domains,
+            'statements_total' => $statements['total'],
+        ];
+    }
+
+    /**
+     * @param array<mixed> $domains
+     * @return list<string>
+     */
+    private static function normalize_domains(array $domains): array
+    {
+        $normalized = [];
+        foreach ($domains as $domain) {
+            if (!is_string($domain)) {
+                throw new InvalidArgumentException('Domain origin must be a string.');
+            }
+            $origin = self::normalize_origin($domain);
+            if ($origin === null) {
+                throw new InvalidArgumentException("Invalid domain origin: {$domain}");
+            }
+            $normalized[$origin] = true;
+        }
+
+        $origins = array_keys($normalized);
+        sort($origins);
+        return array_values($origins);
+    }
+
+    private static function normalize_origin(string $origin): ?string
+    {
+        $origin = trim($origin);
+        if ($origin === '' || strlen($origin) > 2048) {
+            return null;
+        }
+
+        $parts = parse_url($origin);
+        if (!is_array($parts)) {
+            return null;
+        }
+
+        $scheme = $parts['scheme'] ?? null;
+        $host = $parts['host'] ?? null;
+        if (!is_string($scheme) || !is_string($host) || $host === '') {
+            return null;
+        }
+
+        $scheme = strtolower($scheme);
+        if ($scheme !== 'http' && $scheme !== 'https') {
+            return null;
+        }
+
+        foreach (['user', 'pass', 'path', 'query', 'fragment'] as $forbidden) {
+            if (array_key_exists($forbidden, $parts)) {
+                return null;
+            }
+        }
+
+        $normalized = $scheme . '://' . strtolower($host);
+        if (isset($parts['port'])) {
+            if (!is_int($parts['port']) || $parts['port'] < 1 || $parts['port'] > 65535) {
+                return null;
+            }
+            $normalized .= ':' . $parts['port'];
+        }
+
+        return $normalized;
+    }
+
+    /**
+     * @param mixed $payload
+     */
+    private static function write_payload(string $path, $payload, int $flags = 0): void
+    {
+        $json = json_encode($payload, $flags);
+        if (!is_string($json)) {
+            throw new RuntimeException('Failed to encode SQL metadata: ' . json_last_error_msg());
+        }
+
+        $tmp = $path . '.tmp';
+        $bytes = file_put_contents($tmp, $json . "\n");
+        if ($bytes === false) {
+            throw new RuntimeException("Failed to write SQL metadata: {$tmp}");
+        }
+        if (!rename($tmp, $path)) {
+            @unlink($tmp);
+            throw new RuntimeException("Failed to rename SQL metadata: {$tmp} -> {$path}");
+        }
+    }
+}

--- a/packages/reprint-importer/src/lib/url-rewrite/load.php
+++ b/packages/reprint-importer/src/lib/url-rewrite/load.php
@@ -15,6 +15,7 @@ require_once __DIR__ . '/class-json-string-iterator.php';
 require_once __DIR__ . '/class-base64-value-scanner.php';
 require_once __DIR__ . '/class-fast-insert-scanner.php';
 require_once __DIR__ . '/class-sqlite-prepared-insert-builder.php';
+require_once __DIR__ . '/class-sql-pull-metadata.php';
 
 // Depend on the iterators above
 require_once __DIR__ . '/class-structured-data-url-rewriter.php';

--- a/tests/Import/SqlPullMetadataTest.php
+++ b/tests/Import/SqlPullMetadataTest.php
@@ -1,0 +1,238 @@
+<?php
+
+namespace ImportTests;
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../importer/import.php';
+
+class SqlPullMetadataTest extends TestCase
+{
+    private string $tempDir;
+    private string $stateDir;
+    private string $fsRoot;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->tempDir = sys_get_temp_dir() . '/sql-pull-metadata-test-' . uniqid();
+        $this->stateDir = $this->tempDir . '/state';
+        $this->fsRoot = $this->tempDir . '/fs-root';
+        mkdir($this->stateDir, 0755, true);
+        mkdir($this->fsRoot, 0755, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->recursiveDelete($this->tempDir);
+        parent::tearDown();
+    }
+
+    public function testCompleteMetadataRoundTripsWithValidatedFingerprint(): void
+    {
+        $sqlFile = $this->writeSql("SELECT 1;\nSELECT 2;\n");
+
+        \SqlPullMetadata::write_complete(
+            \SqlPullMetadata::path($this->stateDir),
+            $sqlFile,
+            ['https://Example.test:8443', 'http://alpha.test'],
+            2,
+        );
+
+        $reason = null;
+        $metadata = \SqlPullMetadata::read_complete(
+            \SqlPullMetadata::path($this->stateDir),
+            $sqlFile,
+            $reason,
+        );
+
+        $this->assertSame([
+            'http://alpha.test',
+            'https://example.test:8443',
+        ], $metadata['domains'] ?? null);
+        $this->assertSame(2, $metadata['statements_total'] ?? null);
+        $this->assertNull($reason);
+    }
+
+    public function testAbsentAndStaleMetadataAreIgnored(): void
+    {
+        $sqlFile = $this->writeSql("SELECT 1;\n");
+
+        $reason = null;
+        $this->assertNull(\SqlPullMetadata::read_complete(
+            \SqlPullMetadata::path($this->stateDir),
+            $sqlFile,
+            $reason,
+        ));
+        $this->assertSame('metadata file missing', $reason);
+
+        \SqlPullMetadata::write_complete(
+            \SqlPullMetadata::path($this->stateDir),
+            $sqlFile,
+            ['https://fresh.example'],
+            1,
+        );
+
+        // Same byte size as "SELECT 1;\n", forcing validation to rely on the hash.
+        file_put_contents($sqlFile, "SELECT 2;\n");
+
+        $reason = null;
+        $this->assertNull(\SqlPullMetadata::read_complete(
+            \SqlPullMetadata::path($this->stateDir),
+            $sqlFile,
+            $reason,
+        ));
+        $this->assertSame('sql file hash mismatch', $reason);
+    }
+
+    public function testAdversarialMetadataValidationRejectsUnsafeShapes(): void
+    {
+        $sqlFile = $this->writeSql("SELECT 1;\n");
+        $metadataFile = \SqlPullMetadata::path($this->stateDir);
+        \SqlPullMetadata::write_complete($metadataFile, $sqlFile, ['https://valid.example'], 1);
+        $valid = json_decode((string) file_get_contents($metadataFile), true);
+
+        $cases = [
+            'bad version' => function (array $payload): array {
+                $payload['version'] = 999;
+                return $payload;
+            },
+            'domain with path' => function (array $payload): array {
+                $payload['domains']['origins'] = ['https://valid.example/path'];
+                return $payload;
+            },
+            'string statement count' => function (array $payload): array {
+                $payload['statements']['total'] = '1';
+                return $payload;
+            },
+            'negative statement count' => function (array $payload): array {
+                $payload['statements']['total'] = -1;
+                return $payload;
+            },
+        ];
+
+        foreach ($cases as $label => $mutate) {
+            file_put_contents($metadataFile, json_encode($mutate($valid)) . "\n");
+            $reason = null;
+            $this->assertNull(
+                \SqlPullMetadata::read_complete($metadataFile, $sqlFile, $reason),
+                $label,
+            );
+            $this->assertNotNull($reason, $label);
+        }
+    }
+
+    public function testDbDomainsFallsBackToStructuredSqlScanWhenMetadataIsStale(): void
+    {
+        $sqlFile = $this->writeSql("SELECT 1;\n");
+        \SqlPullMetadata::write_complete(
+            \SqlPullMetadata::path($this->stateDir),
+            $sqlFile,
+            ['https://stale.example'],
+            1,
+        );
+
+        file_put_contents($sqlFile, $this->adversarialSqlFixture());
+
+        $client = $this->makeClient();
+        $method = (new \ReflectionClass($client))->getMethod('run_db_domains');
+        $method->setAccessible(true);
+
+        ob_start();
+        try {
+            $method->invoke($client);
+            $output = (string) ob_get_clean();
+        } catch (\Throwable $e) {
+            ob_end_clean();
+            throw $e;
+        }
+
+        $domains = array_values(array_filter(explode("\n", trim($output))));
+        sort($domains);
+        $this->assertSame([
+            'https://cdn.example.test',
+            'https://fresh.example.test',
+        ], $domains);
+        $this->assertNotContains('https://stale.example', $domains);
+        $this->assertNotContains('https://external.example.test', $domains);
+        $this->assertNotContains('https://raw-sql-string.example.test', $domains);
+        $this->assertNotContains('https://updated.example.test', $domains);
+
+        $reason = null;
+        $metadata = \SqlPullMetadata::read_complete(
+            \SqlPullMetadata::path($this->stateDir),
+            $sqlFile,
+            $reason,
+        );
+        $this->assertSame(5, $metadata['statements_total'] ?? null);
+        $this->assertSame($domains, $metadata['domains'] ?? null);
+    }
+
+    private function makeClient(): \ImportClient
+    {
+        return new \ImportClient(
+            'https://source.example.test/?site-export-api',
+            $this->stateDir,
+            $this->fsRoot,
+        );
+    }
+
+    private function writeSql(string $sql): string
+    {
+        $sqlFile = $this->stateDir . '/db.sql';
+        file_put_contents($sqlFile, $sql);
+        return $sqlFile;
+    }
+
+    private function adversarialSqlFixture(): string
+    {
+        $siteUrl = base64_encode('https://fresh.example.test');
+        $cdnMarkup = base64_encode(
+            '<a href="https://external.example.test/page">external</a>' .
+            '<img src="https://cdn.example.test/image.jpg">'
+        );
+        $updated = base64_encode('https://updated.example.test');
+
+        return implode("\n", [
+            'SET NAMES utf8mb4;',
+            sprintf(
+                "INSERT INTO `wp_options` (`option_id`,`option_name`,`option_value`,`autoload`) VALUES " .
+                "(1, FROM_BASE64('%s'), FROM_BASE64('%s'), FROM_BASE64('%s'));",
+                base64_encode('siteurl'),
+                $siteUrl,
+                base64_encode('yes'),
+            ),
+            sprintf(
+                "INSERT INTO `wp_posts` (`ID`,`post_content`) VALUES " .
+                "(1, FROM_BASE64('%s'));",
+                $cdnMarkup,
+            ),
+            sprintf(
+                "UPDATE `wp_options` SET `option_value` = FROM_BASE64('%s') WHERE `option_name` = 'home';",
+                $updated,
+            ),
+            "INSERT INTO `wp_posts` (`ID`,`post_content`) VALUES (2, 'https://raw-sql-string.example.test');",
+        ]) . "\n";
+    }
+
+    private function recursiveDelete(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        foreach (scandir($dir) as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $path = $dir . '/' . $item;
+            if (is_link($path)) {
+                unlink($path);
+            } elseif (is_dir($path)) {
+                $this->recursiveDelete($path);
+            } else {
+                unlink($path);
+            }
+        }
+        rmdir($dir);
+    }
+}


### PR DESCRIPTION
## What it does

Adds a versioned `.import-sql-metadata.json` side-channel for metadata learned during `db-pull`: discovered domain origins and total SQL statement count.

`db-apply` now consumes that metadata only when the envelope validates and its `db.sql` size + SHA-256 fingerprint match the current file. If metadata is absent, malformed, incomplete, or stale, `db-apply` ignores it and falls back to normal execution with no cached totals/domains.

## Rationale

Trunk already persisted `.import-domains.json` and `.import-sql-stats.json`, but those files were unversioned and not tied to the SQL dump they described. That made them unsafe as a side channel after interrupted runs, stale state directories, or manual file replacement.

## Implementation

`SqlPullMetadata` owns the side-channel schema, atomic writes, strict domain-origin validation, and freshness checks.

`db-pull` still derives domains and counts from the existing query stream, `Base64ValueScanner`, and `DomainCollector` path. Partial metadata is written for resume safety, while complete metadata includes a `db.sql` fingerprint. Legacy `.import-domains.json` and `.import-sql-stats.json` are still written for compatibility, but `db-apply` trusts only the validated metadata envelope.

`db-domains` uses validated metadata when available; otherwise it rescans `db.sql` using the same structured parser/scanner path and rewrites the metadata.

## Testing instructions

```bash
php -l packages/reprint-importer/src/import.php
php -l packages/reprint-importer/src/lib/pull/class-pull.php
php -l packages/reprint-importer/src/lib/url-rewrite/load.php
php -l packages/reprint-importer/src/lib/url-rewrite/class-sql-pull-metadata.php
php -l tests/Import/SqlPullMetadataTest.php

./vendor/bin/phpunit -c tests/phpunit.xml \
  tests/Import/SqlPullMetadataTest.php \
  tests/Import/NewSiteUrlSqliteTest.php \
  tests/FastQueryStreamTest.php \
  tests/UrlRewriting/DomainCollectorTest.php

./vendor/bin/phpstan analyse --configuration=phpstan.neon --memory-limit=1G \
  packages/reprint-importer/src/import.php \
  packages/reprint-importer/src/lib/pull/class-pull.php \
  packages/reprint-importer/src/lib/url-rewrite/load.php \
  packages/reprint-importer/src/lib/url-rewrite/class-sql-pull-metadata.php

git diff --check
```

Benchmarked under `flock /tmp/reprint-bench.lock -c` with `BENCH_STAGES=playground-sqlite-db-pull,playground-sqlite-db-apply`:

| Stage | trunk | branch | delta |
|---|---:|---:|---:|
| `playground-sqlite-db-pull` | 408.51 s | 417.30 s | +8.79 s (+2.15%) |
| `playground-sqlite-db-apply` | 72.28 s | 68.83 s | -3.45 s (-4.77%) |
| Total | 480.79 s | 486.13 s | +5.34 s (+1.11%) |
