### PR TITLE
Add wpdb-backed PDO adapter for hosts without ext-pdo_mysql

### DIFF
--- a/packages/reprint-exporter/.gitignore
+++ b/packages/reprint-exporter/.gitignore
@@ -1,0 +1,2 @@
+/vendor/
+/composer.lock

--- a/packages/reprint-exporter/README.md
+++ b/packages/reprint-exporter/README.md
@@ -1,0 +1,13 @@
+# Reprint Exporter
+
+Composer package for the Reprint streaming export engine.
+
+## Development
+
+This repository is a read-only Composer package split from the Reprint monorepo. It is published so Composer can install `wp-php-toolkit/reprint-exporter` directly.
+
+Do not propose changes in this package repository. Open issues and pull requests against the source repository instead:
+
+https://github.com/adamziel/reprint
+
+The package repository is overwritten from `packages/reprint-exporter` in the monorepo during releases, so direct changes here will be lost.

--- a/packages/reprint-exporter/composer.json
+++ b/packages/reprint-exporter/composer.json
@@ -5,10 +5,12 @@
     "license": "GPL-2.0-or-later",
     "require": {
         "php": ">=7.4",
-        "ext-pdo": "*",
-        "ext-pdo_mysql": "*",
         "wp-php-toolkit/data-liberation": "^0.8.0",
         "wp-php-toolkit/html": "^0.8.0"
+    },
+    "suggest": {
+        "ext-pdo": "Needed for the SQLite export path; recommended for MySQL exports (the wpdb fallback handles MySQL when absent).",
+        "ext-pdo_mysql": "Recommended for MySQL exports; falls back to wpdb when absent."
     },
     "autoload": {
         "psr-4": {
@@ -20,10 +22,12 @@
             "src/class-hmac-client.php",
             "src/class-hmac-server.php",
             "src/class-http-server.php",
-            "src/class-sqlite-driver-pdo.php"
+            "src/class-sqlite-driver-pdo.php",
+            "src/class-wpdb-driver-pdo.php"
         ],
         "files": [
-            "src/utils.php"
+            "src/utils.php",
+            "src/class-pdo-polyfill.php"
         ]
     }
 }

--- a/packages/reprint-exporter/src/class-pdo-polyfill.php
+++ b/packages/reprint-exporter/src/class-pdo-polyfill.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * PDO polyfill for hosts without the PDO extension.
+ *
+ * The reprint-exporter codebase references PDO::* constants, \PDOException,
+ * and \PDOStatement at multiple call sites (see the design spec for an audit).
+ * On hosts without ext-pdo, those references would fatal at runtime even
+ * though the wpdb adapter is the chosen connection.
+ *
+ * This file conditionally defines those names in the global namespace so
+ * existing code can resolve them without modification. Constant values
+ * match the real PDO extension exactly so behavior is identical regardless
+ * of which is loaded.
+ *
+ * Side-effect note: on PDO-less hosts, class_exists('PDO') with the default
+ * autoload-true argument now returns true. Co-resident code that uses
+ * class_exists('PDO') as an optional-feature gate (skip PDO path if false)
+ * will see the polyfill and try to use it, fataling where it previously
+ * skipped cleanly. This is acceptable for the exporter's deployment surface
+ * but documented here so a reader can grep for it.
+ */
+
+if (!class_exists('PDO', false)) {
+    eval(<<<'PHP'
+class PDO
+{
+    const FETCH_ASSOC                   = 2;
+    const FETCH_COLUMN                  = 7;
+    const PARAM_STR                     = 2;
+    const ATTR_ERRMODE                  = 3;
+    const ERRMODE_EXCEPTION             = 2;
+    const MYSQL_ATTR_USE_BUFFERED_QUERY = 1000;
+}
+PHP
+    );
+}
+
+if (!class_exists('PDOStatement', false)) {
+    eval(<<<'PHP'
+class PDOStatement
+{
+}
+PHP
+    );
+}
+
+if (!class_exists('PDOException', false)) {
+    // Real PDOException extends \Exception (not \RuntimeException). Match
+    // upstream so `catch (\RuntimeException $e)` does not accidentally catch
+    // the polyfilled exception while missing the real one.
+    eval(<<<'PHP'
+class PDOException extends \Exception
+{
+}
+PHP
+    );
+}

