### PR TITLE
Optimize resumed db-pull SQL file writes

### DIFF
--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -7180,7 +7180,22 @@ class ImportClient
                         fclose($handle);
                     }
                     $actual_size = $tracked_bytes;
+                } elseif ($actual_size < $tracked_bytes) {
+                    throw new RuntimeException(
+                        sprintf(
+                            "Cannot resume SQL download: db.sql is smaller than the saved checkpoint (%d < %d bytes). Use --abort to restart db-pull.",
+                            $actual_size,
+                            $tracked_bytes,
+                        )
+                    );
                 }
+            } elseif ($cursor && $tracked_bytes !== null && $tracked_bytes > 0) {
+                throw new RuntimeException(
+                    sprintf(
+                        "Cannot resume SQL download: db.sql is missing but the saved checkpoint expects %d bytes. Use --abort to restart db-pull.",
+                        $tracked_bytes,
+                    )
+                );
             }
 
             $sql_bytes_written = $cursor ? $actual_size : 0;

--- a/packages/reprint-importer/src/import.php
+++ b/packages/reprint-importer/src/import.php
@@ -960,6 +960,7 @@ class ImportClient
     private const SAVE_STATE_EVERY_N_CHUNKS = 50;
     private const STATE_PATH_ENCODING_PREFIX = "base64:";
     private const SQLITE_PREPARED_INSERT_CACHE_MAX = 128;