--- a/packages/reprint-exporter/src/class-wpdb-driver-pdo.php
+++ b/packages/reprint-exporter/src/class-wpdb-driver-pdo.php
@@ -1,0 +1,271 @@
+<?php
+/**
+ * wpdb-backed PDO adapter for MySQL exports on PDO-less hosts.
+ *
+ * MySQLDumpProducer expects a PDO connection — prepare(), query(), quote(),
+ * and the statement methods fetch(), fetchAll(), fetchColumn(), execute().
+ * On hosts without ext-pdo / ext-pdo_mysql, this adapter wraps WordPress's
+ * global $wpdb so the dump producer can run unchanged.
+ *
+ * Surface area mirrors SqliteDriverPDO 1:1 — only the methods MySQLDumpProducer
+ * and the export endpoints actually call. Behavior parity with real PDO is the
+ * bar; behavioral divergence (wpdb's HTML error rendering, sticky last_error,
+ * get_results null ambiguity) is normalized inside the adapter.
+ *
+ * Charset: wpdb uses the site's DB_CHARSET. The dump producer wraps non-numeric
+ * columns in CAST(... AS BINARY) so the connection charset doesn't influence
+ * emitted bytes — same guarantee as the real-PDO path.
+ */
+
+/**
+ * Wraps a WordPress wpdb instance to look like a PDO connection.
+ */
+class WpdbDriverPDO
+{
+    /** @var object */
+    private $wpdb;
+
+    /**
+     * @param object $wpdb The global WordPress $wpdb. Type hint omitted because
+     *        wpdb subclasses (HyperDB, LudicrousDB, SQLite drop-in) are not
+     *        guaranteed to extend the canonical class in all environments,
+     *        and the test double is not a wpdb subclass.
+     */
+    public function __construct($wpdb)
+    {
+        $this->wpdb = $wpdb;
+
+        // Prevent wpdb from echoing HTML error blocks into the response stream.
+        // The export endpoints emit gzip multipart, so even one HTML chunk
+        // would corrupt the output stream irrecoverably. No restore on
+        // shutdown: export endpoints terminate the request after streaming.
+        $wpdb->suppress_errors(true);
+        $wpdb->hide_errors();
+    }
+
+    public function prepare(string $sql): WpdbDriverPDOStatement
+    {
+        return new WpdbDriverPDOStatement($this->wpdb, $sql);
+    }
+
+    public function query(string $sql): WpdbDriverPDOStatement
+    {
+        $stmt = new WpdbDriverPDOStatement($this->wpdb, $sql);
+        $stmt->execute();
+        return $stmt;
+    }
+
+    /**
+     * Quotes a string for safe inclusion in a query.
+     *
+     * Calls $wpdb->_real_escape() — a public method on wpdb (and its
+     * subclasses); the leading underscore is naming convention only, not
+     * visibility. Calling it directly keeps the adapter free of any global
+     * function dependency and HyperDB / LudicrousDB / SQLite-drop-in safe.
+     */
+    public function quote(string $value, int $type = PDO::PARAM_STR): string
+    {
+        return "'" . $this->wpdb->_real_escape($value) . "'";
+    }
+}
+
+/**
+ * PDOStatement-shaped wrapper around a wpdb query result set.
+ *
+ * Substitutes positional (?) and named (:name) placeholders manually rather
+ * than calling $wpdb->prepare() — wpdb's prepare uses %s/%d and adds quoting
+ * itself, which would conflict with how MySQLDumpProducer builds queries.
+ */
+class WpdbDriverPDOStatement
+{
+    /** @var object */
+    private $wpdb;
+
+    /** @var string */
+    private $sql;
+
+    /** @var array Stored result rows after execution. */
+    private $rows = [];
+
+    /** @var int Current position for fetch(). */
+    private $position = 0;
+
+    /** @var array Parameters bound via bindValue(). */
+    private $bound_params = [];
+
+    /**
+     * @param object $wpdb
+     * @param string $sql
+     */
+    public function __construct($wpdb, string $sql)
+    {
+        $this->wpdb = $wpdb;
+        $this->sql = $sql;
+    }
+
+    /**
+     * Executes the prepared statement.
+     *
+     * Substitutes parameters into $this->sql, clears any sticky
+     * $wpdb->last_error (which can survive from queries that ran before the
+     * exporter took over the request), runs $wpdb->get_results($sql,
+     * ARRAY_A), and disambiguates the null return: null + non-empty
+     * last_error -> \PDOException; null + empty last_error -> empty result
+     * set.
+     *
+     * @param array|null $params Positional or named parameters.
+     */
+    public function execute($params = null): bool
+    {
+        $sql = $this->substitute_placeholders($this->sql, $params ?? $this->bound_params);
+
+        // Clear sticky last_error so the post-dispatch check below can't
+        // throw a phantom PDOException from a prior query.
+        $this->clear_last_error();
+
+        $rows = $this->wpdb->get_results($sql, 'ARRAY_A');
+        $last_error = $this->get_last_error();
+
+        if ($last_error !== '') {
+            throw new \PDOException($last_error);
+        }
+
+        $this->rows = is_array($rows) ? $rows : [];
+        $this->position = 0;
+        return true;
+    }
+
+    /**
+     * $mode is accepted for PDO compatibility but only FETCH_ASSOC is honored.
+     * MySQLDumpProducer never asks for any other mode.
+     */
+    public function fetch(int $mode = PDO::FETCH_ASSOC)
+    {
+        if ($this->position >= count($this->rows)) {
+            return false;
+        }
+        return $this->rows[$this->position++];
+    }
+
+    /**
+     * Honors FETCH_ASSOC (default) and FETCH_COLUMN. Other PDO modes are
+     * unsupported — MySQLDumpProducer never asks for any other mode.
+     */
+    public function fetchAll(int $mode = PDO::FETCH_ASSOC): array
+    {
+        $remaining = array_slice($this->rows, $this->position);
+        $this->position = count($this->rows);
+
+        if ($mode === PDO::FETCH_COLUMN) {
+            return array_map(static function ($row) {
+                return reset($row);
+            }, $remaining);
+        }
+
+        return $remaining;
+    }
+
+    public function fetchColumn(int $column_number = 0)
+    {
+        $row = $this->fetch();
+        if ($row === false) {
+            return false;
+        }
+        $values = array_values($row);
+        return $values[$column_number] ?? false;
+    }
+
+    public function bindValue($parameter, $value, int $type = PDO::PARAM_STR): bool
+    {
+        $this->bound_params[$parameter] = $value;
+        return true;
+    }
+
+    /**
+     * Substitutes ? and :name placeholders with quoted parameter values.
+     *
+     * Walks $sql byte-by-byte tracking single/double-quoted string literals so
+     * a literal '?' or ':name' inside a string is not treated as a placeholder.
+     * Inside a literal, a backslash escapes the next byte (MySQL extension)
+     * so `\'` does not close the string. Positional substitution runs right
+     * to left so earlier offsets stay valid. Named substitution uses a regex
+     * with a word-boundary tail (/:name(?![A-Za-z0-9_])/) so :foo does not
+     * corrupt :foobar.
+     */
+    private function clear_last_error(): void
+    {
+        $this->wpdb->last_error = '';
+    }
+
+    private function get_last_error(): string
+    {
+        return (string) ($this->wpdb->last_error ?? '');
+    }
+
+    private function substitute_placeholders(string $sql, $params): string
+    {
+        if ($params === null || count($params) === 0) {
+            return $sql;
+        }
+
+        $positions = [];
+        $len = strlen($sql);
+        $in_single = false;
+        $in_double = false;
+        $escape_next = false;
+        for ($i = 0; $i < $len; $i++) {
+            if ($escape_next) {
+                $escape_next = false;
+                continue;
+            }
+            $ch = $sql[$i];
+            if (($in_single || $in_double) && $ch === '\\') {
+                $escape_next = true;
+                continue;
+            }
+            if ($ch === "'" && !$in_double) {
+                $in_single = !$in_single;
+            } elseif ($ch === '"' && !$in_single) {
+                $in_double = !$in_double;
+            } elseif ($ch === '?' && !$in_single && !$in_double) {
+                $positions[] = $i;
+            }
+        }
+
+        for ($i = count($positions) - 1; $i >= 0; $i--) {
+            if (!array_key_exists($i, $params)) {
+                continue;
+            }
+            $quoted = $this->quote_value($params[$i]);
+            $sql = substr_replace($sql, $quoted, $positions[$i], 1);
+        }
+
+        foreach ($params as $key => $value) {
+            if (!is_string($key)) {
+                continue;
+            }
+            $name = ltrim($key, ':');
+            if ($name === '') {
+                continue;
+            }
+            $pattern = '/:' . preg_quote($name, '/') . '(?![A-Za-z0-9_])/';
+            $sql = preg_replace_callback(
+                $pattern,
+                function () use ($value) {
+                    return $this->quote_value($value);
+                },
+                $sql
+            );
+        }
+
+        return $sql;
+    }
+
+    private function quote_value($value): string
+    {
+        if ($value === null) {
+            return 'NULL';
+        }
+        return "'" . $this->wpdb->_real_escape((string) $value) . "'";
+    }
+}

--- a/packages/reprint-exporter/src/export.php
+++ b/packages/reprint-exporter/src/export.php
@@ -321,6 +321,12 @@ function create_db_connection(array $creds, array $options = [])
         return create_sqlite_pdo_adapter();
     }
 
+    // Gate on pdo_mysql, not pdo: ext-pdo core without the mysql driver
+    // can't drive MySQL exports.
+    if (!extension_loaded('pdo_mysql')) {
+        return create_wpdb_pdo_adapter();
+    }
+
     // MySQL path (also works for HyperDB — wp-config.php credentials
     // point to the write master).
     $default_options = [
@@ -379,6 +385,29 @@ function create_sqlite_pdo_adapter()
     $raw_pdo = $driver->get_connection()->get_pdo();
 
     return new SqliteDriverPDO($driver, $raw_pdo);
+}
+
+/**
+ * Wraps the global $wpdb in a PDO-shaped adapter.
+ *
+ * Used on hosts without ext-pdo_mysql. Requires WordPress to be loaded
+ * (so $wpdb is available); throws otherwise.
+ */
+function create_wpdb_pdo_adapter()
+{
+    global $wpdb;
+
+    require_once __DIR__ . "/class-wpdb-driver-pdo.php";
+
+    // Guard against a clobbered/half-initialized $wpdb: isset() alone passes
+    // for non-object scalars, which would fatal inside the adapter constructor.
+    if (!isset($wpdb) || !is_object($wpdb)) {
+        throw new RuntimeException(
+            "MySQL export without PDO requires WordPress \$wpdb to be initialized."
+        );
+    }
+
+    return new WpdbDriverPDO($wpdb);
 }
 
 // Guard with existence checks: when loaded via Composer autoloader, both