+    private const SQL_FILE_WRITE_BUFFER_BYTES = 1024 * 1024;
 
     /**
      * Maximum number of consecutive cURL timeouts with no cursor progress
@@ -7157,12 +7158,13 @@ class ImportClient
 
         if ($mode === "file") {
             $sql_file = $this->state_dir . "/db.sql";
+            $sql_file_exists = file_exists($sql_file);
+            $actual_size = $sql_file_exists ? (int) filesize($sql_file) : 0;
 
             // Crash recovery: if SQL file is larger than expected, truncate it.
             // This happens if we crashed after writing but before saving the new cursor.
             $tracked_bytes = $this->state["sql_bytes"] ?? null;
-            if ($tracked_bytes !== null && file_exists($sql_file)) {
-                $actual_size = filesize($sql_file);
+            if ($tracked_bytes !== null && $sql_file_exists) {
                 if ($actual_size > $tracked_bytes) {
                     $this->audit_log(
                         sprintf(
@@ -7177,16 +7179,23 @@ class ImportClient
                         ftruncate($handle, $tracked_bytes);
                         fclose($handle);
                     }
+                    $actual_size = $tracked_bytes;
                 }
             }
 
-            $sql_bytes_written = file_exists($sql_file) ? filesize($sql_file) : 0;
+            $sql_bytes_written = $cursor ? $actual_size : 0;
 
-            // Open in write mode if no cursor (starting fresh), append mode if resuming
-            $sql_handle = fopen($sql_file, $cursor ? "a" : "w");
+            // Open in write mode if no cursor (starting fresh). When resuming,
+            // seek once to the known end instead of using append mode for every
+            // write; PHP.wasm's mounted filesystem pays more for append writes.
+            $sql_handle = fopen($sql_file, $cursor ? "c" : "w");
             if (!$sql_handle) {
                 throw new RuntimeException("Cannot open SQL file: {$sql_file}");
             }
+            if ($cursor && $sql_bytes_written > 0 && fseek($sql_handle, $sql_bytes_written) !== 0) {
+                throw new RuntimeException("Cannot seek SQL file: {$sql_file}");
+            }
+            stream_set_write_buffer($sql_handle, self::SQL_FILE_WRITE_BUFFER_BYTES);
 
         } elseif ($mode === "stdout") {
             $sql_bytes_written = $this->state["sql_bytes"] ?? 0;
@@ -10257,6 +10266,7 @@ class ImportClient
             "current_file_bytes" => null,  // Expected bytes written so far
             // Crash recovery: track SQL file size
             "sql_bytes" => null,           // Expected SQL file size
+            "sql_statements_counted" => 0, // Statements counted during db-pull
             // db-apply state
             "apply" => [
                 "statements_executed" => 0,

--- a/tests/Import/SqlFileWritePathTest.php
+++ b/tests/Import/SqlFileWritePathTest.php
@@ -173,6 +173,28 @@ class SqlFileWritePathTest extends TestCase
         $this->assertSame(2, $stats['statements_total']);
     }
 
+    public function testResumeRefusesSqlFileShorterThanCheckpoint(): void
+    {
+        $prefix = "CREATE TABLE `wp_posts` (`ID` bigint unsigned NOT NULL, `post_title` text);\n";
+
+        $this->writeState([
+            'cursor' => 'cursor-after-prefix',
+            'sql_bytes' => strlen($prefix),
+            'sql_statements_counted' => 1,
+        ]);
+        file_put_contents($this->stateDir . '/db.sql', substr($prefix, 0, 12));
+
+        [$client, $reflection] = $this->prepareClient([
+            ['body' => "INSERT INTO `wp_posts` VALUES (1,FROM_BASE64('aGVsbG8='));\n", 'cursor' => 'cursor-after-suffix'],
+        ]);
+
+        $downloadSql = $reflection->getMethod('download_sql');
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('db.sql is smaller than the saved checkpoint');
+        $downloadSql->invoke($client);
+    }
+
     public function testRetryablePartialResponseFlushesCheckpointedBytesForResume(): void
     {
         $first = "CREATE TABLE `wp_comments` (`comment_ID` bigint unsigned NOT NULL);\n";

--- a/tests/Import/SqlFileWritePathTest.php
+++ b/tests/Import/SqlFileWritePathTest.php
@@ -1,0 +1,251 @@
+<?php
+
+namespace ImportTests;
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../importer/import.php';
+
+class SqlFileWritePathTest extends TestCase
+{
+    private $tempDir;
+    private $stateDir;
+    private $fsRoot;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->tempDir = sys_get_temp_dir() . '/sql-file-write-path-test-' . uniqid();
+        $this->stateDir = $this->tempDir . '/state';
+        $this->fsRoot = $this->tempDir . '/fs-root';
+        mkdir($this->stateDir, 0755, true);
+        mkdir($this->fsRoot, 0755, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->recursiveDelete($this->tempDir);
+        parent::tearDown();
+    }
+
+    private function recursiveDelete(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        foreach (scandir($dir) as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $path = $dir . '/' . $item;
+            if (is_link($path)) {
+                unlink($path);
+            } elseif (is_dir($path)) {
+                $this->recursiveDelete($path);
+            } else {
+                unlink($path);
+            }
+        }
+        rmdir($dir);
+    }
+
+    private function writeState(array $state): void
+    {
+        $defaults = [
+            'command' => 'db-pull',
+            'status' => 'in_progress',
+            'cursor' => null,
+            'stage' => 'sql',
+            'preflight' => ['data' => ['ok' => true], 'http_code' => 200],
+            'remote_protocol_version' => null,
+            'remote_protocol_min_version' => null,
+            'version' => null,
+            'follow_symlinks' => false,
+            'fs_root_nonempty_behavior' => 'preserve-local',
+            'max_allowed_packet' => null,
+            'db_index' => [
+                'file' => $this->stateDir . '/db-tables.jsonl',
+                'tables' => 1,
+                'rows_estimated' => 1,
+                'bytes' => 1,
+                'updated_at' => time(),
+            ],
+        ];
+
+        file_put_contents(
+            $this->stateDir . '/.import-state.json',
+            json_encode(array_merge($defaults, $state), JSON_PRETTY_PRINT) . "\n",
+        );
+    }
+
+    private function prepareClient(array $chunks, ?int $failAfterChunks = null): array
+    {
+        $client = new SqlFileWritePathClient(
+            'https://source.example/export',
+            $this->stateDir,
+            $this->fsRoot,
+        );
+        $client->sqlChunks = $chunks;
+        $client->failAfterChunks = $failAfterChunks;
+
+        $reflection = new \ReflectionClass(\ImportClient::class);
+
+        $stateProperty = $reflection->getProperty('state');
+        $loadState = $reflection->getMethod('load_state');
+        $stateProperty->setValue($client, $loadState->invoke($client));
+
+        $ttyProperty = $reflection->getProperty('is_tty');
+        $ttyProperty->setValue($client, false);
+
+        $modeProperty = $reflection->getProperty('sql_output_mode');
+        $modeProperty->setValue($client, 'file');
+
+        return [$client, $reflection];
+    }
+
+    public function testSqlFileOutputPreservesExactBytesAndMetadata(): void
+    {
+        $this->writeState([]);
+        file_put_contents($this->stateDir . '/db.sql', "STALE SQL THAT MUST BE TRUNCATED\n");
+
+        $sql = [
+            "CREATE TABLE `wp_options` (`option_id` bigint unsigned NOT NULL, `option_name` varchar(191), `option_value` longtext);\n",
+            "INSERT INTO `wp_options` VALUES (1,'siteurl',FROM_BASE64('aHR0cHM6Ly9leGFtcGxlLmNvbS9wYXRo'));\n",
+            "INSERT INTO `wp_options` VALUES (2,'plain',FROM_BASE64('bm8tdXJs'));\n",
+        ];
+
+        [$client, $reflection] = $this->prepareClient([
+            ['body' => $sql[0], 'cursor' => 'cursor-create'],
+            ['body' => $sql[1], 'cursor' => 'cursor-siteurl'],
+            ['body' => $sql[2], 'cursor' => 'cursor-plain'],
+        ]);
+
+        $downloadSql = $reflection->getMethod('download_sql');
+        $downloadSql->invoke($client);
+
+        $this->assertSame(
+            implode('', $sql),
+            file_get_contents($this->stateDir . '/db.sql'),
+        );
+
+        $stats = json_decode(
+            file_get_contents($this->stateDir . '/.import-sql-stats.json'),
+            true,
+        );
+        $this->assertSame(3, $stats['statements_total']);
+
+        $domains = json_decode(
+            file_get_contents($this->stateDir . '/.import-domains.json'),
+            true,
+        );
+        $this->assertContains('https://example.com', $domains);
+        $this->assertContains('https://source.example', $domains);
+    }
+
+    public function testResumeTruncatesUncheckpointedBytesBeforeAppending(): void
+    {
+        $prefix = "CREATE TABLE `wp_posts` (`ID` bigint unsigned NOT NULL, `post_title` text);\n";
+        $suffix = "INSERT INTO `wp_posts` VALUES (1,FROM_BASE64('aGVsbG8gd29ybGQ='));\n";
+
+        $this->writeState([
+            'cursor' => 'cursor-after-prefix',
+            'sql_bytes' => strlen($prefix),
+            'sql_statements_counted' => 1,
+        ]);
+        file_put_contents($this->stateDir . '/db.sql', $prefix . "UNCOMMITTED-TAIL");
+
+        [$client, $reflection] = $this->prepareClient([
+            ['body' => $suffix, 'cursor' => 'cursor-after-suffix'],
+        ]);
+
+        $downloadSql = $reflection->getMethod('download_sql');
+        $downloadSql->invoke($client);
+
+        $this->assertSame(
+            $prefix . $suffix,
+            file_get_contents($this->stateDir . '/db.sql'),
+        );
+
+        $stats = json_decode(
+            file_get_contents($this->stateDir . '/.import-sql-stats.json'),
+            true,
+        );
+        $this->assertSame(2, $stats['statements_total']);
+    }
+
+    public function testRetryablePartialResponseFlushesCheckpointedBytesForResume(): void
+    {
+        $first = "CREATE TABLE `wp_comments` (`comment_ID` bigint unsigned NOT NULL);\n";
+        $second = "INSERT INTO `wp_comments` VALUES (1);\n";
+
+        $this->writeState([]);
+
+        [$firstClient, $firstReflection] = $this->prepareClient([
+            ['body' => $first, 'cursor' => 'cursor-after-first'],
+            ['body' => $second, 'cursor' => 'cursor-after-second'],
+        ], 1);
+
+        $downloadSql = $firstReflection->getMethod('download_sql');
+        $downloadSql->invoke($firstClient);
+
+        $this->assertSame($first, file_get_contents($this->stateDir . '/db.sql'));
+
+        $state = json_decode(
+            file_get_contents($this->stateDir . '/.import-state.json'),
+            true,
+        );
+        $this->assertSame('partial', $state['status']);
+        $this->assertSame(strlen($first), $state['sql_bytes']);
+        $this->assertSame(1, $state['sql_statements_counted']);
+
+        [$secondClient, $secondReflection] = $this->prepareClient([
+            ['body' => $second, 'cursor' => 'cursor-after-second'],
+        ]);
+
+        $downloadSql = $secondReflection->getMethod('download_sql');
+        $downloadSql->invoke($secondClient);
+
+        $this->assertSame($first . $second, file_get_contents($this->stateDir . '/db.sql'));
+    }
+}
+
+class SqlFileWritePathClient extends \ImportClient
+{
+    /** @var array<int, array{body: string, cursor: string, query_complete?: bool}> */
+    public array $sqlChunks = [];
+
+    /** @var int|null */
+    public ?int $failAfterChunks = null;
+
+    protected function fetch_streaming(
+        string $url,
+        ?string $cursor,
+        \StreamingContext $context,
+        ?array $post_data = null,
+        ?string $endpoint = null
+    ): void {
+        foreach ($this->sqlChunks as $index => $chunk) {
+            ($context->on_chunk)([
+                'headers' => [
+                    'x-chunk-type' => 'sql',
+                    'x-query-complete' => ($chunk['query_complete'] ?? true) ? '1' : '0',
+                    'x-cursor' => $chunk['cursor'],
+                ],
+                'body' => $chunk['body'],
+            ]);
+
+            if ($this->failAfterChunks !== null && $index + 1 >= $this->failAfterChunks) {
+                throw new \RuntimeException('missing completion chunk');
+            }
+        }
+
+        ($context->on_chunk)([
+            'headers' => [
+                'x-chunk-type' => 'completion',
+                'x-status' => 'complete',
+                'x-batches-processed' => (string) count($this->sqlChunks),
+            ],
+            'body' => '',
+        ]);
+    }
+}