--- a/packages/reprint-importer/README.md
+++ b/packages/reprint-importer/README.md
@@ -1,0 +1,13 @@
+# Reprint Importer
+
+Composer package for the Reprint streaming importer and CLI entry point.
+
+## Development
+
+This repository is a read-only Composer package split from the Reprint monorepo. It is published so Composer can install `wp-php-toolkit/reprint-importer` directly.
+
+Do not propose changes in this package repository. Open issues and pull requests against the source repository instead:
+
+https://github.com/adamziel/reprint
+
+The package repository is overwritten from `packages/reprint-importer` in the monorepo during releases, so direct changes here will be lost.


### PR DESCRIPTION
## Summary

Previously the package required `ext-pdo` and `ext-pdo_mysql`. That fails at `composer install`/`update` on hosts without the extensions. It also fails at runtime when the plugin is built on a machine that has them (so Composer succeeds) and then deployed to a server that does not. wp-env, for example, ships without `pdo_mysql` by default, and the export code fatals on first MySQL access there.

Both extensions are now optional. When `ext-pdo_mysql` is missing, `create_db_connection()` returns a wpdb-backed adapter that satisfies the same PDO-shaped interface the rest of the export pipeline expects.

The adapter (`WpdbDriverPDO`) mirrors `SqliteDriverPDO`'s surface (`prepare`, `query`, `quote`, `fetch`, `fetchAll`, `fetchColumn`, `execute`, `bindValue`) and handles wpdb's divergences from PDO: it suppresses HTML error rendering on construction, clears sticky `last_error` before each dispatch, disambiguates a null `get_results()` return between error and empty-set, and uses a word-boundary regex for named placeholders so `:foo` does not corrupt `:foobar`. The placeholder scanner handles backslash-escaped quotes inside string literals so values produced by `_real_escape` round-trip through prepared statements without mis-pairing.

A PDO polyfill (`PDO`, `PDOStatement`, `PDOException`) is registered via `autoload.files` so `PDO::*` references resolve on hosts where the extension is absent. Constant values match real PDO. `PDOException` extends `\Exception` so consumer catch blocks behave identically.

`packages/reprint-exporter/composer.json` moves `ext-pdo` and `ext-pdo_mysql` from `require` to `suggest`. `create_db_connection()` validates `$wpdb` before handing it to the adapter, so a clobbered or non-object global throws `RuntimeException` instead of fataling in the constructor.

## Provenance

Retargets wp-php-toolkit/reprint-exporter#1 to `adamziel/reprint`, per the latest comment there. The PR author could not be preserved directly because GitHub PR authorship belongs to the user creating the PR, but the implementation commit preserves the original author, Luca Tumedei (`@lucatume`), and keeps the original co-author trailer.

An embedded copy of this adapter is in use on the `main` branch of [sirreal/wp-live-sandbox-editor](https://github.com/sirreal/wp-live-sandbox-editor), where it drives wpdb-backed MySQL exports. This PR extracts that implementation into reprint-exporter so consumers can pull it via Composer instead of vendoring a copy.

The companion PR [sirreal/wp-live-sandbox-editor#43](https://github.com/sirreal/wp-live-sandbox-editor/pull/43) replaces the in-tree `Wpdb_Pdo_Adapter`/`Wpdb_Pdo_Statement` with `WpdbDriverPDO` from this branch.

## Verification

- `php -l packages/reprint-exporter/src/class-pdo-polyfill.php`
- `php -l packages/reprint-exporter/src/class-wpdb-driver-pdo.php`
- `php -l packages/reprint-exporter/src/export.php`
- `composer validate --no-check-publish`
- `composer validate --no-check-publish packages/reprint-exporter/composer.json`