### PR DESCRIPTION
## What it does

Speeds up PHP.wasm `db-pull` file output by changing resumed `db.sql` writes from append mode to a single seek followed by sequential writes. It also gives the SQL file stream a 1 MiB write buffer and keeps `sql_statements_counted` in the normalized state so partial/resumed pulls preserve statement-count progress.

## Rationale

The PHP.wasm runner writes `db.sql` through a mounted filesystem. Append-mode writes are more expensive there because every write takes the append path. The importer already knows the checkpointed SQL byte count, so it can seek to the expected end once on resume and write normally.

Benchmark under `flock /tmp/reprint-bench.lock -c ...` with `BENCH_STAGES=playground-sqlite-db-pull`:

| Version | Wall time | Delta |
|---|---:|---:|
| `origin/trunk` | 441.66 s | baseline |
| this branch | 405.16 s | -36.50 s (-8.3%) |

## Implementation

On file-mode `download_sql()`:

- Reuses the initial `filesize()` result during crash recovery instead of restatting.
- Opens resumed `db.sql` with `c` and calls `fseek($sql_bytes_written)` once instead of opening with `a`.
- Refuses resume when `db.sql` is missing or shorter than the saved SQL byte checkpoint, avoiding silent holes after local file loss or truncation.
- Uses `stream_set_write_buffer()` with a 1 MiB buffer.
- Leaves SQL chunk bytes, cursors, domain discovery, and error handling paths intact.
- Adds `sql_statements_counted` to the default state schema so existing save/resume code is not discarded by normalization.

## Testing instructions

```bash
php -l packages/reprint-importer/src/import.php
php -l tests/Import/SqlFileWritePathTest.php
./vendor/bin/phpunit --configuration tests/phpunit.xml tests/Import/SqlFileWritePathTest.php
./vendor/bin/phpunit --configuration tests/phpunit.xml tests/Import/CurlTimeoutRecoveryTest.php
git diff --check
./vendor/bin/phpstan analyse --configuration=phpstan.neon --memory-limit=1G packages/reprint-importer/src/import.php
flock /tmp/reprint-bench.lock -c 'BENCH_STAGES=playground-sqlite-db-pull node tests/e2e/benchmark/bench-pull.mjs'
```